### PR TITLE
Auto-apply + atomic flip to data-plane-review-* labels (#45521)

### DIFF
--- a/.github/protected-labels.yml
+++ b/.github/protected-labels.yml
@@ -17,6 +17,26 @@ global-approvers:
   - samvaity
   - praveenkuttappan
 
+# Data-plane API stewardship sign-off. Applying it clears the merge gate, so only the
+# data-plane reviewer pool may apply it; anyone else's application is reverted. This roster
+# mirrors the GitHub team @Azure/azure-data-plane-api-reviewers (the same pool native
+# assignment requests). Collapsing this list onto the team so the roster lives in one place
+# is tracked in #45487.
+data-plane-review-signoff:
+  - kashifkhan
+  - xirzec
+  - maorleger
+  - JonathanGiles
+  - heaths
+  - jeremymeng
+  - LarryOsterman
+  - jhendrixMSFT
+  - alzimmermsft
+  - weidongxu-microsoft
+  - JoshLove-msft
+  - qiaozha
+  - m-nash
+
 # Data-plane REST stewardship reviewers. Gated here as the only users who may apply the
 # sign-off label, the approval that clears the merge gate.
 #

--- a/.github/protected-labels.yml
+++ b/.github/protected-labels.yml
@@ -17,26 +17,6 @@ global-approvers:
   - samvaity
   - praveenkuttappan
 
-# Data-plane API stewardship sign-off. Applying it clears the merge gate, so only the
-# data-plane reviewer pool may apply it; anyone else's application is reverted. This roster
-# mirrors the GitHub team @Azure/azure-data-plane-api-reviewers (the same pool native
-# assignment requests). Collapsing this list onto the team so the roster lives in one place
-# is tracked in #45487.
-data-plane-review-signoff:
-  - kashifkhan
-  - xirzec
-  - maorleger
-  - JonathanGiles
-  - heaths
-  - jeremymeng
-  - LarryOsterman
-  - jhendrixMSFT
-  - alzimmermsft
-  - weidongxu-microsoft
-  - JoshLove-msft
-  - qiaozha
-  - m-nash
-
 # Data-plane REST stewardship reviewers. Gated here as the only users who may apply the
 # sign-off label, the approval that clears the merge gate.
 #
@@ -47,7 +27,7 @@ data-plane-review-signoff:
 # Since this low cost effort and the list changes rarely, the simpler path
 # fits better for now, so we mirror the members by hand. Keep this in sync when team
 # membership changes.
-APIStewardshipBoard-SignedOff:
+data-plane-review-signoff:
   - JonathanGiles
   - heaths
   - weidongxu-microsoft

--- a/.github/workflows/data-plane-review-assignment.yaml
+++ b/.github/workflows/data-plane-review-assignment.yaml
@@ -5,12 +5,13 @@
 # picks the individual member; this workflow only requests the team.
 #
 # Two triggers, because the `data-plane-review-requested` label can arrive two ways:
-#   - `pull_request_target: labeled` — manual label, plus the sign-off that clears it.
+#   - `pull_request_target: labeled` — the label applied manually.
 #   - `workflow_run` on "Summarize Checks" — the auto-applied label. It is applied with the
 #     default GITHUB_TOKEN, which does not re-trigger `labeled` workflows, so this path
 #     reconciles the request from the PR's live labels instead.
 #
-# `unlabeled` is not handled: native delegation owns the individual reviewer.
+# Sign-off and `unlabeled` are not handled: the durable `data-plane-review-signoff` label
+# gates merge on its own, and native delegation owns the individual reviewer.
 name: "Data-Plane API Review - Assign Reviewers"
 
 on:
@@ -30,16 +31,9 @@ permissions:
   contents: read
   pull-requests: write
 
-# Serialize runs per PR so racing events do not interleave. `pull_request_target` keys on the
-# PR number directly; `workflow_run` keys on the triggering run's head SHA (the PR number is
-# only resolved inside the job). Do not cancel in-progress runs: a cancelled run could drop a
-# team request mid-flight.
-concurrency:
-  group: >-
-    data-plane-review-assignment-${{
-      github.event.pull_request.number || github.event.workflow_run.head_sha
-    }}
-  cancel-in-progress: false
+# No `concurrency` block: the job is idempotent, like the other workflow_run label-reaction
+# workflows here. A PR-scoped group isn't possible on the workflow_run path anyway
+# (workflow_run.head_sha is the base tip, shared across open PRs).
 
 jobs:
   assign-reviewers:

--- a/.github/workflows/data-plane-review-assignment.yaml
+++ b/.github/workflows/data-plane-review-assignment.yaml
@@ -1,12 +1,20 @@
 # Data-Plane API Review - Assign Reviewers
 #
-# When the `APIStewardshipBoard-ReviewRequested` label is applied to a data-plane PR,
-# request review from the `azure-data-plane-api-reviewers` team. The team has GitHub
-# code-review auto-assignment enabled, so GitHub delegates the request to one team
-# member using the team's routing algorithm. Removing the label is intentionally not
-# handled: native delegation owns the individual reviewer, so the workflow never removes
-# a reviewer it did not pick, and it does not subscribe to `unlabeled` events. Applying
-# `APIStewardshipBoard-SignedOff` clears the request label.
+# Requests review from the `azure-data-plane-api-reviewers` team when a data-plane PR needs
+# stewardship review. The team has GitHub code-review auto-assignment enabled, so GitHub
+# delegates the request to one team member using the team's routing algorithm.
+#
+# Two triggers, because the `data-plane-review-requested` intake label can arrive two ways:
+#   - `pull_request_target: labeled` handles labels applied by a human (manual request) and
+#     the `data-plane-review-signoff` sign-off that clears the request label.
+#   - `workflow_run` on "Summarize Checks" handles the auto-applied intake label: Summarize
+#     Checks applies it with the default GITHUB_TOKEN, and labels applied by that token do
+#     not re-trigger `labeled` workflows, so this reconciles the reviewer request from the
+#     PR's live labels after Summarize Checks completes.
+#
+# Removing the label is intentionally not handled: native delegation owns the individual
+# reviewer, so the workflow never removes a reviewer it did not pick, and it does not
+# subscribe to `unlabeled` events.
 name: "Data-Plane API Review - Assign Reviewers"
 
 on:
@@ -15,21 +23,40 @@ on:
       - labeled
     branches:
       - main
+  workflow_run:
+    workflows:
+      - "Summarize Checks"
+    types:
+      - completed
 
 permissions:
+  actions: read # extractInputs reads issue-number/head-sha handoff artifacts on workflow_run
   contents: read
   pull-requests: write
 
-# Serialize runs per PR so racing label events do not interleave. Do not cancel
-# in-progress runs: a cancelled run could drop a team request mid-flight.
+# Serialize runs per PR so racing events do not interleave. `pull_request_target` keys on the
+# PR number directly; `workflow_run` keys on the triggering run's head SHA (the PR number is
+# only resolved inside the job). Do not cancel in-progress runs: a cancelled run could drop a
+# team request mid-flight.
 concurrency:
-  group: data-plane-review-assignment-${{ github.event.pull_request.number }}
+  group: >-
+    data-plane-review-assignment-${{
+      github.event.pull_request.number || github.event.workflow_run.head_sha
+    }}
   cancel-in-progress: false
 
 jobs:
   assign-reviewers:
     name: Assign Data-Plane Review Team
-    runs-on: ubuntu-24.04
+    # For workflow_run, skip runs of Summarize Checks that did not succeed: a failed or
+    # cancelled run may not have applied labels, and there is nothing to reconcile.
+    if: >-
+      ${{ github.event_name == 'pull_request_target' ||
+          github.event.workflow_run.conclusion == 'success' }}
+    # ubuntu-slim: this job only calls the GitHub REST API via github-script (no build), and
+    # runs on every Summarize Checks completion, so keep the runner minimal. Matches the other
+    # label-reaction workflows (arm-auto-signoff-status, update-labels).
+    runs-on: ubuntu-slim
     steps:
       # IMPORTANT: This workflow uses pull_request_target, which runs with repo write
       # permissions. Only base-branch code is checked out below, and no PR-head code is

--- a/.github/workflows/data-plane-review-assignment.yaml
+++ b/.github/workflows/data-plane-review-assignment.yaml
@@ -1,20 +1,16 @@
 # Data-Plane API Review - Assign Reviewers
 #
-# Requests review from the `azure-data-plane-api-reviewers` team when a data-plane PR needs
+# Requests review from the `azure-data-plane-api-reviewers` team on data-plane PRs that need
 # stewardship review. The team has GitHub code-review auto-assignment enabled, so GitHub
-# delegates the request to one team member using the team's routing algorithm.
+# picks the individual member; this workflow only requests the team.
 #
-# Two triggers, because the `data-plane-review-requested` intake label can arrive two ways:
-#   - `pull_request_target: labeled` handles labels applied by a human (manual request) and
-#     the `data-plane-review-signoff` sign-off that clears the request label.
-#   - `workflow_run` on "Summarize Checks" handles the auto-applied intake label: Summarize
-#     Checks applies it with the default GITHUB_TOKEN, and labels applied by that token do
-#     not re-trigger `labeled` workflows, so this reconciles the reviewer request from the
-#     PR's live labels after Summarize Checks completes.
+# Two triggers, because the `data-plane-review-requested` label can arrive two ways:
+#   - `pull_request_target: labeled` — manual label, plus the sign-off that clears it.
+#   - `workflow_run` on "Summarize Checks" — the auto-applied label. It is applied with the
+#     default GITHUB_TOKEN, which does not re-trigger `labeled` workflows, so this path
+#     reconciles the request from the PR's live labels instead.
 #
-# Removing the label is intentionally not handled: native delegation owns the individual
-# reviewer, so the workflow never removes a reviewer it did not pick, and it does not
-# subscribe to `unlabeled` events.
+# `unlabeled` is not handled: native delegation owns the individual reviewer.
 name: "Data-Plane API Review - Assign Reviewers"
 
 on:
@@ -48,14 +44,12 @@ concurrency:
 jobs:
   assign-reviewers:
     name: Assign Data-Plane Review Team
-    # For workflow_run, skip runs of Summarize Checks that did not succeed: a failed or
-    # cancelled run may not have applied labels, and there is nothing to reconcile.
+    # Skip Summarize Checks runs that did not succeed: nothing to reconcile.
     if: >-
       ${{ github.event_name == 'pull_request_target' ||
           github.event.workflow_run.conclusion == 'success' }}
-    # ubuntu-slim: this job only calls the GitHub REST API via github-script (no build), and
-    # runs on every Summarize Checks completion, so keep the runner minimal. Matches the other
-    # label-reaction workflows (arm-auto-signoff-status, update-labels).
+    # ubuntu-slim: REST-only job (no build) that runs on every Summarize Checks completion,
+    # matching the other label-reaction workflows (arm-auto-signoff-status, update-labels).
     runs-on: ubuntu-slim
     steps:
       # IMPORTANT: This workflow uses pull_request_target, which runs with repo write

--- a/.github/workflows/src/data-plane-review/assign-reviewers.js
+++ b/.github/workflows/src/data-plane-review/assign-reviewers.js
@@ -94,24 +94,16 @@ async function loadAuthorizedSigners() {
 }
 
 /**
- * Assign the stewardship review team or complete the review.
+ * Assign the stewardship review team, or complete the review on sign-off.
  *
  * Two entry paths:
+ * 1. `pull_request_target: labeled` — a manual {@link TRIGGER_LABEL} requests the team; a
+ *    {@link SIGNOFF_LABEL} clears the fulfilled request label.
+ * 2. `workflow_run` on "Summarize Checks" — reconciles the team request for the
+ *    auto-applied {@link TRIGGER_LABEL} (see {@link assignFromWorkflowRun}).
  *
- * 1. `pull_request_target` `labeled` events. On {@link TRIGGER_LABEL} added: requests
- *    {@link REVIEWER_TEAM} as a reviewer; the team's code-review auto-assignment then
- *    delegates to one member. On {@link SIGNOFF_LABEL} added: clears the fulfilled
- *    {@link TRIGGER_LABEL}. This path covers manually applied labels and human sign-off.
- *
- * 2. `workflow_run` completion of "Summarize Checks" (see {@link assignFromWorkflowRun}).
- *    {@link TRIGGER_LABEL} is applied by Summarize Checks with the default `GITHUB_TOKEN`,
- *    and labels applied by that token do NOT re-trigger `labeled` workflows. So the intake
- *    label alone would never reach path 1. Summarize Checks hands off here on completion
- *    instead, and this path reconciles the reviewer request from the PR's live labels.
- *
- * Label removal is not handled: the workflow does not subscribe to `unlabeled` events,
- * because native delegation owns the individual reviewer and the automation never removes
- * a reviewer it did not pick.
+ * `unlabeled` is intentionally not handled: native delegation owns the individual reviewer,
+ * so the automation never removes a reviewer it did not pick.
  *
  * @param {import("@actions/github-script").AsyncFunctionArguments} args
  */
@@ -156,16 +148,13 @@ export default async function assignReviewers({ github, context, core }) {
 }
 
 /**
- * Reconcile the reviewer request after "Summarize Checks" completes. Summarize Checks
- * applies {@link TRIGGER_LABEL} with the default `GITHUB_TOKEN`, which does not re-trigger
- * `labeled` workflows, so this workflow_run handoff is the only path that reacts to the
- * auto-applied intake label.
+ * Reconcile the team request after "Summarize Checks" completes. The intake label is
+ * auto-applied with the default `GITHUB_TOKEN`, which does not re-trigger `labeled`
+ * workflows, so this is the only path that reacts to it.
  *
- * Because the workflow_run event carries no label payload, the decision is driven entirely
- * by the PR's live state: request {@link REVIEWER_TEAM} only when the PR is open, not a
- * draft, still carries {@link TRIGGER_LABEL}, is not already signed off, and does not
- * already have the team requested. Every condition is idempotent, so the repeated Summarize
- * Checks completions across a PR's life converge on a single team request.
+ * The event carries no label payload, so the decision reads live PR state: request the team
+ * only when the PR is open, non-draft, still carries {@link TRIGGER_LABEL}, is not signed
+ * off, and does not already have the team requested. All conditions are idempotent.
  *
  * @param {Pick<import("@actions/github-script").AsyncFunctionArguments, "github" | "context" | "core">} args
  */

--- a/.github/workflows/src/data-plane-review/assign-reviewers.js
+++ b/.github/workflows/src/data-plane-review/assign-reviewers.js
@@ -1,8 +1,4 @@
-import { readFile } from "fs/promises";
-import yaml from "js-yaml";
 import { extractInputs } from "../context.js";
-import { removeLabelIfPresent } from "../package-name-approval/labels.js";
-import { ALLOWED_BOT_LOGINS } from "../protected-labels/check-label.js";
 
 /**
  * Intake label for data-plane stewardship review. The merge gate keys off the same label
@@ -11,99 +7,30 @@ import { ALLOWED_BOT_LOGINS } from "../protected-labels/check-label.js";
  */
 export const TRIGGER_LABEL = "data-plane-review-requested";
 
-/** Path (relative to repo root) to the protected-labels config that lists the sign-off approvers. */
-const PROTECTED_LABELS_PATH = ".github/protected-labels.yml";
-
 /**
- * Sign-off label — the gated approval that clears the merge gate. Applying it clears the
- * fulfilled {@link TRIGGER_LABEL}. {@link TRIGGER_LABEL} is machine-applied and not gated.
- * Its authorized-users list in `protected-labels.yml` also gates who may apply it.
+ * Sign-off label: the durable approval that satisfies the merge gate. It coexists with
+ * {@link TRIGGER_LABEL}; this workflow never removes the request label. Who may apply it is
+ * enforced centrally by the protected-labels workflow.
  */
 export const SIGNOFF_LABEL = "data-plane-review-signoff";
 
 /**
- * GitHub team requested as reviewer on intake. The team has code-review auto-assignment
- * enabled, so GitHub replaces the team request with one of
- * its members using the team's routing algorithm; the workflow never picks the individual,
- * it only requests the team. Kept as a constant here; unifying assignment + sign-off
- * authorization onto this team in config is tracked separately (issue #45487).
+ * GitHub team requested as reviewer on intake. The team has code-review auto-assignment, so
+ * GitHub delegates the team request to a member; this workflow only requests the team.
+ * Unifying assignment + sign-off authorization onto this team is tracked in #45487.
  */
 export const REVIEWER_TEAM = "azure-data-plane-api-reviewers";
 
 /**
- * Read and parse the shared `protected-labels.yml` config.
- *
- * @returns {Promise<Record<string, unknown>>}
- */
-async function loadConfig() {
-  const content = await readFile(PROTECTED_LABELS_PATH, "utf8");
-  return /** @type {Record<string, unknown>} */ (yaml.load(content) ?? {});
-}
-
-/**
- * Flatten a config entry into a deduplicated, trimmed list of logins. An entry is either a
- * flat array of logins or an object keyed by plane (`{ "management-plane": [...],
- * "data-plane": [...] }`); both shapes are supported.
- *
- * @param {unknown} entry
- * @returns {string[]}
- */
-function extractLogins(entry) {
-  /** @type {unknown[]} */
-  let logins = [];
-  if (Array.isArray(entry)) {
-    logins = entry;
-  } else if (entry && typeof entry === "object") {
-    logins = Object.values(/** @type {Record<string, unknown>} */ (entry)).flatMap((value) =>
-      Array.isArray(value) ? /** @type {unknown[]} */ (value) : [],
-    );
-  }
-
-  return [
-    ...new Set(
-      logins
-        .filter((/** @type {unknown} */ r) => typeof r === "string" && r.trim().length > 0)
-        .map((r) => /** @type {string} */ (r).trim()),
-    ),
-  ];
-}
-
-/**
- * Case-insensitive membership test.
- *
- * @param {string[]} list
- * @param {string} login
- */
-function includesLogin(list, login) {
-  const lower = login.toLowerCase();
-  return list.some((entry) => entry.toLowerCase() === lower);
-}
-
-/**
- * Users authorized to apply the gated {@link SIGNOFF_LABEL}: its authorized-users list plus
- * the `global-approvers` list from `protected-labels.yml` (the same set that workflow
- * enforces). Trusted bots are handled separately by the caller via {@link ALLOWED_BOT_LOGINS}.
- *
- * @returns {Promise<string[]>}
- */
-async function loadAuthorizedSigners() {
-  const config = await loadConfig();
-  const signers = extractLogins(config[SIGNOFF_LABEL]);
-  const globals = extractLogins(config["global-approvers"]);
-  return [...new Set([...signers, ...globals])];
-}
-
-/**
- * Assign the stewardship review team, or complete the review on sign-off.
+ * Assign the stewardship review team.
  *
  * Two entry paths:
- * 1. `pull_request_target: labeled` — a manual {@link TRIGGER_LABEL} requests the team; a
- *    {@link SIGNOFF_LABEL} clears the fulfilled request label.
- * 2. `workflow_run` on "Summarize Checks" — reconciles the team request for the
- *    auto-applied {@link TRIGGER_LABEL} (see {@link assignFromWorkflowRun}).
+ * 1. `pull_request_target: labeled` — a manual {@link TRIGGER_LABEL} requests the team.
+ * 2. `workflow_run` on "Summarize Checks" — reconciles the auto-applied {@link TRIGGER_LABEL}
+ *    (see {@link assignFromWorkflowRun}).
  *
- * `unlabeled` is intentionally not handled: native delegation owns the individual reviewer,
- * so the automation never removes a reviewer it did not pick.
+ * Sign-off and `unlabeled` are not handled: {@link SIGNOFF_LABEL} gates merge on its own, and
+ * native delegation owns the individual reviewer.
  *
  * @param {import("@actions/github-script").AsyncFunctionArguments} args
  */
@@ -118,43 +45,23 @@ export default async function assignReviewers({ github, context, core }) {
 
   const targetLabel = payload.label?.name;
 
-  // Sign-off completes the review, so clear the fulfilled request label.
-  if (targetLabel === SIGNOFF_LABEL) {
-    const { owner, repo, issue_number } = await extractInputs(github, context, core);
-    return await completeReviewOnSignOff({
-      github,
-      core,
-      owner,
-      repo,
-      prNumber: issue_number,
-      payload,
-    });
-  }
-
   if (targetLabel !== TRIGGER_LABEL) {
-    core.info(`Label '${targetLabel}' is not '${TRIGGER_LABEL}' or '${SIGNOFF_LABEL}', skipping.`);
+    core.info(`Label '${targetLabel}' is not '${TRIGGER_LABEL}', skipping.`);
     return;
   }
 
   const { owner, repo, issue_number } = await extractInputs(github, context, core);
-  await requestReviewerTeam({
-    github,
-    core,
-    owner,
-    repo,
-    prNumber: issue_number,
-    requestedTeams: payload.pull_request.requested_teams,
-  });
+  await requestReviewerTeam({ github, core, owner, repo, prNumber: issue_number });
 }
 
 /**
  * Reconcile the team request after "Summarize Checks" completes. The intake label is
- * auto-applied with the default `GITHUB_TOKEN`, which does not re-trigger `labeled`
- * workflows, so this is the only path that reacts to it.
+ * auto-applied with the default `GITHUB_TOKEN`, which does not re-trigger `labeled` workflows,
+ * so this is the only path that reacts to it.
  *
- * The event carries no label payload, so the decision reads live PR state: request the team
- * only when the PR is open, non-draft, still carries {@link TRIGGER_LABEL}, is not signed
- * off, and does not already have the team requested. All conditions are idempotent.
+ * With no label payload, the decision reads live PR state: request only when the PR is open,
+ * non-draft, still carries {@link TRIGGER_LABEL}, and is not signed off. All conditions are
+ * idempotent, and {@link requestReviewerTeam} dedupes the request itself.
  *
  * @param {Pick<import("@actions/github-script").AsyncFunctionArguments, "github" | "context" | "core">} args
  */
@@ -192,22 +99,14 @@ async function assignFromWorkflowRun({ github, context, core }) {
     return;
   }
 
-  await requestReviewerTeam({
-    github,
-    core,
-    owner,
-    repo,
-    prNumber: issue_number,
-    requestedTeams: /** @type {{ slug?: string }[]} */ (
-      /** @type {unknown} */ (pr.requested_teams ?? [])
-    ),
-  });
+  await requestReviewerTeam({ github, core, owner, repo, prNumber: issue_number });
 }
 
 /**
- * Request {@link REVIEWER_TEAM} as a reviewer so the team's code-review auto-assignment
- * delegates to one member. Skips the request if the team is already pending on the PR so
- * repeated events do not queue a second delegation.
+ * Request {@link REVIEWER_TEAM} so its code-review auto-assignment delegates to a member.
+ * Requests at most once per PR: dedupes on the durable `review_requested` timeline event,
+ * which survives delegation swapping the team for an individual (the live `requested_teams`
+ * is emptied on delegation, so it alone would let a later run re-request and re-notify).
  *
  * @param {object} params
  * @param {import("@actions/github-script").AsyncFunctionArguments["github"]} params.github
@@ -215,16 +114,22 @@ async function assignFromWorkflowRun({ github, context, core }) {
  * @param {string} params.owner
  * @param {string} params.repo
  * @param {number} params.prNumber
- * @param {{ slug?: string }[] | undefined} params.requestedTeams - teams already requested on the PR
  */
-async function requestReviewerTeam({ github, core, owner, repo, prNumber, requestedTeams }) {
-  // requested_teams lists teams whose request is still pending (before delegation swaps the
-  // team for a member). If our team is already pending, another run already requested it.
-  const alreadyRequested = (requestedTeams ?? []).some(
-    (t) => (t.slug ?? "").toLowerCase() === REVIEWER_TEAM.toLowerCase(),
-  );
+async function requestReviewerTeam({ github, core, owner, repo, prNumber }) {
+  const events = await github.paginate(github.rest.issues.listEvents, {
+    owner,
+    repo,
+    issue_number: prNumber,
+    per_page: 100,
+  });
+  const alreadyRequested = events.some((event) => {
+    if (event.event !== "review_requested") return false;
+    const requestedTeam = /** @type {{ requested_team?: { slug?: string } }} */ (event)
+      .requested_team;
+    return (requestedTeam?.slug ?? "").toLowerCase() === REVIEWER_TEAM.toLowerCase();
+  });
   if (alreadyRequested) {
-    core.info(`Team '${REVIEWER_TEAM}' is already a requested reviewer; nothing to do.`);
+    core.info(`Team '${REVIEWER_TEAM}' was already requested on PR #${prNumber}; nothing to do.`);
     return;
   }
 
@@ -235,66 +140,4 @@ async function requestReviewerTeam({ github, core, owner, repo, prNumber, reques
     team_reviewers: [REVIEWER_TEAM],
   });
   core.info(`Requested review from team '${REVIEWER_TEAM}'.`);
-}
-
-/**
- * On sign-off, clear the fulfilled {@link TRIGGER_LABEL} so the request no longer shows as
- * pending. The assigned reviewer is left in place. No comment is posted, matching the ARM
- * sign-off flows. Safe against the merge gate: once {@link SIGNOFF_LABEL} is present the
- * gate's required-label condition is already satisfied.
- *
- * The signer is verified against the authorized approver list first. Because a label removed
- * with the default token does not re-trigger a workflow, an unverified path could let an
- * unauthorized sign-off clear the request label before `protected-labels` reverts the bogus
- * label. Skipping unauthorized signers keeps that reversal the source of truth.
- *
- * This in-workflow authorization check duplicates the protected-labels authorization list
- * only because the clearing action lives in this separate job. Consolidating the clearing
- * into the trusted central label flow removes this duplicate check; tracked in issue #45494.
- *
- * @param {object} params
- * @param {import("@actions/github-script").AsyncFunctionArguments["github"]} params.github
- * @param {import("@actions/github-script").AsyncFunctionArguments["core"]} params.core
- * @param {string} params.owner
- * @param {string} params.repo
- * @param {number} params.prNumber
- * @param {import("@octokit/webhooks-types").PullRequestLabeledEvent} params.payload
- */
-async function completeReviewOnSignOff({ github, core, owner, repo, prNumber, payload }) {
-  const signer = payload.sender?.login ?? "";
-  if (!ALLOWED_BOT_LOGINS.includes(signer)) {
-    const authorizedSigners = await loadAuthorizedSigners();
-    if (!includesLogin(authorizedSigners, signer)) {
-      core.info(
-        `'${signer}' is not authorized to apply '${SIGNOFF_LABEL}'; leaving '${TRIGGER_LABEL}' ` +
-          `for the protected-labels workflow to reconcile.`,
-      );
-      return;
-    }
-  }
-
-  // Read the labels live rather than from the cached event payload.
-  const currentLabels = await github.paginate(github.rest.issues.listLabelsOnIssue, {
-    owner,
-    repo,
-    issue_number: prNumber,
-    per_page: 100,
-  });
-  const currentLabelNames = currentLabels.map((label) => label.name);
-
-  if (!currentLabelNames.includes(SIGNOFF_LABEL)) {
-    core.info(
-      `'${SIGNOFF_LABEL}' is no longer present on PR #${prNumber}; sign-off was retracted before ` +
-        `this ran, leaving '${TRIGGER_LABEL}' in place.`,
-    );
-    return;
-  }
-
-  if (!currentLabelNames.includes(TRIGGER_LABEL)) {
-    core.info(`'${TRIGGER_LABEL}' not present on PR #${prNumber}; nothing to clear on sign-off.`);
-    return;
-  }
-
-  await removeLabelIfPresent(github, owner, repo, prNumber, TRIGGER_LABEL);
-  core.info(`Sign-off recorded on PR #${prNumber}; cleared '${TRIGGER_LABEL}'.`);
 }

--- a/.github/workflows/src/data-plane-review/assign-reviewers.js
+++ b/.github/workflows/src/data-plane-review/assign-reviewers.js
@@ -9,7 +9,7 @@ import { ALLOWED_BOT_LOGINS } from "../protected-labels/check-label.js";
  * (see `.github/workflows/src/summarize-checks/labelling.js`), so intake, assignment, and
  * the gate share one name. Kept as a constant so it can be changed in one place.
  */
-export const TRIGGER_LABEL = "APIStewardshipBoard-ReviewRequested";
+export const TRIGGER_LABEL = "data-plane-review-requested";
 
 /** Path (relative to repo root) to the protected-labels config that lists the sign-off approvers. */
 const PROTECTED_LABELS_PATH = ".github/protected-labels.yml";
@@ -19,7 +19,7 @@ const PROTECTED_LABELS_PATH = ".github/protected-labels.yml";
  * fulfilled {@link TRIGGER_LABEL}. {@link TRIGGER_LABEL} is machine-applied and not gated.
  * Its authorized-users list in `protected-labels.yml` also gates who may apply it.
  */
-export const SIGNOFF_LABEL = "APIStewardshipBoard-SignedOff";
+export const SIGNOFF_LABEL = "data-plane-review-signoff";
 
 /**
  * GitHub team requested as reviewer on intake. The team has code-review auto-assignment

--- a/.github/workflows/src/data-plane-review/assign-reviewers.js
+++ b/.github/workflows/src/data-plane-review/assign-reviewers.js
@@ -94,18 +94,32 @@ async function loadAuthorizedSigners() {
 }
 
 /**
- * Assign the stewardship review team or complete the review, based on a label event.
+ * Assign the stewardship review team or complete the review.
  *
- * Runs on `pull_request_target` `labeled` events. On {@link TRIGGER_LABEL} added:
- * requests {@link REVIEWER_TEAM} as a reviewer; the team's code-review auto-assignment
- * then delegates to one member. On {@link SIGNOFF_LABEL} added: clears the fulfilled
- * {@link TRIGGER_LABEL}. Label removal is not handled: the workflow does not subscribe to
- * `unlabeled` events, because native delegation owns the individual reviewer and the
- * automation never removes a reviewer it did not pick.
+ * Two entry paths:
+ *
+ * 1. `pull_request_target` `labeled` events. On {@link TRIGGER_LABEL} added: requests
+ *    {@link REVIEWER_TEAM} as a reviewer; the team's code-review auto-assignment then
+ *    delegates to one member. On {@link SIGNOFF_LABEL} added: clears the fulfilled
+ *    {@link TRIGGER_LABEL}. This path covers manually applied labels and human sign-off.
+ *
+ * 2. `workflow_run` completion of "Summarize Checks" (see {@link assignFromWorkflowRun}).
+ *    {@link TRIGGER_LABEL} is applied by Summarize Checks with the default `GITHUB_TOKEN`,
+ *    and labels applied by that token do NOT re-trigger `labeled` workflows. So the intake
+ *    label alone would never reach path 1. Summarize Checks hands off here on completion
+ *    instead, and this path reconciles the reviewer request from the PR's live labels.
+ *
+ * Label removal is not handled: the workflow does not subscribe to `unlabeled` events,
+ * because native delegation owns the individual reviewer and the automation never removes
+ * a reviewer it did not pick.
  *
  * @param {import("@actions/github-script").AsyncFunctionArguments} args
  */
 export default async function assignReviewers({ github, context, core }) {
+  if (context.eventName === "workflow_run") {
+    return await assignFromWorkflowRun({ github, context, core });
+  }
+
   const payload = /** @type {import("@octokit/webhooks-types").PullRequestLabeledEvent} */ (
     context.payload
   );
@@ -131,13 +145,80 @@ export default async function assignReviewers({ github, context, core }) {
   }
 
   const { owner, repo, issue_number } = await extractInputs(github, context, core);
-  await requestReviewerTeam({ github, core, owner, repo, prNumber: issue_number, payload });
+  await requestReviewerTeam({
+    github,
+    core,
+    owner,
+    repo,
+    prNumber: issue_number,
+    requestedTeams: payload.pull_request.requested_teams,
+  });
+}
+
+/**
+ * Reconcile the reviewer request after "Summarize Checks" completes. Summarize Checks
+ * applies {@link TRIGGER_LABEL} with the default `GITHUB_TOKEN`, which does not re-trigger
+ * `labeled` workflows, so this workflow_run handoff is the only path that reacts to the
+ * auto-applied intake label.
+ *
+ * Because the workflow_run event carries no label payload, the decision is driven entirely
+ * by the PR's live state: request {@link REVIEWER_TEAM} only when the PR is open, not a
+ * draft, still carries {@link TRIGGER_LABEL}, is not already signed off, and does not
+ * already have the team requested. Every condition is idempotent, so the repeated Summarize
+ * Checks completions across a PR's life converge on a single team request.
+ *
+ * @param {Pick<import("@actions/github-script").AsyncFunctionArguments, "github" | "context" | "core">} args
+ */
+async function assignFromWorkflowRun({ github, context, core }) {
+  const { owner, repo, issue_number } = await extractInputs(github, context, core);
+  if (!issue_number) {
+    core.info("No pull request resolved from the workflow_run event; nothing to assign.");
+    return;
+  }
+
+  const { data: pr } = await github.rest.pulls.get({
+    owner,
+    repo,
+    pull_number: issue_number,
+  });
+
+  if (pr.state !== "open" || pr.draft) {
+    core.info(
+      `PR #${issue_number} is ${pr.draft ? "a draft" : `'${pr.state}'`}; not requesting review.`,
+    );
+    return;
+  }
+
+  const labelNames = (pr.labels ?? []).map((label) =>
+    typeof label === "string" ? label : (label?.name ?? ""),
+  );
+
+  if (!labelNames.includes(TRIGGER_LABEL)) {
+    core.info(`'${TRIGGER_LABEL}' not present on PR #${issue_number}; nothing to assign.`);
+    return;
+  }
+
+  if (labelNames.includes(SIGNOFF_LABEL)) {
+    core.info(`PR #${issue_number} is already signed off; not requesting review.`);
+    return;
+  }
+
+  await requestReviewerTeam({
+    github,
+    core,
+    owner,
+    repo,
+    prNumber: issue_number,
+    requestedTeams: /** @type {{ slug?: string }[]} */ (
+      /** @type {unknown} */ (pr.requested_teams ?? [])
+    ),
+  });
 }
 
 /**
  * Request {@link REVIEWER_TEAM} as a reviewer so the team's code-review auto-assignment
  * delegates to one member. Skips the request if the team is already pending on the PR so
- * repeated label events do not queue a second delegation.
+ * repeated events do not queue a second delegation.
  *
  * @param {object} params
  * @param {import("@actions/github-script").AsyncFunctionArguments["github"]} params.github
@@ -145,15 +226,12 @@ export default async function assignReviewers({ github, context, core }) {
  * @param {string} params.owner
  * @param {string} params.repo
  * @param {number} params.prNumber
- * @param {import("@octokit/webhooks-types").PullRequestLabeledEvent} params.payload
+ * @param {{ slug?: string }[] | undefined} params.requestedTeams - teams already requested on the PR
  */
-async function requestReviewerTeam({ github, core, owner, repo, prNumber, payload }) {
+async function requestReviewerTeam({ github, core, owner, repo, prNumber, requestedTeams }) {
   // requested_teams lists teams whose request is still pending (before delegation swaps the
   // team for a member). If our team is already pending, another run already requested it.
-  const requestedTeams = /** @type {{ slug?: string }[]} */ (
-    /** @type {unknown} */ (payload.pull_request.requested_teams ?? [])
-  );
-  const alreadyRequested = requestedTeams.some(
+  const alreadyRequested = (requestedTeams ?? []).some(
     (t) => (t.slug ?? "").toLowerCase() === REVIEWER_TEAM.toLowerCase(),
   );
   if (alreadyRequested) {

--- a/.github/workflows/src/summarize-checks/labelling.js
+++ b/.github/workflows/src/summarize-checks/labelling.js
@@ -546,14 +546,15 @@ export function processImpactAssessment(labelContext, impactAssessment) {
     if (impactAssessment.isNewApiVersion) {
       newApiVersionLabel.shouldBePresent = true;
 
-      // For data-plane PRs, a new API version requires API stewardship review. Apply the
-      // intake label unless the review has already been signed off: assign-reviewers.js
-      // clears this label on sign-off, and re-adding it here would re-request the reviewer
-      // team. See rulesPri0dataPlane below.
-      if (
-        impactAssessment.dataPlaneRequired &&
-        !labelContext.present.has("data-plane-review-signoff")
-      ) {
+      // For data-plane PRs, a new API version requires API stewardship review, so apply the
+      // intake label. This is a pure classification of PR content and never keys off the
+      // protected data-plane-review-signoff label. Reading that protected label here would
+      // be unsafe: an unauthorized user can transiently apply it before the Protected Labels
+      // workflow reverts it, and neither that application nor its reversal (both via the
+      // default token) re-runs this workflow, so its presence is not proof of sign-off.
+      // The gate in rulesPri0dataPlane requires signoff whenever this label is present, and
+      // assign-reviewers.js clears this label only on an authorization-verified sign-off.
+      if (impactAssessment.dataPlaneRequired) {
         dataPlaneReviewRequestedLabel.shouldBePresent = true;
       }
     }

--- a/.github/workflows/src/summarize-checks/labelling.js
+++ b/.github/workflows/src/summarize-checks/labelling.js
@@ -496,7 +496,10 @@ export function processImpactAssessment(labelContext, impactAssessment) {
     "data-plane-review-requested",
     labelContext.present,
   );
-  dataPlaneReviewRequestedLabel.shouldBePresent = false;
+  // Add-only: default to current presence so reconciliation never removes it. A qualifying
+  // PR adds it below; otherwise it's left as-is. Preserves manual requests and avoids a
+  // remove/re-add flip that would re-queue an approved PR.
+  dataPlaneReviewRequestedLabel.shouldBePresent = dataPlaneReviewRequestedLabel.present ?? false;
 
   const typeSpecLabel = new Label("TypeSpec", labelContext.present);
   typeSpecLabel.shouldBePresent = impactAssessment.typeSpecChanged || false;
@@ -546,11 +549,8 @@ export function processImpactAssessment(labelContext, impactAssessment) {
     if (impactAssessment.isNewApiVersion) {
       newApiVersionLabel.shouldBePresent = true;
 
-      // Data-plane new API versions need stewardship review. Classify purely from PR
-      // content; never read the protected data-plane-review-signoff label here (its presence
-      // isn't proof of sign-off, and reading it would be racy). The gate requires sign-off
-      // whenever this label is present, and only assign-reviewers.js clears it, on a
-      // verified sign-off.
+      // Classify from PR content only; never read the protected signoff label here (racy,
+      // not proof of sign-off). The label is add-only, so an approved PR is never re-queued.
       if (impactAssessment.dataPlaneRequired) {
         dataPlaneReviewRequestedLabel.shouldBePresent = true;
       }
@@ -843,15 +843,16 @@ const rulesPri0dataPlane = [
   // and https://github.com/Azure/azure-sdk-tools/issues/6612
   //
   //   IF the label data-plane-review-requested is present,
-  //   THEN require the label data-plane-review-signoff.
+  //   THEN require data-plane-review-signoff (or, during migration, the legacy
+  //   APIStewardshipBoard-SignedOff).
   //
-  // data-plane-review-requested is auto-applied in processImpactAssessment above whenever a
-  // data-plane PR introduces a new API version, so the previous data-plane + new-api-version
-  // fallback prerequisite is no longer needed.
+  // data-plane-review-requested is auto-applied in processImpactAssessment above, so the old
+  // data-plane + new-api-version fallback is no longer needed. The legacy signoff is accepted
+  // as a transition bridge; remove it once no open PR carries it (tracked in #45521).
   {
     precedence: 0,
     anyPrerequisiteLabels: ["data-plane-review-requested"],
-    anyRequiredLabels: ["data-plane-review-signoff"],
+    anyRequiredLabels: ["data-plane-review-signoff", "APIStewardshipBoard-SignedOff"],
     troubleshootingGuide:
       `Your PR requires an API stewardship board review as it introduces a new API version (label: <code>new-api-version</code>). ` +
       `Send an email to ${href("azureapirbcore@microsoft.com", "mailto:azureapirbcore@microsoft.com")} with your PR link for offline review.`,

--- a/.github/workflows/src/summarize-checks/labelling.js
+++ b/.github/workflows/src/summarize-checks/labelling.js
@@ -843,16 +843,17 @@ const rulesPri0dataPlane = [
   // and https://github.com/Azure/azure-sdk-tools/issues/6612
   //
   //   IF the label data-plane-review-requested is present,
-  //   THEN require data-plane-review-signoff (or, during migration, the legacy
-  //   APIStewardshipBoard-SignedOff).
+  //   THEN require data-plane-review-signoff.
   //
   // data-plane-review-requested is auto-applied in processImpactAssessment above, so the old
-  // data-plane + new-api-version fallback is no longer needed. The legacy signoff is accepted
-  // as a transition bridge; remove it once no open PR carries it (tracked in #45521).
+  // data-plane + new-api-version fallback is no longer needed. The gate reads only the new
+  // protected sign-off label; the legacy APIStewardshipBoard-SignedOff is not accepted (it is
+  // no longer protected, so accepting it would let anyone satisfy the gate). Existing legacy
+  // sign-offs are migrated by re-stamping with data-plane-review-signoff (see #45521).
   {
     precedence: 0,
     anyPrerequisiteLabels: ["data-plane-review-requested"],
-    anyRequiredLabels: ["data-plane-review-signoff", "APIStewardshipBoard-SignedOff"],
+    anyRequiredLabels: ["data-plane-review-signoff"],
     troubleshootingGuide:
       `Your PR requires an API stewardship board review as it introduces a new API version (label: <code>new-api-version</code>). ` +
       `Send an email to ${href("azureapirbcore@microsoft.com", "mailto:azureapirbcore@microsoft.com")} with your PR link for offline review.`,

--- a/.github/workflows/src/summarize-checks/labelling.js
+++ b/.github/workflows/src/summarize-checks/labelling.js
@@ -546,14 +546,11 @@ export function processImpactAssessment(labelContext, impactAssessment) {
     if (impactAssessment.isNewApiVersion) {
       newApiVersionLabel.shouldBePresent = true;
 
-      // For data-plane PRs, a new API version requires API stewardship review, so apply the
-      // intake label. This is a pure classification of PR content and never keys off the
-      // protected data-plane-review-signoff label. Reading that protected label here would
-      // be unsafe: an unauthorized user can transiently apply it before the Protected Labels
-      // workflow reverts it, and neither that application nor its reversal (both via the
-      // default token) re-runs this workflow, so its presence is not proof of sign-off.
-      // The gate in rulesPri0dataPlane requires signoff whenever this label is present, and
-      // assign-reviewers.js clears this label only on an authorization-verified sign-off.
+      // Data-plane new API versions need stewardship review. Classify purely from PR
+      // content; never read the protected data-plane-review-signoff label here (its presence
+      // isn't proof of sign-off, and reading it would be racy). The gate requires sign-off
+      // whenever this label is present, and only assign-reviewers.js clears it, on a
+      // verified sign-off.
       if (impactAssessment.dataPlaneRequired) {
         dataPlaneReviewRequestedLabel.shouldBePresent = true;
       }

--- a/.github/workflows/src/summarize-checks/labelling.js
+++ b/.github/workflows/src/summarize-checks/labelling.js
@@ -487,6 +487,17 @@ export function processImpactAssessment(labelContext, impactAssessment) {
   const dataplaneLabel = new Label("data-plane", labelContext.present);
   dataplaneLabel.shouldBePresent = impactAssessment.dataPlaneRequired || false;
 
+  // Auto-applied intake signal for data-plane stewardship review. Present exactly when a
+  // data-plane PR introduces a new API version (i.e. when both `data-plane` and
+  // `new-api-version` would be present). This single label is what the merge gate, native
+  // reviewer assignment, and the review queue all key off. See rulesPri0dataPlane below and
+  // .github/workflows/src/data-plane-review/assign-reviewers.js (TRIGGER_LABEL).
+  const dataPlaneReviewRequestedLabel = new Label(
+    "data-plane-review-requested",
+    labelContext.present,
+  );
+  dataPlaneReviewRequestedLabel.shouldBePresent = false;
+
   const typeSpecLabel = new Label("TypeSpec", labelContext.present);
   typeSpecLabel.shouldBePresent = impactAssessment.typeSpecChanged || false;
 
@@ -533,10 +544,18 @@ export function processImpactAssessment(labelContext, impactAssessment) {
   let specReviewApplies = !impactAssessment.isDraft && isBranchInScopeOfSpecReview;
   if (specReviewApplies) {
     if (impactAssessment.isNewApiVersion) {
-      // Note that in case of data-plane PRs, the addition of this label will result
-      // in API stewardship board review being required.
-      // See requiredLabelsRules.ts.
       newApiVersionLabel.shouldBePresent = true;
+
+      // For data-plane PRs, a new API version requires API stewardship review. Apply the
+      // intake label unless the review has already been signed off: assign-reviewers.js
+      // clears this label on sign-off, and re-adding it here would re-request the reviewer
+      // team. See rulesPri0dataPlane below.
+      if (
+        impactAssessment.dataPlaneRequired &&
+        !labelContext.present.has("data-plane-review-signoff")
+      ) {
+        dataPlaneReviewRequestedLabel.shouldBePresent = true;
+      }
     }
 
     armReviewLabel.shouldBePresent = impactAssessment.resourceManagerRequired;
@@ -550,6 +569,7 @@ export function processImpactAssessment(labelContext, impactAssessment) {
   }
 
   dataplaneLabel.applyStateChange(labelContext.toAdd, labelContext.toRemove);
+  dataPlaneReviewRequestedLabel.applyStateChange(labelContext.toAdd, labelContext.toRemove);
   resourceManagerLabel.applyStateChange(labelContext.toAdd, labelContext.toRemove);
   newApiVersionLabel.applyStateChange(labelContext.toAdd, labelContext.toRemove);
   armReviewLabel.applyStateChange(labelContext.toAdd, labelContext.toRemove);
@@ -823,19 +843,17 @@ const rulesPri0dataPlane = [
   },
   // For context on this rule see https://github.com/Azure/azure-sdk-tools/issues/6184
   // and https://github.com/Azure/azure-sdk-tools/issues/6612
-  // This rule says:
   //
-  //   IF (the label APIStewardshipBoard-ReviewRequested is present)
-  //   OR (both labels data-plane AND new-api-version are present),
-  //   THEN (require label APIStewardshipBoard-SignedOff)
+  //   IF the label data-plane-review-requested is present,
+  //   THEN require the label data-plane-review-signoff.
   //
-  // TODO: need to implement, in the prSummary.ts, addition of the APIStewardshipBoard-ReviewRequested label
-  // Once done, remove "data-plane" and "new-api-version" from here.
+  // data-plane-review-requested is auto-applied in processImpactAssessment above whenever a
+  // data-plane PR introduces a new API version, so the previous data-plane + new-api-version
+  // fallback prerequisite is no longer needed.
   {
     precedence: 0,
-    anyPrerequisiteLabels: ["APIStewardshipBoard-ReviewRequested"],
-    allPrerequisiteLabels: ["data-plane", "new-api-version"],
-    anyRequiredLabels: ["APIStewardshipBoard-SignedOff"],
+    anyPrerequisiteLabels: ["data-plane-review-requested"],
+    anyRequiredLabels: ["data-plane-review-signoff"],
     troubleshootingGuide:
       `Your PR requires an API stewardship board review as it introduces a new API version (label: <code>new-api-version</code>). ` +
       `Send an email to ${href("azureapirbcore@microsoft.com", "mailto:azureapirbcore@microsoft.com")} with your PR link for offline review.`,

--- a/.github/workflows/src/summarize-checks/summarize-checks.js
+++ b/.github/workflows/src/summarize-checks/summarize-checks.js
@@ -267,10 +267,10 @@ export default async function summarizeChecks({ github, context, core }) {
     return;
   }
 
-  // Publish the PR identity as step outputs so the workflow can upload `issue-number` /
-  // `head-sha` handoff artifacts. Downstream workflow_run consumers (e.g. data-plane review
-  // assignment, which must react to the labels applied below but cannot see labels set with
-  // the default GITHUB_TOKEN) resolve the PR from these artifacts via extractInputs.
+  // Publish PR identity as step outputs so the workflow can upload issue-number / head-sha
+  // handoff artifacts. Downstream workflow_run consumers (e.g. data-plane review assignment)
+  // resolve the PR from these via extractInputs, since labels applied below use the default
+  // token and are invisible to `labeled` triggers.
   core.setOutput("issue_number", issue_number);
   if (head_sha) {
     core.setOutput("head_sha", head_sha);

--- a/.github/workflows/src/summarize-checks/summarize-checks.js
+++ b/.github/workflows/src/summarize-checks/summarize-checks.js
@@ -267,6 +267,15 @@ export default async function summarizeChecks({ github, context, core }) {
     return;
   }
 
+  // Publish the PR identity as step outputs so the workflow can upload `issue-number` /
+  // `head-sha` handoff artifacts. Downstream workflow_run consumers (e.g. data-plane review
+  // assignment, which must react to the labels applied below but cannot see labels set with
+  // the default GITHUB_TOKEN) resolve the PR from these artifacts via extractInputs.
+  core.setOutput("issue_number", issue_number);
+  if (head_sha) {
+    core.setOutput("head_sha", head_sha);
+  }
+
   const targetBranch =
     context.eventName === "pull_request_target"
       ? /** @type {import("@octokit/webhooks-types").PullRequestEvent} */ (context.payload)

--- a/.github/workflows/summarize-checks.yaml
+++ b/.github/workflows/summarize-checks.yaml
@@ -87,3 +87,21 @@ jobs:
           path: ${{ steps.summarize-checks.outputs.summary }}
           # If the file doesn't exist, just don't add the artifact
           if-no-files-found: ignore
+
+      # PR identity handoff for downstream workflow_run consumers (e.g. Data-Plane API
+      # Review - Assign Reviewers). Labels applied above use the default GITHUB_TOKEN, which
+      # does not re-trigger `labeled` workflows, so those consumers react to this run's
+      # completion and resolve the PR from these artifacts via extractInputs.
+      - if: ${{ always() && steps.summarize-checks.outputs.issue_number }}
+        name: Upload artifact with issue number
+        uses: ./.github/actions/add-empty-artifact
+        with:
+          name: issue-number
+          value: ${{ steps.summarize-checks.outputs.issue_number }}
+
+      - if: ${{ always() && steps.summarize-checks.outputs.head_sha }}
+        name: Upload artifact with head SHA
+        uses: ./.github/actions/add-empty-artifact
+        with:
+          name: head-sha
+          value: ${{ steps.summarize-checks.outputs.head_sha }}

--- a/.github/workflows/summarize-checks.yaml
+++ b/.github/workflows/summarize-checks.yaml
@@ -88,10 +88,9 @@ jobs:
           # If the file doesn't exist, just don't add the artifact
           if-no-files-found: ignore
 
-      # PR identity handoff for downstream workflow_run consumers (e.g. Data-Plane API
-      # Review - Assign Reviewers). Labels applied above use the default GITHUB_TOKEN, which
-      # does not re-trigger `labeled` workflows, so those consumers react to this run's
-      # completion and resolve the PR from these artifacts via extractInputs.
+      # PR identity handoff for workflow_run consumers (e.g. Data-Plane Assign Reviewers):
+      # labels applied above use the default token and don't re-trigger `labeled` workflows,
+      # so consumers react to this run and resolve the PR from these artifacts.
       - if: ${{ always() && steps.summarize-checks.outputs.issue_number }}
         name: Upload artifact with issue number
         uses: ./.github/actions/add-empty-artifact

--- a/.github/workflows/test/data-plane-review/assign-reviewers.test.js
+++ b/.github/workflows/test/data-plane-review/assign-reviewers.test.js
@@ -1,42 +1,28 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createMockContext, createMockCore, createMockGithub } from "../mocks.js";
 
-vi.mock("fs/promises", () => ({
-  readFile: vi.fn(),
-}));
-vi.mock("js-yaml", () => ({
-  default: { load: vi.fn() },
-}));
-
-import { readFile } from "fs/promises";
-import yaml from "js-yaml";
 import assignReviewers, {
   REVIEWER_TEAM,
   SIGNOFF_LABEL,
   TRIGGER_LABEL,
 } from "../../src/data-plane-review/assign-reviewers.js";
 
-/** Mock protected-labels config (as yaml.load would return). Gates the sign-off label. */
-const protectedLabelsConfig = {
-  "data-plane-review-signoff": ["username1", "username2"],
+/** A durable `review_requested` timeline event for our team, as GitHub records it. */
+const teamRequestedEvent = {
+  event: "review_requested",
+  requested_team: { slug: REVIEWER_TEAM },
 };
 
-function setupConfigMock() {
-  /** @type {ReturnType<typeof vi.fn>} */ (readFile).mockResolvedValue("yaml-content");
-  /** @type {ReturnType<typeof vi.fn>} */ (yaml.load).mockReturnValue(protectedLabelsConfig);
-}
-
 /**
- * Set the labels returned by the live `listLabelsOnIssue` read (paginated). The sign-off path
- * reads labels live rather than from the cached event payload.
+ * Set the issue events returned by the durable `listEvents` read used to dedupe the team
+ * request. GitHub records a `review_requested` event when the team is requested, and it
+ * survives delegation swapping the team for an individual.
  *
  * @param {ReturnType<typeof createMockGithub>} github
- * @param {string[]} names
+ * @param {object[]} events
  */
-function setLiveLabels(github, names) {
-  /** @type {any} */ (github.rest.issues).listLabelsOnIssue = vi
-    .fn()
-    .mockResolvedValue({ data: names.map((name) => ({ name })) });
+function setTimelineEvents(github, events) {
+  /** @type {any} */ (github.rest.issues).listEvents = vi.fn().mockResolvedValue({ data: events });
 }
 
 /**
@@ -134,7 +120,6 @@ describe("assign-reviewers", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    setupConfigMock();
     github = createMockGithub();
     context = createMockContext();
     context.eventName = "pull_request_target";
@@ -144,7 +129,7 @@ describe("assign-reviewers", () => {
     /** @type {any} */ (github.rest.pulls).requestReviewers = vi.fn().mockResolvedValue({});
   });
 
-  it("ignores labels other than the trigger or sign-off label", async () => {
+  it("ignores labels other than the trigger label", async () => {
     context.payload = createPayload({ action: "labeled", labelName: "some-other-label" });
     await assignReviewers(args());
 
@@ -167,15 +152,39 @@ describe("assign-reviewers", () => {
     expect(github.rest.issues.createComment).not.toHaveBeenCalled();
   });
 
-  it("does not re-request the team when it is already a requested reviewer", async () => {
-    context.payload = createPayload({
-      action: "labeled",
-      labelName: TRIGGER_LABEL,
-      requestedTeams: [{ slug: REVIEWER_TEAM }],
-    });
+  it("does not re-request the team when it was already requested (timeline event present)", async () => {
+    context.payload = createPayload({ action: "labeled", labelName: TRIGGER_LABEL });
+    setTimelineEvents(github, [teamRequestedEvent]);
     await assignReviewers(args());
 
     expect(/** @type {any} */ (github.rest.pulls).requestReviewers).not.toHaveBeenCalled();
+  });
+
+  it("does not re-request after delegation swapped the team for an individual", async () => {
+    // The team is no longer in requested_teams (delegation removed it), but the durable
+    // review_requested timeline event remains, so we must not re-request.
+    context.payload = createPayload({ action: "labeled", labelName: TRIGGER_LABEL });
+    setTimelineEvents(github, [
+      teamRequestedEvent,
+      { event: "review_request_removed", requested_team: { slug: REVIEWER_TEAM } },
+    ]);
+    await assignReviewers(args());
+
+    expect(/** @type {any} */ (github.rest.pulls).requestReviewers).not.toHaveBeenCalled();
+  });
+
+  it("requests the team when only unrelated reviewers are on the PR", async () => {
+    // A review_requested event for a different team/user must not be mistaken for our handoff.
+    context.payload = createPayload({ action: "labeled", labelName: TRIGGER_LABEL });
+    setTimelineEvents(github, [
+      { event: "review_requested", requested_team: { slug: "some-other-team" } },
+      { event: "review_requested", requested_reviewer: { login: "someone" } },
+    ]);
+    await assignReviewers(args());
+
+    expect(/** @type {any} */ (github.rest.pulls).requestReviewers).toHaveBeenCalledWith(
+      expect.objectContaining({ team_reviewers: [REVIEWER_TEAM] }),
+    );
   });
 
   describe("workflow_run handoff", () => {
@@ -217,12 +226,10 @@ describe("assign-reviewers", () => {
       expect(/** @type {any} */ (github.rest.pulls).requestReviewers).not.toHaveBeenCalled();
     });
 
-    it("does not re-request the team when it is already a requested reviewer", async () => {
+    it("does not re-request the team when it was already requested (timeline event present)", async () => {
       context.payload = createWorkflowRunPayload();
-      setPullRequest(github, {
-        labels: [TRIGGER_LABEL],
-        requestedTeams: [{ slug: REVIEWER_TEAM }],
-      });
+      setPullRequest(github, { labels: [TRIGGER_LABEL] });
+      setTimelineEvents(github, [teamRequestedEvent]);
 
       await assignReviewers(args());
 
@@ -245,128 +252,6 @@ describe("assign-reviewers", () => {
       await assignReviewers(args());
 
       expect(/** @type {any} */ (github.rest.pulls).requestReviewers).not.toHaveBeenCalled();
-    });
-  });
-
-  describe("sign-off", () => {
-    it("clears the review-request label when the sign-off label is applied", async () => {
-      context.payload = createPayload({
-        action: "labeled",
-        labelName: SIGNOFF_LABEL,
-        sender: "username1",
-      });
-      setLiveLabels(github, [SIGNOFF_LABEL, TRIGGER_LABEL, "data-plane"]);
-
-      await assignReviewers(args());
-
-      expect(/** @type {any} */ (github.rest.issues).removeLabel).toHaveBeenCalledWith(
-        expect.objectContaining({
-          owner: "owner",
-          repo: "repo",
-          issue_number: 42,
-          name: TRIGGER_LABEL,
-        }),
-      );
-      // Sign-off syncs labels silently, matching the ARM sign-off flows — no comment.
-      expect(github.rest.issues.createComment).not.toHaveBeenCalled();
-    });
-
-    it("reads the shared config only once while authorizing a sign-off", async () => {
-      context.payload = createPayload({
-        action: "labeled",
-        labelName: SIGNOFF_LABEL,
-        sender: "username1",
-      });
-      setLiveLabels(github, [SIGNOFF_LABEL, TRIGGER_LABEL]);
-
-      await assignReviewers(args());
-
-      expect(readFile).toHaveBeenCalledTimes(1);
-    });
-
-    it("does not request the team when signing off", async () => {
-      context.payload = createPayload({
-        action: "labeled",
-        labelName: SIGNOFF_LABEL,
-        sender: "username1",
-      });
-      setLiveLabels(github, [SIGNOFF_LABEL, TRIGGER_LABEL]);
-
-      await assignReviewers(args());
-
-      expect(/** @type {any} */ (github.rest.pulls).requestReviewers).not.toHaveBeenCalled();
-    });
-
-    it("is a no-op on sign-off when the review-request label is absent", async () => {
-      context.payload = createPayload({
-        action: "labeled",
-        labelName: SIGNOFF_LABEL,
-        sender: "username1",
-      });
-      setLiveLabels(github, [SIGNOFF_LABEL, "data-plane"]);
-
-      await assignReviewers(args());
-
-      expect(/** @type {any} */ (github.rest.issues).removeLabel).not.toHaveBeenCalled();
-      expect(github.rest.issues.createComment).not.toHaveBeenCalled();
-    });
-
-    it("does not clear the request label when the sign-off was retracted before this ran", async () => {
-      // The event fired on sign-off, but a live read shows it is already gone.
-      context.payload = createPayload({
-        action: "labeled",
-        labelName: SIGNOFF_LABEL,
-        sender: "username1",
-      });
-      setLiveLabels(github, [TRIGGER_LABEL, "data-plane"]);
-
-      await assignReviewers(args());
-
-      expect(/** @type {any} */ (github.rest.issues).removeLabel).not.toHaveBeenCalled();
-      expect(github.rest.issues.createComment).not.toHaveBeenCalled();
-    });
-
-    it("does not clear the request label when an unauthorized user applies sign-off", async () => {
-      context.payload = createPayload({
-        action: "labeled",
-        labelName: SIGNOFF_LABEL,
-        sender: "random-user",
-      });
-      setLiveLabels(github, [SIGNOFF_LABEL, TRIGGER_LABEL]);
-
-      await assignReviewers(args());
-
-      expect(/** @type {any} */ (github.rest.issues).removeLabel).not.toHaveBeenCalled();
-    });
-
-    it("clears the request label when a trusted bot applies sign-off", async () => {
-      context.payload = createPayload({
-        action: "labeled",
-        labelName: SIGNOFF_LABEL,
-        sender: "azure-sdk",
-      });
-      setLiveLabels(github, [SIGNOFF_LABEL, TRIGGER_LABEL]);
-
-      await assignReviewers(args());
-
-      expect(/** @type {any} */ (github.rest.issues).removeLabel).toHaveBeenCalledWith(
-        expect.objectContaining({ name: TRIGGER_LABEL }),
-      );
-    });
-
-    it("does not fail when the label was already removed (404)", async () => {
-      /** @type {any} */ (github.rest.issues).removeLabel = vi
-        .fn()
-        .mockRejectedValue(Object.assign(new Error("Not Found"), { status: 404 }));
-      context.payload = createPayload({
-        action: "labeled",
-        labelName: SIGNOFF_LABEL,
-        sender: "username1",
-      });
-      setLiveLabels(github, [SIGNOFF_LABEL, TRIGGER_LABEL]);
-
-      await expect(assignReviewers(args())).resolves.toBeUndefined();
-      expect(github.rest.issues.createComment).not.toHaveBeenCalled();
     });
   });
 });

--- a/.github/workflows/test/data-plane-review/assign-reviewers.test.js
+++ b/.github/workflows/test/data-plane-review/assign-reviewers.test.js
@@ -71,6 +71,52 @@ function createPayload({
   };
 }
 
+/**
+ * Build a `workflow_run: completed` payload for the "Summarize Checks" handoff. The
+ * `workflow_run.event` is `pull_request_target`, so extractInputs resolves the PR number
+ * directly from `pull_requests` without any API call.
+ *
+ * @param {object} [opts]
+ * @param {number} [opts.prNumber]
+ */
+function createWorkflowRunPayload({ prNumber = 42 } = {}) {
+  return {
+    action: "completed",
+    workflow_run: {
+      event: "pull_request_target",
+      head_sha: "abc123",
+      id: 999,
+      repository: { owner: { login: "owner" }, name: "repo", id: 1 },
+      head_repository: { owner: { login: "owner" }, name: "repo", id: 1 },
+      pull_requests: [{ number: prNumber, base: { repo: { id: 1 } } }],
+    },
+  };
+}
+
+/**
+ * Set the PR returned by the live `pulls.get` read used by the workflow_run handoff.
+ *
+ * @param {ReturnType<typeof createMockGithub>} github
+ * @param {object} pr
+ * @param {string} [pr.state]
+ * @param {boolean} [pr.draft]
+ * @param {string[]} [pr.labels]
+ * @param {{ slug: string }[]} [pr.requestedTeams]
+ */
+function setPullRequest(
+  github,
+  { state = "open", draft = false, labels = [], requestedTeams = [] },
+) {
+  /** @type {any} */ (github.rest.pulls).get = vi.fn().mockResolvedValue({
+    data: {
+      state,
+      draft,
+      labels: labels.map((name) => ({ name })),
+      requested_teams: requestedTeams,
+    },
+  });
+}
+
 describe("assign-reviewers", () => {
   /** @type {ReturnType<typeof createMockGithub>} */
   let github;
@@ -130,6 +176,76 @@ describe("assign-reviewers", () => {
     await assignReviewers(args());
 
     expect(/** @type {any} */ (github.rest.pulls).requestReviewers).not.toHaveBeenCalled();
+  });
+
+  describe("workflow_run handoff", () => {
+    beforeEach(() => {
+      context.eventName = "workflow_run";
+    });
+
+    it("requests the reviewer team when the request label is present and not signed off", async () => {
+      context.payload = createWorkflowRunPayload();
+      setPullRequest(github, { labels: [TRIGGER_LABEL, "data-plane"] });
+
+      await assignReviewers(args());
+
+      expect(/** @type {any} */ (github.rest.pulls).requestReviewers).toHaveBeenCalledWith(
+        expect.objectContaining({
+          owner: "owner",
+          repo: "repo",
+          pull_number: 42,
+          team_reviewers: [REVIEWER_TEAM],
+        }),
+      );
+    });
+
+    it("does not request the team when the request label is absent", async () => {
+      context.payload = createWorkflowRunPayload();
+      setPullRequest(github, { labels: ["data-plane"] });
+
+      await assignReviewers(args());
+
+      expect(/** @type {any} */ (github.rest.pulls).requestReviewers).not.toHaveBeenCalled();
+    });
+
+    it("does not request the team when the PR is already signed off", async () => {
+      context.payload = createWorkflowRunPayload();
+      setPullRequest(github, { labels: [TRIGGER_LABEL, SIGNOFF_LABEL] });
+
+      await assignReviewers(args());
+
+      expect(/** @type {any} */ (github.rest.pulls).requestReviewers).not.toHaveBeenCalled();
+    });
+
+    it("does not re-request the team when it is already a requested reviewer", async () => {
+      context.payload = createWorkflowRunPayload();
+      setPullRequest(github, {
+        labels: [TRIGGER_LABEL],
+        requestedTeams: [{ slug: REVIEWER_TEAM }],
+      });
+
+      await assignReviewers(args());
+
+      expect(/** @type {any} */ (github.rest.pulls).requestReviewers).not.toHaveBeenCalled();
+    });
+
+    it("does not request the team on a draft PR", async () => {
+      context.payload = createWorkflowRunPayload();
+      setPullRequest(github, { draft: true, labels: [TRIGGER_LABEL] });
+
+      await assignReviewers(args());
+
+      expect(/** @type {any} */ (github.rest.pulls).requestReviewers).not.toHaveBeenCalled();
+    });
+
+    it("does not request the team on a closed PR", async () => {
+      context.payload = createWorkflowRunPayload();
+      setPullRequest(github, { state: "closed", labels: [TRIGGER_LABEL] });
+
+      await assignReviewers(args());
+
+      expect(/** @type {any} */ (github.rest.pulls).requestReviewers).not.toHaveBeenCalled();
+    });
   });
 
   describe("sign-off", () => {

--- a/.github/workflows/test/data-plane-review/assign-reviewers.test.js
+++ b/.github/workflows/test/data-plane-review/assign-reviewers.test.js
@@ -18,7 +18,7 @@ import assignReviewers, {
 
 /** Mock protected-labels config (as yaml.load would return). Gates the sign-off label. */
 const protectedLabelsConfig = {
-  "APIStewardshipBoard-SignedOff": ["username1", "username2"],
+  "data-plane-review-signoff": ["username1", "username2"],
 };
 
 function setupConfigMock() {

--- a/.github/workflows/test/mocks.js
+++ b/.github/workflows/test/mocks.js
@@ -52,6 +52,7 @@ function createMockGithubImpl() {
         createComment: vi.fn(),
         deleteComment: vi.fn(),
         listComments: vi.fn().mockResolvedValue({ data: [] }),
+        listEvents: vi.fn().mockResolvedValue({ data: [] }),
         listLabelsOnIssue: vi.fn().mockResolvedValue({ data: [] }),
         removeLabel: vi.fn(),
         updateComment: vi.fn(),

--- a/.github/workflows/test/summarize-checks/labelling.test.js
+++ b/.github/workflows/test/summarize-checks/labelling.test.js
@@ -375,9 +375,41 @@ describe("update labels", () => {
     },
     {
       description:
-        "Shouldn't add data-plane-review-requested when the review is already signed off",
+        "Should add data-plane-review-requested even when an (unverified) sign-off label is already present",
       existingLabels: ["other-label", "data-plane-review-signoff"],
-      expectedLabelsToAdd: ["TypeSpec", "data-plane", "new-api-version"],
+      expectedLabelsToAdd: [
+        "TypeSpec",
+        "data-plane",
+        "new-api-version",
+        "data-plane-review-requested",
+      ],
+      expectedLabelsToRemove: [],
+      impactAssessment: {
+        suppressionReviewRequired: false,
+        rpaasChange: false,
+        newRP: false,
+        rpaasRPMissing: false,
+        rpaasRpNotInPrivateRepo: false,
+        resourceManagerRequired: false,
+        dataPlaneRequired: true,
+        typeSpecChanged: true,
+        isNewApiVersion: true,
+        isDraft: false,
+        targetBranch: "main",
+      },
+    },
+    {
+      description:
+        "Shouldn't remove data-plane-review-requested when a sign-off label is present (presence is not proof of sign-off)",
+      existingLabels: [
+        "other-label",
+        "data-plane",
+        "new-api-version",
+        "data-plane-review-requested",
+        "data-plane-review-signoff",
+        "TypeSpec",
+      ],
+      expectedLabelsToAdd: [],
       expectedLabelsToRemove: [],
       impactAssessment: {
         suppressionReviewRequired: false,

--- a/.github/workflows/test/summarize-checks/labelling.test.js
+++ b/.github/workflows/test/summarize-checks/labelling.test.js
@@ -348,6 +348,51 @@ describe("update labels", () => {
         targetBranch: "main",
       },
     },
+    {
+      description:
+        "Should add data-plane-review-requested for a data-plane PR with a new API version",
+      existingLabels: ["other-label"],
+      expectedLabelsToAdd: [
+        "TypeSpec",
+        "data-plane",
+        "new-api-version",
+        "data-plane-review-requested",
+      ],
+      expectedLabelsToRemove: [],
+      impactAssessment: {
+        suppressionReviewRequired: false,
+        rpaasChange: false,
+        newRP: false,
+        rpaasRPMissing: false,
+        rpaasRpNotInPrivateRepo: false,
+        resourceManagerRequired: false,
+        dataPlaneRequired: true,
+        typeSpecChanged: true,
+        isNewApiVersion: true,
+        isDraft: false,
+        targetBranch: "main",
+      },
+    },
+    {
+      description:
+        "Shouldn't add data-plane-review-requested when the review is already signed off",
+      existingLabels: ["other-label", "data-plane-review-signoff"],
+      expectedLabelsToAdd: ["TypeSpec", "data-plane", "new-api-version"],
+      expectedLabelsToRemove: [],
+      impactAssessment: {
+        suppressionReviewRequired: false,
+        rpaasChange: false,
+        newRP: false,
+        rpaasRPMissing: false,
+        rpaasRpNotInPrivateRepo: false,
+        resourceManagerRequired: false,
+        dataPlaneRequired: true,
+        typeSpecChanged: true,
+        isNewApiVersion: true,
+        isDraft: false,
+        targetBranch: "main",
+      },
+    },
   ];
   it.each(testCases)(
     "$description",

--- a/.github/workflows/test/summarize-checks/labelling.test.js
+++ b/.github/workflows/test/summarize-checks/labelling.test.js
@@ -425,6 +425,26 @@ describe("update labels", () => {
         targetBranch: "main",
       },
     },
+    {
+      description:
+        "Add-only: keeps an existing data-plane-review-requested when the PR no longer qualifies (e.g. a manual request)",
+      existingLabels: ["data-plane-review-requested", "other-label"],
+      expectedLabelsToAdd: [],
+      expectedLabelsToRemove: [],
+      impactAssessment: {
+        suppressionReviewRequired: false,
+        rpaasChange: false,
+        newRP: false,
+        rpaasRPMissing: false,
+        rpaasRpNotInPrivateRepo: false,
+        resourceManagerRequired: false,
+        dataPlaneRequired: false,
+        typeSpecChanged: false,
+        isNewApiVersion: false,
+        isDraft: false,
+        targetBranch: "main",
+      },
+    },
   ];
   it.each(testCases)(
     "$description",


### PR DESCRIPTION
Implements #45521 (part of #45437). One atomic PR that moves data-plane stewardship review onto the new `data-plane-review-requested` / `data-plane-review-signoff` labels, so the merge gate never stops enforcing sign-off mid-flip.

## What changes
| Piece | Before | After |
|---|---|---|
| Intake label | manual `APIStewardshipBoard-ReviewRequested` | auto-applied `data-plane-review-requested` on new data-plane API versions |
| Merge gate | old label + `data-plane`/`new-api-version` fallback | requires `data-plane-review-signoff` when the request label is present |
| Requesting the reviewer team | fired only on the manual label | also fires on the auto-applied label (trigger fix below) |
| Sign-off protection | `APIStewardshipBoard-SignedOff` | `data-plane-review-signoff` (same roster) |

Reviewer selection is unchanged: the workflow requests the `@Azure/azure-data-plane-api-reviewers` team, and GitHub's team code-review auto-assignment picks the individual member. This PR only changes what triggers that team request.

## The trigger fix
The intake label is auto-applied by Summarize Checks with the default `GITHUB_TOKEN`, and labels set by that token do not re-trigger `labeled` workflows. So the team request now also runs on `workflow_run` of "Summarize Checks" and reconciles from the PR's live labels. Mirrors the existing `arm-auto-signoff-status.yaml` pattern.

## Not in this PR (follow-ups once this merges)
- Delete the old `APIStewardshipBoard-ReviewRequested` and `APIStewardshipBoard-SignedOff` labels, once nothing references them anymore.
- Review-agent trigger (#45450): on hold for seeding.

## Validation
45 tests passing; lint + prettier clean.