### PR TITLE
Apply build-failed label to generated SDK PRs

### DIFF
--- a/.github/workflows/spec-gen-sdk-runner-test.yaml
+++ b/.github/workflows/spec-gen-sdk-runner-test.yaml
@@ -15,6 +15,7 @@ on:
       - eng/tools/package.json
       - eng/tools/tsconfig.json
       - eng/tools/spec-gen-sdk-runner/**
+      - eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
   workflow_dispatch:
 
 permissions:

--- a/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
+++ b/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
@@ -128,6 +128,8 @@ stages:
           Write-Host "##vso[task.setvariable variable=ReleasePlanInfo]$releasePlanInfo"
           $prUrl = ""
           Write-Host "##vso[task.setvariable variable=PullRequestUrl]$prUrl"
+          $buildFailedLabel = ""
+          Write-Host "##vso[task.setvariable variable=BuildFailedLabel]$buildFailedLabel"
         displayName: "Create Run Time Variables"
 
       - ${{ if and(eq(variables['System.TeamProject'], 'internal'), ne(variables['Build.Reason'], 'PullRequest')) }}:
@@ -378,6 +380,20 @@ stages:
               -PRBody "$(GeneratedSDKInformation)  $(ReleasePlanInfo)"
               -OpenAsDraft $$(OpenSdkPullRequestAsDraft)
               -UpdateExistingPullRequest $true
+
+        - task: PowerShell@2
+          displayName: Add build-failed label
+          condition: and(succeeded(), eq(variables['HasChanges'], 'true'), ne(variables['Build.Reason'], 'PullRequest'), not(endsWith(variables['SdkRepoName'], '-pr')), ne(variables['BuildFailedLabel'], ''))
+          inputs:
+            pwsh: true
+            workingDirectory: $(SdkRepoDirectory)
+            filePath: $(SdkRepoDirectory)/eng/common/scripts/Add-IssueLabels.ps1
+            arguments: >
+              -RepoOwner "azure"
+              -RepoName "$(SdkRepoName)"
+              -IssueNumber "$(Submitted.PullRequest.Number)"
+              -Labels "$(BuildFailedLabel)"
+              -AuthToken "$(GH_TOKEN)"
 
         - ${{ if endsWith(parameters.TriggerSource, '-release') }}:
           - task: PowerShell@2

--- a/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
+++ b/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
@@ -378,22 +378,9 @@ stages:
               -AuthToken "$(GH_TOKEN)"
               -PRTitle "$(PrTitle)-generated-from-$(Build.DefinitionName)-$(Build.BuildId)"
               -PRBody "$(GeneratedSDKInformation)  $(ReleasePlanInfo)"
+              -PRLabels "$(BuildFailedLabel)"
               -OpenAsDraft $$(OpenSdkPullRequestAsDraft)
               -UpdateExistingPullRequest $true
-
-        - task: PowerShell@2
-          displayName: Add build-failed label
-          condition: and(succeeded(), eq(variables['HasChanges'], 'true'), ne(variables['Build.Reason'], 'PullRequest'), not(endsWith(variables['SdkRepoName'], '-pr')), ne(variables['BuildFailedLabel'], ''))
-          inputs:
-            pwsh: true
-            workingDirectory: $(SdkRepoDirectory)
-            filePath: $(SdkRepoDirectory)/eng/common/scripts/Add-IssueLabels.ps1
-            arguments: >
-              -RepoOwner "azure"
-              -RepoName "$(SdkRepoName)"
-              -IssueNumber "$(Submitted.PullRequest.Number)"
-              -Labels "$(BuildFailedLabel)"
-              -AuthToken "$(GH_TOKEN)"
 
         - ${{ if endsWith(parameters.TriggerSource, '-release') }}:
           - task: PowerShell@2

--- a/eng/tools/spec-gen-sdk-runner/test/pipeline-labeling.test.ts
+++ b/eng/tools/spec-gen-sdk-runner/test/pipeline-labeling.test.ts
@@ -34,27 +34,18 @@ describe("SDK PR build-failed labeling pipeline", () => {
     expect(initializationIndex).toBeLessThan(generationIndex);
   });
 
-  test("applies the emitted label to the submitted SDK pull request", () => {
-    const task = getTask("Add build-failed label");
+  test("passes the emitted label when creating the SDK pull request", () => {
+    const task = getTask("Create pull request");
 
-    expect(task).toContain("filePath: $(SdkRepoDirectory)/eng/common/scripts/Add-IssueLabels.ps1");
-    expect(task).toContain('-IssueNumber "$(Submitted.PullRequest.Number)"');
-    expect(task).toContain('-Labels "$(BuildFailedLabel)"');
+    expect(task).toContain(
+      "filePath: $(SdkRepoDirectory)/eng/common/scripts/Submit-PullRequest.ps1",
+    );
+    expect(task).toContain('-PRLabels "$(BuildFailedLabel)"');
     expect(task).toContain('-AuthToken "$(GH_TOKEN)"');
   });
 
-  test("runs only after an SDK pull request exists and a label was emitted", () => {
-    const createPullRequestIndex = pipelineTemplate.indexOf("displayName: Create pull request");
-    const buildFailedLabelIndex = pipelineTemplate.indexOf("displayName: Add build-failed label");
-    const autoReleaseLabelIndex = pipelineTemplate.indexOf("displayName: Add auto-release label");
-    const task = getTask("Add build-failed label");
-
-    expect(buildFailedLabelIndex).toBeGreaterThan(createPullRequestIndex);
-    expect(buildFailedLabelIndex).toBeLessThan(autoReleaseLabelIndex);
-    expect(task).toContain("succeeded()");
-    expect(task).toContain("eq(variables['HasChanges'], 'true')");
-    expect(task).toContain("ne(variables['Build.Reason'], 'PullRequest')");
-    expect(task).toContain("not(endsWith(variables['SdkRepoName'], '-pr'))");
-    expect(task).toContain("ne(variables['BuildFailedLabel'], '')");
+  test("does not add the build-failed label after pull request creation", () => {
+    expect(pipelineTemplate).not.toContain("displayName: Add build-failed label");
+    expect(pipelineTemplate).not.toContain('-Labels "$(BuildFailedLabel)"');
   });
 });

--- a/eng/tools/spec-gen-sdk-runner/test/pipeline-labeling.test.ts
+++ b/eng/tools/spec-gen-sdk-runner/test/pipeline-labeling.test.ts
@@ -1,0 +1,60 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "vitest";
+
+const testDirectory = path.dirname(fileURLToPath(import.meta.url));
+const pipelineTemplatePath = path.resolve(
+  testDirectory,
+  "../../../pipelines/templates/stages/archetype-spec-gen-sdk.yml",
+);
+const pipelineTemplate = fs.readFileSync(pipelineTemplatePath, "utf8");
+
+function getTask(displayName: string): string {
+  const displayNameIndex = pipelineTemplate.indexOf(`displayName: ${displayName}`);
+  expect(displayNameIndex).toBeGreaterThanOrEqual(0);
+
+  const taskStart = pipelineTemplate.lastIndexOf("        - task:", displayNameIndex);
+  const taskEnd = pipelineTemplate.indexOf("\n        - ", displayNameIndex);
+  expect(taskStart).toBeGreaterThanOrEqual(0);
+  expect(taskEnd).toBeGreaterThan(displayNameIndex);
+
+  return pipelineTemplate.slice(taskStart, taskEnd);
+}
+
+describe("SDK PR build-failed labeling pipeline", () => {
+  test("initializes the optional label before SDK generation", () => {
+    const initialization =
+      'Write-Host "##vso[task.setvariable variable=BuildFailedLabel]$buildFailedLabel"';
+    const initializationIndex = pipelineTemplate.indexOf(initialization);
+    const generationIndex = pipelineTemplate.indexOf("displayName: 'Generate SDK'");
+
+    expect(pipelineTemplate).toContain('$buildFailedLabel = ""');
+    expect(initializationIndex).toBeGreaterThanOrEqual(0);
+    expect(initializationIndex).toBeLessThan(generationIndex);
+  });
+
+  test("applies the emitted label to the submitted SDK pull request", () => {
+    const task = getTask("Add build-failed label");
+
+    expect(task).toContain("filePath: $(SdkRepoDirectory)/eng/common/scripts/Add-IssueLabels.ps1");
+    expect(task).toContain('-IssueNumber "$(Submitted.PullRequest.Number)"');
+    expect(task).toContain('-Labels "$(BuildFailedLabel)"');
+    expect(task).toContain('-AuthToken "$(GH_TOKEN)"');
+  });
+
+  test("runs only after an SDK pull request exists and a label was emitted", () => {
+    const createPullRequestIndex = pipelineTemplate.indexOf("displayName: Create pull request");
+    const buildFailedLabelIndex = pipelineTemplate.indexOf("displayName: Add build-failed label");
+    const autoReleaseLabelIndex = pipelineTemplate.indexOf("displayName: Add auto-release label");
+    const task = getTask("Add build-failed label");
+
+    expect(buildFailedLabelIndex).toBeGreaterThan(createPullRequestIndex);
+    expect(buildFailedLabelIndex).toBeLessThan(autoReleaseLabelIndex);
+    expect(task).toContain("succeeded()");
+    expect(task).toContain("eq(variables['HasChanges'], 'true')");
+    expect(task).toContain("ne(variables['Build.Reason'], 'PullRequest')");
+    expect(task).toContain("not(endsWith(variables['SdkRepoName'], '-pr'))");
+    expect(task).toContain("ne(variables['BuildFailedLabel'], '')");
+  });
+});


### PR DESCRIPTION
## Summary
- apply the `BuildFailedLabel` emitted by `spec-gen-sdk-runner` when creating a generated SDK pull request
- do not apply the label when a rerun updates an existing pull request
- initialize the optional variable so successful builds and non-opted-in languages remain unlabeled
- add regression coverage for the creation-only wiring

## Root cause

#43760 implemented and tested the producer, but `archetype-spec-gen-sdk.yml` never consumed the emitted pipeline variable. As a result, release-planner SDK PRs were created without `auto-sdk-build-fix`.

The pipeline now passes `BuildFailedLabel` through `Submit-PullRequest.ps1`'s `-PRLabels` argument. That script applies `PRLabels` only in its new-PR branch; its existing-PR branch updates only the title and body. Therefore a rerun cannot add this eligibility label to an existing PR.

## Validation

- `npm run check` in `eng/tools/spec-gen-sdk-runner` (233 tests)
- parsed `archetype-spec-gen-sdk.yml` with the repository's `yaml` dependency

Related: Azure/azure-sdk-for-net#59651