### PR TITLE
Add SDK autogen PR command

### DIFF
--- a/.github/workflows/sdk-autogen.yaml
+++ b/.github/workflows/sdk-autogen.yaml
@@ -1,0 +1,34 @@
+name: SDK Autogen
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  sdk-autogen:
+    if: >
+      github.event.issue.pull_request != null &&
+      (github.event.comment.body == '/sdk-autogen' ||
+       startsWith(github.event.comment.body, '/sdk-autogen '))
+    runs-on: ubuntu-slim
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          sparse-checkout: |
+            .github
+          persist-credentials: false
+
+      - name: Create and assign SDK regeneration issue
+        id: create-issue
+        uses: actions/github-script@v8
+        with:
+          # Cross-repository issue creation and Copilot assignment require a user token.
+          github-token: ${{ secrets.GITHUB_PERSONAL_ACCESS_TOKEN }}
+          script: |
+            const { runSdkAutogen } =
+              await import('${{ github.workspace }}/.github/workflows/src/sdk-autogen.js');
+            return await runSdkAutogen({ github, context, core });

--- a/.github/workflows/src/sdk-autogen.js
+++ b/.github/workflows/src/sdk-autogen.js
@@ -2,6 +2,7 @@ const COMMAND = "/sdk-autogen";
 const DEFAULT_BRANCH = "main";
 const WRITE_PERMISSIONS = new Set(["admin", "maintain", "write"]);
 
+/** @type {Readonly<Record<string, Readonly<SdkLanguageConfig>>>} */
 const LANGUAGE_CONFIGS = Object.freeze({
   javascript: Object.freeze({
     owner: "Azure",
@@ -13,7 +14,16 @@ const LANGUAGE_CONFIGS = Object.freeze({
 });
 
 /**
- * @param {string} body
+ * @typedef {object} SdkLanguageConfig
+ * @property {string} owner
+ * @property {string} repository
+ * @property {string} titlePrefix
+ * @property {string} customAgent
+ * @property {string} assignmentCheck
+ */
+
+/**
+ * @param {unknown} body
  * @returns {{ language: string, branch: string }}
  */
 export function parseSdkAutogenCommand(body) {
@@ -100,9 +110,12 @@ export async function runSdkAutogen({ github, context, core }) {
     throw new Error(`${COMMAND} can only be invoked from a pull request comment`);
   }
 
-  const { language, branch } = parseSdkAutogenCommand(context.payload.comment?.body);
-  const username = context.payload.comment?.user?.login;
-  if (!username) {
+  const comment = /** @type {{ body?: unknown, user?: { login?: unknown } } | undefined} */ (
+    context.payload.comment
+  );
+  const { language, branch } = parseSdkAutogenCommand(comment?.body);
+  const username = comment?.user?.login;
+  if (typeof username !== "string" || !username) {
     throw new Error("Unable to identify the command author");
   }
 
@@ -126,6 +139,9 @@ export async function runSdkAutogen({ github, context, core }) {
   }
 
   const config = LANGUAGE_CONFIGS[language];
+  if (!config) {
+    throw new Error(`Unsupported SDK language: ${language}`);
+  }
   await github.rest.repos.getBranch({
     owner: config.owner,
     repo: config.repository,

--- a/.github/workflows/src/sdk-autogen.js
+++ b/.github/workflows/src/sdk-autogen.js
@@ -1,66 +1,93 @@
+import { aiProjectsLibrary } from "./sdk-autogen/ai-projects.js";
+
 const COMMAND = "/sdk-autogen";
 const DEFAULT_BRANCH = "main";
 const WRITE_PERMISSIONS = new Set(["admin", "maintain", "write"]);
+const USAGE = `${COMMAND} <library> <lang> [<lang repo branch>]`;
 
-/** @type {Readonly<Record<string, Readonly<SdkLanguageConfig>>>} */
-const LANGUAGE_CONFIGS = Object.freeze({
-  javascript: Object.freeze({
-    owner: "Azure",
-    repository: "azure-sdk-for-js",
-    titlePrefix: "ai-projects",
-    customAgent: "ai-projects-regen",
-    assignmentCheck: "ai-projects-typespec-regen:v1",
-  }),
+/** @typedef {import("./sdk-autogen/ai-projects.js").SdkLibraryConfig} SdkLibraryConfig */
+
+/** @type {Readonly<Record<string, Readonly<SdkLibraryConfig>>>} */
+const LIBRARY_CONFIGS = Object.freeze({
+  [aiProjectsLibrary.name]: aiProjectsLibrary,
 });
 
 /**
- * @typedef {object} SdkLanguageConfig
- * @property {string} owner
- * @property {string} repository
- * @property {string} titlePrefix
- * @property {string} customAgent
- * @property {string} assignmentCheck
+ * @param {string} library
+ * @returns {Readonly<SdkLibraryConfig>}
  */
+function getLibraryConfig(library) {
+  const config = LIBRARY_CONFIGS[library];
+  if (!config) {
+    throw new Error(
+      `Unsupported SDK library: ${library}. Supported libraries: ${Object.keys(LIBRARY_CONFIGS).join(", ")}`,
+    );
+  }
+  return config;
+}
+
+/**
+ * @param {Readonly<SdkLibraryConfig>} libraryConfig
+ * @param {string} library
+ * @param {string} language
+ * @returns {Readonly<import("./sdk-autogen/ai-projects.js").SdkLanguageConfig>}
+ */
+function getLanguageConfig(libraryConfig, library, language) {
+  const config = libraryConfig.languages[language];
+  if (!config) {
+    throw new Error(
+      `Unsupported SDK language for ${library}: ${language}. Supported languages: ${Object.keys(libraryConfig.languages).join(", ")}`,
+    );
+  }
+  return config;
+}
 
 /**
  * @param {unknown} body
- * @returns {{ language: string, branch: string }}
+ * @returns {{ library: string, language: string, branch: string }}
  */
 export function parseSdkAutogenCommand(body) {
   if (typeof body !== "string" || body.includes("\n") || body.includes("\r")) {
-    throw new Error(`Usage: ${COMMAND} <lang> [<lang repo branch>]`);
+    throw new Error(`Usage: ${USAGE}`);
   }
 
-  const match = body.match(/^\/sdk-autogen(?:[ \t]+([^ \t]+))?(?:[ \t]+([^ \t]+))?[ \t]*$/);
-  if (!match || !match[1]) {
-    throw new Error(`Usage: ${COMMAND} <lang> [<lang repo branch>]`);
+  const match = body.match(
+    /^\/sdk-autogen(?:[ \t]+([^ \t]+))?(?:[ \t]+([^ \t]+))?(?:[ \t]+([^ \t]+))?[ \t]*$/,
+  );
+  if (!match || !match[1] || !match[2]) {
+    throw new Error(`Usage: ${USAGE}`);
   }
 
-  const language = match[1].toLowerCase();
-  if (!Object.hasOwn(LANGUAGE_CONFIGS, language)) {
-    throw new Error(`Unsupported SDK language: ${match[1]}. Supported languages: javascript`);
-  }
+  const library = match[1].toLowerCase();
+  const libraryConfig = getLibraryConfig(library);
+  const language = match[2].toLowerCase();
+  getLanguageConfig(libraryConfig, library, language);
 
-  const branch = match[2] ?? DEFAULT_BRANCH;
+  const branch = match[3] ?? DEFAULT_BRANCH;
   if (!/^[A-Za-z0-9][A-Za-z0-9._/-]*$/.test(branch)) {
     throw new Error(`Invalid SDK repository branch: ${branch}`);
   }
 
-  return { language, branch };
+  return { library, language, branch };
 }
 
 /**
  * @param {object} options
+ * @param {string} options.library
  * @param {string} options.language
  * @param {string} options.branch
  * @param {string} options.headSha
  * @param {string} options.pullRequestUrl
  */
-export function buildSdkAutogenIssueRequest({ language, branch, headSha, pullRequestUrl }) {
-  const config = LANGUAGE_CONFIGS[language];
-  if (!config) {
-    throw new Error(`Unsupported SDK language: ${language}`);
-  }
+export function buildSdkAutogenIssueRequest({
+  library,
+  language,
+  branch,
+  headSha,
+  pullRequestUrl,
+}) {
+  const libraryConfig = getLibraryConfig(library);
+  const config = getLanguageConfig(libraryConfig, library, language);
   if (!/^[0-9a-f]{40}$/.test(headSha)) {
     throw new Error(`Invalid pull request head commit: ${headSha}`);
   }
@@ -113,7 +140,7 @@ export async function runSdkAutogen({ github, context, core }) {
   const comment = /** @type {{ body?: unknown, user?: { login?: unknown } } | undefined} */ (
     context.payload.comment
   );
-  const { language, branch } = parseSdkAutogenCommand(comment?.body);
+  const { library, language, branch } = parseSdkAutogenCommand(comment?.body);
   const username = comment?.user?.login;
   if (typeof username !== "string" || !username) {
     throw new Error("Unable to identify the command author");
@@ -138,10 +165,8 @@ export async function runSdkAutogen({ github, context, core }) {
     throw new Error(`${COMMAND} can only be invoked on an open pull request`);
   }
 
-  const config = LANGUAGE_CONFIGS[language];
-  if (!config) {
-    throw new Error(`Unsupported SDK language: ${language}`);
-  }
+  const libraryConfig = getLibraryConfig(library);
+  const config = getLanguageConfig(libraryConfig, library, language);
   await github.rest.repos.getBranch({
     owner: config.owner,
     repo: config.repository,
@@ -149,6 +174,7 @@ export async function runSdkAutogen({ github, context, core }) {
   });
 
   const request = buildSdkAutogenIssueRequest({
+    library,
     language,
     branch,
     headSha: pullRequest.head.sha,

--- a/.github/workflows/src/sdk-autogen.js
+++ b/.github/workflows/src/sdk-autogen.js
@@ -1,0 +1,146 @@
+const COMMAND = "/sdk-autogen";
+const DEFAULT_BRANCH = "main";
+const WRITE_PERMISSIONS = new Set(["admin", "maintain", "write"]);
+
+const LANGUAGE_CONFIGS = Object.freeze({
+  javascript: Object.freeze({
+    owner: "Azure",
+    repository: "azure-sdk-for-js",
+    titlePrefix: "ai-projects",
+    customAgent: "ai-projects-regen",
+    assignmentCheck: "ai-projects-typespec-regen:v1",
+  }),
+});
+
+/**
+ * @param {string} body
+ * @returns {{ language: string, branch: string }}
+ */
+export function parseSdkAutogenCommand(body) {
+  if (typeof body !== "string" || body.includes("\n") || body.includes("\r")) {
+    throw new Error(`Usage: ${COMMAND} <lang> [<lang repo branch>]`);
+  }
+
+  const match = body.match(/^\/sdk-autogen(?:[ \t]+([^ \t]+))?(?:[ \t]+([^ \t]+))?[ \t]*$/);
+  if (!match || !match[1]) {
+    throw new Error(`Usage: ${COMMAND} <lang> [<lang repo branch>]`);
+  }
+
+  const language = match[1].toLowerCase();
+  if (!Object.hasOwn(LANGUAGE_CONFIGS, language)) {
+    throw new Error(`Unsupported SDK language: ${match[1]}. Supported languages: javascript`);
+  }
+
+  const branch = match[2] ?? DEFAULT_BRANCH;
+  if (!/^[A-Za-z0-9][A-Za-z0-9._/-]*$/.test(branch)) {
+    throw new Error(`Invalid SDK repository branch: ${branch}`);
+  }
+
+  return { language, branch };
+}
+
+/**
+ * @param {object} options
+ * @param {string} options.language
+ * @param {string} options.branch
+ * @param {string} options.headSha
+ * @param {string} options.pullRequestUrl
+ */
+export function buildSdkAutogenIssueRequest({ language, branch, headSha, pullRequestUrl }) {
+  const config = LANGUAGE_CONFIGS[language];
+  if (!config) {
+    throw new Error(`Unsupported SDK language: ${language}`);
+  }
+  if (!/^[0-9a-f]{40}$/.test(headSha)) {
+    throw new Error(`Invalid pull request head commit: ${headSha}`);
+  }
+
+  const targetRepository = `${config.owner}/${config.repository}`;
+  const title = `[${config.titlePrefix}] regen from ${headSha} against ${branch}`;
+  const body = [
+    "### TypeSpec commit",
+    headSha,
+    "",
+    "### Base branch",
+    branch,
+    "",
+    "### Assignment check",
+    "",
+    `- [x] ${config.assignmentCheck} - The title, base branch field, and Copilot starting branch all match.`,
+    "",
+    "### Source pull request",
+    pullRequestUrl,
+  ].join("\n");
+
+  return {
+    owner: config.owner,
+    repo: config.repository,
+    title,
+    body,
+    assignees: ["copilot-swe-agent[bot]"],
+    agent_assignment: {
+      target_repo: targetRepository,
+      base_branch: branch,
+      custom_instructions: "",
+      custom_agent: config.customAgent,
+      model: "",
+    },
+    headers: {
+      accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+  };
+}
+
+/**
+ * @param {import('@actions/github-script').AsyncFunctionArguments} args
+ */
+export async function runSdkAutogen({ github, context, core }) {
+  if (context.eventName !== "issue_comment" || !context.payload.issue?.pull_request) {
+    throw new Error(`${COMMAND} can only be invoked from a pull request comment`);
+  }
+
+  const { language, branch } = parseSdkAutogenCommand(context.payload.comment?.body);
+  const username = context.payload.comment?.user?.login;
+  if (!username) {
+    throw new Error("Unable to identify the command author");
+  }
+
+  const { data: collaborator } = await github.rest.repos.getCollaboratorPermissionLevel({
+    ...context.repo,
+    username,
+  });
+  const canWrite =
+    WRITE_PERMISSIONS.has(collaborator.permission) || collaborator.user?.permissions?.push === true;
+  if (!canWrite) {
+    throw new Error(`${username} must have write access to invoke ${COMMAND}`);
+  }
+
+  const pullNumber = context.payload.issue.number;
+  const { data: pullRequest } = await github.rest.pulls.get({
+    ...context.repo,
+    pull_number: pullNumber,
+  });
+  if (pullRequest.state !== "open") {
+    throw new Error(`${COMMAND} can only be invoked on an open pull request`);
+  }
+
+  const config = LANGUAGE_CONFIGS[language];
+  await github.rest.repos.getBranch({
+    owner: config.owner,
+    repo: config.repository,
+    branch,
+  });
+
+  const request = buildSdkAutogenIssueRequest({
+    language,
+    branch,
+    headSha: pullRequest.head.sha,
+    pullRequestUrl: pullRequest.html_url,
+  });
+  const { data: issue } = await github.request("POST /repos/{owner}/{repo}/issues", request);
+
+  core.info(`Created and assigned ${issue.html_url}`);
+  core.setOutput("issue-url", issue.html_url);
+  return { issueNumber: issue.number, issueUrl: issue.html_url };
+}

--- a/.github/workflows/src/sdk-autogen/ai-projects.js
+++ b/.github/workflows/src/sdk-autogen/ai-projects.js
@@ -1,0 +1,28 @@
+/**
+ * @typedef {object} SdkLanguageConfig
+ * @property {string} owner
+ * @property {string} repository
+ * @property {string} titlePrefix
+ * @property {string} customAgent
+ * @property {string} assignmentCheck
+ */
+
+/**
+ * @typedef {object} SdkLibraryConfig
+ * @property {string} name
+ * @property {Readonly<Record<string, Readonly<SdkLanguageConfig>>>} languages
+ */
+
+/** @type {Readonly<SdkLibraryConfig>} */
+export const aiProjectsLibrary = Object.freeze({
+  name: "ai-projects",
+  languages: Object.freeze({
+    javascript: Object.freeze({
+      owner: "Azure",
+      repository: "azure-sdk-for-js",
+      titlePrefix: "ai-projects",
+      customAgent: "ai-projects-regen",
+      assignmentCheck: "ai-projects-typespec-regen:v1",
+    }),
+  }),
+});

--- a/.github/workflows/test/sdk-autogen.test.js
+++ b/.github/workflows/test/sdk-autogen.test.js
@@ -1,0 +1,151 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildSdkAutogenIssueRequest,
+  parseSdkAutogenCommand,
+  runSdkAutogen,
+} from "../src/sdk-autogen.js";
+
+const HEAD_SHA = "0123456789abcdef0123456789abcdef01234567";
+const PULL_REQUEST_URL = "https://github.com/Azure/azure-rest-api-specs/pull/123";
+
+describe("sdk-autogen", () => {
+  it("defaults the target branch to main", () => {
+    expect(parseSdkAutogenCommand("/sdk-autogen javascript")).toEqual({
+      language: "javascript",
+      branch: "main",
+    });
+  });
+
+  it("accepts an explicit target branch", () => {
+    expect(parseSdkAutogenCommand("/sdk-autogen JavaScript feature/regen-v2")).toEqual({
+      language: "javascript",
+      branch: "feature/regen-v2",
+    });
+  });
+
+  it.each([
+    "/sdk-autogen",
+    "/sdk-autogen python",
+    "/sdk-autogen javascript branch extra",
+    "/sdk-autogen javascript invalid branch",
+  ])("rejects an unsupported command: %s", (command) => {
+    expect(() => parseSdkAutogenCommand(command)).toThrow();
+  });
+
+  it("builds the JavaScript issue and Copilot assignment payload", () => {
+    const request = buildSdkAutogenIssueRequest({
+      language: "javascript",
+      branch: "feature/regen-v2",
+      headSha: HEAD_SHA,
+      pullRequestUrl: PULL_REQUEST_URL,
+    });
+
+    expect(request).toMatchObject({
+      owner: "Azure",
+      repo: "azure-sdk-for-js",
+      title: `[ai-projects] regen from ${HEAD_SHA} against feature/regen-v2`,
+      assignees: ["copilot-swe-agent[bot]"],
+      agent_assignment: {
+        target_repo: "Azure/azure-sdk-for-js",
+        base_branch: "feature/regen-v2",
+        custom_instructions: "",
+        custom_agent: "ai-projects-regen",
+        model: "",
+      },
+    });
+    expect(request.body).toBe(`### TypeSpec commit
+${HEAD_SHA}
+
+### Base branch
+feature/regen-v2
+
+### Assignment check
+
+- [x] ai-projects-typespec-regen:v1 - The title, base branch field, and Copilot starting branch all match.
+
+### Source pull request
+${PULL_REQUEST_URL}`);
+  });
+
+  it("resolves the PR head and creates the assigned issue", async () => {
+    const getCollaboratorPermissionLevel = vi.fn().mockResolvedValue({
+      data: { permission: "write" },
+    });
+    const getBranch = vi.fn().mockResolvedValue({ data: { name: "main" } });
+    const getPull = vi.fn().mockResolvedValue({
+      data: { state: "open", head: { sha: HEAD_SHA }, html_url: PULL_REQUEST_URL },
+    });
+    const request = vi.fn().mockResolvedValue({
+      data: { number: 456, html_url: "https://github.com/Azure/azure-sdk-for-js/issues/456" },
+    });
+    const setOutput = vi.fn();
+    const github = {
+      rest: {
+        repos: { getCollaboratorPermissionLevel, getBranch },
+        pulls: { get: getPull },
+      },
+      request,
+    };
+    const context = {
+      eventName: "issue_comment",
+      repo: { owner: "Azure", repo: "azure-rest-api-specs" },
+      payload: {
+        issue: { number: 123, pull_request: {} },
+        comment: { body: "/sdk-autogen javascript", user: { login: "maintainer" } },
+      },
+    };
+    const core = { info: vi.fn(), setOutput };
+
+    await expect(runSdkAutogen({ github, context, core })).resolves.toEqual({
+      issueNumber: 456,
+      issueUrl: "https://github.com/Azure/azure-sdk-for-js/issues/456",
+    });
+    expect(getBranch).toHaveBeenCalledWith({
+      owner: "Azure",
+      repo: "azure-sdk-for-js",
+      branch: "main",
+    });
+    expect(request).toHaveBeenCalledWith(
+      "POST /repos/{owner}/{repo}/issues",
+      expect.objectContaining({
+        title: `[ai-projects] regen from ${HEAD_SHA} against main`,
+        body: expect.stringContaining(PULL_REQUEST_URL),
+        agent_assignment: expect.objectContaining({
+          base_branch: "main",
+          custom_agent: "ai-projects-regen",
+        }),
+      }),
+    );
+    expect(setOutput).toHaveBeenCalledWith(
+      "issue-url",
+      "https://github.com/Azure/azure-sdk-for-js/issues/456",
+    );
+  });
+
+  it("rejects command authors without write access", async () => {
+    const request = vi.fn();
+    const github = {
+      rest: {
+        repos: {
+          getCollaboratorPermissionLevel: vi.fn().mockResolvedValue({
+            data: { permission: "read", user: { permissions: { push: false } } },
+          }),
+        },
+      },
+      request,
+    };
+    const context = {
+      eventName: "issue_comment",
+      repo: { owner: "Azure", repo: "azure-rest-api-specs" },
+      payload: {
+        issue: { number: 123, pull_request: {} },
+        comment: { body: "/sdk-autogen javascript", user: { login: "reader" } },
+      },
+    };
+
+    await expect(
+      runSdkAutogen({ github, context, core: { info: vi.fn(), setOutput: vi.fn() } }),
+    ).rejects.toThrow("reader must have write access");
+    expect(request).not.toHaveBeenCalled();
+  });
+});

--- a/.github/workflows/test/sdk-autogen.test.js
+++ b/.github/workflows/test/sdk-autogen.test.js
@@ -19,14 +19,16 @@ function invokeSdkAutogen(args) {
 
 describe("sdk-autogen", () => {
   it("defaults the target branch to main", () => {
-    expect(parseSdkAutogenCommand("/sdk-autogen javascript")).toEqual({
+    expect(parseSdkAutogenCommand("/sdk-autogen ai-projects javascript")).toEqual({
+      library: "ai-projects",
       language: "javascript",
       branch: "main",
     });
   });
 
   it("accepts an explicit target branch", () => {
-    expect(parseSdkAutogenCommand("/sdk-autogen JavaScript feature/regen-v2")).toEqual({
+    expect(parseSdkAutogenCommand("/sdk-autogen AI-Projects JavaScript feature/regen-v2")).toEqual({
+      library: "ai-projects",
       language: "javascript",
       branch: "feature/regen-v2",
     });
@@ -34,15 +36,30 @@ describe("sdk-autogen", () => {
 
   it.each([
     "/sdk-autogen",
-    "/sdk-autogen python",
-    "/sdk-autogen javascript branch extra",
-    "/sdk-autogen javascript invalid branch",
+    "/sdk-autogen ai-projects",
+    "/sdk-autogen unknown javascript",
+    "/sdk-autogen ai-projects python",
+    "/sdk-autogen ai-projects javascript branch extra",
+    "/sdk-autogen ai-projects javascript invalid branch",
   ])("rejects an unsupported command: %s", (command) => {
     expect(() => parseSdkAutogenCommand(command)).toThrow();
   });
 
+  it("reports the supported library", () => {
+    expect(() => parseSdkAutogenCommand("/sdk-autogen unknown javascript")).toThrow(
+      "Unsupported SDK library: unknown. Supported libraries: ai-projects",
+    );
+  });
+
+  it("reports the languages supported by the selected library", () => {
+    expect(() => parseSdkAutogenCommand("/sdk-autogen ai-projects python")).toThrow(
+      "Unsupported SDK language for ai-projects: python. Supported languages: javascript",
+    );
+  });
+
   it("builds the JavaScript issue and Copilot assignment payload", () => {
     const request = buildSdkAutogenIssueRequest({
+      library: "ai-projects",
       language: "javascript",
       branch: "feature/regen-v2",
       headSha: HEAD_SHA,
@@ -100,7 +117,10 @@ ${PULL_REQUEST_URL}`);
       repo: { owner: "Azure", repo: "azure-rest-api-specs" },
       payload: {
         issue: { number: 123, pull_request: {} },
-        comment: { body: "/sdk-autogen javascript", user: { login: "maintainer" } },
+        comment: {
+          body: "/sdk-autogen ai-projects javascript",
+          user: { login: "maintainer" },
+        },
       },
     };
     const core = { info: vi.fn(), setOutput };
@@ -150,7 +170,10 @@ ${PULL_REQUEST_URL}`);
       repo: { owner: "Azure", repo: "azure-rest-api-specs" },
       payload: {
         issue: { number: 123, pull_request: {} },
-        comment: { body: "/sdk-autogen javascript", user: { login: "reader" } },
+        comment: {
+          body: "/sdk-autogen ai-projects javascript",
+          user: { login: "reader" },
+        },
       },
     };
 

--- a/.github/workflows/test/sdk-autogen.test.js
+++ b/.github/workflows/test/sdk-autogen.test.js
@@ -8,6 +8,15 @@ import {
 const HEAD_SHA = "0123456789abcdef0123456789abcdef01234567";
 const PULL_REQUEST_URL = "https://github.com/Azure/azure-rest-api-specs/pull/123";
 
+/**
+ * @param {unknown} args
+ */
+function invokeSdkAutogen(args) {
+  return runSdkAutogen(
+    /** @type {import("@actions/github-script").AsyncFunctionArguments} */ (args),
+  );
+}
+
 describe("sdk-autogen", () => {
   it("defaults the target branch to main", () => {
     expect(parseSdkAutogenCommand("/sdk-autogen javascript")).toEqual({
@@ -96,7 +105,7 @@ ${PULL_REQUEST_URL}`);
     };
     const core = { info: vi.fn(), setOutput };
 
-    await expect(runSdkAutogen({ github, context, core })).resolves.toEqual({
+    await expect(invokeSdkAutogen({ github, context, core })).resolves.toEqual({
       issueNumber: 456,
       issueUrl: "https://github.com/Azure/azure-sdk-for-js/issues/456",
     });
@@ -109,11 +118,13 @@ ${PULL_REQUEST_URL}`);
       "POST /repos/{owner}/{repo}/issues",
       expect.objectContaining({
         title: `[ai-projects] regen from ${HEAD_SHA} against main`,
-        body: expect.stringContaining(PULL_REQUEST_URL),
-        agent_assignment: expect.objectContaining({
-          base_branch: "main",
-          custom_agent: "ai-projects-regen",
-        }),
+        body: /** @type {unknown} */ (expect.stringContaining(PULL_REQUEST_URL)),
+        agent_assignment: /** @type {unknown} */ (
+          expect.objectContaining({
+            base_branch: "main",
+            custom_agent: "ai-projects-regen",
+          })
+        ),
       }),
     );
     expect(setOutput).toHaveBeenCalledWith(
@@ -144,7 +155,7 @@ ${PULL_REQUEST_URL}`);
     };
 
     await expect(
-      runSdkAutogen({ github, context, core: { info: vi.fn(), setOutput: vi.fn() } }),
+      invokeSdkAutogen({ github, context, core: { info: vi.fn(), setOutput: vi.fn() } }),
     ).rejects.toThrow("reader must have write access");
     expect(request).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary

- add `/sdk-autogen <library> <lang> [<lang repo branch>]` for pull request comments
- keep authorization and GitHub API orchestration in a generic root dispatcher
- define AI Projects repository, title, assignment marker, custom agent, and JavaScript support in a dedicated library module
- create a linked issue in `Azure/azure-sdk-for-js` using the PR head commit and requested branch, defaulting to `main`
- add focused coverage for library/language parsing, payload construction, authorization, and issue creation

## Testing

- `npx vitest run .github/workflows/test/sdk-autogen.test.js .github/workflows/test/workflows.test.js`
- `npx prettier --check .github/workflows/sdk-autogen.yaml .github/workflows/src/sdk-autogen.js .github/workflows/src/sdk-autogen/ai-projects.js .github/workflows/test/sdk-autogen.test.js`