### PR TITLE
Polish Kubernetes Configuration Flux C# names

### DIFF
--- a/specification/kubernetesconfiguration/resource-manager/Microsoft.KubernetesConfiguration/fluxConfigurations/client.tsp
+++ b/specification/kubernetesconfiguration/resource-manager/Microsoft.KubernetesConfiguration/fluxConfigurations/client.tsp
@@ -4,78 +4,65 @@ import "@azure-tools/typespec-client-generator-core";
 using Azure.ClientGenerator.Core;
 using Microsoft.KubernetesConfiguration;
 
-@@clientName(
-  Microsoft.KubernetesConfiguration,
+@@clientName(Microsoft.KubernetesConfiguration,
   "KubernetesConfigurationFluxConfigurationsMgmtClient",
   "python"
 );
 
-@@clientName(
-  Microsoft.KubernetesConfiguration,
+@@clientName(Microsoft.KubernetesConfiguration,
   "FluxConfigurationClient",
   "javascript"
 );
 
 @@clientName(Microsoft.KubernetesConfiguration, "FluxConfigClient", "java");
-@@clientName(
-  Microsoft.KubernetesConfiguration.KustomizationDefinition.wait,
+@@clientName(Microsoft.KubernetesConfiguration.KustomizationDefinition.wait,
   "waitValue",
   "java"
 );
-@@clientName(
-  Microsoft.KubernetesConfiguration.KustomizationPatchDefinition.wait,
+@@clientName(Microsoft.KubernetesConfiguration.KustomizationPatchDefinition.wait,
   "waitValue",
   "java"
 );
 
-@@clientName(
-  Microsoft.KubernetesConfiguration.OCIRepositoryDefinition,
+@@clientName(Microsoft.KubernetesConfiguration.OCIRepositoryDefinition,
   "OciRepositoryDefinition",
   "java"
 );
 
-@@clientName(
-  Microsoft.KubernetesConfiguration.OCIRepositoryRefDefinition,
+@@clientName(Microsoft.KubernetesConfiguration.OCIRepositoryRefDefinition,
   "OciRepositoryRefDefinition",
   "java"
 );
 
-@@clientName(
-  Microsoft.KubernetesConfiguration.SourceKindType.OCIRepository,
+@@clientName(Microsoft.KubernetesConfiguration.SourceKindType.OCIRepository,
   "OciRepository",
   "java"
 );
 
-@@clientName(
-  Microsoft.KubernetesConfiguration.OCIRepositoryPatchDefinition,
+@@clientName(Microsoft.KubernetesConfiguration.OCIRepositoryPatchDefinition,
   "OciRepositoryPatchDefinition",
   "java"
 );
 
-@@clientName(
-  Microsoft.KubernetesConfiguration.OCIRepositoryRefPatchDefinition,
+@@clientName(Microsoft.KubernetesConfiguration.OCIRepositoryRefPatchDefinition,
   "OciRepositoryRefPatchDefinition",
   "java"
 );
-@@clientName(
-  Microsoft.KubernetesConfiguration.FluxConfigurations.fluxConfigOperationStatusGet,
+@@clientName(Microsoft.KubernetesConfiguration.FluxConfigurations.fluxConfigOperationStatusGet,
   "OperationStatus",
   "java"
 );
-@@clientName(
-  Microsoft.KubernetesConfiguration.FluxConfigurations,
+@@clientName(Microsoft.KubernetesConfiguration.FluxConfigurations,
   "FluxConfigs",
   "java"
 );
-@@clientName(
-  Microsoft.KubernetesConfiguration.FluxConfigurationPatchProperties,
+@@clientName(Microsoft.KubernetesConfiguration.FluxConfigurationPatchProperties,
   "FluxConfigPatchProperties",
   "java"
 );
 
 // C# type customizations for backward compatibility
-@@alternateType(
-  Azure.ResourceManager.CommonTypes.Resource.id,
+@@alternateType(Azure.ResourceManager.CommonTypes.Resource.id,
   Azure.Core.armResourceIdentifier,
   "csharp"
 );
@@ -84,67 +71,78 @@ using Microsoft.KubernetesConfiguration;
 @@clientName(ProvisioningState, "FluxConfigurationProvisioningState", "csharp");
 @@clientName(ScopeType, "FluxConfigurationScopeType", "csharp");
 @@clientName(SourceKindType, "FluxConfigurationSourceKindType", "csharp");
-@@clientName(ProviderType, "FluxConfigurationProviderType", "csharp");
-@@clientName(OperationType, "FluxConfigurationOperationType", "csharp");
+@@clientName(ProviderType, "FluxGitRepositoryProviderType", "csharp");
+@@clientName(OperationType, "FluxLayerOperationType", "csharp");
 @@clientName(FluxConfigurationProperties.suspend, "IsSuspended", "csharp");
-@@clientName(
-  FluxConfigurationProperties.waitForReconciliation,
+@@clientName(FluxConfigurationProperties.waitForReconciliation,
   "IsWaitForReconciliation",
   "csharp"
 );
 @@clientName(BucketDefinition.insecure, "IsInsecure", "csharp");
-@@clientName(KustomizationDefinition.force, "IsForce", "csharp");
-@@clientName(KustomizationDefinition.prune, "IsPrune", "csharp");
-@@clientName(KustomizationDefinition.wait, "IsWait", "csharp");
+@@clientName(GitRepositoryDefinition.httpsCACert,
+  "HttpsCaCertificate",
+  "csharp"
+);
+@@clientName(KustomizationDefinition.force, "IsForceEnabled", "csharp");
+@@clientName(KustomizationDefinition.prune, "IsPruningEnabled", "csharp");
+@@clientName(KustomizationDefinition.wait, "IsHealthCheckEnabled", "csharp");
 @@clientName(SubstituteFromDefinition.optional, "IsOptional", "csharp");
-@@clientName(
-  ServicePrincipalDefinition.clientCertificateSendChain,
-  "IsClientCertificateSendChain",
+@@clientName(ServicePrincipalDefinition.clientCertificateSendChain,
+  "IsClientCertificateChainIncluded",
   "csharp"
 );
 @@clientName(FluxConfigurationPatchProperties.suspend, "IsSuspended", "csharp");
 @@clientName(BucketPatchDefinition.insecure, "IsInsecure", "csharp");
 @@clientName(OCIRepositoryDefinition.insecure, "IsInsecure", "csharp");
 @@clientName(OCIRepositoryPatchDefinition.insecure, "IsInsecure", "csharp");
-@@clientName(KustomizationPatchDefinition.force, "IsForce", "csharp");
-@@clientName(KustomizationPatchDefinition.prune, "IsPrune", "csharp");
-@@clientName(KustomizationPatchDefinition.wait, "IsWait", "csharp");
+@@clientName(GitRepositoryPatchDefinition.httpsCACert,
+  "HttpsCaCertificate",
+  "csharp"
+);
+@@clientName(KustomizationPatchDefinition.force, "IsForceEnabled", "csharp");
+@@clientName(KustomizationPatchDefinition.prune, "IsPruningEnabled", "csharp");
+@@clientName(KustomizationPatchDefinition.wait,
+  "IsHealthCheckEnabled",
+  "csharp"
+);
 @@clientName(SubstituteFromPatchDefinition.optional, "IsOptional", "csharp");
-@@clientName(
-  ServicePrincipalPatchDefinition.clientCertificateSendChain,
-  "IsClientCertificateSendChain",
+@@clientName(ServicePrincipalPatchDefinition.clientCertificateSendChain,
+  "IsClientCertificateChainIncluded",
   "csharp"
 );
 // C# fixes (AZC0031): drop redundant "Definition" suffix from model type names
-@@clientName(AzureBlobDefinition, "AzureBlob", "csharp");
-@@clientName(AzureBlobPatchDefinition, "AzureBlobPatch", "csharp");
+@@clientName(AzureBlobDefinition, "FluxAzureBlob", "csharp");
+@@clientName(AzureBlobPatchDefinition, "FluxAzureBlobPatch", "csharp");
 @@clientName(BucketDefinition, "FluxBucket", "csharp");
 @@clientName(BucketPatchDefinition, "FluxBucketPatch", "csharp");
 @@clientName(GitRepositoryDefinition, "FluxGitRepository", "csharp");
 @@clientName(GitRepositoryPatchDefinition, "FluxGitRepositoryPatch", "csharp");
-@@clientName(KustomizationDefinition, "Kustomization", "csharp");
-@@clientName(KustomizationPatchDefinition, "KustomizationPatch", "csharp");
+@@clientName(KustomizationDefinition, "FluxKustomization", "csharp");
+@@clientName(KustomizationPatchDefinition, "FluxKustomizationPatch", "csharp");
 @@clientName(LayerSelectorDefinition, "FluxLayerSelector", "csharp");
 @@clientName(LayerSelectorPatchDefinition, "FluxLayerSelectorPatch", "csharp");
-@@clientName(MatchOidcIdentityDefinition, "MatchOidcIdentity", "csharp");
-@@clientName(
-  MatchOidcIdentityPatchDefinition,
-  "MatchOidcIdentityPatch",
+@@clientName(MatchOidcIdentityDefinition,
+  "FluxOciRepositoryMatchOidcIdentity",
   "csharp"
 );
-@@clientName(OCIRepositoryDefinition, "OciRepository", "csharp");
-@@clientName(OCIRepositoryPatchDefinition, "OciRepositoryPatch", "csharp");
-@@clientName(OCIRepositoryRefDefinition, "OciRepositoryRef", "csharp");
-@@clientName(
-  OCIRepositoryRefPatchDefinition,
-  "OciRepositoryRefPatch",
+@@clientName(MatchOidcIdentityPatchDefinition,
+  "FluxOciRepositoryMatchOidcIdentityPatch",
+  "csharp"
+);
+@@clientName(OCIRepositoryDefinition, "FluxOciRepository", "csharp");
+@@clientName(OCIRepositoryPatchDefinition, "FluxOciRepositoryPatch", "csharp");
+@@clientName(OCIRepositoryRefDefinition,
+  "FluxOciRepositoryReference",
+  "csharp"
+);
+@@clientName(OCIRepositoryRefPatchDefinition,
+  "FluxOciRepositoryReferencePatch",
   "csharp"
 );
 @@clientName(PostBuildDefinition, "FluxPostBuild", "csharp");
 @@clientName(PostBuildPatchDefinition, "FluxPostBuildPatch", "csharp");
 @@clientName(ServicePrincipalDefinition, "FluxServicePrincipal", "csharp");
-@@clientName(
-  ServicePrincipalPatchDefinition,
+@@clientName(ServicePrincipalPatchDefinition,
   "FluxServicePrincipalPatch",
   "csharp"
 );
@@ -152,16 +150,17 @@ using Microsoft.KubernetesConfiguration;
 @@clientName(SubstituteFromPatchDefinition, "FluxSubstitutionPatch", "csharp");
 @@clientName(TlsConfigDefinition, "FluxTlsConfig", "csharp");
 @@clientName(TlsConfigPatchDefinition, "FluxTlsConfigPatch", "csharp");
-@@clientName(VerifyDefinition, "OciRepositoryVerify", "csharp");
-@@clientName(VerifyPatchDefinition, "OciRepositoryVerifyPatch", "csharp");
-@@clientName(
-  HelmReleasePropertiesDefinition,
-  "HelmReleaseProperties",
+@@clientName(VerifyDefinition, "FluxOciRepositoryVerification", "csharp");
+@@clientName(VerifyPatchDefinition,
+  "FluxOciRepositoryVerificationPatch",
+  "csharp"
+);
+@@clientName(HelmReleasePropertiesDefinition,
+  "FluxHelmReleaseProperties",
   "csharp"
 );
 @@clientName(ObjectReferenceDefinition, "FluxObjectReference", "csharp");
-@@clientName(
-  ObjectStatusConditionDefinition,
+@@clientName(ObjectStatusConditionDefinition,
   "FluxObjectStatusCondition",
   "csharp"
 );


### PR DESCRIPTION
## Summary
- add contextual `Flux` prefixes to C# model names
- clarify Git repository provider and OCI layer operation type names
- expand OCI reference and verification names
- improve C# boolean and certificate-authority property names

Companion SDK PR: Azure/azure-sdk-for-net#62198