### PR TITLE
Rename Flux kustomization for C#

### DIFF
--- a/specification/kubernetesconfiguration/resource-manager/Microsoft.KubernetesConfiguration/fluxConfigurations/client.tsp
+++ b/specification/kubernetesconfiguration/resource-manager/Microsoft.KubernetesConfiguration/fluxConfigurations/client.tsp
@@ -127,7 +127,11 @@ using Microsoft.KubernetesConfiguration;
   "FluxConfigurationsKustomization",
   "csharp"
 );
-@@clientName(KustomizationPatchDefinition, "KustomizationPatch", "csharp");
+@@clientName(
+  KustomizationPatchDefinition,
+  "FluxConfigurationsKustomizationPatch",
+  "csharp"
+);
 @@clientName(LayerSelectorDefinition, "FluxLayerSelector", "csharp");
 @@clientName(LayerSelectorPatchDefinition, "FluxLayerSelectorPatch", "csharp");
 @@clientName(MatchOidcIdentityDefinition, "MatchOidcIdentity", "csharp");

--- a/specification/kubernetesconfiguration/resource-manager/Microsoft.KubernetesConfiguration/fluxConfigurations/client.tsp
+++ b/specification/kubernetesconfiguration/resource-manager/Microsoft.KubernetesConfiguration/fluxConfigurations/client.tsp
@@ -122,7 +122,11 @@ using Microsoft.KubernetesConfiguration;
 @@clientName(BucketPatchDefinition, "FluxBucketPatch", "csharp");
 @@clientName(GitRepositoryDefinition, "FluxGitRepository", "csharp");
 @@clientName(GitRepositoryPatchDefinition, "FluxGitRepositoryPatch", "csharp");
-@@clientName(KustomizationDefinition, "Kustomization", "csharp");
+@@clientName(
+  KustomizationDefinition,
+  "FluxConfigurationsKustomization",
+  "csharp"
+);
 @@clientName(KustomizationPatchDefinition, "KustomizationPatch", "csharp");
 @@clientName(LayerSelectorDefinition, "FluxLayerSelector", "csharp");
 @@clientName(LayerSelectorPatchDefinition, "FluxLayerSelectorPatch", "csharp");


### PR DESCRIPTION
## Summary

- Rename the C# client type for KustomizationDefinition to FluxConfigurationsKustomization.
- Move the existing SDK-side provisioning rename into the TypeSpec specification so management and provisioning generation use the official name.

## Validation

- TypeSpec compilation succeeds for the FluxConfigurations specification.