### PR TITLE
Add logicalCoreCount property to Hardware Profile

### DIFF
--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/models.tsp
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/models.tsp
@@ -7546,8 +7546,8 @@ model HardwareProfile {
   cpuCores?: int64;
 
   /**
-   * The logical (SMT/hyper-threaded) core count synchronized from Arc Machine DetectedProperties.
-   * Arc Machine remains the source of truth for capacity computation.
+   * The logical (SMT/hyper-threaded) core count reported by the edge device agent.
+   * When present, preferred over the HC RP-derived value for capacity computation.
    */
   @visibility(Lifecycle.Read)
   logicalCoreCount?: int32;

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/models.tsp
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/models.tsp
@@ -7546,6 +7546,13 @@ model HardwareProfile {
   cpuCores?: int64;
 
   /**
+   * The logical (SMT/hyper-threaded) core count synchronized from Arc Machine DetectedProperties.
+   * Arc Machine remains the source of truth for capacity computation.
+   */
+  @visibility(Lifecycle.Read)
+  logicalCoreCount?: int32;
+
+  /**
    * Number of cpu sockets in the machine
    */
   @visibility(Lifecycle.Read)


### PR DESCRIPTION
## Summary
Adds a new optional logicalCoreCount property to the HardwareProfile model (used by EdgeMachineReportedProperties.hardwareProfile) in the AzureStackHCI TypeSpec definitions (specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/models.tsp).

This tracks the logical (SMT/hyper-threaded) core count reported by the edge device agent. When present, it is preferred over the HC RP-derived value for capacity computation.

## Details
- New field: logicalCoreCount?: int32
- Added to HardwareProfile, alongside the existing cpuCores field
- Marked @visibility(Lifecycle.Read), consistent with sibling read-only fields on HardwareProfile
- HardwareProfile is reported via EdgeMachineReportedProperties.hardwareProfile, so this surfaces on the EdgeMachine resource

## Corresponding C# property
\\\csharp
public int? CpuCores { get; set; }
public int? CpuSockets { get; set; }

/// <summary>
/// The logical (SMT/hyper-threaded) core count reported by the edge device agent.
/// When present, preferred over the HC RP-derived value for capacity computation.
/// </summary>
public int? LogicalCoreCount { get; set; }

public int? MemoryCapacityInGb { get; set; }
\\\
