### PR TITLE
Centurion WAF: add WAF policy tier + Basic_v2/Basic_WAF_v2 SKUs (2026-01-01)

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/ApplicationGatewayCreateBasicV2.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/ApplicationGatewayCreateBasicV2.json
@@ -1,0 +1,824 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "applicationGatewayName": "appgw",
+    "parameters": {
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1": {}
+        }
+      },
+      "location": "eastus",
+      "properties": {
+        "backendAddressPools": [
+          {
+            "name": "appgwpool",
+            "properties": {
+              "backendAddresses": [
+                {
+                  "ipAddress": "10.0.1.1"
+                },
+                {
+                  "ipAddress": "10.0.1.2"
+                }
+              ]
+            }
+          },
+          {
+            "name": "appgwpool1",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool1",
+            "properties": {
+              "backendAddresses": [
+                {
+                  "ipAddress": "10.0.0.1"
+                },
+                {
+                  "ipAddress": "10.0.0.2"
+                }
+              ]
+            }
+          }
+        ],
+        "backendHttpSettingsCollection": [
+          {
+            "name": "appgwbhs",
+            "properties": {
+              "cookieBasedAffinity": "Disabled",
+              "port": 80,
+              "requestTimeout": 30,
+              "protocol": "Http"
+            }
+          }
+        ],
+        "entraJWTValidationConfigs": [
+          {
+            "name": "entraJWTValidationConfig1",
+            "properties": {
+              "clientId": "37293f5a-97b3-451d-b786-f532d711c9ff",
+              "tenantId": "70a036f6-8e4d-4615-bad6-149c02e7720d",
+              "unAuthorizedRequestAction": "Deny"
+            }
+          }
+        ],
+        "frontendIPConfigurations": [
+          {
+            "name": "appgwfip",
+            "properties": {
+              "publicIPAddress": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/appgwpip"
+              }
+            }
+          }
+        ],
+        "frontendPorts": [
+          {
+            "name": "appgwfp",
+            "properties": {
+              "port": 443
+            }
+          },
+          {
+            "name": "appgwfp80",
+            "properties": {
+              "port": 80
+            }
+          }
+        ],
+        "gatewayIPConfigurations": [
+          {
+            "name": "appgwipc",
+            "properties": {
+              "subnet": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnet/subnets/appgwsubnet"
+              }
+            }
+          }
+        ],
+        "globalConfiguration": {
+          "enableRequestBuffering": true,
+          "enableResponseBuffering": true
+        },
+        "httpListeners": [
+          {
+            "name": "appgwhl",
+            "properties": {
+              "frontendIPConfiguration": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendIPConfigurations/appgwfip"
+              },
+              "frontendPort": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendPorts/appgwfp"
+              },
+              "requireServerNameIndication": false,
+              "sslCertificate": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/sslCertificates/sslcert"
+              },
+              "sslProfile": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/sslProfiles/sslProfile1"
+              },
+              "protocol": "Https"
+            }
+          },
+          {
+            "name": "appgwhttplistener",
+            "properties": {
+              "frontendIPConfiguration": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendIPConfigurations/appgwfip"
+              },
+              "frontendPort": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendPorts/appgwfp80"
+              },
+              "protocol": "Http"
+            }
+          }
+        ],
+        "requestRoutingRules": [
+          {
+            "name": "appgwrule",
+            "properties": {
+              "backendAddressPool": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
+              },
+              "backendHttpSettings": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs"
+              },
+              "entraJWTValidationConfig": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/entraJWTValidationConfigs/entraJWTValidationConfig1"
+              },
+              "httpListener": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhl"
+              },
+              "priority": 10,
+              "rewriteRuleSet": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1"
+              },
+              "ruleType": "Basic"
+            }
+          }
+        ],
+        "rewriteRuleSets": [
+          {
+            "name": "rewriteRuleSet1",
+            "properties": {
+              "rewriteRules": [
+                {
+                  "name": "Set X-Forwarded-For",
+                  "actionSet": {
+                    "requestHeaderConfigurations": [
+                      {
+                        "headerName": "X-Forwarded-For",
+                        "headerValue": "{var_add_x_forwarded_for_proxy}"
+                      }
+                    ],
+                    "responseHeaderConfigurations": [
+                      {
+                        "headerName": "Strict-Transport-Security",
+                        "headerValue": "max-age=31536000"
+                      }
+                    ],
+                    "urlConfiguration": {
+                      "modifiedPath": "/abc"
+                    }
+                  },
+                  "conditions": [
+                    {
+                      "ignoreCase": true,
+                      "negate": false,
+                      "pattern": "^Bearer",
+                      "variable": "http_req_Authorization"
+                    }
+                  ],
+                  "ruleSequence": 102
+                }
+              ]
+            }
+          }
+        ],
+        "sku": {
+          "name": "Basic_v2",
+          "tier": "Basic_v2"
+        },
+        "reservedCapacity": 3,
+        "sslCertificates": [
+          {
+            "name": "sslcert",
+            "properties": {
+              "data": "****",
+              "password": "****"
+            }
+          },
+          {
+            "name": "sslcert2",
+            "properties": {
+              "keyVaultSecretId": "https://kv/secret"
+            }
+          }
+        ],
+        "sslProfiles": [
+          {
+            "name": "sslProfile1",
+            "properties": {
+              "clientAuthConfiguration": {
+                "verifyClientCertIssuerDN": true
+              },
+              "sslPolicy": {
+                "cipherSuites": [
+                  "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256"
+                ],
+                "minProtocolVersion": "TLSv1_1",
+                "policyType": "Custom"
+              },
+              "trustedClientCertificates": [
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/trustedClientCertificates/clientcert"
+                }
+              ]
+            }
+          }
+        ],
+        "trustedClientCertificates": [
+          {
+            "name": "clientcert",
+            "properties": {
+              "data": "****"
+            }
+          }
+        ],
+        "trustedRootCertificates": [
+          {
+            "name": "rootcert",
+            "properties": {
+              "data": "****"
+            }
+          },
+          {
+            "name": "rootcert1",
+            "properties": {
+              "keyVaultSecretId": "https://kv/secret"
+            }
+          }
+        ]
+      }
+    },
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "appgw",
+        "type": "Microsoft.Network/applicationGateways",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw",
+        "location": "southcentralus",
+        "properties": {
+          "authenticationCertificates": [],
+          "backendAddressPools": [
+            {
+              "name": "appgwpool",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool",
+              "properties": {
+                "backendAddresses": [
+                  {
+                    "ipAddress": "10.0.1.1"
+                  },
+                  {
+                    "ipAddress": "10.0.1.2"
+                  }
+                ],
+                "provisioningState": "Succeeded"
+              }
+            },
+            {
+              "name": "appgwpool1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool1",
+              "properties": {
+                "backendAddresses": [
+                  {
+                    "ipAddress": "10.0.0.1"
+                  },
+                  {
+                    "ipAddress": "10.0.0.2"
+                  }
+                ],
+                "provisioningState": "Succeeded"
+              }
+            }
+          ],
+          "backendHttpSettingsCollection": [
+            {
+              "name": "appgwbhs",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs",
+              "properties": {
+                "cookieBasedAffinity": "Disabled",
+                "port": 80,
+                "provisioningState": "Succeeded",
+                "requestTimeout": 30,
+                "protocol": "Http"
+              }
+            }
+          ],
+          "entraJWTValidationConfigs": [
+            {
+              "name": "entraJWTValidationConfig1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/entraJWTValidationConfigs/entraJWTValidationConfig1",
+              "properties": {
+                "clientId": "37293f5a-97b3-451d-b786-f532d711c9ff",
+                "provisioningState": "Succeeded",
+                "tenantId": "70a036f6-8e4d-4615-bad6-149c02e7720d",
+                "unAuthorizedRequestAction": "Deny"
+              }
+            }
+          ],
+          "frontendIPConfigurations": [
+            {
+              "name": "appgwfip",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendIPConfigurations/appgwfip",
+              "properties": {
+                "privateIPAllocationMethod": "Dynamic",
+                "provisioningState": "Succeeded",
+                "publicIPAddress": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/appgwpip"
+                }
+              }
+            }
+          ],
+          "frontendPorts": [
+            {
+              "name": "appgwfp",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendPorts/appgwfp",
+              "properties": {
+                "port": 443,
+                "provisioningState": "Succeeded"
+              }
+            },
+            {
+              "name": "appgwfp80",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendPorts/appgwfp80",
+              "properties": {
+                "port": 80,
+                "provisioningState": "Succeeded"
+              }
+            }
+          ],
+          "gatewayIPConfigurations": [
+            {
+              "name": "appgwipc",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/gatewayIPConfigurations/appgwipc",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "subnet": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/virtualNetwork1/subnets/appgwsubnet"
+                }
+              }
+            }
+          ],
+          "globalConfiguration": {
+            "enableRequestBuffering": true,
+            "enableResponseBuffering": true
+          },
+          "httpListeners": [
+            {
+              "name": "appgwhl",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhl",
+              "properties": {
+                "frontendIPConfiguration": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendIPConfigurations/appgwfip"
+                },
+                "frontendPort": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendPorts/appgwfp"
+                },
+                "provisioningState": "Succeeded",
+                "requireServerNameIndication": false,
+                "sslCertificate": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/sslCertificates/sslcert"
+                },
+                "sslProfile": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/sslProfiles/sslProfile1"
+                },
+                "protocol": "Https"
+              }
+            },
+            {
+              "name": "appgwhttplistener",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhttplistener",
+              "properties": {
+                "frontendIPConfiguration": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendIPConfigurations/appgwfip"
+                },
+                "frontendPort": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendPorts/appgwfp80"
+                },
+                "provisioningState": "Succeeded",
+                "protocol": "Http"
+              }
+            }
+          ],
+          "listeners": [],
+          "loadDistributionPolicies": [],
+          "operationalState": "Running",
+          "privateEndpointConnections": [],
+          "probes": [],
+          "provisioningState": "Succeeded",
+          "redirectConfigurations": [],
+          "requestRoutingRules": [
+            {
+              "name": "appgwrule",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/requestRoutingRules/appgwrule",
+              "properties": {
+                "backendAddressPool": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
+                },
+                "backendHttpSettings": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs"
+                },
+                "entraJWTValidationConfig": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/entraJWTValidationConfigs/entraJWTValidationConfig1"
+                },
+                "httpListener": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhl"
+                },
+                "provisioningState": "Succeeded",
+                "rewriteRuleSet": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1"
+                },
+                "ruleType": "Basic"
+              }
+            }
+          ],
+          "rewriteRuleSets": [
+            {
+              "name": "rewriteRuleSet1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "rewriteRules": [
+                  {
+                    "name": "Set X-Forwarded-For",
+                    "actionSet": {
+                      "requestHeaderConfigurations": [
+                        {
+                          "headerName": "X-Forwarded-For",
+                          "headerValue": "{var_remote-addr}"
+                        }
+                      ],
+                      "responseHeaderConfigurations": [
+                        {
+                          "headerName": "Strict-Transport-Security",
+                          "headerValue": "max-age=31536000"
+                        }
+                      ],
+                      "urlConfiguration": {
+                        "modifiedPath": "/abc",
+                        "modifiedQueryString": "x=y&a=b"
+                      }
+                    },
+                    "conditions": [
+                      {
+                        "ignoreCase": true,
+                        "negate": false,
+                        "pattern": "^Bearer",
+                        "variable": "http_req_Authorization"
+                      }
+                    ],
+                    "ruleSequence": 102
+                  }
+                ]
+              }
+            }
+          ],
+          "routingRules": [],
+          "sku": {
+            "name": "Basic_v2",
+            "tier": "Basic_v2"
+          },
+          "reservedCapacity": 3,
+          "sslCertificates": [
+            {
+              "name": "sslcert",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/sslCertificates/sslcert",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "publicCertData": "*****"
+              }
+            }
+          ],
+          "sslProfiles": [
+            {
+              "name": "sslProfile1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/sslProfiles/sslProfile1",
+              "properties": {
+                "clientAuthConfiguration": {
+                  "verifyClientCertIssuerDN": true
+                },
+                "provisioningState": "Succeeded",
+                "sslPolicy": {
+                  "cipherSuites": [
+                    "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256"
+                  ],
+                  "minProtocolVersion": "TLSv1_1",
+                  "policyType": "Custom"
+                },
+                "trustedClientCertificates": [
+                  {
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/trustedClientCertificates/clientcert"
+                  }
+                ]
+              }
+            }
+          ],
+          "trustedClientCertificates": [
+            {
+              "name": "clientcert",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/trustedClientCertificates/clientcert",
+              "properties": {
+                "data": "****",
+                "provisioningState": "Succeeded"
+              }
+            }
+          ],
+          "urlPathMaps": []
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "appgw",
+        "type": "Microsoft.Network/applicationGateways",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw",
+        "location": "southcentralus",
+        "properties": {
+          "authenticationCertificates": [],
+          "backendAddressPools": [
+            {
+              "name": "appgwpool",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool",
+              "properties": {
+                "backendAddresses": [
+                  {
+                    "ipAddress": "10.0.1.1"
+                  },
+                  {
+                    "ipAddress": "10.0.1.2"
+                  }
+                ],
+                "provisioningState": "Succeeded"
+              }
+            },
+            {
+              "name": "appgwpool1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool1",
+              "properties": {
+                "backendAddresses": [
+                  {
+                    "ipAddress": "10.0.0.1"
+                  },
+                  {
+                    "ipAddress": "10.0.0.2"
+                  }
+                ],
+                "provisioningState": "Succeeded"
+              }
+            }
+          ],
+          "backendHttpSettingsCollection": [
+            {
+              "name": "appgwbhs",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs",
+              "properties": {
+                "cookieBasedAffinity": "Disabled",
+                "port": 80,
+                "provisioningState": "Succeeded",
+                "requestTimeout": 30,
+                "protocol": "Http"
+              }
+            }
+          ],
+          "entraJWTValidationConfigs": [
+            {
+              "name": "entraJWTValidationConfig1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/entraJWTValidationConfigs/entraJWTValidationConfig1",
+              "properties": {
+                "clientId": "37293f5a-97b3-451d-b786-f532d711c9ff",
+                "provisioningState": "Succeeded",
+                "tenantId": "70a036f6-8e4d-4615-bad6-149c02e7720d",
+                "unAuthorizedRequestAction": "Deny"
+              }
+            }
+          ],
+          "frontendIPConfigurations": [
+            {
+              "name": "appgwfip",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendIPConfigurations/appgwfip",
+              "properties": {
+                "privateIPAllocationMethod": "Dynamic",
+                "provisioningState": "Succeeded",
+                "publicIPAddress": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/appgwpip"
+                }
+              }
+            }
+          ],
+          "frontendPorts": [
+            {
+              "name": "appgwfp",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendPorts/appgwfp",
+              "properties": {
+                "port": 443,
+                "provisioningState": "Succeeded"
+              }
+            },
+            {
+              "name": "appgwfp80",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendPorts/appgwfp80",
+              "properties": {
+                "port": 80,
+                "provisioningState": "Succeeded"
+              }
+            }
+          ],
+          "gatewayIPConfigurations": [
+            {
+              "name": "appgwipc",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/gatewayIPConfigurations/appgwipc",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "subnet": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/virtualNetwork1/subnets/appgwsubnet"
+                }
+              }
+            }
+          ],
+          "globalConfiguration": {
+            "enableRequestBuffering": true,
+            "enableResponseBuffering": true
+          },
+          "httpListeners": [
+            {
+              "name": "appgwhl",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhl",
+              "properties": {
+                "frontendIPConfiguration": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendIPConfigurations/appgwfip"
+                },
+                "frontendPort": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendPorts/appgwfp"
+                },
+                "provisioningState": "Succeeded",
+                "requireServerNameIndication": false,
+                "sslCertificate": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/sslCertificates/sslcert"
+                },
+                "sslProfile": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/sslProfiles/sslProfile1"
+                },
+                "protocol": "Https"
+              }
+            },
+            {
+              "name": "appgwhttplistener",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhttplistener",
+              "properties": {
+                "frontendIPConfiguration": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendIPConfigurations/appgwfip"
+                },
+                "frontendPort": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendPorts/appgwfp80"
+                },
+                "provisioningState": "Succeeded",
+                "protocol": "Http"
+              }
+            }
+          ],
+          "listeners": [],
+          "loadDistributionPolicies": [],
+          "operationalState": "Running",
+          "privateEndpointConnections": [],
+          "probes": [],
+          "provisioningState": "Succeeded",
+          "redirectConfigurations": [],
+          "requestRoutingRules": [
+            {
+              "name": "appgwrule",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/requestRoutingRules/appgwrule",
+              "properties": {
+                "backendAddressPool": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
+                },
+                "backendHttpSettings": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs"
+                },
+                "entraJWTValidationConfig": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/entraJWTValidationConfigs/entraJWTValidationConfig1"
+                },
+                "httpListener": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhl"
+                },
+                "provisioningState": "Succeeded",
+                "rewriteRuleSet": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1"
+                },
+                "ruleType": "Basic"
+              }
+            }
+          ],
+          "rewriteRuleSets": [
+            {
+              "name": "rewriteRuleSet1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "rewriteRules": [
+                  {
+                    "name": "Set X-Forwarded-For",
+                    "actionSet": {
+                      "requestHeaderConfigurations": [
+                        {
+                          "headerName": "X-Forwarded-For",
+                          "headerValue": "{var_remote-addr}"
+                        }
+                      ],
+                      "responseHeaderConfigurations": [
+                        {
+                          "headerName": "Strict-Transport-Security",
+                          "headerValue": "max-age=31536000"
+                        }
+                      ],
+                      "urlConfiguration": {
+                        "modifiedPath": "/abc",
+                        "reroute": true
+                      }
+                    },
+                    "conditions": [
+                      {
+                        "ignoreCase": true,
+                        "negate": false,
+                        "pattern": "^Bearer",
+                        "variable": "http_req_Authorization"
+                      }
+                    ],
+                    "ruleSequence": 102
+                  }
+                ]
+              }
+            }
+          ],
+          "routingRules": [],
+          "sku": {
+            "name": "Basic_v2",
+            "tier": "Basic_v2"
+          },
+          "reservedCapacity": 3,
+          "sslCertificates": [
+            {
+              "name": "sslcert",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/sslCertificates/sslcert",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "publicCertData": "*****"
+              }
+            }
+          ],
+          "sslProfiles": [
+            {
+              "name": "sslProfile1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/sslProfiles/sslProfile1",
+              "properties": {
+                "clientAuthConfiguration": {
+                  "verifyClientAuthMode": "Strict",
+                  "verifyClientCertIssuerDN": true,
+                  "verifyClientRevocation": "OCSP"
+                },
+                "provisioningState": "Succeeded",
+                "sslPolicy": {
+                  "cipherSuites": [
+                    "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256"
+                  ],
+                  "minProtocolVersion": "TLSv1_1",
+                  "policyType": "Custom"
+                },
+                "trustedClientCertificates": [
+                  {
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/trustedClientCertificates/clientcert"
+                  }
+                ]
+              }
+            }
+          ],
+          "trustedClientCertificates": [
+            {
+              "name": "clientcert",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/trustedClientCertificates/clientcert",
+              "properties": {
+                "data": "****",
+                "provisioningState": "Succeeded"
+              }
+            }
+          ],
+          "urlPathMaps": []
+        }
+      }
+    }
+  },
+  "operationId": "ApplicationGateways_CreateOrUpdate",
+  "title": "Create Basic_v2 Application Gateway"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/ApplicationGatewayCreateBasicWafV2.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/ApplicationGatewayCreateBasicWafV2.json
@@ -1,0 +1,833 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "applicationGatewayName": "appgw",
+    "parameters": {
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1": {}
+        }
+      },
+      "location": "eastus",
+      "properties": {
+        "backendAddressPools": [
+          {
+            "name": "appgwpool",
+            "properties": {
+              "backendAddresses": [
+                {
+                  "ipAddress": "10.0.1.1"
+                },
+                {
+                  "ipAddress": "10.0.1.2"
+                }
+              ]
+            }
+          },
+          {
+            "name": "appgwpool1",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool1",
+            "properties": {
+              "backendAddresses": [
+                {
+                  "ipAddress": "10.0.0.1"
+                },
+                {
+                  "ipAddress": "10.0.0.2"
+                }
+              ]
+            }
+          }
+        ],
+        "backendHttpSettingsCollection": [
+          {
+            "name": "appgwbhs",
+            "properties": {
+              "cookieBasedAffinity": "Disabled",
+              "port": 80,
+              "requestTimeout": 30,
+              "protocol": "Http"
+            }
+          }
+        ],
+        "entraJWTValidationConfigs": [
+          {
+            "name": "entraJWTValidationConfig1",
+            "properties": {
+              "clientId": "37293f5a-97b3-451d-b786-f532d711c9ff",
+              "tenantId": "70a036f6-8e4d-4615-bad6-149c02e7720d",
+              "unAuthorizedRequestAction": "Deny"
+            }
+          }
+        ],
+        "frontendIPConfigurations": [
+          {
+            "name": "appgwfip",
+            "properties": {
+              "publicIPAddress": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/appgwpip"
+              }
+            }
+          }
+        ],
+        "frontendPorts": [
+          {
+            "name": "appgwfp",
+            "properties": {
+              "port": 443
+            }
+          },
+          {
+            "name": "appgwfp80",
+            "properties": {
+              "port": 80
+            }
+          }
+        ],
+        "gatewayIPConfigurations": [
+          {
+            "name": "appgwipc",
+            "properties": {
+              "subnet": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnet/subnets/appgwsubnet"
+              }
+            }
+          }
+        ],
+        "globalConfiguration": {
+          "enableRequestBuffering": true,
+          "enableResponseBuffering": true
+        },
+        "httpListeners": [
+          {
+            "name": "appgwhl",
+            "properties": {
+              "frontendIPConfiguration": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendIPConfigurations/appgwfip"
+              },
+              "frontendPort": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendPorts/appgwfp"
+              },
+              "requireServerNameIndication": false,
+              "sslCertificate": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/sslCertificates/sslcert"
+              },
+              "sslProfile": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/sslProfiles/sslProfile1"
+              },
+              "protocol": "Https"
+            }
+          },
+          {
+            "name": "appgwhttplistener",
+            "properties": {
+              "frontendIPConfiguration": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendIPConfigurations/appgwfip"
+              },
+              "frontendPort": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendPorts/appgwfp80"
+              },
+              "protocol": "Http"
+            }
+          }
+        ],
+        "requestRoutingRules": [
+          {
+            "name": "appgwrule",
+            "properties": {
+              "backendAddressPool": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
+              },
+              "backendHttpSettings": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs"
+              },
+              "entraJWTValidationConfig": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/entraJWTValidationConfigs/entraJWTValidationConfig1"
+              },
+              "httpListener": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhl"
+              },
+              "priority": 10,
+              "rewriteRuleSet": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1"
+              },
+              "ruleType": "Basic"
+            }
+          }
+        ],
+        "rewriteRuleSets": [
+          {
+            "name": "rewriteRuleSet1",
+            "properties": {
+              "rewriteRules": [
+                {
+                  "name": "Set X-Forwarded-For",
+                  "actionSet": {
+                    "requestHeaderConfigurations": [
+                      {
+                        "headerName": "X-Forwarded-For",
+                        "headerValue": "{var_add_x_forwarded_for_proxy}"
+                      }
+                    ],
+                    "responseHeaderConfigurations": [
+                      {
+                        "headerName": "Strict-Transport-Security",
+                        "headerValue": "max-age=31536000"
+                      }
+                    ],
+                    "urlConfiguration": {
+                      "modifiedPath": "/abc"
+                    }
+                  },
+                  "conditions": [
+                    {
+                      "ignoreCase": true,
+                      "negate": false,
+                      "pattern": "^Bearer",
+                      "variable": "http_req_Authorization"
+                    }
+                  ],
+                  "ruleSequence": 102
+                }
+              ]
+            }
+          }
+        ],
+        "sku": {
+          "name": "Basic_WAF_v2",
+          "tier": "Basic_WAF_v2"
+        },
+        "reservedCapacity": 3,
+        "firewallPolicy": {
+          "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies/Policy1"
+        },
+        "sslCertificates": [
+          {
+            "name": "sslcert",
+            "properties": {
+              "data": "****",
+              "password": "****"
+            }
+          },
+          {
+            "name": "sslcert2",
+            "properties": {
+              "keyVaultSecretId": "https://kv/secret"
+            }
+          }
+        ],
+        "sslProfiles": [
+          {
+            "name": "sslProfile1",
+            "properties": {
+              "clientAuthConfiguration": {
+                "verifyClientCertIssuerDN": true
+              },
+              "sslPolicy": {
+                "cipherSuites": [
+                  "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256"
+                ],
+                "minProtocolVersion": "TLSv1_1",
+                "policyType": "Custom"
+              },
+              "trustedClientCertificates": [
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/trustedClientCertificates/clientcert"
+                }
+              ]
+            }
+          }
+        ],
+        "trustedClientCertificates": [
+          {
+            "name": "clientcert",
+            "properties": {
+              "data": "****"
+            }
+          }
+        ],
+        "trustedRootCertificates": [
+          {
+            "name": "rootcert",
+            "properties": {
+              "data": "****"
+            }
+          },
+          {
+            "name": "rootcert1",
+            "properties": {
+              "keyVaultSecretId": "https://kv/secret"
+            }
+          }
+        ]
+      }
+    },
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "appgw",
+        "type": "Microsoft.Network/applicationGateways",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw",
+        "location": "southcentralus",
+        "properties": {
+          "authenticationCertificates": [],
+          "backendAddressPools": [
+            {
+              "name": "appgwpool",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool",
+              "properties": {
+                "backendAddresses": [
+                  {
+                    "ipAddress": "10.0.1.1"
+                  },
+                  {
+                    "ipAddress": "10.0.1.2"
+                  }
+                ],
+                "provisioningState": "Succeeded"
+              }
+            },
+            {
+              "name": "appgwpool1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool1",
+              "properties": {
+                "backendAddresses": [
+                  {
+                    "ipAddress": "10.0.0.1"
+                  },
+                  {
+                    "ipAddress": "10.0.0.2"
+                  }
+                ],
+                "provisioningState": "Succeeded"
+              }
+            }
+          ],
+          "backendHttpSettingsCollection": [
+            {
+              "name": "appgwbhs",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs",
+              "properties": {
+                "cookieBasedAffinity": "Disabled",
+                "port": 80,
+                "provisioningState": "Succeeded",
+                "requestTimeout": 30,
+                "protocol": "Http"
+              }
+            }
+          ],
+          "entraJWTValidationConfigs": [
+            {
+              "name": "entraJWTValidationConfig1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/entraJWTValidationConfigs/entraJWTValidationConfig1",
+              "properties": {
+                "clientId": "37293f5a-97b3-451d-b786-f532d711c9ff",
+                "provisioningState": "Succeeded",
+                "tenantId": "70a036f6-8e4d-4615-bad6-149c02e7720d",
+                "unAuthorizedRequestAction": "Deny"
+              }
+            }
+          ],
+          "frontendIPConfigurations": [
+            {
+              "name": "appgwfip",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendIPConfigurations/appgwfip",
+              "properties": {
+                "privateIPAllocationMethod": "Dynamic",
+                "provisioningState": "Succeeded",
+                "publicIPAddress": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/appgwpip"
+                }
+              }
+            }
+          ],
+          "frontendPorts": [
+            {
+              "name": "appgwfp",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendPorts/appgwfp",
+              "properties": {
+                "port": 443,
+                "provisioningState": "Succeeded"
+              }
+            },
+            {
+              "name": "appgwfp80",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendPorts/appgwfp80",
+              "properties": {
+                "port": 80,
+                "provisioningState": "Succeeded"
+              }
+            }
+          ],
+          "gatewayIPConfigurations": [
+            {
+              "name": "appgwipc",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/gatewayIPConfigurations/appgwipc",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "subnet": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/virtualNetwork1/subnets/appgwsubnet"
+                }
+              }
+            }
+          ],
+          "globalConfiguration": {
+            "enableRequestBuffering": true,
+            "enableResponseBuffering": true
+          },
+          "httpListeners": [
+            {
+              "name": "appgwhl",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhl",
+              "properties": {
+                "frontendIPConfiguration": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendIPConfigurations/appgwfip"
+                },
+                "frontendPort": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendPorts/appgwfp"
+                },
+                "provisioningState": "Succeeded",
+                "requireServerNameIndication": false,
+                "sslCertificate": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/sslCertificates/sslcert"
+                },
+                "sslProfile": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/sslProfiles/sslProfile1"
+                },
+                "protocol": "Https"
+              }
+            },
+            {
+              "name": "appgwhttplistener",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhttplistener",
+              "properties": {
+                "frontendIPConfiguration": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendIPConfigurations/appgwfip"
+                },
+                "frontendPort": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendPorts/appgwfp80"
+                },
+                "provisioningState": "Succeeded",
+                "protocol": "Http"
+              }
+            }
+          ],
+          "listeners": [],
+          "loadDistributionPolicies": [],
+          "operationalState": "Running",
+          "privateEndpointConnections": [],
+          "probes": [],
+          "provisioningState": "Succeeded",
+          "redirectConfigurations": [],
+          "requestRoutingRules": [
+            {
+              "name": "appgwrule",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/requestRoutingRules/appgwrule",
+              "properties": {
+                "backendAddressPool": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
+                },
+                "backendHttpSettings": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs"
+                },
+                "entraJWTValidationConfig": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/entraJWTValidationConfigs/entraJWTValidationConfig1"
+                },
+                "httpListener": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhl"
+                },
+                "provisioningState": "Succeeded",
+                "rewriteRuleSet": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1"
+                },
+                "ruleType": "Basic"
+              }
+            }
+          ],
+          "rewriteRuleSets": [
+            {
+              "name": "rewriteRuleSet1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "rewriteRules": [
+                  {
+                    "name": "Set X-Forwarded-For",
+                    "actionSet": {
+                      "requestHeaderConfigurations": [
+                        {
+                          "headerName": "X-Forwarded-For",
+                          "headerValue": "{var_remote-addr}"
+                        }
+                      ],
+                      "responseHeaderConfigurations": [
+                        {
+                          "headerName": "Strict-Transport-Security",
+                          "headerValue": "max-age=31536000"
+                        }
+                      ],
+                      "urlConfiguration": {
+                        "modifiedPath": "/abc",
+                        "modifiedQueryString": "x=y&a=b"
+                      }
+                    },
+                    "conditions": [
+                      {
+                        "ignoreCase": true,
+                        "negate": false,
+                        "pattern": "^Bearer",
+                        "variable": "http_req_Authorization"
+                      }
+                    ],
+                    "ruleSequence": 102
+                  }
+                ]
+              }
+            }
+          ],
+          "routingRules": [],
+          "sku": {
+            "name": "Basic_WAF_v2",
+            "tier": "Basic_WAF_v2"
+          },
+          "reservedCapacity": 3,
+          "firewallPolicy": {
+            "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies/Policy1"
+          },
+          "sslCertificates": [
+            {
+              "name": "sslcert",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/sslCertificates/sslcert",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "publicCertData": "*****"
+              }
+            }
+          ],
+          "sslProfiles": [
+            {
+              "name": "sslProfile1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/sslProfiles/sslProfile1",
+              "properties": {
+                "clientAuthConfiguration": {
+                  "verifyClientCertIssuerDN": true
+                },
+                "provisioningState": "Succeeded",
+                "sslPolicy": {
+                  "cipherSuites": [
+                    "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256"
+                  ],
+                  "minProtocolVersion": "TLSv1_1",
+                  "policyType": "Custom"
+                },
+                "trustedClientCertificates": [
+                  {
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/trustedClientCertificates/clientcert"
+                  }
+                ]
+              }
+            }
+          ],
+          "trustedClientCertificates": [
+            {
+              "name": "clientcert",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/trustedClientCertificates/clientcert",
+              "properties": {
+                "data": "****",
+                "provisioningState": "Succeeded"
+              }
+            }
+          ],
+          "urlPathMaps": []
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "appgw",
+        "type": "Microsoft.Network/applicationGateways",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw",
+        "location": "southcentralus",
+        "properties": {
+          "authenticationCertificates": [],
+          "backendAddressPools": [
+            {
+              "name": "appgwpool",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool",
+              "properties": {
+                "backendAddresses": [
+                  {
+                    "ipAddress": "10.0.1.1"
+                  },
+                  {
+                    "ipAddress": "10.0.1.2"
+                  }
+                ],
+                "provisioningState": "Succeeded"
+              }
+            },
+            {
+              "name": "appgwpool1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool1",
+              "properties": {
+                "backendAddresses": [
+                  {
+                    "ipAddress": "10.0.0.1"
+                  },
+                  {
+                    "ipAddress": "10.0.0.2"
+                  }
+                ],
+                "provisioningState": "Succeeded"
+              }
+            }
+          ],
+          "backendHttpSettingsCollection": [
+            {
+              "name": "appgwbhs",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs",
+              "properties": {
+                "cookieBasedAffinity": "Disabled",
+                "port": 80,
+                "provisioningState": "Succeeded",
+                "requestTimeout": 30,
+                "protocol": "Http"
+              }
+            }
+          ],
+          "entraJWTValidationConfigs": [
+            {
+              "name": "entraJWTValidationConfig1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/entraJWTValidationConfigs/entraJWTValidationConfig1",
+              "properties": {
+                "clientId": "37293f5a-97b3-451d-b786-f532d711c9ff",
+                "provisioningState": "Succeeded",
+                "tenantId": "70a036f6-8e4d-4615-bad6-149c02e7720d",
+                "unAuthorizedRequestAction": "Deny"
+              }
+            }
+          ],
+          "frontendIPConfigurations": [
+            {
+              "name": "appgwfip",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendIPConfigurations/appgwfip",
+              "properties": {
+                "privateIPAllocationMethod": "Dynamic",
+                "provisioningState": "Succeeded",
+                "publicIPAddress": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/appgwpip"
+                }
+              }
+            }
+          ],
+          "frontendPorts": [
+            {
+              "name": "appgwfp",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendPorts/appgwfp",
+              "properties": {
+                "port": 443,
+                "provisioningState": "Succeeded"
+              }
+            },
+            {
+              "name": "appgwfp80",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendPorts/appgwfp80",
+              "properties": {
+                "port": 80,
+                "provisioningState": "Succeeded"
+              }
+            }
+          ],
+          "gatewayIPConfigurations": [
+            {
+              "name": "appgwipc",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/gatewayIPConfigurations/appgwipc",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "subnet": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/virtualNetwork1/subnets/appgwsubnet"
+                }
+              }
+            }
+          ],
+          "globalConfiguration": {
+            "enableRequestBuffering": true,
+            "enableResponseBuffering": true
+          },
+          "httpListeners": [
+            {
+              "name": "appgwhl",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhl",
+              "properties": {
+                "frontendIPConfiguration": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendIPConfigurations/appgwfip"
+                },
+                "frontendPort": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendPorts/appgwfp"
+                },
+                "provisioningState": "Succeeded",
+                "requireServerNameIndication": false,
+                "sslCertificate": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/sslCertificates/sslcert"
+                },
+                "sslProfile": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/sslProfiles/sslProfile1"
+                },
+                "protocol": "Https"
+              }
+            },
+            {
+              "name": "appgwhttplistener",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhttplistener",
+              "properties": {
+                "frontendIPConfiguration": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendIPConfigurations/appgwfip"
+                },
+                "frontendPort": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendPorts/appgwfp80"
+                },
+                "provisioningState": "Succeeded",
+                "protocol": "Http"
+              }
+            }
+          ],
+          "listeners": [],
+          "loadDistributionPolicies": [],
+          "operationalState": "Running",
+          "privateEndpointConnections": [],
+          "probes": [],
+          "provisioningState": "Succeeded",
+          "redirectConfigurations": [],
+          "requestRoutingRules": [
+            {
+              "name": "appgwrule",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/requestRoutingRules/appgwrule",
+              "properties": {
+                "backendAddressPool": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
+                },
+                "backendHttpSettings": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs"
+                },
+                "entraJWTValidationConfig": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/entraJWTValidationConfigs/entraJWTValidationConfig1"
+                },
+                "httpListener": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhl"
+                },
+                "provisioningState": "Succeeded",
+                "rewriteRuleSet": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1"
+                },
+                "ruleType": "Basic"
+              }
+            }
+          ],
+          "rewriteRuleSets": [
+            {
+              "name": "rewriteRuleSet1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "rewriteRules": [
+                  {
+                    "name": "Set X-Forwarded-For",
+                    "actionSet": {
+                      "requestHeaderConfigurations": [
+                        {
+                          "headerName": "X-Forwarded-For",
+                          "headerValue": "{var_remote-addr}"
+                        }
+                      ],
+                      "responseHeaderConfigurations": [
+                        {
+                          "headerName": "Strict-Transport-Security",
+                          "headerValue": "max-age=31536000"
+                        }
+                      ],
+                      "urlConfiguration": {
+                        "modifiedPath": "/abc",
+                        "reroute": true
+                      }
+                    },
+                    "conditions": [
+                      {
+                        "ignoreCase": true,
+                        "negate": false,
+                        "pattern": "^Bearer",
+                        "variable": "http_req_Authorization"
+                      }
+                    ],
+                    "ruleSequence": 102
+                  }
+                ]
+              }
+            }
+          ],
+          "routingRules": [],
+          "sku": {
+            "name": "Basic_WAF_v2",
+            "tier": "Basic_WAF_v2"
+          },
+          "reservedCapacity": 3,
+          "firewallPolicy": {
+            "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies/Policy1"
+          },
+          "sslCertificates": [
+            {
+              "name": "sslcert",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/sslCertificates/sslcert",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "publicCertData": "*****"
+              }
+            }
+          ],
+          "sslProfiles": [
+            {
+              "name": "sslProfile1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/sslProfiles/sslProfile1",
+              "properties": {
+                "clientAuthConfiguration": {
+                  "verifyClientAuthMode": "Strict",
+                  "verifyClientCertIssuerDN": true,
+                  "verifyClientRevocation": "OCSP"
+                },
+                "provisioningState": "Succeeded",
+                "sslPolicy": {
+                  "cipherSuites": [
+                    "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256"
+                  ],
+                  "minProtocolVersion": "TLSv1_1",
+                  "policyType": "Custom"
+                },
+                "trustedClientCertificates": [
+                  {
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/trustedClientCertificates/clientcert"
+                  }
+                ]
+              }
+            }
+          ],
+          "trustedClientCertificates": [
+            {
+              "name": "clientcert",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/trustedClientCertificates/clientcert",
+              "properties": {
+                "data": "****",
+                "provisioningState": "Succeeded"
+              }
+            }
+          ],
+          "urlPathMaps": []
+        }
+      }
+    }
+  },
+  "operationId": "ApplicationGateways_CreateOrUpdate",
+  "title": "Create Basic_WAF_v2 Application Gateway"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/ApplicationGatewayGetBasicV2.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/ApplicationGatewayGetBasicV2.json
@@ -1,0 +1,411 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "applicationGatewayName": "appgw",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "appgw",
+        "type": "Microsoft.Network/applicationGateways",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw",
+        "location": "southcentralus",
+        "properties": {
+          "authenticationCertificates": [],
+          "backendAddressPools": [
+            {
+              "name": "appgwpool",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool",
+              "properties": {
+                "backendAddresses": [],
+                "provisioningState": "Succeeded"
+              }
+            },
+            {
+              "name": "appgwpool1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool1",
+              "properties": {
+                "backendAddresses": [
+                  {
+                    "ipAddress": "10.0.0.1"
+                  },
+                  {
+                    "ipAddress": "10.0.0.2"
+                  }
+                ],
+                "provisioningState": "Succeeded"
+              }
+            }
+          ],
+          "backendHttpSettingsCollection": [
+            {
+              "name": "appgwbhs",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs",
+              "properties": {
+                "cookieBasedAffinity": "Disabled",
+                "port": 80,
+                "provisioningState": "Succeeded",
+                "requestTimeout": 30,
+                "protocol": "Http"
+              }
+            }
+          ],
+          "entraJWTValidationConfigs": [
+            {
+              "name": "entraJWTValidationConfig1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/entraJWTValidationConfigs/entraJWTValidationConfig1",
+              "properties": {
+                "clientId": "37293f5a-97b3-451d-b786-f532d711c9ff",
+                "provisioningState": "Succeeded",
+                "tenantId": "70a036f6-8e4d-4615-bad6-149c02e7720d",
+                "unAuthorizedRequestAction": "Deny"
+              }
+            }
+          ],
+          "frontendIPConfigurations": [
+            {
+              "name": "appgwfip",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendIPConfigurations/appgwfip",
+              "properties": {
+                "privateIPAllocationMethod": "Dynamic",
+                "provisioningState": "Succeeded",
+                "publicIPAddress": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/appgwpip"
+                }
+              }
+            }
+          ],
+          "frontendPorts": [
+            {
+              "name": "appgwfp",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendPorts/appgwfp",
+              "properties": {
+                "port": 443,
+                "provisioningState": "Succeeded"
+              }
+            },
+            {
+              "name": "appgwfp80",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendPorts/appgwfp80",
+              "properties": {
+                "port": 80,
+                "provisioningState": "Succeeded"
+              }
+            }
+          ],
+          "gatewayIPConfigurations": [
+            {
+              "name": "appgwipc",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/gatewayIPConfigurations/appgwipc",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "subnet": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/virtualNetwork1/subnets/appgwsubnet"
+                }
+              }
+            }
+          ],
+          "globalConfiguration": {
+            "enableRequestBuffering": true,
+            "enableResponseBuffering": true
+          },
+          "httpListeners": [
+            {
+              "name": "appgwhl",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhl",
+              "properties": {
+                "frontendIPConfiguration": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendIPConfigurations/appgwfip"
+                },
+                "frontendPort": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendPorts/appgwfp"
+                },
+                "provisioningState": "Succeeded",
+                "requireServerNameIndication": false,
+                "sslCertificate": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/sslCertificates/sslcert"
+                },
+                "sslProfile": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/sslProfiles/sslProfile1"
+                },
+                "protocol": "Https"
+              }
+            },
+            {
+              "name": "appgwhttplistener",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhttplistener",
+              "properties": {
+                "frontendIPConfiguration": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendIPConfigurations/appgwfip"
+                },
+                "frontendPort": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendPorts/appgwfp80"
+                },
+                "provisioningState": "Succeeded",
+                "protocol": "Http"
+              }
+            }
+          ],
+          "loadDistributionPolicies": [
+            {
+              "name": "ldp1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1",
+              "properties": {
+                "loadDistributionAlgorithm": "RoundRobin",
+                "loadDistributionTargets": [
+                  {
+                    "name": "ld11",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1/loadDistributionTargets/ldt1",
+                    "properties": {
+                      "backendAddressPool": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
+                      },
+                      "weightPerServer": 40
+                    }
+                  },
+                  {
+                    "name": "ld11",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1/loadDistributionTargets/ldt1",
+                    "properties": {
+                      "backendAddressPool": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool1"
+                      },
+                      "weightPerServer": 60
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "operationalState": "Running",
+          "privateEndpointConnections": [],
+          "privateLinkConfigurations": [
+            {
+              "name": "privateLink1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/privateLinkConfigurations/privateLink1",
+              "properties": {
+                "ipConfigurations": [
+                  {
+                    "name": "natNicIpconfig1",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/privateLinkConfigurations/privateLink1/privateLinkConfigurations/privateLink1/ipConfigurations/natNicIpconfig1",
+                    "properties": {
+                      "primary": true,
+                      "privateIPAllocationMethod": "Dynamic",
+                      "provisioningState": "Succeeded",
+                      "subnet": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/virtualNetwork1/subnets/appgwsubnet"
+                      }
+                    }
+                  },
+                  {
+                    "name": "natNicIpconfig2",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/privateLinkConfigurations/privateLink1/privateLinkConfigurations/privateLink1/ipConfigurations/natNicIpconfig2",
+                    "properties": {
+                      "privateIPAllocationMethod": "Dynamic",
+                      "provisioningState": "Succeeded",
+                      "subnet": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/virtualNetwork1/subnets/appgwsubnet"
+                      }
+                    }
+                  }
+                ],
+                "provisioningState": "Succeeded"
+              }
+            }
+          ],
+          "probes": [],
+          "provisioningState": "Succeeded",
+          "requestRoutingRules": [
+            {
+              "name": "appgwrule",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/requestRoutingRules/appgwrule",
+              "properties": {
+                "backendAddressPool": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
+                },
+                "backendHttpSettings": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs"
+                },
+                "httpListener": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhl"
+                },
+                "loadDistributionPolicy": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1"
+                },
+                "priority": 10,
+                "provisioningState": "Succeeded",
+                "rewriteRuleSet": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1"
+                },
+                "ruleType": "Basic"
+              }
+            },
+            {
+              "name": "appgwPathBasedRule",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/requestRoutingRules/appgwPathBasedRule",
+              "properties": {
+                "entraJWTValidationConfig": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/entraJWTValidationConfigs/entraJWTValidationConfig1"
+                },
+                "httpListener": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhttplistener"
+                },
+                "priority": 20,
+                "provisioningState": "Succeeded",
+                "ruleType": "PathBasedRouting",
+                "urlPathMap": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/urlPathMaps/pathMap1"
+                }
+              }
+            }
+          ],
+          "rewriteRuleSets": [
+            {
+              "name": "rewriteRuleSet1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "rewriteRules": [
+                  {
+                    "name": "Set X-Forwarded-For",
+                    "actionSet": {
+                      "requestHeaderConfigurations": [
+                        {
+                          "headerName": "X-Forwarded-For",
+                          "headerValue": "{var_remote-addr}"
+                        }
+                      ],
+                      "responseHeaderConfigurations": [
+                        {
+                          "headerName": "Strict-Transport-Security",
+                          "headerValue": "max-age=31536000"
+                        }
+                      ],
+                      "urlConfiguration": {
+                        "modifiedPath": "/abc",
+                        "modifiedQueryString": "x=y&a=b",
+                        "reroute": false
+                      }
+                    },
+                    "conditions": [
+                      {
+                        "ignoreCase": true,
+                        "negate": false,
+                        "pattern": "^Bearer",
+                        "variable": "http_req_Authorization"
+                      }
+                    ],
+                    "ruleSequence": 102
+                  }
+                ]
+              }
+            }
+          ],
+          "sku": {
+            "name": "Basic_v2",
+            "tier": "Basic_v2"
+          },
+          "reservedCapacity": 3,
+          "sslCertificates": [
+            {
+              "name": "sslcert",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/sslCertificates/sslcert",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "publicCertData": "*****"
+              }
+            }
+          ],
+          "sslProfiles": [
+            {
+              "name": "sslProfile1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/sslProfiles/sslProfile1",
+              "properties": {
+                "clientAuthConfiguration": {
+                  "verifyClientAuthMode": "Strict",
+                  "verifyClientCertIssuerDN": true,
+                  "verifyClientRevocation": "OCSP"
+                },
+                "provisioningState": "Succeeded",
+                "sslPolicy": {
+                  "cipherSuites": [
+                    "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256"
+                  ],
+                  "minProtocolVersion": "TLSv1_1",
+                  "policyType": "Custom"
+                },
+                "trustedClientCertificates": [
+                  {
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/trustedClientCertificates/clientcert"
+                  }
+                ]
+              }
+            }
+          ],
+          "trustedClientCertificates": [
+            {
+              "name": "clientcert",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/trustedClientCertificates/clientcert",
+              "properties": {
+                "clientCertIssuerDN": "CN=User1, OU=Eng, O=Company Ltd, L=D4, S=Arizona, C=US",
+                "data": "****",
+                "provisioningState": "Succeeded",
+                "validatedCertData": "****"
+              }
+            }
+          ],
+          "urlPathMaps": [
+            {
+              "name": "pathMap1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/urlPathMaps/pathMap1",
+              "properties": {
+                "defaultBackendAddressPool": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
+                },
+                "defaultBackendHttpSettings": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs"
+                },
+                "defaultLoadDistributionPolicy": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1"
+                },
+                "defaultRewriteRuleSet": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1"
+                },
+                "pathRules": [
+                  {
+                    "name": "apiPaths",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/urlPathMaps/pathMap1/pathRules/apiPaths",
+                    "properties": {
+                      "backendAddressPool": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
+                      },
+                      "backendHttpSettings": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs"
+                      },
+                      "loadDistributionPolicy": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1"
+                      },
+                      "paths": [
+                        "/api",
+                        "/v1/api"
+                      ],
+                      "provisioningState": "Succeeded",
+                      "rewriteRuleSet": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1"
+                      }
+                    }
+                  }
+                ],
+                "provisioningState": "Succeeded"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "ApplicationGateways_Get",
+  "title": "Get Basic_v2 Application Gateway"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/ApplicationGatewayGetBasicWafV2.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/ApplicationGatewayGetBasicWafV2.json
@@ -1,0 +1,414 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "applicationGatewayName": "appgw",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "appgw",
+        "type": "Microsoft.Network/applicationGateways",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw",
+        "location": "southcentralus",
+        "properties": {
+          "authenticationCertificates": [],
+          "backendAddressPools": [
+            {
+              "name": "appgwpool",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool",
+              "properties": {
+                "backendAddresses": [],
+                "provisioningState": "Succeeded"
+              }
+            },
+            {
+              "name": "appgwpool1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool1",
+              "properties": {
+                "backendAddresses": [
+                  {
+                    "ipAddress": "10.0.0.1"
+                  },
+                  {
+                    "ipAddress": "10.0.0.2"
+                  }
+                ],
+                "provisioningState": "Succeeded"
+              }
+            }
+          ],
+          "backendHttpSettingsCollection": [
+            {
+              "name": "appgwbhs",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs",
+              "properties": {
+                "cookieBasedAffinity": "Disabled",
+                "port": 80,
+                "provisioningState": "Succeeded",
+                "requestTimeout": 30,
+                "protocol": "Http"
+              }
+            }
+          ],
+          "entraJWTValidationConfigs": [
+            {
+              "name": "entraJWTValidationConfig1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/entraJWTValidationConfigs/entraJWTValidationConfig1",
+              "properties": {
+                "clientId": "37293f5a-97b3-451d-b786-f532d711c9ff",
+                "provisioningState": "Succeeded",
+                "tenantId": "70a036f6-8e4d-4615-bad6-149c02e7720d",
+                "unAuthorizedRequestAction": "Deny"
+              }
+            }
+          ],
+          "frontendIPConfigurations": [
+            {
+              "name": "appgwfip",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendIPConfigurations/appgwfip",
+              "properties": {
+                "privateIPAllocationMethod": "Dynamic",
+                "provisioningState": "Succeeded",
+                "publicIPAddress": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/appgwpip"
+                }
+              }
+            }
+          ],
+          "frontendPorts": [
+            {
+              "name": "appgwfp",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendPorts/appgwfp",
+              "properties": {
+                "port": 443,
+                "provisioningState": "Succeeded"
+              }
+            },
+            {
+              "name": "appgwfp80",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendPorts/appgwfp80",
+              "properties": {
+                "port": 80,
+                "provisioningState": "Succeeded"
+              }
+            }
+          ],
+          "gatewayIPConfigurations": [
+            {
+              "name": "appgwipc",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/gatewayIPConfigurations/appgwipc",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "subnet": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/virtualNetwork1/subnets/appgwsubnet"
+                }
+              }
+            }
+          ],
+          "globalConfiguration": {
+            "enableRequestBuffering": true,
+            "enableResponseBuffering": true
+          },
+          "httpListeners": [
+            {
+              "name": "appgwhl",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhl",
+              "properties": {
+                "frontendIPConfiguration": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendIPConfigurations/appgwfip"
+                },
+                "frontendPort": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendPorts/appgwfp"
+                },
+                "provisioningState": "Succeeded",
+                "requireServerNameIndication": false,
+                "sslCertificate": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/sslCertificates/sslcert"
+                },
+                "sslProfile": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/sslProfiles/sslProfile1"
+                },
+                "protocol": "Https"
+              }
+            },
+            {
+              "name": "appgwhttplistener",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhttplistener",
+              "properties": {
+                "frontendIPConfiguration": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendIPConfigurations/appgwfip"
+                },
+                "frontendPort": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendPorts/appgwfp80"
+                },
+                "provisioningState": "Succeeded",
+                "protocol": "Http"
+              }
+            }
+          ],
+          "loadDistributionPolicies": [
+            {
+              "name": "ldp1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1",
+              "properties": {
+                "loadDistributionAlgorithm": "RoundRobin",
+                "loadDistributionTargets": [
+                  {
+                    "name": "ld11",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1/loadDistributionTargets/ldt1",
+                    "properties": {
+                      "backendAddressPool": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
+                      },
+                      "weightPerServer": 40
+                    }
+                  },
+                  {
+                    "name": "ld11",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1/loadDistributionTargets/ldt1",
+                    "properties": {
+                      "backendAddressPool": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool1"
+                      },
+                      "weightPerServer": 60
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "operationalState": "Running",
+          "privateEndpointConnections": [],
+          "privateLinkConfigurations": [
+            {
+              "name": "privateLink1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/privateLinkConfigurations/privateLink1",
+              "properties": {
+                "ipConfigurations": [
+                  {
+                    "name": "natNicIpconfig1",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/privateLinkConfigurations/privateLink1/privateLinkConfigurations/privateLink1/ipConfigurations/natNicIpconfig1",
+                    "properties": {
+                      "primary": true,
+                      "privateIPAllocationMethod": "Dynamic",
+                      "provisioningState": "Succeeded",
+                      "subnet": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/virtualNetwork1/subnets/appgwsubnet"
+                      }
+                    }
+                  },
+                  {
+                    "name": "natNicIpconfig2",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/privateLinkConfigurations/privateLink1/privateLinkConfigurations/privateLink1/ipConfigurations/natNicIpconfig2",
+                    "properties": {
+                      "privateIPAllocationMethod": "Dynamic",
+                      "provisioningState": "Succeeded",
+                      "subnet": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/virtualNetwork1/subnets/appgwsubnet"
+                      }
+                    }
+                  }
+                ],
+                "provisioningState": "Succeeded"
+              }
+            }
+          ],
+          "probes": [],
+          "provisioningState": "Succeeded",
+          "requestRoutingRules": [
+            {
+              "name": "appgwrule",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/requestRoutingRules/appgwrule",
+              "properties": {
+                "backendAddressPool": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
+                },
+                "backendHttpSettings": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs"
+                },
+                "httpListener": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhl"
+                },
+                "loadDistributionPolicy": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1"
+                },
+                "priority": 10,
+                "provisioningState": "Succeeded",
+                "rewriteRuleSet": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1"
+                },
+                "ruleType": "Basic"
+              }
+            },
+            {
+              "name": "appgwPathBasedRule",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/requestRoutingRules/appgwPathBasedRule",
+              "properties": {
+                "entraJWTValidationConfig": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/entraJWTValidationConfigs/entraJWTValidationConfig1"
+                },
+                "httpListener": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhttplistener"
+                },
+                "priority": 20,
+                "provisioningState": "Succeeded",
+                "ruleType": "PathBasedRouting",
+                "urlPathMap": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/urlPathMaps/pathMap1"
+                }
+              }
+            }
+          ],
+          "rewriteRuleSets": [
+            {
+              "name": "rewriteRuleSet1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "rewriteRules": [
+                  {
+                    "name": "Set X-Forwarded-For",
+                    "actionSet": {
+                      "requestHeaderConfigurations": [
+                        {
+                          "headerName": "X-Forwarded-For",
+                          "headerValue": "{var_remote-addr}"
+                        }
+                      ],
+                      "responseHeaderConfigurations": [
+                        {
+                          "headerName": "Strict-Transport-Security",
+                          "headerValue": "max-age=31536000"
+                        }
+                      ],
+                      "urlConfiguration": {
+                        "modifiedPath": "/abc",
+                        "modifiedQueryString": "x=y&a=b",
+                        "reroute": false
+                      }
+                    },
+                    "conditions": [
+                      {
+                        "ignoreCase": true,
+                        "negate": false,
+                        "pattern": "^Bearer",
+                        "variable": "http_req_Authorization"
+                      }
+                    ],
+                    "ruleSequence": 102
+                  }
+                ]
+              }
+            }
+          ],
+          "sku": {
+            "name": "Basic_WAF_v2",
+            "tier": "Basic_WAF_v2"
+          },
+          "reservedCapacity": 3,
+          "firewallPolicy": {
+            "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies/Policy1"
+          },
+          "sslCertificates": [
+            {
+              "name": "sslcert",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/sslCertificates/sslcert",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "publicCertData": "*****"
+              }
+            }
+          ],
+          "sslProfiles": [
+            {
+              "name": "sslProfile1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/sslProfiles/sslProfile1",
+              "properties": {
+                "clientAuthConfiguration": {
+                  "verifyClientAuthMode": "Strict",
+                  "verifyClientCertIssuerDN": true,
+                  "verifyClientRevocation": "OCSP"
+                },
+                "provisioningState": "Succeeded",
+                "sslPolicy": {
+                  "cipherSuites": [
+                    "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256"
+                  ],
+                  "minProtocolVersion": "TLSv1_1",
+                  "policyType": "Custom"
+                },
+                "trustedClientCertificates": [
+                  {
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/trustedClientCertificates/clientcert"
+                  }
+                ]
+              }
+            }
+          ],
+          "trustedClientCertificates": [
+            {
+              "name": "clientcert",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/trustedClientCertificates/clientcert",
+              "properties": {
+                "clientCertIssuerDN": "CN=User1, OU=Eng, O=Company Ltd, L=D4, S=Arizona, C=US",
+                "data": "****",
+                "provisioningState": "Succeeded",
+                "validatedCertData": "****"
+              }
+            }
+          ],
+          "urlPathMaps": [
+            {
+              "name": "pathMap1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/urlPathMaps/pathMap1",
+              "properties": {
+                "defaultBackendAddressPool": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
+                },
+                "defaultBackendHttpSettings": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs"
+                },
+                "defaultLoadDistributionPolicy": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1"
+                },
+                "defaultRewriteRuleSet": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1"
+                },
+                "pathRules": [
+                  {
+                    "name": "apiPaths",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/urlPathMaps/pathMap1/pathRules/apiPaths",
+                    "properties": {
+                      "backendAddressPool": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
+                      },
+                      "backendHttpSettings": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs"
+                      },
+                      "loadDistributionPolicy": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1"
+                      },
+                      "paths": [
+                        "/api",
+                        "/v1/api"
+                      ],
+                      "provisioningState": "Succeeded",
+                      "rewriteRuleSet": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1"
+                      }
+                    }
+                  }
+                ],
+                "provisioningState": "Succeeded"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "ApplicationGateways_Get",
+  "title": "Get Basic_WAF_v2 Application Gateway"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/WafPolicyCreateOrUpdate.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/WafPolicyCreateOrUpdate.json
@@ -4,6 +4,7 @@
     "parameters": {
       "location": "WestUs",
       "properties": {
+        "tier": "Standard",
         "customRules": [
           {
             "name": "Rule1",

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/WafPolicyCreateOrUpdateBasic.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/WafPolicyCreateOrUpdateBasic.json
@@ -1,0 +1,995 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "parameters": {
+      "location": "WestUs",
+      "properties": {
+        "tier": "Basic",
+        "customRules": [
+          {
+            "name": "Rule1",
+            "action": "Block",
+            "matchConditions": [
+              {
+                "matchValues": [
+                  "192.168.1.0/24",
+                  "10.0.0.0/24"
+                ],
+                "matchVariables": [
+                  {
+                    "selector": null,
+                    "variableName": "RemoteAddr"
+                  }
+                ],
+                "operator": "IPMatch"
+              }
+            ],
+            "priority": 1,
+            "ruleType": "MatchRule"
+          },
+          {
+            "name": "Rule2",
+            "action": "Block",
+            "matchConditions": [
+              {
+                "matchValues": [
+                  "192.168.1.0/24"
+                ],
+                "matchVariables": [
+                  {
+                    "selector": null,
+                    "variableName": "RemoteAddr"
+                  }
+                ],
+                "operator": "IPMatch"
+              },
+              {
+                "matchValues": [
+                  "Windows"
+                ],
+                "matchVariables": [
+                  {
+                    "selector": "UserAgent",
+                    "variableName": "RequestHeaders"
+                  }
+                ],
+                "operator": "Contains"
+              }
+            ],
+            "priority": 2,
+            "ruleType": "MatchRule"
+          },
+          {
+            "name": "RateLimitRule3",
+            "action": "Block",
+            "groupByUserSession": [
+              {
+                "groupByVariables": [
+                  {
+                    "variableName": "ClientAddr"
+                  }
+                ]
+              }
+            ],
+            "matchConditions": [
+              {
+                "matchValues": [
+                  "192.168.1.0/24",
+                  "10.0.0.0/24"
+                ],
+                "matchVariables": [
+                  {
+                    "selector": null,
+                    "variableName": "RemoteAddr"
+                  }
+                ],
+                "negationConditon": true,
+                "operator": "IPMatch"
+              }
+            ],
+            "priority": 3,
+            "rateLimitDuration": "OneMin",
+            "rateLimitThreshold": 10,
+            "ruleType": "RateLimitRule"
+          },
+          {
+            "name": "Rule4",
+            "action": "JSChallenge",
+            "matchConditions": [
+              {
+                "matchValues": [
+                  "192.168.1.0/24"
+                ],
+                "matchVariables": [
+                  {
+                    "selector": null,
+                    "variableName": "RemoteAddr"
+                  }
+                ],
+                "operator": "IPMatch"
+              },
+              {
+                "matchValues": [
+                  "Bot"
+                ],
+                "matchVariables": [
+                  {
+                    "selector": "UserAgent",
+                    "variableName": "RequestHeaders"
+                  }
+                ],
+                "operator": "Contains"
+              }
+            ],
+            "priority": 4,
+            "ruleType": "MatchRule"
+          }
+        ],
+        "managedRules": {
+          "exclusions": [
+            {
+              "exclusionManagedRuleSets": [
+                {
+                  "ruleGroups": [
+                    {
+                      "ruleGroupName": "REQUEST-930-APPLICATION-ATTACK-LFI",
+                      "rules": [
+                        {
+                          "ruleId": "930120"
+                        }
+                      ]
+                    },
+                    {
+                      "ruleGroupName": "REQUEST-932-APPLICATION-ATTACK-RCE"
+                    }
+                  ],
+                  "ruleSetType": "OWASP",
+                  "ruleSetVersion": "3.2"
+                }
+              ],
+              "matchVariable": "RequestArgNames",
+              "selector": "hello",
+              "selectorMatchOperator": "StartsWith"
+            },
+            {
+              "exclusionManagedRuleSets": [
+                {
+                  "ruleGroups": [],
+                  "ruleSetType": "OWASP",
+                  "ruleSetVersion": "3.1"
+                }
+              ],
+              "matchVariable": "RequestArgNames",
+              "selector": "hello",
+              "selectorMatchOperator": "EndsWith"
+            },
+            {
+              "matchVariable": "RequestArgNames",
+              "selector": "test",
+              "selectorMatchOperator": "StartsWith"
+            },
+            {
+              "matchVariable": "RequestArgValues",
+              "selector": "test",
+              "selectorMatchOperator": "StartsWith"
+            }
+          ],
+          "managedRuleSets": [
+            {
+              "ruleGroupOverrides": [
+                {
+                  "ruleGroupName": "REQUEST-931-APPLICATION-ATTACK-RFI",
+                  "rules": [
+                    {
+                      "action": "Log",
+                      "ruleId": "931120",
+                      "state": "Enabled"
+                    },
+                    {
+                      "action": "AnomalyScoring",
+                      "ruleId": "931130",
+                      "state": "Disabled"
+                    }
+                  ]
+                }
+              ],
+              "ruleSetType": "OWASP",
+              "ruleSetVersion": "3.2"
+            },
+            {
+              "ruleGroupOverrides": [
+                {
+                  "ruleGroupName": "UnknownBots",
+                  "rules": [
+                    {
+                      "action": "JSChallenge",
+                      "ruleId": "300700",
+                      "state": "Enabled"
+                    }
+                  ]
+                }
+              ],
+              "ruleSetType": "Microsoft_BotManagerRuleSet",
+              "ruleSetVersion": "1.0"
+            },
+            {
+              "ruleGroupOverrides": [
+                {
+                  "ruleGroupName": "ExcessiveRequests",
+                  "rules": [
+                    {
+                      "action": "Block",
+                      "ruleId": "500100",
+                      "sensitivity": "High",
+                      "state": "Enabled"
+                    }
+                  ]
+                }
+              ],
+              "ruleSetType": "Microsoft_HTTPDDoSRuleSet",
+              "ruleSetVersion": "1.0"
+            }
+          ],
+          "exceptions": [
+            {
+              "exceptionManagedRuleSets": [
+                {
+                  "ruleSetType": "OWASP",
+                  "ruleSetVersion": "3.2"
+                }
+              ],
+              "matchVariable": "RequestURI",
+              "valueMatchOperator": "Contains",
+              "values": [
+                "health",
+                "account/images",
+                "default.aspx"
+              ]
+            },
+            {
+              "exceptionManagedRuleSets": [
+                {
+                  "ruleGroups": [
+                    {
+                      "ruleGroupName": "REQUEST-932-APPLICATION-ATTACK-RCE"
+                    }
+                  ],
+                  "ruleSetType": "OWASP",
+                  "ruleSetVersion": "3.2"
+                }
+              ],
+              "matchVariable": "RequestHeader",
+              "selector": "User-Agent",
+              "selectorMatchOperator": "StartsWith",
+              "valueMatchOperator": "Contains",
+              "values": [
+                "Mozilla/5.0",
+                "Chrome/122.0.0.0"
+              ]
+            },
+            {
+              "exceptionManagedRuleSets": [
+                {
+                  "ruleGroups": [
+                    {
+                      "ruleGroupName": "BadBots",
+                      "rules": [
+                        {
+                          "ruleId": "100100"
+                        }
+                      ]
+                    }
+                  ],
+                  "ruleSetType": "Microsoft_BotManagerRuleSet",
+                  "ruleSetVersion": "1.0"
+                }
+              ],
+              "matchVariable": "RemoteAddr",
+              "valueMatchOperator": "IPMatch",
+              "values": [
+                "1.2.3.4",
+                "10.0.0.1/6"
+              ]
+            }
+          ]
+        },
+        "policySettings": {
+          "jsChallengeCookieExpirationInMins": 100,
+          "logScrubbing": {
+            "scrubbingRules": [
+              {
+                "matchVariable": "RequestArgNames",
+                "selector": "test",
+                "selectorMatchOperator": "Equals",
+                "state": "Enabled"
+              },
+              {
+                "matchVariable": "RequestIPAddress",
+                "selectorMatchOperator": "EqualsAny",
+                "state": "Enabled"
+              }
+            ],
+            "state": "Enabled"
+          }
+        }
+      }
+    },
+    "policyName": "Policy1",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "Policy1",
+        "type": "Microsoft.Network/applicationgatewaywebapplicationfirewallpolicies",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies/Policy1",
+        "location": "WestUs",
+        "properties": {
+          "customRules": [
+            {
+              "name": "Rule1",
+              "action": "Block",
+              "matchConditions": [
+                {
+                  "matchValues": [
+                    "192.168.1.0/24",
+                    "10.0.0.0/24"
+                  ],
+                  "matchVariables": [
+                    {
+                      "selector": null,
+                      "variableName": "RemoteAddr"
+                    }
+                  ],
+                  "negationConditon": false,
+                  "operator": "IPMatch",
+                  "transforms": []
+                }
+              ],
+              "priority": 1,
+              "ruleType": "MatchRule",
+              "state": "Enabled"
+            },
+            {
+              "name": "Rule2",
+              "action": "Block",
+              "matchConditions": [
+                {
+                  "matchValues": [
+                    "192.168.1.0/24"
+                  ],
+                  "matchVariables": [
+                    {
+                      "selector": null,
+                      "variableName": "RemoteAddr"
+                    }
+                  ],
+                  "negationConditon": false,
+                  "operator": "IPMatch"
+                },
+                {
+                  "matchValues": [
+                    "Windows"
+                  ],
+                  "matchVariables": [
+                    {
+                      "selector": "UserAgent",
+                      "variableName": "RequestHeader"
+                    }
+                  ],
+                  "negationConditon": false,
+                  "operator": "Contains"
+                }
+              ],
+              "priority": 2,
+              "ruleType": "MatchRule",
+              "state": "Enabled"
+            },
+            {
+              "name": "RateLimitRule3",
+              "action": "Block",
+              "groupByUserSession": [
+                {
+                  "groupByVariables": [
+                    {
+                      "variableName": "ClientAddr"
+                    }
+                  ]
+                }
+              ],
+              "matchConditions": [
+                {
+                  "matchValues": [
+                    "192.168.1.0/24",
+                    "10.0.0.0/24"
+                  ],
+                  "matchVariables": [
+                    {
+                      "selector": null,
+                      "variableName": "RemoteAddr"
+                    }
+                  ],
+                  "negationConditon": true,
+                  "operator": "IPMatch"
+                }
+              ],
+              "priority": 3,
+              "rateLimitDuration": "OneMin",
+              "rateLimitThreshold": 10,
+              "ruleType": "RateLimitRule"
+            },
+            {
+              "name": "Rule4",
+              "action": "JSChallenge",
+              "matchConditions": [
+                {
+                  "matchValues": [
+                    "192.168.1.0/24"
+                  ],
+                  "matchVariables": [
+                    {
+                      "selector": null,
+                      "variableName": "RemoteAddr"
+                    }
+                  ],
+                  "negationConditon": false,
+                  "operator": "IPMatch"
+                },
+                {
+                  "matchValues": [
+                    "Bot"
+                  ],
+                  "matchVariables": [
+                    {
+                      "selector": "UserAgent",
+                      "variableName": "RequestHeaders"
+                    }
+                  ],
+                  "negationConditon": false,
+                  "operator": "Contains"
+                }
+              ],
+              "priority": 4,
+              "ruleType": "MatchRule",
+              "state": "Enabled"
+            }
+          ],
+          "managedRules": {
+            "exclusions": [
+              {
+                "exclusionManagedRuleSets": [
+                  {
+                    "ruleGroups": [
+                      {
+                        "ruleGroupName": "REQUEST-930-APPLICATION-ATTACK-LFI",
+                        "rules": [
+                          {
+                            "ruleId": "930120"
+                          }
+                        ]
+                      },
+                      {
+                        "ruleGroupName": "REQUEST-932-APPLICATION-ATTACK-RCE"
+                      }
+                    ],
+                    "ruleSetType": "OWASP",
+                    "ruleSetVersion": "3.2"
+                  }
+                ],
+                "matchVariable": "RequestArgNames",
+                "selector": "hello",
+                "selectorMatchOperator": "StartsWith"
+              },
+              {
+                "exclusionManagedRuleSets": [
+                  {
+                    "ruleGroups": [],
+                    "ruleSetType": "OWASP",
+                    "ruleSetVersion": "3.1"
+                  }
+                ],
+                "matchVariable": "RequestArgNames",
+                "selector": "hello",
+                "selectorMatchOperator": "EndsWith"
+              },
+              {
+                "matchVariable": "RequestArgNames",
+                "selector": "test",
+                "selectorMatchOperator": "StartsWith"
+              },
+              {
+                "matchVariable": "RequestArgValues",
+                "selector": "test",
+                "selectorMatchOperator": "StartsWith"
+              }
+            ],
+            "managedRuleSets": [
+              {
+                "ruleGroupOverrides": [
+                  {
+                    "ruleGroupName": "REQUEST-931-APPLICATION-ATTACK-RFI",
+                    "rules": [
+                      {
+                        "action": "Log",
+                        "ruleId": "931120",
+                        "state": "Enabled"
+                      },
+                      {
+                        "action": "AnomalyScoring",
+                        "ruleId": "931130",
+                        "state": "Disabled"
+                      }
+                    ]
+                  }
+                ],
+                "ruleSetType": "OWASP",
+                "ruleSetVersion": "3.2"
+              },
+              {
+                "ruleGroupOverrides": [
+                  {
+                    "ruleGroupName": "UnknownBots",
+                    "rules": [
+                      {
+                        "action": "JSChallenge",
+                        "ruleId": "300700",
+                        "state": "Enabled"
+                      }
+                    ]
+                  }
+                ],
+                "ruleSetType": "Microsoft_BotManagerRuleSet",
+                "ruleSetVersion": "1.0"
+              },
+              {
+                "ruleGroupOverrides": [
+                  {
+                    "ruleGroupName": "ExcessiveRequests",
+                    "rules": [
+                      {
+                        "action": "Block",
+                        "ruleId": "500100",
+                        "sensitivity": "High",
+                        "state": "Enabled"
+                      }
+                    ]
+                  }
+                ],
+                "ruleSetType": "Microsoft_HTTPDDoSRuleSet",
+                "ruleSetVersion": "1.0"
+              }
+            ],
+            "exceptions": [
+              {
+                "exceptionManagedRuleSets": [
+                  {
+                    "ruleSetType": "OWASP",
+                    "ruleSetVersion": "3.2"
+                  }
+                ],
+                "matchVariable": "RequestURI",
+                "valueMatchOperator": "Contains",
+                "values": [
+                  "health",
+                  "account/images",
+                  "default.aspx"
+                ]
+              },
+              {
+                "exceptionManagedRuleSets": [
+                  {
+                    "ruleGroups": [
+                      {
+                        "ruleGroupName": "REQUEST-932-APPLICATION-ATTACK-RCE"
+                      }
+                    ],
+                    "ruleSetType": "OWASP",
+                    "ruleSetVersion": "3.2"
+                  }
+                ],
+                "matchVariable": "RequestHeader",
+                "selector": "User-Agent",
+                "selectorMatchOperator": "StartsWith",
+                "valueMatchOperator": "Contains",
+                "values": [
+                  "Mozilla/5.0",
+                  "Chrome/122.0.0.0"
+                ]
+              },
+              {
+                "exceptionManagedRuleSets": [
+                  {
+                    "ruleGroups": [
+                      {
+                        "ruleGroupName": "BadBots",
+                        "rules": [
+                          {
+                            "ruleId": "100100"
+                          }
+                        ]
+                      }
+                    ],
+                    "ruleSetType": "Microsoft_BotManagerRuleSet",
+                    "ruleSetVersion": "1.0"
+                  }
+                ],
+                "matchVariable": "RemoteAddr",
+                "valueMatchOperator": "IPMatch",
+                "values": [
+                  "1.2.3.4",
+                  "10.0.0.1/6"
+                ]
+              }
+            ]
+          },
+          "policySettings": {
+            "customBlockResponseBody": "SGVsbG8=",
+            "customBlockResponseStatusCode": 405,
+            "fileUploadEnforcement": true,
+            "fileUploadLimitInMb": 4000,
+            "jsChallengeCookieExpirationInMins": 100,
+            "logScrubbing": {
+              "scrubbingRules": [
+                {
+                  "matchVariable": "RequestArgNames",
+                  "selector": "test",
+                  "selectorMatchOperator": "Equals",
+                  "state": "Enabled"
+                },
+                {
+                  "matchVariable": "RequestIPAddress",
+                  "selectorMatchOperator": "EqualsAny",
+                  "state": "Enabled"
+                }
+              ],
+              "state": "Enabled"
+            },
+            "maxRequestBodySizeInKb": 2000,
+            "mode": "Detection",
+            "requestBodyCheck": true,
+            "requestBodyEnforcement": true,
+            "requestBodyInspectLimitInKB": 2000,
+            "state": "Enabled"
+          },
+          "provisioningState": "Succeeded",
+          "resourceState": "Enabled",
+          "tier": "Basic"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "Policy1",
+        "type": "Microsoft.Network/applicationgatewaywebapplicationfirewallpolicies",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies/Policy1",
+        "location": "WestUs",
+        "properties": {
+          "customRules": [
+            {
+              "name": "Rule1",
+              "action": "Block",
+              "matchConditions": [
+                {
+                  "matchValues": [
+                    "192.168.1.0/24",
+                    "10.0.0.0/24"
+                  ],
+                  "matchVariables": [
+                    {
+                      "selector": null,
+                      "variableName": "RemoteAddr"
+                    }
+                  ],
+                  "negationConditon": false,
+                  "operator": "IPMatch",
+                  "transforms": []
+                }
+              ],
+              "priority": 1,
+              "ruleType": "MatchRule",
+              "state": "Enabled"
+            },
+            {
+              "name": "Rule2",
+              "action": "Block",
+              "matchConditions": [
+                {
+                  "matchValues": [
+                    "192.168.1.0/24"
+                  ],
+                  "matchVariables": [
+                    {
+                      "selector": null,
+                      "variableName": "RemoteAddr"
+                    }
+                  ],
+                  "negationConditon": false,
+                  "operator": "IPMatch"
+                },
+                {
+                  "matchValues": [
+                    "Windows"
+                  ],
+                  "matchVariables": [
+                    {
+                      "selector": "UserAgent",
+                      "variableName": "RequestHeader"
+                    }
+                  ],
+                  "negationConditon": false,
+                  "operator": "Contains"
+                }
+              ],
+              "priority": 2,
+              "ruleType": "MatchRule",
+              "state": "Enabled"
+            },
+            {
+              "name": "RateLimitRule3",
+              "action": "Block",
+              "groupByUserSession": [
+                {
+                  "groupByVariables": [
+                    {
+                      "variableName": "ClientAddr"
+                    }
+                  ]
+                }
+              ],
+              "matchConditions": [
+                {
+                  "matchValues": [
+                    "192.168.1.0/24",
+                    "10.0.0.0/24"
+                  ],
+                  "matchVariables": [
+                    {
+                      "selector": null,
+                      "variableName": "RemoteAddr"
+                    }
+                  ],
+                  "negationConditon": true,
+                  "operator": "IPMatch"
+                }
+              ],
+              "priority": 3,
+              "rateLimitDuration": "OneMin",
+              "rateLimitThreshold": 10,
+              "ruleType": "RateLimitRule"
+            },
+            {
+              "name": "Rule4",
+              "action": "JSChallenge",
+              "matchConditions": [
+                {
+                  "matchValues": [
+                    "192.168.1.0/24"
+                  ],
+                  "matchVariables": [
+                    {
+                      "selector": null,
+                      "variableName": "RemoteAddr"
+                    }
+                  ],
+                  "negationConditon": false,
+                  "operator": "IPMatch"
+                },
+                {
+                  "matchValues": [
+                    "Bot"
+                  ],
+                  "matchVariables": [
+                    {
+                      "selector": "UserAgent",
+                      "variableName": "RequestHeaders"
+                    }
+                  ],
+                  "negationConditon": false,
+                  "operator": "Contains"
+                }
+              ],
+              "priority": 4,
+              "ruleType": "MatchRule",
+              "state": "Enabled"
+            }
+          ],
+          "managedRules": {
+            "exclusions": [
+              {
+                "exclusionManagedRuleSets": [
+                  {
+                    "ruleGroups": [
+                      {
+                        "ruleGroupName": "REQUEST-930-APPLICATION-ATTACK-LFI",
+                        "rules": [
+                          {
+                            "ruleId": "930120"
+                          }
+                        ]
+                      },
+                      {
+                        "ruleGroupName": "REQUEST-932-APPLICATION-ATTACK-RCE"
+                      }
+                    ],
+                    "ruleSetType": "OWASP",
+                    "ruleSetVersion": "3.2"
+                  }
+                ],
+                "matchVariable": "RequestArgNames",
+                "selector": "hello",
+                "selectorMatchOperator": "StartsWith"
+              },
+              {
+                "exclusionManagedRuleSets": [
+                  {
+                    "ruleGroups": [],
+                    "ruleSetType": "OWASP",
+                    "ruleSetVersion": "3.1"
+                  }
+                ],
+                "matchVariable": "RequestArgNames",
+                "selector": "hello",
+                "selectorMatchOperator": "EndsWith"
+              },
+              {
+                "matchVariable": "RequestArgNames",
+                "selector": "test",
+                "selectorMatchOperator": "StartsWith"
+              },
+              {
+                "matchVariable": "RequestArgValues",
+                "selector": "test",
+                "selectorMatchOperator": "StartsWith"
+              }
+            ],
+            "managedRuleSets": [
+              {
+                "ruleGroupOverrides": [
+                  {
+                    "ruleGroupName": "REQUEST-931-APPLICATION-ATTACK-RFI",
+                    "rules": [
+                      {
+                        "action": "Log",
+                        "ruleId": "931120",
+                        "state": "Enabled"
+                      },
+                      {
+                        "action": "AnomalyScoring",
+                        "ruleId": "931130",
+                        "state": "Disabled"
+                      }
+                    ]
+                  }
+                ],
+                "ruleSetType": "OWASP",
+                "ruleSetVersion": "3.2"
+              },
+              {
+                "ruleGroupOverrides": [
+                  {
+                    "ruleGroupName": "UnknownBots",
+                    "rules": [
+                      {
+                        "action": "JSChallenge",
+                        "ruleId": "300700",
+                        "state": "Enabled"
+                      }
+                    ]
+                  }
+                ],
+                "ruleSetType": "Microsoft_BotManagerRuleSet",
+                "ruleSetVersion": "1.0"
+              },
+              {
+                "ruleGroupOverrides": [
+                  {
+                    "ruleGroupName": "ExcessiveRequests",
+                    "rules": [
+                      {
+                        "action": "Block",
+                        "ruleId": "500100",
+                        "sensitivity": "High",
+                        "state": "Enabled"
+                      }
+                    ]
+                  }
+                ],
+                "ruleSetType": "Microsoft_HTTPDDoSRuleSet",
+                "ruleSetVersion": "1.0"
+              }
+            ],
+            "exceptions": [
+              {
+                "exceptionManagedRuleSets": [
+                  {
+                    "ruleSetType": "OWASP",
+                    "ruleSetVersion": "3.2"
+                  }
+                ],
+                "matchVariable": "RequestURI",
+                "valueMatchOperator": "Contains",
+                "values": [
+                  "health",
+                  "account/images",
+                  "default.aspx"
+                ]
+              },
+              {
+                "exceptionManagedRuleSets": [
+                  {
+                    "ruleGroups": [
+                      {
+                        "ruleGroupName": "REQUEST-932-APPLICATION-ATTACK-RCE"
+                      }
+                    ],
+                    "ruleSetType": "OWASP",
+                    "ruleSetVersion": "3.2"
+                  }
+                ],
+                "matchVariable": "RequestHeader",
+                "selector": "User-Agent",
+                "selectorMatchOperator": "StartsWith",
+                "valueMatchOperator": "Contains",
+                "values": [
+                  "Mozilla/5.0",
+                  "Chrome/122.0.0.0"
+                ]
+              },
+              {
+                "exceptionManagedRuleSets": [
+                  {
+                    "ruleGroups": [
+                      {
+                        "ruleGroupName": "BadBots",
+                        "rules": [
+                          {
+                            "ruleId": "100100"
+                          }
+                        ]
+                      }
+                    ],
+                    "ruleSetType": "Microsoft_BotManagerRuleSet",
+                    "ruleSetVersion": "1.0"
+                  }
+                ],
+                "matchVariable": "RemoteAddr",
+                "valueMatchOperator": "IPMatch",
+                "values": [
+                  "1.2.3.4",
+                  "10.0.0.1/6"
+                ]
+              }
+            ]
+          },
+          "policySettings": {
+            "customBlockResponseBody": "SGVsbG8=",
+            "customBlockResponseStatusCode": 405,
+            "fileUploadEnforcement": true,
+            "fileUploadLimitInMb": 4000,
+            "jsChallengeCookieExpirationInMins": 100,
+            "maxRequestBodySizeInKb": 2000,
+            "mode": "Detection",
+            "requestBodyCheck": true,
+            "requestBodyEnforcement": true,
+            "requestBodyInspectLimitInKB": 2000,
+            "state": "Enabled"
+          },
+          "provisioningState": "Succeeded",
+          "resourceState": "Enabled",
+          "tier": "Basic"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "WebApplicationFirewallPolicies_CreateOrUpdate",
+  "title": "Creates or updates a Basic tier WAF policy within a resource group"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/WafPolicyGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/WafPolicyGet.json
@@ -397,7 +397,8 @@
             "state": "Enabled"
           },
           "provisioningState": "Succeeded",
-          "resourceState": "Enabled"
+          "resourceState": "Enabled",
+          "tier": "Standard"
         },
         "tags": {
           "key1": "value1",

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/WafPolicyGetBasic.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/WafPolicyGetBasic.json
@@ -1,0 +1,412 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "policyName": "Policy1",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "Policy1",
+        "type": "Microsoft.Network/applicationgatewaywebapplicationfirewallpolicies",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies/Policy1",
+        "location": "WestUs",
+        "properties": {
+          "applicationGatewayForContainers": [
+            {
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ServiceNetworking/trafficControllers/agc1"
+            }
+          ],
+          "customRules": [
+            {
+              "name": "Rule1",
+              "action": "Block",
+              "matchConditions": [
+                {
+                  "matchValues": [
+                    "192.168.1.0/24",
+                    "10.0.0.0/24"
+                  ],
+                  "matchVariables": [
+                    {
+                      "selector": null,
+                      "variableName": "RemoteAddr"
+                    }
+                  ],
+                  "negationConditon": false,
+                  "operator": "IPMatch",
+                  "transforms": []
+                }
+              ],
+              "priority": 1,
+              "ruleType": "MatchRule",
+              "state": "Enabled"
+            },
+            {
+              "name": "Rule2",
+              "action": "Block",
+              "matchConditions": [
+                {
+                  "matchValues": [
+                    "192.168.1.0/24"
+                  ],
+                  "matchVariables": [
+                    {
+                      "selector": null,
+                      "variableName": "RemoteAddr"
+                    }
+                  ],
+                  "negationConditon": false,
+                  "operator": "IPMatch"
+                },
+                {
+                  "matchValues": [
+                    "Windows"
+                  ],
+                  "matchVariables": [
+                    {
+                      "selector": "UserAgent",
+                      "variableName": "RequestHeader"
+                    }
+                  ],
+                  "negationConditon": false,
+                  "operator": "Contains"
+                }
+              ],
+              "priority": 2,
+              "ruleType": "MatchRule",
+              "state": "Enabled"
+            },
+            {
+              "name": "RateLimitRule3",
+              "action": "Block",
+              "groupByUserSession": [
+                {
+                  "groupByVariables": [
+                    {
+                      "variableName": "ClientAddr"
+                    }
+                  ]
+                }
+              ],
+              "matchConditions": [
+                {
+                  "matchValues": [
+                    "192.168.1.0/24",
+                    "10.0.0.0/24"
+                  ],
+                  "matchVariables": [
+                    {
+                      "selector": null,
+                      "variableName": "RemoteAddr"
+                    }
+                  ],
+                  "negationConditon": true,
+                  "operator": "IPMatch"
+                }
+              ],
+              "priority": 3,
+              "rateLimitDuration": "OneMin",
+              "rateLimitThreshold": 10,
+              "ruleType": "RateLimitRule"
+            },
+            {
+              "name": "Rule4",
+              "action": "JSChallenge",
+              "matchConditions": [
+                {
+                  "matchValues": [
+                    "192.168.1.0/24"
+                  ],
+                  "matchVariables": [
+                    {
+                      "selector": null,
+                      "variableName": "RemoteAddr"
+                    }
+                  ],
+                  "negationConditon": false,
+                  "operator": "IPMatch"
+                },
+                {
+                  "matchValues": [
+                    "Bot"
+                  ],
+                  "matchVariables": [
+                    {
+                      "selector": "UserAgent",
+                      "variableName": "RequestHeaders"
+                    }
+                  ],
+                  "negationConditon": false,
+                  "operator": "Contains"
+                }
+              ],
+              "priority": 4,
+              "ruleType": "MatchRule",
+              "state": "Enabled"
+            }
+          ],
+          "managedRules": {
+            "exclusions": [
+              {
+                "matchVariable": "RequestHeaderNames",
+                "selector": "testHeader1",
+                "selectorMatchOperator": "Equals"
+              },
+              {
+                "matchVariable": "RequestHeaderNames",
+                "selector": "testHeader2",
+                "selectorMatchOperator": "StartsWith"
+              },
+              {
+                "matchVariable": "RequestArgValues",
+                "selector": "hello",
+                "selectorMatchOperator": "StartsWith"
+              },
+              {
+                "exclusionManagedRuleSets": [
+                  {
+                    "ruleGroups": [
+                      {
+                        "ruleGroupName": "REQUEST-930-APPLICATION-ATTACK-LFI",
+                        "rules": [
+                          {
+                            "ruleId": "930120"
+                          }
+                        ]
+                      },
+                      {
+                        "ruleGroupName": "REQUEST-932-APPLICATION-ATTACK-RCE"
+                      }
+                    ],
+                    "ruleSetType": "OWASP",
+                    "ruleSetVersion": "3.2"
+                  }
+                ],
+                "matchVariable": "RequestArgNames",
+                "selector": "hello",
+                "selectorMatchOperator": "StartsWith"
+              },
+              {
+                "exclusionManagedRuleSets": [
+                  {
+                    "ruleGroups": [],
+                    "ruleSetType": "OWASP",
+                    "ruleSetVersion": "3.1"
+                  }
+                ],
+                "matchVariable": "RequestArgNames",
+                "selector": "hello",
+                "selectorMatchOperator": "EndsWith"
+              }
+            ],
+            "managedRuleSets": [
+              {
+                "computedDisabledRules": [
+                  {
+                    "ruleGroupName": "REQUEST-942-APPLICATION-ATTACK-SQLI",
+                    "rules": [
+                      942130,
+                      942110
+                    ]
+                  },
+                  {
+                    "ruleGroupName": "REQUEST-920-PROTOCOL-ENFORCEMENT",
+                    "rules": [
+                      920100,
+                      920120
+                    ]
+                  },
+                  {
+                    "ruleGroupName": "General",
+                    "rules": [
+                      200003
+                    ]
+                  }
+                ],
+                "ruleGroupOverrides": [
+                  {
+                    "ruleGroupName": "REQUEST-942-APPLICATION-ATTACK-SQLI",
+                    "rules": [
+                      {
+                        "action": "AnomalyScoring",
+                        "ruleId": "942130",
+                        "state": "Disabled"
+                      },
+                      {
+                        "action": "AnomalyScoring",
+                        "ruleId": "942110",
+                        "state": "Disabled"
+                      },
+                      {
+                        "action": "Log",
+                        "ruleId": "942140",
+                        "state": "Enabled"
+                      }
+                    ]
+                  },
+                  {
+                    "ruleGroupName": "REQUEST-920-PROTOCOL-ENFORCEMENT",
+                    "rules": [
+                      {
+                        "action": "AnomalyScoring",
+                        "ruleId": "920100",
+                        "state": "Disabled"
+                      },
+                      {
+                        "action": "AnomalyScoring",
+                        "ruleId": "920120",
+                        "state": "Disabled"
+                      },
+                      {
+                        "action": "Block",
+                        "ruleId": "920130",
+                        "state": "Enabled"
+                      }
+                    ]
+                  }
+                ],
+                "ruleSetType": "OWASP",
+                "ruleSetVersion": "3.2"
+              },
+              {
+                "ruleGroupOverrides": [
+                  {
+                    "ruleGroupName": "UnknownBots",
+                    "rules": [
+                      {
+                        "action": "JSChallenge",
+                        "ruleId": "300700",
+                        "state": "Enabled"
+                      }
+                    ]
+                  }
+                ],
+                "ruleSetType": "Microsoft_BotManagerRuleSet",
+                "ruleSetVersion": "1.0"
+              },
+              {
+                "ruleGroupOverrides": [
+                  {
+                    "ruleGroupName": "ExcessiveRequests",
+                    "rules": [
+                      {
+                        "action": "Block",
+                        "ruleId": "500100",
+                        "sensitivity": "High",
+                        "state": "Enabled"
+                      }
+                    ]
+                  }
+                ],
+                "ruleSetType": "Microsoft_HTTPDDoSRuleSet",
+                "ruleSetVersion": "1.0"
+              }
+            ],
+            "exceptions": [
+              {
+                "exceptionManagedRuleSets": [
+                  {
+                    "ruleSetType": "OWASP",
+                    "ruleSetVersion": "3.2"
+                  }
+                ],
+                "matchVariable": "RequestURI",
+                "valueMatchOperator": "Contains",
+                "values": [
+                  "health",
+                  "account/images",
+                  "default.aspx"
+                ]
+              },
+              {
+                "exceptionManagedRuleSets": [
+                  {
+                    "ruleGroups": [
+                      {
+                        "ruleGroupName": "REQUEST-932-APPLICATION-ATTACK-RCE"
+                      }
+                    ],
+                    "ruleSetType": "OWASP",
+                    "ruleSetVersion": "3.2"
+                  }
+                ],
+                "matchVariable": "RequestHeader",
+                "selector": "User-Agent",
+                "selectorMatchOperator": "StartsWith",
+                "valueMatchOperator": "Contains",
+                "values": [
+                  "Mozilla/5.0",
+                  "Chrome/122.0.0.0"
+                ]
+              },
+              {
+                "exceptionManagedRuleSets": [
+                  {
+                    "ruleGroups": [
+                      {
+                        "ruleGroupName": "BadBots",
+                        "rules": [
+                          {
+                            "ruleId": "100100"
+                          }
+                        ]
+                      }
+                    ],
+                    "ruleSetType": "Microsoft_BotManagerRuleSet",
+                    "ruleSetVersion": "1.0"
+                  }
+                ],
+                "matchVariable": "RemoteAddr",
+                "valueMatchOperator": "IPMatch",
+                "values": [
+                  "1.2.3.4",
+                  "10.0.0.1/6"
+                ]
+              }
+            ]
+          },
+          "policySettings": {
+            "customBlockResponseBody": "SGVsbG8=",
+            "customBlockResponseStatusCode": 405,
+            "fileUploadEnforcement": true,
+            "fileUploadLimitInMb": 4000,
+            "jsChallengeCookieExpirationInMins": 100,
+            "logScrubbing": {
+              "scrubbingRules": [
+                {
+                  "matchVariable": "RequestArgNames",
+                  "selector": "test",
+                  "selectorMatchOperator": "Equals",
+                  "state": "Enabled"
+                },
+                {
+                  "matchVariable": "RequestIPAddress",
+                  "selectorMatchOperator": "EqualsAny",
+                  "state": "Enabled"
+                }
+              ],
+              "state": "Enabled"
+            },
+            "maxRequestBodySizeInKb": 2000,
+            "mode": "Prevention",
+            "requestBodyCheck": true,
+            "requestBodyEnforcement": true,
+            "requestBodyInspectLimitInKB": 2000,
+            "state": "Enabled"
+          },
+          "provisioningState": "Succeeded",
+          "resourceState": "Enabled",
+          "tier": "Basic"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "WebApplicationFirewallPolicies_Get",
+  "title": "Gets a Basic tier WAF policy within a resource group"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/models.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/models.tsp
@@ -62,6 +62,18 @@ union ApplicationGatewaySkuName {
    * Basic
    */
   Basic: "Basic",
+
+  /**
+   * Basic tier Application Gateway.
+   */
+  @added(Versions.v2026_01_01)
+  Basic_v2: "Basic_v2",
+
+  /**
+   * Basic tier Application Gateway with WAF enabled.
+   */
+  @added(Versions.v2026_01_01)
+  Basic_WAF_v2: "Basic_WAF_v2",
 }
 
 /**
@@ -6425,6 +6437,12 @@ model ApplicationGatewayPropertiesFormat {
    * Autoscale Configuration.
    */
   autoscaleConfiguration?: ApplicationGatewayAutoscaleConfiguration;
+
+  /**
+   * The reserved capacity of the application gateway resource. Applicable to the Basic_v2 and Basic_WAF_v2 SKU tiers.
+   */
+  @added(Versions.v2026_01_01)
+  reservedCapacity?: int32;
 
   /**
    * PrivateLink configurations on application gateway.
@@ -25618,6 +25636,26 @@ model ConnectionPolicyProperties {
 model ListConnectionPoliciesResult is Azure.Core.Page<ConnectionPolicy>;
 
 /**
+ * Tier of a web application firewall policy.
+ */
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+@Azure.ResourceManager.Legacy.feature(Features.applicationGateway)
+@added(Versions.v2026_01_01)
+union WebApplicationFirewallPolicyTier {
+  string,
+
+  /**
+   * Basic tier web application firewall policy.
+   */
+  Basic: "Basic",
+
+  /**
+   * Standard tier web application firewall policy.
+   */
+  Standard: "Standard",
+}
+
+/**
  * Defines web application firewall policy properties.
  */
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
@@ -25674,6 +25712,12 @@ model WebApplicationFirewallPolicyPropertiesFormat {
    */
   @visibility(Lifecycle.Read)
   applicationGatewayForContainers?: ApplicationGatewayForContainersReferenceDefinition[];
+
+  /**
+   * Tier of a web application firewall policy.
+   */
+  @added(Versions.v2026_01_01)
+  tier?: WebApplicationFirewallPolicyTier;
 }
 
 /**

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/models.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/models.tsp
@@ -108,6 +108,18 @@ union ApplicationGatewayTier {
    * Basic
    */
   Basic: "Basic",
+
+  /**
+   * Basic tier Application Gateway.
+   */
+  @added(Versions.v2026_01_01)
+  Basic_v2: "Basic_v2",
+
+  /**
+   * Basic tier Application Gateway with WAF enabled.
+   */
+  @added(Versions.v2026_01_01)
+  Basic_WAF_v2: "Basic_WAF_v2",
 }
 
 /**
@@ -25645,14 +25657,14 @@ union WebApplicationFirewallPolicyTier {
   string,
 
   /**
-   * Basic tier web application firewall policy.
-   */
-  Basic: "Basic",
-
-  /**
    * Standard tier web application firewall policy.
    */
   Standard: "Standard",
+
+  /**
+   * Basic tier web application firewall policy.
+   */
+  Basic: "Basic",
 }
 
 /**

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/applicationGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/applicationGateway.json
@@ -3540,6 +3540,11 @@
           "$ref": "#/definitions/ApplicationGatewayAutoscaleConfiguration",
           "description": "Autoscale Configuration."
         },
+        "reservedCapacity": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The reserved capacity of the application gateway resource. Applicable to the Basic_v2 and Basic_WAF_v2 SKU tiers."
+        },
         "privateLinkConfigurations": {
           "type": "array",
           "description": "PrivateLink configurations on application gateway.",
@@ -5107,6 +5112,10 @@
             "$ref": "#/definitions/ApplicationGatewayForContainersReferenceDefinition"
           },
           "readOnly": true
+        },
+        "tier": {
+          "$ref": "./common.json#/definitions/WebApplicationFirewallPolicyTier",
+          "description": "Tier of a web application firewall policy."
         }
       },
       "required": [

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/applicationGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/applicationGateway.json
@@ -568,6 +568,9 @@
           }
         },
         "x-ms-examples": {
+          "Gets a Basic tier WAF policy within a resource group": {
+            "$ref": "./examples/WafPolicyGetBasic.json"
+          },
           "Gets a WAF policy within a resource group": {
             "$ref": "./examples/WafPolicyGet.json"
           }
@@ -628,6 +631,9 @@
           }
         },
         "x-ms-examples": {
+          "Creates or updates a Basic tier WAF policy within a resource group": {
+            "$ref": "./examples/WafPolicyCreateOrUpdateBasic.json"
+          },
           "Creates or updates a WAF policy within a resource group": {
             "$ref": "./examples/WafPolicyCreateOrUpdate.json"
           }
@@ -781,6 +787,12 @@
         "x-ms-examples": {
           "Get ApplicationGateway": {
             "$ref": "./examples/ApplicationGatewayGet.json"
+          },
+          "Get Basic_WAF_v2 Application Gateway": {
+            "$ref": "./examples/ApplicationGatewayGetBasicWafV2.json"
+          },
+          "Get Basic_v2 Application Gateway": {
+            "$ref": "./examples/ApplicationGatewayGetBasicV2.json"
           }
         }
       },
@@ -851,6 +863,12 @@
         "x-ms-examples": {
           "Create Application Gateway": {
             "$ref": "./examples/ApplicationGatewayCreate.json"
+          },
+          "Create Basic_WAF_v2 Application Gateway": {
+            "$ref": "./examples/ApplicationGatewayCreateBasicWafV2.json"
+          },
+          "Create Basic_v2 Application Gateway": {
+            "$ref": "./examples/ApplicationGatewayCreateBasicV2.json"
           }
         },
         "x-ms-long-running-operation-options": {

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/common.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/common.json
@@ -1219,7 +1219,9 @@
         "WAF",
         "Standard_v2",
         "WAF_v2",
-        "Basic"
+        "Basic",
+        "Basic_v2",
+        "Basic_WAF_v2"
       ],
       "x-ms-enum": {
         "name": "ApplicationGatewayTier",
@@ -1249,6 +1251,16 @@
             "name": "Basic",
             "value": "Basic",
             "description": "Basic"
+          },
+          {
+            "name": "Basic_v2",
+            "value": "Basic_v2",
+            "description": "Basic tier Application Gateway."
+          },
+          {
+            "name": "Basic_WAF_v2",
+            "value": "Basic_WAF_v2",
+            "description": "Basic tier Application Gateway with WAF enabled."
           }
         ]
       }
@@ -9950,22 +9962,22 @@
       "type": "string",
       "description": "Tier of a web application firewall policy.",
       "enum": [
-        "Basic",
-        "Standard"
+        "Standard",
+        "Basic"
       ],
       "x-ms-enum": {
         "name": "WebApplicationFirewallPolicyTier",
         "modelAsString": true,
         "values": [
           {
-            "name": "Basic",
-            "value": "Basic",
-            "description": "Basic tier web application firewall policy."
-          },
-          {
             "name": "Standard",
             "value": "Standard",
             "description": "Standard tier web application firewall policy."
+          },
+          {
+            "name": "Basic",
+            "value": "Basic",
+            "description": "Basic tier web application firewall policy."
           }
         ]
       }

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/common.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/common.json
@@ -862,7 +862,9 @@
         "WAF_Large",
         "Standard_v2",
         "WAF_v2",
-        "Basic"
+        "Basic",
+        "Basic_v2",
+        "Basic_WAF_v2"
       ],
       "x-ms-enum": {
         "name": "ApplicationGatewaySkuName",
@@ -907,6 +909,16 @@
             "name": "Basic",
             "value": "Basic",
             "description": "Basic"
+          },
+          {
+            "name": "Basic_v2",
+            "value": "Basic_v2",
+            "description": "Basic tier Application Gateway."
+          },
+          {
+            "name": "Basic_WAF_v2",
+            "value": "Basic_WAF_v2",
+            "description": "Basic tier Application Gateway with WAF enabled."
           }
         ]
       }
@@ -9930,6 +9942,30 @@
             "name": "Deleting",
             "value": "Deleting",
             "description": "Deleting"
+          }
+        ]
+      }
+    },
+    "WebApplicationFirewallPolicyTier": {
+      "type": "string",
+      "description": "Tier of a web application firewall policy.",
+      "enum": [
+        "Basic",
+        "Standard"
+      ],
+      "x-ms-enum": {
+        "name": "WebApplicationFirewallPolicyTier",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Basic",
+            "value": "Basic",
+            "description": "Basic tier web application firewall policy."
+          },
+          {
+            "name": "Standard",
+            "value": "Standard",
+            "description": "Standard tier web application firewall policy."
           }
         ]
       }

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/ApplicationGatewayCreateBasicV2.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/ApplicationGatewayCreateBasicV2.json
@@ -1,0 +1,824 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "applicationGatewayName": "appgw",
+    "parameters": {
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1": {}
+        }
+      },
+      "location": "eastus",
+      "properties": {
+        "backendAddressPools": [
+          {
+            "name": "appgwpool",
+            "properties": {
+              "backendAddresses": [
+                {
+                  "ipAddress": "10.0.1.1"
+                },
+                {
+                  "ipAddress": "10.0.1.2"
+                }
+              ]
+            }
+          },
+          {
+            "name": "appgwpool1",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool1",
+            "properties": {
+              "backendAddresses": [
+                {
+                  "ipAddress": "10.0.0.1"
+                },
+                {
+                  "ipAddress": "10.0.0.2"
+                }
+              ]
+            }
+          }
+        ],
+        "backendHttpSettingsCollection": [
+          {
+            "name": "appgwbhs",
+            "properties": {
+              "cookieBasedAffinity": "Disabled",
+              "port": 80,
+              "requestTimeout": 30,
+              "protocol": "Http"
+            }
+          }
+        ],
+        "entraJWTValidationConfigs": [
+          {
+            "name": "entraJWTValidationConfig1",
+            "properties": {
+              "clientId": "37293f5a-97b3-451d-b786-f532d711c9ff",
+              "tenantId": "70a036f6-8e4d-4615-bad6-149c02e7720d",
+              "unAuthorizedRequestAction": "Deny"
+            }
+          }
+        ],
+        "frontendIPConfigurations": [
+          {
+            "name": "appgwfip",
+            "properties": {
+              "publicIPAddress": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/appgwpip"
+              }
+            }
+          }
+        ],
+        "frontendPorts": [
+          {
+            "name": "appgwfp",
+            "properties": {
+              "port": 443
+            }
+          },
+          {
+            "name": "appgwfp80",
+            "properties": {
+              "port": 80
+            }
+          }
+        ],
+        "gatewayIPConfigurations": [
+          {
+            "name": "appgwipc",
+            "properties": {
+              "subnet": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnet/subnets/appgwsubnet"
+              }
+            }
+          }
+        ],
+        "globalConfiguration": {
+          "enableRequestBuffering": true,
+          "enableResponseBuffering": true
+        },
+        "httpListeners": [
+          {
+            "name": "appgwhl",
+            "properties": {
+              "frontendIPConfiguration": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendIPConfigurations/appgwfip"
+              },
+              "frontendPort": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendPorts/appgwfp"
+              },
+              "requireServerNameIndication": false,
+              "sslCertificate": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/sslCertificates/sslcert"
+              },
+              "sslProfile": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/sslProfiles/sslProfile1"
+              },
+              "protocol": "Https"
+            }
+          },
+          {
+            "name": "appgwhttplistener",
+            "properties": {
+              "frontendIPConfiguration": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendIPConfigurations/appgwfip"
+              },
+              "frontendPort": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendPorts/appgwfp80"
+              },
+              "protocol": "Http"
+            }
+          }
+        ],
+        "requestRoutingRules": [
+          {
+            "name": "appgwrule",
+            "properties": {
+              "backendAddressPool": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
+              },
+              "backendHttpSettings": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs"
+              },
+              "entraJWTValidationConfig": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/entraJWTValidationConfigs/entraJWTValidationConfig1"
+              },
+              "httpListener": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhl"
+              },
+              "priority": 10,
+              "rewriteRuleSet": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1"
+              },
+              "ruleType": "Basic"
+            }
+          }
+        ],
+        "rewriteRuleSets": [
+          {
+            "name": "rewriteRuleSet1",
+            "properties": {
+              "rewriteRules": [
+                {
+                  "name": "Set X-Forwarded-For",
+                  "actionSet": {
+                    "requestHeaderConfigurations": [
+                      {
+                        "headerName": "X-Forwarded-For",
+                        "headerValue": "{var_add_x_forwarded_for_proxy}"
+                      }
+                    ],
+                    "responseHeaderConfigurations": [
+                      {
+                        "headerName": "Strict-Transport-Security",
+                        "headerValue": "max-age=31536000"
+                      }
+                    ],
+                    "urlConfiguration": {
+                      "modifiedPath": "/abc"
+                    }
+                  },
+                  "conditions": [
+                    {
+                      "ignoreCase": true,
+                      "negate": false,
+                      "pattern": "^Bearer",
+                      "variable": "http_req_Authorization"
+                    }
+                  ],
+                  "ruleSequence": 102
+                }
+              ]
+            }
+          }
+        ],
+        "sku": {
+          "name": "Basic_v2",
+          "tier": "Basic_v2"
+        },
+        "reservedCapacity": 3,
+        "sslCertificates": [
+          {
+            "name": "sslcert",
+            "properties": {
+              "data": "****",
+              "password": "****"
+            }
+          },
+          {
+            "name": "sslcert2",
+            "properties": {
+              "keyVaultSecretId": "https://kv/secret"
+            }
+          }
+        ],
+        "sslProfiles": [
+          {
+            "name": "sslProfile1",
+            "properties": {
+              "clientAuthConfiguration": {
+                "verifyClientCertIssuerDN": true
+              },
+              "sslPolicy": {
+                "cipherSuites": [
+                  "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256"
+                ],
+                "minProtocolVersion": "TLSv1_1",
+                "policyType": "Custom"
+              },
+              "trustedClientCertificates": [
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/trustedClientCertificates/clientcert"
+                }
+              ]
+            }
+          }
+        ],
+        "trustedClientCertificates": [
+          {
+            "name": "clientcert",
+            "properties": {
+              "data": "****"
+            }
+          }
+        ],
+        "trustedRootCertificates": [
+          {
+            "name": "rootcert",
+            "properties": {
+              "data": "****"
+            }
+          },
+          {
+            "name": "rootcert1",
+            "properties": {
+              "keyVaultSecretId": "https://kv/secret"
+            }
+          }
+        ]
+      }
+    },
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "appgw",
+        "type": "Microsoft.Network/applicationGateways",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw",
+        "location": "southcentralus",
+        "properties": {
+          "authenticationCertificates": [],
+          "backendAddressPools": [
+            {
+              "name": "appgwpool",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool",
+              "properties": {
+                "backendAddresses": [
+                  {
+                    "ipAddress": "10.0.1.1"
+                  },
+                  {
+                    "ipAddress": "10.0.1.2"
+                  }
+                ],
+                "provisioningState": "Succeeded"
+              }
+            },
+            {
+              "name": "appgwpool1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool1",
+              "properties": {
+                "backendAddresses": [
+                  {
+                    "ipAddress": "10.0.0.1"
+                  },
+                  {
+                    "ipAddress": "10.0.0.2"
+                  }
+                ],
+                "provisioningState": "Succeeded"
+              }
+            }
+          ],
+          "backendHttpSettingsCollection": [
+            {
+              "name": "appgwbhs",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs",
+              "properties": {
+                "cookieBasedAffinity": "Disabled",
+                "port": 80,
+                "provisioningState": "Succeeded",
+                "requestTimeout": 30,
+                "protocol": "Http"
+              }
+            }
+          ],
+          "entraJWTValidationConfigs": [
+            {
+              "name": "entraJWTValidationConfig1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/entraJWTValidationConfigs/entraJWTValidationConfig1",
+              "properties": {
+                "clientId": "37293f5a-97b3-451d-b786-f532d711c9ff",
+                "provisioningState": "Succeeded",
+                "tenantId": "70a036f6-8e4d-4615-bad6-149c02e7720d",
+                "unAuthorizedRequestAction": "Deny"
+              }
+            }
+          ],
+          "frontendIPConfigurations": [
+            {
+              "name": "appgwfip",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendIPConfigurations/appgwfip",
+              "properties": {
+                "privateIPAllocationMethod": "Dynamic",
+                "provisioningState": "Succeeded",
+                "publicIPAddress": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/appgwpip"
+                }
+              }
+            }
+          ],
+          "frontendPorts": [
+            {
+              "name": "appgwfp",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendPorts/appgwfp",
+              "properties": {
+                "port": 443,
+                "provisioningState": "Succeeded"
+              }
+            },
+            {
+              "name": "appgwfp80",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendPorts/appgwfp80",
+              "properties": {
+                "port": 80,
+                "provisioningState": "Succeeded"
+              }
+            }
+          ],
+          "gatewayIPConfigurations": [
+            {
+              "name": "appgwipc",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/gatewayIPConfigurations/appgwipc",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "subnet": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/virtualNetwork1/subnets/appgwsubnet"
+                }
+              }
+            }
+          ],
+          "globalConfiguration": {
+            "enableRequestBuffering": true,
+            "enableResponseBuffering": true
+          },
+          "httpListeners": [
+            {
+              "name": "appgwhl",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhl",
+              "properties": {
+                "frontendIPConfiguration": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendIPConfigurations/appgwfip"
+                },
+                "frontendPort": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendPorts/appgwfp"
+                },
+                "provisioningState": "Succeeded",
+                "requireServerNameIndication": false,
+                "sslCertificate": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/sslCertificates/sslcert"
+                },
+                "sslProfile": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/sslProfiles/sslProfile1"
+                },
+                "protocol": "Https"
+              }
+            },
+            {
+              "name": "appgwhttplistener",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhttplistener",
+              "properties": {
+                "frontendIPConfiguration": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendIPConfigurations/appgwfip"
+                },
+                "frontendPort": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendPorts/appgwfp80"
+                },
+                "provisioningState": "Succeeded",
+                "protocol": "Http"
+              }
+            }
+          ],
+          "listeners": [],
+          "loadDistributionPolicies": [],
+          "operationalState": "Running",
+          "privateEndpointConnections": [],
+          "probes": [],
+          "provisioningState": "Succeeded",
+          "redirectConfigurations": [],
+          "requestRoutingRules": [
+            {
+              "name": "appgwrule",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/requestRoutingRules/appgwrule",
+              "properties": {
+                "backendAddressPool": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
+                },
+                "backendHttpSettings": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs"
+                },
+                "entraJWTValidationConfig": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/entraJWTValidationConfigs/entraJWTValidationConfig1"
+                },
+                "httpListener": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhl"
+                },
+                "provisioningState": "Succeeded",
+                "rewriteRuleSet": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1"
+                },
+                "ruleType": "Basic"
+              }
+            }
+          ],
+          "rewriteRuleSets": [
+            {
+              "name": "rewriteRuleSet1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "rewriteRules": [
+                  {
+                    "name": "Set X-Forwarded-For",
+                    "actionSet": {
+                      "requestHeaderConfigurations": [
+                        {
+                          "headerName": "X-Forwarded-For",
+                          "headerValue": "{var_remote-addr}"
+                        }
+                      ],
+                      "responseHeaderConfigurations": [
+                        {
+                          "headerName": "Strict-Transport-Security",
+                          "headerValue": "max-age=31536000"
+                        }
+                      ],
+                      "urlConfiguration": {
+                        "modifiedPath": "/abc",
+                        "modifiedQueryString": "x=y&a=b"
+                      }
+                    },
+                    "conditions": [
+                      {
+                        "ignoreCase": true,
+                        "negate": false,
+                        "pattern": "^Bearer",
+                        "variable": "http_req_Authorization"
+                      }
+                    ],
+                    "ruleSequence": 102
+                  }
+                ]
+              }
+            }
+          ],
+          "routingRules": [],
+          "sku": {
+            "name": "Basic_v2",
+            "tier": "Basic_v2"
+          },
+          "reservedCapacity": 3,
+          "sslCertificates": [
+            {
+              "name": "sslcert",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/sslCertificates/sslcert",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "publicCertData": "*****"
+              }
+            }
+          ],
+          "sslProfiles": [
+            {
+              "name": "sslProfile1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/sslProfiles/sslProfile1",
+              "properties": {
+                "clientAuthConfiguration": {
+                  "verifyClientCertIssuerDN": true
+                },
+                "provisioningState": "Succeeded",
+                "sslPolicy": {
+                  "cipherSuites": [
+                    "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256"
+                  ],
+                  "minProtocolVersion": "TLSv1_1",
+                  "policyType": "Custom"
+                },
+                "trustedClientCertificates": [
+                  {
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/trustedClientCertificates/clientcert"
+                  }
+                ]
+              }
+            }
+          ],
+          "trustedClientCertificates": [
+            {
+              "name": "clientcert",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/trustedClientCertificates/clientcert",
+              "properties": {
+                "data": "****",
+                "provisioningState": "Succeeded"
+              }
+            }
+          ],
+          "urlPathMaps": []
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "appgw",
+        "type": "Microsoft.Network/applicationGateways",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw",
+        "location": "southcentralus",
+        "properties": {
+          "authenticationCertificates": [],
+          "backendAddressPools": [
+            {
+              "name": "appgwpool",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool",
+              "properties": {
+                "backendAddresses": [
+                  {
+                    "ipAddress": "10.0.1.1"
+                  },
+                  {
+                    "ipAddress": "10.0.1.2"
+                  }
+                ],
+                "provisioningState": "Succeeded"
+              }
+            },
+            {
+              "name": "appgwpool1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool1",
+              "properties": {
+                "backendAddresses": [
+                  {
+                    "ipAddress": "10.0.0.1"
+                  },
+                  {
+                    "ipAddress": "10.0.0.2"
+                  }
+                ],
+                "provisioningState": "Succeeded"
+              }
+            }
+          ],
+          "backendHttpSettingsCollection": [
+            {
+              "name": "appgwbhs",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs",
+              "properties": {
+                "cookieBasedAffinity": "Disabled",
+                "port": 80,
+                "provisioningState": "Succeeded",
+                "requestTimeout": 30,
+                "protocol": "Http"
+              }
+            }
+          ],
+          "entraJWTValidationConfigs": [
+            {
+              "name": "entraJWTValidationConfig1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/entraJWTValidationConfigs/entraJWTValidationConfig1",
+              "properties": {
+                "clientId": "37293f5a-97b3-451d-b786-f532d711c9ff",
+                "provisioningState": "Succeeded",
+                "tenantId": "70a036f6-8e4d-4615-bad6-149c02e7720d",
+                "unAuthorizedRequestAction": "Deny"
+              }
+            }
+          ],
+          "frontendIPConfigurations": [
+            {
+              "name": "appgwfip",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendIPConfigurations/appgwfip",
+              "properties": {
+                "privateIPAllocationMethod": "Dynamic",
+                "provisioningState": "Succeeded",
+                "publicIPAddress": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/appgwpip"
+                }
+              }
+            }
+          ],
+          "frontendPorts": [
+            {
+              "name": "appgwfp",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendPorts/appgwfp",
+              "properties": {
+                "port": 443,
+                "provisioningState": "Succeeded"
+              }
+            },
+            {
+              "name": "appgwfp80",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendPorts/appgwfp80",
+              "properties": {
+                "port": 80,
+                "provisioningState": "Succeeded"
+              }
+            }
+          ],
+          "gatewayIPConfigurations": [
+            {
+              "name": "appgwipc",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/gatewayIPConfigurations/appgwipc",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "subnet": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/virtualNetwork1/subnets/appgwsubnet"
+                }
+              }
+            }
+          ],
+          "globalConfiguration": {
+            "enableRequestBuffering": true,
+            "enableResponseBuffering": true
+          },
+          "httpListeners": [
+            {
+              "name": "appgwhl",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhl",
+              "properties": {
+                "frontendIPConfiguration": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendIPConfigurations/appgwfip"
+                },
+                "frontendPort": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendPorts/appgwfp"
+                },
+                "provisioningState": "Succeeded",
+                "requireServerNameIndication": false,
+                "sslCertificate": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/sslCertificates/sslcert"
+                },
+                "sslProfile": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/sslProfiles/sslProfile1"
+                },
+                "protocol": "Https"
+              }
+            },
+            {
+              "name": "appgwhttplistener",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhttplistener",
+              "properties": {
+                "frontendIPConfiguration": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendIPConfigurations/appgwfip"
+                },
+                "frontendPort": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendPorts/appgwfp80"
+                },
+                "provisioningState": "Succeeded",
+                "protocol": "Http"
+              }
+            }
+          ],
+          "listeners": [],
+          "loadDistributionPolicies": [],
+          "operationalState": "Running",
+          "privateEndpointConnections": [],
+          "probes": [],
+          "provisioningState": "Succeeded",
+          "redirectConfigurations": [],
+          "requestRoutingRules": [
+            {
+              "name": "appgwrule",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/requestRoutingRules/appgwrule",
+              "properties": {
+                "backendAddressPool": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
+                },
+                "backendHttpSettings": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs"
+                },
+                "entraJWTValidationConfig": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/entraJWTValidationConfigs/entraJWTValidationConfig1"
+                },
+                "httpListener": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhl"
+                },
+                "provisioningState": "Succeeded",
+                "rewriteRuleSet": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1"
+                },
+                "ruleType": "Basic"
+              }
+            }
+          ],
+          "rewriteRuleSets": [
+            {
+              "name": "rewriteRuleSet1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "rewriteRules": [
+                  {
+                    "name": "Set X-Forwarded-For",
+                    "actionSet": {
+                      "requestHeaderConfigurations": [
+                        {
+                          "headerName": "X-Forwarded-For",
+                          "headerValue": "{var_remote-addr}"
+                        }
+                      ],
+                      "responseHeaderConfigurations": [
+                        {
+                          "headerName": "Strict-Transport-Security",
+                          "headerValue": "max-age=31536000"
+                        }
+                      ],
+                      "urlConfiguration": {
+                        "modifiedPath": "/abc",
+                        "reroute": true
+                      }
+                    },
+                    "conditions": [
+                      {
+                        "ignoreCase": true,
+                        "negate": false,
+                        "pattern": "^Bearer",
+                        "variable": "http_req_Authorization"
+                      }
+                    ],
+                    "ruleSequence": 102
+                  }
+                ]
+              }
+            }
+          ],
+          "routingRules": [],
+          "sku": {
+            "name": "Basic_v2",
+            "tier": "Basic_v2"
+          },
+          "reservedCapacity": 3,
+          "sslCertificates": [
+            {
+              "name": "sslcert",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/sslCertificates/sslcert",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "publicCertData": "*****"
+              }
+            }
+          ],
+          "sslProfiles": [
+            {
+              "name": "sslProfile1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/sslProfiles/sslProfile1",
+              "properties": {
+                "clientAuthConfiguration": {
+                  "verifyClientAuthMode": "Strict",
+                  "verifyClientCertIssuerDN": true,
+                  "verifyClientRevocation": "OCSP"
+                },
+                "provisioningState": "Succeeded",
+                "sslPolicy": {
+                  "cipherSuites": [
+                    "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256"
+                  ],
+                  "minProtocolVersion": "TLSv1_1",
+                  "policyType": "Custom"
+                },
+                "trustedClientCertificates": [
+                  {
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/trustedClientCertificates/clientcert"
+                  }
+                ]
+              }
+            }
+          ],
+          "trustedClientCertificates": [
+            {
+              "name": "clientcert",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/trustedClientCertificates/clientcert",
+              "properties": {
+                "data": "****",
+                "provisioningState": "Succeeded"
+              }
+            }
+          ],
+          "urlPathMaps": []
+        }
+      }
+    }
+  },
+  "operationId": "ApplicationGateways_CreateOrUpdate",
+  "title": "Create Basic_v2 Application Gateway"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/ApplicationGatewayCreateBasicWafV2.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/ApplicationGatewayCreateBasicWafV2.json
@@ -1,0 +1,833 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "applicationGatewayName": "appgw",
+    "parameters": {
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1": {}
+        }
+      },
+      "location": "eastus",
+      "properties": {
+        "backendAddressPools": [
+          {
+            "name": "appgwpool",
+            "properties": {
+              "backendAddresses": [
+                {
+                  "ipAddress": "10.0.1.1"
+                },
+                {
+                  "ipAddress": "10.0.1.2"
+                }
+              ]
+            }
+          },
+          {
+            "name": "appgwpool1",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool1",
+            "properties": {
+              "backendAddresses": [
+                {
+                  "ipAddress": "10.0.0.1"
+                },
+                {
+                  "ipAddress": "10.0.0.2"
+                }
+              ]
+            }
+          }
+        ],
+        "backendHttpSettingsCollection": [
+          {
+            "name": "appgwbhs",
+            "properties": {
+              "cookieBasedAffinity": "Disabled",
+              "port": 80,
+              "requestTimeout": 30,
+              "protocol": "Http"
+            }
+          }
+        ],
+        "entraJWTValidationConfigs": [
+          {
+            "name": "entraJWTValidationConfig1",
+            "properties": {
+              "clientId": "37293f5a-97b3-451d-b786-f532d711c9ff",
+              "tenantId": "70a036f6-8e4d-4615-bad6-149c02e7720d",
+              "unAuthorizedRequestAction": "Deny"
+            }
+          }
+        ],
+        "frontendIPConfigurations": [
+          {
+            "name": "appgwfip",
+            "properties": {
+              "publicIPAddress": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/appgwpip"
+              }
+            }
+          }
+        ],
+        "frontendPorts": [
+          {
+            "name": "appgwfp",
+            "properties": {
+              "port": 443
+            }
+          },
+          {
+            "name": "appgwfp80",
+            "properties": {
+              "port": 80
+            }
+          }
+        ],
+        "gatewayIPConfigurations": [
+          {
+            "name": "appgwipc",
+            "properties": {
+              "subnet": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnet/subnets/appgwsubnet"
+              }
+            }
+          }
+        ],
+        "globalConfiguration": {
+          "enableRequestBuffering": true,
+          "enableResponseBuffering": true
+        },
+        "httpListeners": [
+          {
+            "name": "appgwhl",
+            "properties": {
+              "frontendIPConfiguration": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendIPConfigurations/appgwfip"
+              },
+              "frontendPort": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendPorts/appgwfp"
+              },
+              "requireServerNameIndication": false,
+              "sslCertificate": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/sslCertificates/sslcert"
+              },
+              "sslProfile": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/sslProfiles/sslProfile1"
+              },
+              "protocol": "Https"
+            }
+          },
+          {
+            "name": "appgwhttplistener",
+            "properties": {
+              "frontendIPConfiguration": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendIPConfigurations/appgwfip"
+              },
+              "frontendPort": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendPorts/appgwfp80"
+              },
+              "protocol": "Http"
+            }
+          }
+        ],
+        "requestRoutingRules": [
+          {
+            "name": "appgwrule",
+            "properties": {
+              "backendAddressPool": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
+              },
+              "backendHttpSettings": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs"
+              },
+              "entraJWTValidationConfig": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/entraJWTValidationConfigs/entraJWTValidationConfig1"
+              },
+              "httpListener": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhl"
+              },
+              "priority": 10,
+              "rewriteRuleSet": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1"
+              },
+              "ruleType": "Basic"
+            }
+          }
+        ],
+        "rewriteRuleSets": [
+          {
+            "name": "rewriteRuleSet1",
+            "properties": {
+              "rewriteRules": [
+                {
+                  "name": "Set X-Forwarded-For",
+                  "actionSet": {
+                    "requestHeaderConfigurations": [
+                      {
+                        "headerName": "X-Forwarded-For",
+                        "headerValue": "{var_add_x_forwarded_for_proxy}"
+                      }
+                    ],
+                    "responseHeaderConfigurations": [
+                      {
+                        "headerName": "Strict-Transport-Security",
+                        "headerValue": "max-age=31536000"
+                      }
+                    ],
+                    "urlConfiguration": {
+                      "modifiedPath": "/abc"
+                    }
+                  },
+                  "conditions": [
+                    {
+                      "ignoreCase": true,
+                      "negate": false,
+                      "pattern": "^Bearer",
+                      "variable": "http_req_Authorization"
+                    }
+                  ],
+                  "ruleSequence": 102
+                }
+              ]
+            }
+          }
+        ],
+        "sku": {
+          "name": "Basic_WAF_v2",
+          "tier": "Basic_WAF_v2"
+        },
+        "reservedCapacity": 3,
+        "firewallPolicy": {
+          "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies/Policy1"
+        },
+        "sslCertificates": [
+          {
+            "name": "sslcert",
+            "properties": {
+              "data": "****",
+              "password": "****"
+            }
+          },
+          {
+            "name": "sslcert2",
+            "properties": {
+              "keyVaultSecretId": "https://kv/secret"
+            }
+          }
+        ],
+        "sslProfiles": [
+          {
+            "name": "sslProfile1",
+            "properties": {
+              "clientAuthConfiguration": {
+                "verifyClientCertIssuerDN": true
+              },
+              "sslPolicy": {
+                "cipherSuites": [
+                  "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256"
+                ],
+                "minProtocolVersion": "TLSv1_1",
+                "policyType": "Custom"
+              },
+              "trustedClientCertificates": [
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/trustedClientCertificates/clientcert"
+                }
+              ]
+            }
+          }
+        ],
+        "trustedClientCertificates": [
+          {
+            "name": "clientcert",
+            "properties": {
+              "data": "****"
+            }
+          }
+        ],
+        "trustedRootCertificates": [
+          {
+            "name": "rootcert",
+            "properties": {
+              "data": "****"
+            }
+          },
+          {
+            "name": "rootcert1",
+            "properties": {
+              "keyVaultSecretId": "https://kv/secret"
+            }
+          }
+        ]
+      }
+    },
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "appgw",
+        "type": "Microsoft.Network/applicationGateways",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw",
+        "location": "southcentralus",
+        "properties": {
+          "authenticationCertificates": [],
+          "backendAddressPools": [
+            {
+              "name": "appgwpool",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool",
+              "properties": {
+                "backendAddresses": [
+                  {
+                    "ipAddress": "10.0.1.1"
+                  },
+                  {
+                    "ipAddress": "10.0.1.2"
+                  }
+                ],
+                "provisioningState": "Succeeded"
+              }
+            },
+            {
+              "name": "appgwpool1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool1",
+              "properties": {
+                "backendAddresses": [
+                  {
+                    "ipAddress": "10.0.0.1"
+                  },
+                  {
+                    "ipAddress": "10.0.0.2"
+                  }
+                ],
+                "provisioningState": "Succeeded"
+              }
+            }
+          ],
+          "backendHttpSettingsCollection": [
+            {
+              "name": "appgwbhs",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs",
+              "properties": {
+                "cookieBasedAffinity": "Disabled",
+                "port": 80,
+                "provisioningState": "Succeeded",
+                "requestTimeout": 30,
+                "protocol": "Http"
+              }
+            }
+          ],
+          "entraJWTValidationConfigs": [
+            {
+              "name": "entraJWTValidationConfig1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/entraJWTValidationConfigs/entraJWTValidationConfig1",
+              "properties": {
+                "clientId": "37293f5a-97b3-451d-b786-f532d711c9ff",
+                "provisioningState": "Succeeded",
+                "tenantId": "70a036f6-8e4d-4615-bad6-149c02e7720d",
+                "unAuthorizedRequestAction": "Deny"
+              }
+            }
+          ],
+          "frontendIPConfigurations": [
+            {
+              "name": "appgwfip",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendIPConfigurations/appgwfip",
+              "properties": {
+                "privateIPAllocationMethod": "Dynamic",
+                "provisioningState": "Succeeded",
+                "publicIPAddress": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/appgwpip"
+                }
+              }
+            }
+          ],
+          "frontendPorts": [
+            {
+              "name": "appgwfp",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendPorts/appgwfp",
+              "properties": {
+                "port": 443,
+                "provisioningState": "Succeeded"
+              }
+            },
+            {
+              "name": "appgwfp80",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendPorts/appgwfp80",
+              "properties": {
+                "port": 80,
+                "provisioningState": "Succeeded"
+              }
+            }
+          ],
+          "gatewayIPConfigurations": [
+            {
+              "name": "appgwipc",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/gatewayIPConfigurations/appgwipc",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "subnet": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/virtualNetwork1/subnets/appgwsubnet"
+                }
+              }
+            }
+          ],
+          "globalConfiguration": {
+            "enableRequestBuffering": true,
+            "enableResponseBuffering": true
+          },
+          "httpListeners": [
+            {
+              "name": "appgwhl",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhl",
+              "properties": {
+                "frontendIPConfiguration": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendIPConfigurations/appgwfip"
+                },
+                "frontendPort": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendPorts/appgwfp"
+                },
+                "provisioningState": "Succeeded",
+                "requireServerNameIndication": false,
+                "sslCertificate": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/sslCertificates/sslcert"
+                },
+                "sslProfile": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/sslProfiles/sslProfile1"
+                },
+                "protocol": "Https"
+              }
+            },
+            {
+              "name": "appgwhttplistener",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhttplistener",
+              "properties": {
+                "frontendIPConfiguration": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendIPConfigurations/appgwfip"
+                },
+                "frontendPort": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendPorts/appgwfp80"
+                },
+                "provisioningState": "Succeeded",
+                "protocol": "Http"
+              }
+            }
+          ],
+          "listeners": [],
+          "loadDistributionPolicies": [],
+          "operationalState": "Running",
+          "privateEndpointConnections": [],
+          "probes": [],
+          "provisioningState": "Succeeded",
+          "redirectConfigurations": [],
+          "requestRoutingRules": [
+            {
+              "name": "appgwrule",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/requestRoutingRules/appgwrule",
+              "properties": {
+                "backendAddressPool": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
+                },
+                "backendHttpSettings": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs"
+                },
+                "entraJWTValidationConfig": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/entraJWTValidationConfigs/entraJWTValidationConfig1"
+                },
+                "httpListener": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhl"
+                },
+                "provisioningState": "Succeeded",
+                "rewriteRuleSet": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1"
+                },
+                "ruleType": "Basic"
+              }
+            }
+          ],
+          "rewriteRuleSets": [
+            {
+              "name": "rewriteRuleSet1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "rewriteRules": [
+                  {
+                    "name": "Set X-Forwarded-For",
+                    "actionSet": {
+                      "requestHeaderConfigurations": [
+                        {
+                          "headerName": "X-Forwarded-For",
+                          "headerValue": "{var_remote-addr}"
+                        }
+                      ],
+                      "responseHeaderConfigurations": [
+                        {
+                          "headerName": "Strict-Transport-Security",
+                          "headerValue": "max-age=31536000"
+                        }
+                      ],
+                      "urlConfiguration": {
+                        "modifiedPath": "/abc",
+                        "modifiedQueryString": "x=y&a=b"
+                      }
+                    },
+                    "conditions": [
+                      {
+                        "ignoreCase": true,
+                        "negate": false,
+                        "pattern": "^Bearer",
+                        "variable": "http_req_Authorization"
+                      }
+                    ],
+                    "ruleSequence": 102
+                  }
+                ]
+              }
+            }
+          ],
+          "routingRules": [],
+          "sku": {
+            "name": "Basic_WAF_v2",
+            "tier": "Basic_WAF_v2"
+          },
+          "reservedCapacity": 3,
+          "firewallPolicy": {
+            "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies/Policy1"
+          },
+          "sslCertificates": [
+            {
+              "name": "sslcert",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/sslCertificates/sslcert",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "publicCertData": "*****"
+              }
+            }
+          ],
+          "sslProfiles": [
+            {
+              "name": "sslProfile1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/sslProfiles/sslProfile1",
+              "properties": {
+                "clientAuthConfiguration": {
+                  "verifyClientCertIssuerDN": true
+                },
+                "provisioningState": "Succeeded",
+                "sslPolicy": {
+                  "cipherSuites": [
+                    "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256"
+                  ],
+                  "minProtocolVersion": "TLSv1_1",
+                  "policyType": "Custom"
+                },
+                "trustedClientCertificates": [
+                  {
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/trustedClientCertificates/clientcert"
+                  }
+                ]
+              }
+            }
+          ],
+          "trustedClientCertificates": [
+            {
+              "name": "clientcert",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/trustedClientCertificates/clientcert",
+              "properties": {
+                "data": "****",
+                "provisioningState": "Succeeded"
+              }
+            }
+          ],
+          "urlPathMaps": []
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "appgw",
+        "type": "Microsoft.Network/applicationGateways",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw",
+        "location": "southcentralus",
+        "properties": {
+          "authenticationCertificates": [],
+          "backendAddressPools": [
+            {
+              "name": "appgwpool",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool",
+              "properties": {
+                "backendAddresses": [
+                  {
+                    "ipAddress": "10.0.1.1"
+                  },
+                  {
+                    "ipAddress": "10.0.1.2"
+                  }
+                ],
+                "provisioningState": "Succeeded"
+              }
+            },
+            {
+              "name": "appgwpool1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool1",
+              "properties": {
+                "backendAddresses": [
+                  {
+                    "ipAddress": "10.0.0.1"
+                  },
+                  {
+                    "ipAddress": "10.0.0.2"
+                  }
+                ],
+                "provisioningState": "Succeeded"
+              }
+            }
+          ],
+          "backendHttpSettingsCollection": [
+            {
+              "name": "appgwbhs",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs",
+              "properties": {
+                "cookieBasedAffinity": "Disabled",
+                "port": 80,
+                "provisioningState": "Succeeded",
+                "requestTimeout": 30,
+                "protocol": "Http"
+              }
+            }
+          ],
+          "entraJWTValidationConfigs": [
+            {
+              "name": "entraJWTValidationConfig1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/entraJWTValidationConfigs/entraJWTValidationConfig1",
+              "properties": {
+                "clientId": "37293f5a-97b3-451d-b786-f532d711c9ff",
+                "provisioningState": "Succeeded",
+                "tenantId": "70a036f6-8e4d-4615-bad6-149c02e7720d",
+                "unAuthorizedRequestAction": "Deny"
+              }
+            }
+          ],
+          "frontendIPConfigurations": [
+            {
+              "name": "appgwfip",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendIPConfigurations/appgwfip",
+              "properties": {
+                "privateIPAllocationMethod": "Dynamic",
+                "provisioningState": "Succeeded",
+                "publicIPAddress": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/appgwpip"
+                }
+              }
+            }
+          ],
+          "frontendPorts": [
+            {
+              "name": "appgwfp",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendPorts/appgwfp",
+              "properties": {
+                "port": 443,
+                "provisioningState": "Succeeded"
+              }
+            },
+            {
+              "name": "appgwfp80",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendPorts/appgwfp80",
+              "properties": {
+                "port": 80,
+                "provisioningState": "Succeeded"
+              }
+            }
+          ],
+          "gatewayIPConfigurations": [
+            {
+              "name": "appgwipc",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/gatewayIPConfigurations/appgwipc",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "subnet": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/virtualNetwork1/subnets/appgwsubnet"
+                }
+              }
+            }
+          ],
+          "globalConfiguration": {
+            "enableRequestBuffering": true,
+            "enableResponseBuffering": true
+          },
+          "httpListeners": [
+            {
+              "name": "appgwhl",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhl",
+              "properties": {
+                "frontendIPConfiguration": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendIPConfigurations/appgwfip"
+                },
+                "frontendPort": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendPorts/appgwfp"
+                },
+                "provisioningState": "Succeeded",
+                "requireServerNameIndication": false,
+                "sslCertificate": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/sslCertificates/sslcert"
+                },
+                "sslProfile": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/sslProfiles/sslProfile1"
+                },
+                "protocol": "Https"
+              }
+            },
+            {
+              "name": "appgwhttplistener",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhttplistener",
+              "properties": {
+                "frontendIPConfiguration": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendIPConfigurations/appgwfip"
+                },
+                "frontendPort": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendPorts/appgwfp80"
+                },
+                "provisioningState": "Succeeded",
+                "protocol": "Http"
+              }
+            }
+          ],
+          "listeners": [],
+          "loadDistributionPolicies": [],
+          "operationalState": "Running",
+          "privateEndpointConnections": [],
+          "probes": [],
+          "provisioningState": "Succeeded",
+          "redirectConfigurations": [],
+          "requestRoutingRules": [
+            {
+              "name": "appgwrule",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/requestRoutingRules/appgwrule",
+              "properties": {
+                "backendAddressPool": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
+                },
+                "backendHttpSettings": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs"
+                },
+                "entraJWTValidationConfig": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/entraJWTValidationConfigs/entraJWTValidationConfig1"
+                },
+                "httpListener": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhl"
+                },
+                "provisioningState": "Succeeded",
+                "rewriteRuleSet": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1"
+                },
+                "ruleType": "Basic"
+              }
+            }
+          ],
+          "rewriteRuleSets": [
+            {
+              "name": "rewriteRuleSet1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "rewriteRules": [
+                  {
+                    "name": "Set X-Forwarded-For",
+                    "actionSet": {
+                      "requestHeaderConfigurations": [
+                        {
+                          "headerName": "X-Forwarded-For",
+                          "headerValue": "{var_remote-addr}"
+                        }
+                      ],
+                      "responseHeaderConfigurations": [
+                        {
+                          "headerName": "Strict-Transport-Security",
+                          "headerValue": "max-age=31536000"
+                        }
+                      ],
+                      "urlConfiguration": {
+                        "modifiedPath": "/abc",
+                        "reroute": true
+                      }
+                    },
+                    "conditions": [
+                      {
+                        "ignoreCase": true,
+                        "negate": false,
+                        "pattern": "^Bearer",
+                        "variable": "http_req_Authorization"
+                      }
+                    ],
+                    "ruleSequence": 102
+                  }
+                ]
+              }
+            }
+          ],
+          "routingRules": [],
+          "sku": {
+            "name": "Basic_WAF_v2",
+            "tier": "Basic_WAF_v2"
+          },
+          "reservedCapacity": 3,
+          "firewallPolicy": {
+            "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies/Policy1"
+          },
+          "sslCertificates": [
+            {
+              "name": "sslcert",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/sslCertificates/sslcert",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "publicCertData": "*****"
+              }
+            }
+          ],
+          "sslProfiles": [
+            {
+              "name": "sslProfile1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/sslProfiles/sslProfile1",
+              "properties": {
+                "clientAuthConfiguration": {
+                  "verifyClientAuthMode": "Strict",
+                  "verifyClientCertIssuerDN": true,
+                  "verifyClientRevocation": "OCSP"
+                },
+                "provisioningState": "Succeeded",
+                "sslPolicy": {
+                  "cipherSuites": [
+                    "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256"
+                  ],
+                  "minProtocolVersion": "TLSv1_1",
+                  "policyType": "Custom"
+                },
+                "trustedClientCertificates": [
+                  {
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/trustedClientCertificates/clientcert"
+                  }
+                ]
+              }
+            }
+          ],
+          "trustedClientCertificates": [
+            {
+              "name": "clientcert",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/trustedClientCertificates/clientcert",
+              "properties": {
+                "data": "****",
+                "provisioningState": "Succeeded"
+              }
+            }
+          ],
+          "urlPathMaps": []
+        }
+      }
+    }
+  },
+  "operationId": "ApplicationGateways_CreateOrUpdate",
+  "title": "Create Basic_WAF_v2 Application Gateway"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/ApplicationGatewayGetBasicV2.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/ApplicationGatewayGetBasicV2.json
@@ -1,0 +1,411 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "applicationGatewayName": "appgw",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "appgw",
+        "type": "Microsoft.Network/applicationGateways",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw",
+        "location": "southcentralus",
+        "properties": {
+          "authenticationCertificates": [],
+          "backendAddressPools": [
+            {
+              "name": "appgwpool",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool",
+              "properties": {
+                "backendAddresses": [],
+                "provisioningState": "Succeeded"
+              }
+            },
+            {
+              "name": "appgwpool1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool1",
+              "properties": {
+                "backendAddresses": [
+                  {
+                    "ipAddress": "10.0.0.1"
+                  },
+                  {
+                    "ipAddress": "10.0.0.2"
+                  }
+                ],
+                "provisioningState": "Succeeded"
+              }
+            }
+          ],
+          "backendHttpSettingsCollection": [
+            {
+              "name": "appgwbhs",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs",
+              "properties": {
+                "cookieBasedAffinity": "Disabled",
+                "port": 80,
+                "provisioningState": "Succeeded",
+                "requestTimeout": 30,
+                "protocol": "Http"
+              }
+            }
+          ],
+          "entraJWTValidationConfigs": [
+            {
+              "name": "entraJWTValidationConfig1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/entraJWTValidationConfigs/entraJWTValidationConfig1",
+              "properties": {
+                "clientId": "37293f5a-97b3-451d-b786-f532d711c9ff",
+                "provisioningState": "Succeeded",
+                "tenantId": "70a036f6-8e4d-4615-bad6-149c02e7720d",
+                "unAuthorizedRequestAction": "Deny"
+              }
+            }
+          ],
+          "frontendIPConfigurations": [
+            {
+              "name": "appgwfip",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendIPConfigurations/appgwfip",
+              "properties": {
+                "privateIPAllocationMethod": "Dynamic",
+                "provisioningState": "Succeeded",
+                "publicIPAddress": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/appgwpip"
+                }
+              }
+            }
+          ],
+          "frontendPorts": [
+            {
+              "name": "appgwfp",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendPorts/appgwfp",
+              "properties": {
+                "port": 443,
+                "provisioningState": "Succeeded"
+              }
+            },
+            {
+              "name": "appgwfp80",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendPorts/appgwfp80",
+              "properties": {
+                "port": 80,
+                "provisioningState": "Succeeded"
+              }
+            }
+          ],
+          "gatewayIPConfigurations": [
+            {
+              "name": "appgwipc",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/gatewayIPConfigurations/appgwipc",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "subnet": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/virtualNetwork1/subnets/appgwsubnet"
+                }
+              }
+            }
+          ],
+          "globalConfiguration": {
+            "enableRequestBuffering": true,
+            "enableResponseBuffering": true
+          },
+          "httpListeners": [
+            {
+              "name": "appgwhl",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhl",
+              "properties": {
+                "frontendIPConfiguration": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendIPConfigurations/appgwfip"
+                },
+                "frontendPort": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendPorts/appgwfp"
+                },
+                "provisioningState": "Succeeded",
+                "requireServerNameIndication": false,
+                "sslCertificate": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/sslCertificates/sslcert"
+                },
+                "sslProfile": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/sslProfiles/sslProfile1"
+                },
+                "protocol": "Https"
+              }
+            },
+            {
+              "name": "appgwhttplistener",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhttplistener",
+              "properties": {
+                "frontendIPConfiguration": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendIPConfigurations/appgwfip"
+                },
+                "frontendPort": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendPorts/appgwfp80"
+                },
+                "provisioningState": "Succeeded",
+                "protocol": "Http"
+              }
+            }
+          ],
+          "loadDistributionPolicies": [
+            {
+              "name": "ldp1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1",
+              "properties": {
+                "loadDistributionAlgorithm": "RoundRobin",
+                "loadDistributionTargets": [
+                  {
+                    "name": "ld11",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1/loadDistributionTargets/ldt1",
+                    "properties": {
+                      "backendAddressPool": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
+                      },
+                      "weightPerServer": 40
+                    }
+                  },
+                  {
+                    "name": "ld11",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1/loadDistributionTargets/ldt1",
+                    "properties": {
+                      "backendAddressPool": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool1"
+                      },
+                      "weightPerServer": 60
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "operationalState": "Running",
+          "privateEndpointConnections": [],
+          "privateLinkConfigurations": [
+            {
+              "name": "privateLink1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/privateLinkConfigurations/privateLink1",
+              "properties": {
+                "ipConfigurations": [
+                  {
+                    "name": "natNicIpconfig1",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/privateLinkConfigurations/privateLink1/privateLinkConfigurations/privateLink1/ipConfigurations/natNicIpconfig1",
+                    "properties": {
+                      "primary": true,
+                      "privateIPAllocationMethod": "Dynamic",
+                      "provisioningState": "Succeeded",
+                      "subnet": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/virtualNetwork1/subnets/appgwsubnet"
+                      }
+                    }
+                  },
+                  {
+                    "name": "natNicIpconfig2",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/privateLinkConfigurations/privateLink1/privateLinkConfigurations/privateLink1/ipConfigurations/natNicIpconfig2",
+                    "properties": {
+                      "privateIPAllocationMethod": "Dynamic",
+                      "provisioningState": "Succeeded",
+                      "subnet": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/virtualNetwork1/subnets/appgwsubnet"
+                      }
+                    }
+                  }
+                ],
+                "provisioningState": "Succeeded"
+              }
+            }
+          ],
+          "probes": [],
+          "provisioningState": "Succeeded",
+          "requestRoutingRules": [
+            {
+              "name": "appgwrule",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/requestRoutingRules/appgwrule",
+              "properties": {
+                "backendAddressPool": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
+                },
+                "backendHttpSettings": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs"
+                },
+                "httpListener": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhl"
+                },
+                "loadDistributionPolicy": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1"
+                },
+                "priority": 10,
+                "provisioningState": "Succeeded",
+                "rewriteRuleSet": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1"
+                },
+                "ruleType": "Basic"
+              }
+            },
+            {
+              "name": "appgwPathBasedRule",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/requestRoutingRules/appgwPathBasedRule",
+              "properties": {
+                "entraJWTValidationConfig": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/entraJWTValidationConfigs/entraJWTValidationConfig1"
+                },
+                "httpListener": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhttplistener"
+                },
+                "priority": 20,
+                "provisioningState": "Succeeded",
+                "ruleType": "PathBasedRouting",
+                "urlPathMap": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/urlPathMaps/pathMap1"
+                }
+              }
+            }
+          ],
+          "rewriteRuleSets": [
+            {
+              "name": "rewriteRuleSet1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "rewriteRules": [
+                  {
+                    "name": "Set X-Forwarded-For",
+                    "actionSet": {
+                      "requestHeaderConfigurations": [
+                        {
+                          "headerName": "X-Forwarded-For",
+                          "headerValue": "{var_remote-addr}"
+                        }
+                      ],
+                      "responseHeaderConfigurations": [
+                        {
+                          "headerName": "Strict-Transport-Security",
+                          "headerValue": "max-age=31536000"
+                        }
+                      ],
+                      "urlConfiguration": {
+                        "modifiedPath": "/abc",
+                        "modifiedQueryString": "x=y&a=b",
+                        "reroute": false
+                      }
+                    },
+                    "conditions": [
+                      {
+                        "ignoreCase": true,
+                        "negate": false,
+                        "pattern": "^Bearer",
+                        "variable": "http_req_Authorization"
+                      }
+                    ],
+                    "ruleSequence": 102
+                  }
+                ]
+              }
+            }
+          ],
+          "sku": {
+            "name": "Basic_v2",
+            "tier": "Basic_v2"
+          },
+          "reservedCapacity": 3,
+          "sslCertificates": [
+            {
+              "name": "sslcert",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/sslCertificates/sslcert",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "publicCertData": "*****"
+              }
+            }
+          ],
+          "sslProfiles": [
+            {
+              "name": "sslProfile1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/sslProfiles/sslProfile1",
+              "properties": {
+                "clientAuthConfiguration": {
+                  "verifyClientAuthMode": "Strict",
+                  "verifyClientCertIssuerDN": true,
+                  "verifyClientRevocation": "OCSP"
+                },
+                "provisioningState": "Succeeded",
+                "sslPolicy": {
+                  "cipherSuites": [
+                    "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256"
+                  ],
+                  "minProtocolVersion": "TLSv1_1",
+                  "policyType": "Custom"
+                },
+                "trustedClientCertificates": [
+                  {
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/trustedClientCertificates/clientcert"
+                  }
+                ]
+              }
+            }
+          ],
+          "trustedClientCertificates": [
+            {
+              "name": "clientcert",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/trustedClientCertificates/clientcert",
+              "properties": {
+                "clientCertIssuerDN": "CN=User1, OU=Eng, O=Company Ltd, L=D4, S=Arizona, C=US",
+                "data": "****",
+                "provisioningState": "Succeeded",
+                "validatedCertData": "****"
+              }
+            }
+          ],
+          "urlPathMaps": [
+            {
+              "name": "pathMap1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/urlPathMaps/pathMap1",
+              "properties": {
+                "defaultBackendAddressPool": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
+                },
+                "defaultBackendHttpSettings": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs"
+                },
+                "defaultLoadDistributionPolicy": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1"
+                },
+                "defaultRewriteRuleSet": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1"
+                },
+                "pathRules": [
+                  {
+                    "name": "apiPaths",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/urlPathMaps/pathMap1/pathRules/apiPaths",
+                    "properties": {
+                      "backendAddressPool": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
+                      },
+                      "backendHttpSettings": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs"
+                      },
+                      "loadDistributionPolicy": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1"
+                      },
+                      "paths": [
+                        "/api",
+                        "/v1/api"
+                      ],
+                      "provisioningState": "Succeeded",
+                      "rewriteRuleSet": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1"
+                      }
+                    }
+                  }
+                ],
+                "provisioningState": "Succeeded"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "ApplicationGateways_Get",
+  "title": "Get Basic_v2 Application Gateway"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/ApplicationGatewayGetBasicWafV2.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/ApplicationGatewayGetBasicWafV2.json
@@ -1,0 +1,414 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "applicationGatewayName": "appgw",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "appgw",
+        "type": "Microsoft.Network/applicationGateways",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw",
+        "location": "southcentralus",
+        "properties": {
+          "authenticationCertificates": [],
+          "backendAddressPools": [
+            {
+              "name": "appgwpool",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool",
+              "properties": {
+                "backendAddresses": [],
+                "provisioningState": "Succeeded"
+              }
+            },
+            {
+              "name": "appgwpool1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool1",
+              "properties": {
+                "backendAddresses": [
+                  {
+                    "ipAddress": "10.0.0.1"
+                  },
+                  {
+                    "ipAddress": "10.0.0.2"
+                  }
+                ],
+                "provisioningState": "Succeeded"
+              }
+            }
+          ],
+          "backendHttpSettingsCollection": [
+            {
+              "name": "appgwbhs",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs",
+              "properties": {
+                "cookieBasedAffinity": "Disabled",
+                "port": 80,
+                "provisioningState": "Succeeded",
+                "requestTimeout": 30,
+                "protocol": "Http"
+              }
+            }
+          ],
+          "entraJWTValidationConfigs": [
+            {
+              "name": "entraJWTValidationConfig1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/entraJWTValidationConfigs/entraJWTValidationConfig1",
+              "properties": {
+                "clientId": "37293f5a-97b3-451d-b786-f532d711c9ff",
+                "provisioningState": "Succeeded",
+                "tenantId": "70a036f6-8e4d-4615-bad6-149c02e7720d",
+                "unAuthorizedRequestAction": "Deny"
+              }
+            }
+          ],
+          "frontendIPConfigurations": [
+            {
+              "name": "appgwfip",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendIPConfigurations/appgwfip",
+              "properties": {
+                "privateIPAllocationMethod": "Dynamic",
+                "provisioningState": "Succeeded",
+                "publicIPAddress": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/publicIPAddresses/appgwpip"
+                }
+              }
+            }
+          ],
+          "frontendPorts": [
+            {
+              "name": "appgwfp",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendPorts/appgwfp",
+              "properties": {
+                "port": 443,
+                "provisioningState": "Succeeded"
+              }
+            },
+            {
+              "name": "appgwfp80",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendPorts/appgwfp80",
+              "properties": {
+                "port": 80,
+                "provisioningState": "Succeeded"
+              }
+            }
+          ],
+          "gatewayIPConfigurations": [
+            {
+              "name": "appgwipc",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/gatewayIPConfigurations/appgwipc",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "subnet": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/virtualNetwork1/subnets/appgwsubnet"
+                }
+              }
+            }
+          ],
+          "globalConfiguration": {
+            "enableRequestBuffering": true,
+            "enableResponseBuffering": true
+          },
+          "httpListeners": [
+            {
+              "name": "appgwhl",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhl",
+              "properties": {
+                "frontendIPConfiguration": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendIPConfigurations/appgwfip"
+                },
+                "frontendPort": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendPorts/appgwfp"
+                },
+                "provisioningState": "Succeeded",
+                "requireServerNameIndication": false,
+                "sslCertificate": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/sslCertificates/sslcert"
+                },
+                "sslProfile": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/sslProfiles/sslProfile1"
+                },
+                "protocol": "Https"
+              }
+            },
+            {
+              "name": "appgwhttplistener",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhttplistener",
+              "properties": {
+                "frontendIPConfiguration": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendIPConfigurations/appgwfip"
+                },
+                "frontendPort": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendPorts/appgwfp80"
+                },
+                "provisioningState": "Succeeded",
+                "protocol": "Http"
+              }
+            }
+          ],
+          "loadDistributionPolicies": [
+            {
+              "name": "ldp1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1",
+              "properties": {
+                "loadDistributionAlgorithm": "RoundRobin",
+                "loadDistributionTargets": [
+                  {
+                    "name": "ld11",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1/loadDistributionTargets/ldt1",
+                    "properties": {
+                      "backendAddressPool": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
+                      },
+                      "weightPerServer": 40
+                    }
+                  },
+                  {
+                    "name": "ld11",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1/loadDistributionTargets/ldt1",
+                    "properties": {
+                      "backendAddressPool": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool1"
+                      },
+                      "weightPerServer": 60
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "operationalState": "Running",
+          "privateEndpointConnections": [],
+          "privateLinkConfigurations": [
+            {
+              "name": "privateLink1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/privateLinkConfigurations/privateLink1",
+              "properties": {
+                "ipConfigurations": [
+                  {
+                    "name": "natNicIpconfig1",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/privateLinkConfigurations/privateLink1/privateLinkConfigurations/privateLink1/ipConfigurations/natNicIpconfig1",
+                    "properties": {
+                      "primary": true,
+                      "privateIPAllocationMethod": "Dynamic",
+                      "provisioningState": "Succeeded",
+                      "subnet": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/virtualNetwork1/subnets/appgwsubnet"
+                      }
+                    }
+                  },
+                  {
+                    "name": "natNicIpconfig2",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/privateLinkConfigurations/privateLink1/privateLinkConfigurations/privateLink1/ipConfigurations/natNicIpconfig2",
+                    "properties": {
+                      "privateIPAllocationMethod": "Dynamic",
+                      "provisioningState": "Succeeded",
+                      "subnet": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/virtualNetwork1/subnets/appgwsubnet"
+                      }
+                    }
+                  }
+                ],
+                "provisioningState": "Succeeded"
+              }
+            }
+          ],
+          "probes": [],
+          "provisioningState": "Succeeded",
+          "requestRoutingRules": [
+            {
+              "name": "appgwrule",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/requestRoutingRules/appgwrule",
+              "properties": {
+                "backendAddressPool": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
+                },
+                "backendHttpSettings": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs"
+                },
+                "httpListener": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhl"
+                },
+                "loadDistributionPolicy": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1"
+                },
+                "priority": 10,
+                "provisioningState": "Succeeded",
+                "rewriteRuleSet": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1"
+                },
+                "ruleType": "Basic"
+              }
+            },
+            {
+              "name": "appgwPathBasedRule",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/requestRoutingRules/appgwPathBasedRule",
+              "properties": {
+                "entraJWTValidationConfig": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/entraJWTValidationConfigs/entraJWTValidationConfig1"
+                },
+                "httpListener": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhttplistener"
+                },
+                "priority": 20,
+                "provisioningState": "Succeeded",
+                "ruleType": "PathBasedRouting",
+                "urlPathMap": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/urlPathMaps/pathMap1"
+                }
+              }
+            }
+          ],
+          "rewriteRuleSets": [
+            {
+              "name": "rewriteRuleSet1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "rewriteRules": [
+                  {
+                    "name": "Set X-Forwarded-For",
+                    "actionSet": {
+                      "requestHeaderConfigurations": [
+                        {
+                          "headerName": "X-Forwarded-For",
+                          "headerValue": "{var_remote-addr}"
+                        }
+                      ],
+                      "responseHeaderConfigurations": [
+                        {
+                          "headerName": "Strict-Transport-Security",
+                          "headerValue": "max-age=31536000"
+                        }
+                      ],
+                      "urlConfiguration": {
+                        "modifiedPath": "/abc",
+                        "modifiedQueryString": "x=y&a=b",
+                        "reroute": false
+                      }
+                    },
+                    "conditions": [
+                      {
+                        "ignoreCase": true,
+                        "negate": false,
+                        "pattern": "^Bearer",
+                        "variable": "http_req_Authorization"
+                      }
+                    ],
+                    "ruleSequence": 102
+                  }
+                ]
+              }
+            }
+          ],
+          "sku": {
+            "name": "Basic_WAF_v2",
+            "tier": "Basic_WAF_v2"
+          },
+          "reservedCapacity": 3,
+          "firewallPolicy": {
+            "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies/Policy1"
+          },
+          "sslCertificates": [
+            {
+              "name": "sslcert",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/sslCertificates/sslcert",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "publicCertData": "*****"
+              }
+            }
+          ],
+          "sslProfiles": [
+            {
+              "name": "sslProfile1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/sslProfiles/sslProfile1",
+              "properties": {
+                "clientAuthConfiguration": {
+                  "verifyClientAuthMode": "Strict",
+                  "verifyClientCertIssuerDN": true,
+                  "verifyClientRevocation": "OCSP"
+                },
+                "provisioningState": "Succeeded",
+                "sslPolicy": {
+                  "cipherSuites": [
+                    "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256"
+                  ],
+                  "minProtocolVersion": "TLSv1_1",
+                  "policyType": "Custom"
+                },
+                "trustedClientCertificates": [
+                  {
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/trustedClientCertificates/clientcert"
+                  }
+                ]
+              }
+            }
+          ],
+          "trustedClientCertificates": [
+            {
+              "name": "clientcert",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/trustedClientCertificates/clientcert",
+              "properties": {
+                "clientCertIssuerDN": "CN=User1, OU=Eng, O=Company Ltd, L=D4, S=Arizona, C=US",
+                "data": "****",
+                "provisioningState": "Succeeded",
+                "validatedCertData": "****"
+              }
+            }
+          ],
+          "urlPathMaps": [
+            {
+              "name": "pathMap1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/urlPathMaps/pathMap1",
+              "properties": {
+                "defaultBackendAddressPool": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
+                },
+                "defaultBackendHttpSettings": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs"
+                },
+                "defaultLoadDistributionPolicy": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1"
+                },
+                "defaultRewriteRuleSet": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1"
+                },
+                "pathRules": [
+                  {
+                    "name": "apiPaths",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/urlPathMaps/pathMap1/pathRules/apiPaths",
+                    "properties": {
+                      "backendAddressPool": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
+                      },
+                      "backendHttpSettings": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs"
+                      },
+                      "loadDistributionPolicy": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/loadDistributionPolicies/ldp1"
+                      },
+                      "paths": [
+                        "/api",
+                        "/v1/api"
+                      ],
+                      "provisioningState": "Succeeded",
+                      "rewriteRuleSet": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1"
+                      }
+                    }
+                  }
+                ],
+                "provisioningState": "Succeeded"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "ApplicationGateways_Get",
+  "title": "Get Basic_WAF_v2 Application Gateway"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/WafPolicyCreateOrUpdate.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/WafPolicyCreateOrUpdate.json
@@ -4,6 +4,7 @@
     "parameters": {
       "location": "WestUs",
       "properties": {
+        "tier": "Standard",
         "customRules": [
           {
             "name": "Rule1",

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/WafPolicyCreateOrUpdateBasic.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/WafPolicyCreateOrUpdateBasic.json
@@ -1,0 +1,995 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "parameters": {
+      "location": "WestUs",
+      "properties": {
+        "tier": "Basic",
+        "customRules": [
+          {
+            "name": "Rule1",
+            "action": "Block",
+            "matchConditions": [
+              {
+                "matchValues": [
+                  "192.168.1.0/24",
+                  "10.0.0.0/24"
+                ],
+                "matchVariables": [
+                  {
+                    "selector": null,
+                    "variableName": "RemoteAddr"
+                  }
+                ],
+                "operator": "IPMatch"
+              }
+            ],
+            "priority": 1,
+            "ruleType": "MatchRule"
+          },
+          {
+            "name": "Rule2",
+            "action": "Block",
+            "matchConditions": [
+              {
+                "matchValues": [
+                  "192.168.1.0/24"
+                ],
+                "matchVariables": [
+                  {
+                    "selector": null,
+                    "variableName": "RemoteAddr"
+                  }
+                ],
+                "operator": "IPMatch"
+              },
+              {
+                "matchValues": [
+                  "Windows"
+                ],
+                "matchVariables": [
+                  {
+                    "selector": "UserAgent",
+                    "variableName": "RequestHeaders"
+                  }
+                ],
+                "operator": "Contains"
+              }
+            ],
+            "priority": 2,
+            "ruleType": "MatchRule"
+          },
+          {
+            "name": "RateLimitRule3",
+            "action": "Block",
+            "groupByUserSession": [
+              {
+                "groupByVariables": [
+                  {
+                    "variableName": "ClientAddr"
+                  }
+                ]
+              }
+            ],
+            "matchConditions": [
+              {
+                "matchValues": [
+                  "192.168.1.0/24",
+                  "10.0.0.0/24"
+                ],
+                "matchVariables": [
+                  {
+                    "selector": null,
+                    "variableName": "RemoteAddr"
+                  }
+                ],
+                "negationConditon": true,
+                "operator": "IPMatch"
+              }
+            ],
+            "priority": 3,
+            "rateLimitDuration": "OneMin",
+            "rateLimitThreshold": 10,
+            "ruleType": "RateLimitRule"
+          },
+          {
+            "name": "Rule4",
+            "action": "JSChallenge",
+            "matchConditions": [
+              {
+                "matchValues": [
+                  "192.168.1.0/24"
+                ],
+                "matchVariables": [
+                  {
+                    "selector": null,
+                    "variableName": "RemoteAddr"
+                  }
+                ],
+                "operator": "IPMatch"
+              },
+              {
+                "matchValues": [
+                  "Bot"
+                ],
+                "matchVariables": [
+                  {
+                    "selector": "UserAgent",
+                    "variableName": "RequestHeaders"
+                  }
+                ],
+                "operator": "Contains"
+              }
+            ],
+            "priority": 4,
+            "ruleType": "MatchRule"
+          }
+        ],
+        "managedRules": {
+          "exclusions": [
+            {
+              "exclusionManagedRuleSets": [
+                {
+                  "ruleGroups": [
+                    {
+                      "ruleGroupName": "REQUEST-930-APPLICATION-ATTACK-LFI",
+                      "rules": [
+                        {
+                          "ruleId": "930120"
+                        }
+                      ]
+                    },
+                    {
+                      "ruleGroupName": "REQUEST-932-APPLICATION-ATTACK-RCE"
+                    }
+                  ],
+                  "ruleSetType": "OWASP",
+                  "ruleSetVersion": "3.2"
+                }
+              ],
+              "matchVariable": "RequestArgNames",
+              "selector": "hello",
+              "selectorMatchOperator": "StartsWith"
+            },
+            {
+              "exclusionManagedRuleSets": [
+                {
+                  "ruleGroups": [],
+                  "ruleSetType": "OWASP",
+                  "ruleSetVersion": "3.1"
+                }
+              ],
+              "matchVariable": "RequestArgNames",
+              "selector": "hello",
+              "selectorMatchOperator": "EndsWith"
+            },
+            {
+              "matchVariable": "RequestArgNames",
+              "selector": "test",
+              "selectorMatchOperator": "StartsWith"
+            },
+            {
+              "matchVariable": "RequestArgValues",
+              "selector": "test",
+              "selectorMatchOperator": "StartsWith"
+            }
+          ],
+          "managedRuleSets": [
+            {
+              "ruleGroupOverrides": [
+                {
+                  "ruleGroupName": "REQUEST-931-APPLICATION-ATTACK-RFI",
+                  "rules": [
+                    {
+                      "action": "Log",
+                      "ruleId": "931120",
+                      "state": "Enabled"
+                    },
+                    {
+                      "action": "AnomalyScoring",
+                      "ruleId": "931130",
+                      "state": "Disabled"
+                    }
+                  ]
+                }
+              ],
+              "ruleSetType": "OWASP",
+              "ruleSetVersion": "3.2"
+            },
+            {
+              "ruleGroupOverrides": [
+                {
+                  "ruleGroupName": "UnknownBots",
+                  "rules": [
+                    {
+                      "action": "JSChallenge",
+                      "ruleId": "300700",
+                      "state": "Enabled"
+                    }
+                  ]
+                }
+              ],
+              "ruleSetType": "Microsoft_BotManagerRuleSet",
+              "ruleSetVersion": "1.0"
+            },
+            {
+              "ruleGroupOverrides": [
+                {
+                  "ruleGroupName": "ExcessiveRequests",
+                  "rules": [
+                    {
+                      "action": "Block",
+                      "ruleId": "500100",
+                      "sensitivity": "High",
+                      "state": "Enabled"
+                    }
+                  ]
+                }
+              ],
+              "ruleSetType": "Microsoft_HTTPDDoSRuleSet",
+              "ruleSetVersion": "1.0"
+            }
+          ],
+          "exceptions": [
+            {
+              "exceptionManagedRuleSets": [
+                {
+                  "ruleSetType": "OWASP",
+                  "ruleSetVersion": "3.2"
+                }
+              ],
+              "matchVariable": "RequestURI",
+              "valueMatchOperator": "Contains",
+              "values": [
+                "health",
+                "account/images",
+                "default.aspx"
+              ]
+            },
+            {
+              "exceptionManagedRuleSets": [
+                {
+                  "ruleGroups": [
+                    {
+                      "ruleGroupName": "REQUEST-932-APPLICATION-ATTACK-RCE"
+                    }
+                  ],
+                  "ruleSetType": "OWASP",
+                  "ruleSetVersion": "3.2"
+                }
+              ],
+              "matchVariable": "RequestHeader",
+              "selector": "User-Agent",
+              "selectorMatchOperator": "StartsWith",
+              "valueMatchOperator": "Contains",
+              "values": [
+                "Mozilla/5.0",
+                "Chrome/122.0.0.0"
+              ]
+            },
+            {
+              "exceptionManagedRuleSets": [
+                {
+                  "ruleGroups": [
+                    {
+                      "ruleGroupName": "BadBots",
+                      "rules": [
+                        {
+                          "ruleId": "100100"
+                        }
+                      ]
+                    }
+                  ],
+                  "ruleSetType": "Microsoft_BotManagerRuleSet",
+                  "ruleSetVersion": "1.0"
+                }
+              ],
+              "matchVariable": "RemoteAddr",
+              "valueMatchOperator": "IPMatch",
+              "values": [
+                "1.2.3.4",
+                "10.0.0.1/6"
+              ]
+            }
+          ]
+        },
+        "policySettings": {
+          "jsChallengeCookieExpirationInMins": 100,
+          "logScrubbing": {
+            "scrubbingRules": [
+              {
+                "matchVariable": "RequestArgNames",
+                "selector": "test",
+                "selectorMatchOperator": "Equals",
+                "state": "Enabled"
+              },
+              {
+                "matchVariable": "RequestIPAddress",
+                "selectorMatchOperator": "EqualsAny",
+                "state": "Enabled"
+              }
+            ],
+            "state": "Enabled"
+          }
+        }
+      }
+    },
+    "policyName": "Policy1",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "Policy1",
+        "type": "Microsoft.Network/applicationgatewaywebapplicationfirewallpolicies",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies/Policy1",
+        "location": "WestUs",
+        "properties": {
+          "customRules": [
+            {
+              "name": "Rule1",
+              "action": "Block",
+              "matchConditions": [
+                {
+                  "matchValues": [
+                    "192.168.1.0/24",
+                    "10.0.0.0/24"
+                  ],
+                  "matchVariables": [
+                    {
+                      "selector": null,
+                      "variableName": "RemoteAddr"
+                    }
+                  ],
+                  "negationConditon": false,
+                  "operator": "IPMatch",
+                  "transforms": []
+                }
+              ],
+              "priority": 1,
+              "ruleType": "MatchRule",
+              "state": "Enabled"
+            },
+            {
+              "name": "Rule2",
+              "action": "Block",
+              "matchConditions": [
+                {
+                  "matchValues": [
+                    "192.168.1.0/24"
+                  ],
+                  "matchVariables": [
+                    {
+                      "selector": null,
+                      "variableName": "RemoteAddr"
+                    }
+                  ],
+                  "negationConditon": false,
+                  "operator": "IPMatch"
+                },
+                {
+                  "matchValues": [
+                    "Windows"
+                  ],
+                  "matchVariables": [
+                    {
+                      "selector": "UserAgent",
+                      "variableName": "RequestHeader"
+                    }
+                  ],
+                  "negationConditon": false,
+                  "operator": "Contains"
+                }
+              ],
+              "priority": 2,
+              "ruleType": "MatchRule",
+              "state": "Enabled"
+            },
+            {
+              "name": "RateLimitRule3",
+              "action": "Block",
+              "groupByUserSession": [
+                {
+                  "groupByVariables": [
+                    {
+                      "variableName": "ClientAddr"
+                    }
+                  ]
+                }
+              ],
+              "matchConditions": [
+                {
+                  "matchValues": [
+                    "192.168.1.0/24",
+                    "10.0.0.0/24"
+                  ],
+                  "matchVariables": [
+                    {
+                      "selector": null,
+                      "variableName": "RemoteAddr"
+                    }
+                  ],
+                  "negationConditon": true,
+                  "operator": "IPMatch"
+                }
+              ],
+              "priority": 3,
+              "rateLimitDuration": "OneMin",
+              "rateLimitThreshold": 10,
+              "ruleType": "RateLimitRule"
+            },
+            {
+              "name": "Rule4",
+              "action": "JSChallenge",
+              "matchConditions": [
+                {
+                  "matchValues": [
+                    "192.168.1.0/24"
+                  ],
+                  "matchVariables": [
+                    {
+                      "selector": null,
+                      "variableName": "RemoteAddr"
+                    }
+                  ],
+                  "negationConditon": false,
+                  "operator": "IPMatch"
+                },
+                {
+                  "matchValues": [
+                    "Bot"
+                  ],
+                  "matchVariables": [
+                    {
+                      "selector": "UserAgent",
+                      "variableName": "RequestHeaders"
+                    }
+                  ],
+                  "negationConditon": false,
+                  "operator": "Contains"
+                }
+              ],
+              "priority": 4,
+              "ruleType": "MatchRule",
+              "state": "Enabled"
+            }
+          ],
+          "managedRules": {
+            "exclusions": [
+              {
+                "exclusionManagedRuleSets": [
+                  {
+                    "ruleGroups": [
+                      {
+                        "ruleGroupName": "REQUEST-930-APPLICATION-ATTACK-LFI",
+                        "rules": [
+                          {
+                            "ruleId": "930120"
+                          }
+                        ]
+                      },
+                      {
+                        "ruleGroupName": "REQUEST-932-APPLICATION-ATTACK-RCE"
+                      }
+                    ],
+                    "ruleSetType": "OWASP",
+                    "ruleSetVersion": "3.2"
+                  }
+                ],
+                "matchVariable": "RequestArgNames",
+                "selector": "hello",
+                "selectorMatchOperator": "StartsWith"
+              },
+              {
+                "exclusionManagedRuleSets": [
+                  {
+                    "ruleGroups": [],
+                    "ruleSetType": "OWASP",
+                    "ruleSetVersion": "3.1"
+                  }
+                ],
+                "matchVariable": "RequestArgNames",
+                "selector": "hello",
+                "selectorMatchOperator": "EndsWith"
+              },
+              {
+                "matchVariable": "RequestArgNames",
+                "selector": "test",
+                "selectorMatchOperator": "StartsWith"
+              },
+              {
+                "matchVariable": "RequestArgValues",
+                "selector": "test",
+                "selectorMatchOperator": "StartsWith"
+              }
+            ],
+            "managedRuleSets": [
+              {
+                "ruleGroupOverrides": [
+                  {
+                    "ruleGroupName": "REQUEST-931-APPLICATION-ATTACK-RFI",
+                    "rules": [
+                      {
+                        "action": "Log",
+                        "ruleId": "931120",
+                        "state": "Enabled"
+                      },
+                      {
+                        "action": "AnomalyScoring",
+                        "ruleId": "931130",
+                        "state": "Disabled"
+                      }
+                    ]
+                  }
+                ],
+                "ruleSetType": "OWASP",
+                "ruleSetVersion": "3.2"
+              },
+              {
+                "ruleGroupOverrides": [
+                  {
+                    "ruleGroupName": "UnknownBots",
+                    "rules": [
+                      {
+                        "action": "JSChallenge",
+                        "ruleId": "300700",
+                        "state": "Enabled"
+                      }
+                    ]
+                  }
+                ],
+                "ruleSetType": "Microsoft_BotManagerRuleSet",
+                "ruleSetVersion": "1.0"
+              },
+              {
+                "ruleGroupOverrides": [
+                  {
+                    "ruleGroupName": "ExcessiveRequests",
+                    "rules": [
+                      {
+                        "action": "Block",
+                        "ruleId": "500100",
+                        "sensitivity": "High",
+                        "state": "Enabled"
+                      }
+                    ]
+                  }
+                ],
+                "ruleSetType": "Microsoft_HTTPDDoSRuleSet",
+                "ruleSetVersion": "1.0"
+              }
+            ],
+            "exceptions": [
+              {
+                "exceptionManagedRuleSets": [
+                  {
+                    "ruleSetType": "OWASP",
+                    "ruleSetVersion": "3.2"
+                  }
+                ],
+                "matchVariable": "RequestURI",
+                "valueMatchOperator": "Contains",
+                "values": [
+                  "health",
+                  "account/images",
+                  "default.aspx"
+                ]
+              },
+              {
+                "exceptionManagedRuleSets": [
+                  {
+                    "ruleGroups": [
+                      {
+                        "ruleGroupName": "REQUEST-932-APPLICATION-ATTACK-RCE"
+                      }
+                    ],
+                    "ruleSetType": "OWASP",
+                    "ruleSetVersion": "3.2"
+                  }
+                ],
+                "matchVariable": "RequestHeader",
+                "selector": "User-Agent",
+                "selectorMatchOperator": "StartsWith",
+                "valueMatchOperator": "Contains",
+                "values": [
+                  "Mozilla/5.0",
+                  "Chrome/122.0.0.0"
+                ]
+              },
+              {
+                "exceptionManagedRuleSets": [
+                  {
+                    "ruleGroups": [
+                      {
+                        "ruleGroupName": "BadBots",
+                        "rules": [
+                          {
+                            "ruleId": "100100"
+                          }
+                        ]
+                      }
+                    ],
+                    "ruleSetType": "Microsoft_BotManagerRuleSet",
+                    "ruleSetVersion": "1.0"
+                  }
+                ],
+                "matchVariable": "RemoteAddr",
+                "valueMatchOperator": "IPMatch",
+                "values": [
+                  "1.2.3.4",
+                  "10.0.0.1/6"
+                ]
+              }
+            ]
+          },
+          "policySettings": {
+            "customBlockResponseBody": "SGVsbG8=",
+            "customBlockResponseStatusCode": 405,
+            "fileUploadEnforcement": true,
+            "fileUploadLimitInMb": 4000,
+            "jsChallengeCookieExpirationInMins": 100,
+            "logScrubbing": {
+              "scrubbingRules": [
+                {
+                  "matchVariable": "RequestArgNames",
+                  "selector": "test",
+                  "selectorMatchOperator": "Equals",
+                  "state": "Enabled"
+                },
+                {
+                  "matchVariable": "RequestIPAddress",
+                  "selectorMatchOperator": "EqualsAny",
+                  "state": "Enabled"
+                }
+              ],
+              "state": "Enabled"
+            },
+            "maxRequestBodySizeInKb": 2000,
+            "mode": "Detection",
+            "requestBodyCheck": true,
+            "requestBodyEnforcement": true,
+            "requestBodyInspectLimitInKB": 2000,
+            "state": "Enabled"
+          },
+          "provisioningState": "Succeeded",
+          "resourceState": "Enabled",
+          "tier": "Basic"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "Policy1",
+        "type": "Microsoft.Network/applicationgatewaywebapplicationfirewallpolicies",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies/Policy1",
+        "location": "WestUs",
+        "properties": {
+          "customRules": [
+            {
+              "name": "Rule1",
+              "action": "Block",
+              "matchConditions": [
+                {
+                  "matchValues": [
+                    "192.168.1.0/24",
+                    "10.0.0.0/24"
+                  ],
+                  "matchVariables": [
+                    {
+                      "selector": null,
+                      "variableName": "RemoteAddr"
+                    }
+                  ],
+                  "negationConditon": false,
+                  "operator": "IPMatch",
+                  "transforms": []
+                }
+              ],
+              "priority": 1,
+              "ruleType": "MatchRule",
+              "state": "Enabled"
+            },
+            {
+              "name": "Rule2",
+              "action": "Block",
+              "matchConditions": [
+                {
+                  "matchValues": [
+                    "192.168.1.0/24"
+                  ],
+                  "matchVariables": [
+                    {
+                      "selector": null,
+                      "variableName": "RemoteAddr"
+                    }
+                  ],
+                  "negationConditon": false,
+                  "operator": "IPMatch"
+                },
+                {
+                  "matchValues": [
+                    "Windows"
+                  ],
+                  "matchVariables": [
+                    {
+                      "selector": "UserAgent",
+                      "variableName": "RequestHeader"
+                    }
+                  ],
+                  "negationConditon": false,
+                  "operator": "Contains"
+                }
+              ],
+              "priority": 2,
+              "ruleType": "MatchRule",
+              "state": "Enabled"
+            },
+            {
+              "name": "RateLimitRule3",
+              "action": "Block",
+              "groupByUserSession": [
+                {
+                  "groupByVariables": [
+                    {
+                      "variableName": "ClientAddr"
+                    }
+                  ]
+                }
+              ],
+              "matchConditions": [
+                {
+                  "matchValues": [
+                    "192.168.1.0/24",
+                    "10.0.0.0/24"
+                  ],
+                  "matchVariables": [
+                    {
+                      "selector": null,
+                      "variableName": "RemoteAddr"
+                    }
+                  ],
+                  "negationConditon": true,
+                  "operator": "IPMatch"
+                }
+              ],
+              "priority": 3,
+              "rateLimitDuration": "OneMin",
+              "rateLimitThreshold": 10,
+              "ruleType": "RateLimitRule"
+            },
+            {
+              "name": "Rule4",
+              "action": "JSChallenge",
+              "matchConditions": [
+                {
+                  "matchValues": [
+                    "192.168.1.0/24"
+                  ],
+                  "matchVariables": [
+                    {
+                      "selector": null,
+                      "variableName": "RemoteAddr"
+                    }
+                  ],
+                  "negationConditon": false,
+                  "operator": "IPMatch"
+                },
+                {
+                  "matchValues": [
+                    "Bot"
+                  ],
+                  "matchVariables": [
+                    {
+                      "selector": "UserAgent",
+                      "variableName": "RequestHeaders"
+                    }
+                  ],
+                  "negationConditon": false,
+                  "operator": "Contains"
+                }
+              ],
+              "priority": 4,
+              "ruleType": "MatchRule",
+              "state": "Enabled"
+            }
+          ],
+          "managedRules": {
+            "exclusions": [
+              {
+                "exclusionManagedRuleSets": [
+                  {
+                    "ruleGroups": [
+                      {
+                        "ruleGroupName": "REQUEST-930-APPLICATION-ATTACK-LFI",
+                        "rules": [
+                          {
+                            "ruleId": "930120"
+                          }
+                        ]
+                      },
+                      {
+                        "ruleGroupName": "REQUEST-932-APPLICATION-ATTACK-RCE"
+                      }
+                    ],
+                    "ruleSetType": "OWASP",
+                    "ruleSetVersion": "3.2"
+                  }
+                ],
+                "matchVariable": "RequestArgNames",
+                "selector": "hello",
+                "selectorMatchOperator": "StartsWith"
+              },
+              {
+                "exclusionManagedRuleSets": [
+                  {
+                    "ruleGroups": [],
+                    "ruleSetType": "OWASP",
+                    "ruleSetVersion": "3.1"
+                  }
+                ],
+                "matchVariable": "RequestArgNames",
+                "selector": "hello",
+                "selectorMatchOperator": "EndsWith"
+              },
+              {
+                "matchVariable": "RequestArgNames",
+                "selector": "test",
+                "selectorMatchOperator": "StartsWith"
+              },
+              {
+                "matchVariable": "RequestArgValues",
+                "selector": "test",
+                "selectorMatchOperator": "StartsWith"
+              }
+            ],
+            "managedRuleSets": [
+              {
+                "ruleGroupOverrides": [
+                  {
+                    "ruleGroupName": "REQUEST-931-APPLICATION-ATTACK-RFI",
+                    "rules": [
+                      {
+                        "action": "Log",
+                        "ruleId": "931120",
+                        "state": "Enabled"
+                      },
+                      {
+                        "action": "AnomalyScoring",
+                        "ruleId": "931130",
+                        "state": "Disabled"
+                      }
+                    ]
+                  }
+                ],
+                "ruleSetType": "OWASP",
+                "ruleSetVersion": "3.2"
+              },
+              {
+                "ruleGroupOverrides": [
+                  {
+                    "ruleGroupName": "UnknownBots",
+                    "rules": [
+                      {
+                        "action": "JSChallenge",
+                        "ruleId": "300700",
+                        "state": "Enabled"
+                      }
+                    ]
+                  }
+                ],
+                "ruleSetType": "Microsoft_BotManagerRuleSet",
+                "ruleSetVersion": "1.0"
+              },
+              {
+                "ruleGroupOverrides": [
+                  {
+                    "ruleGroupName": "ExcessiveRequests",
+                    "rules": [
+                      {
+                        "action": "Block",
+                        "ruleId": "500100",
+                        "sensitivity": "High",
+                        "state": "Enabled"
+                      }
+                    ]
+                  }
+                ],
+                "ruleSetType": "Microsoft_HTTPDDoSRuleSet",
+                "ruleSetVersion": "1.0"
+              }
+            ],
+            "exceptions": [
+              {
+                "exceptionManagedRuleSets": [
+                  {
+                    "ruleSetType": "OWASP",
+                    "ruleSetVersion": "3.2"
+                  }
+                ],
+                "matchVariable": "RequestURI",
+                "valueMatchOperator": "Contains",
+                "values": [
+                  "health",
+                  "account/images",
+                  "default.aspx"
+                ]
+              },
+              {
+                "exceptionManagedRuleSets": [
+                  {
+                    "ruleGroups": [
+                      {
+                        "ruleGroupName": "REQUEST-932-APPLICATION-ATTACK-RCE"
+                      }
+                    ],
+                    "ruleSetType": "OWASP",
+                    "ruleSetVersion": "3.2"
+                  }
+                ],
+                "matchVariable": "RequestHeader",
+                "selector": "User-Agent",
+                "selectorMatchOperator": "StartsWith",
+                "valueMatchOperator": "Contains",
+                "values": [
+                  "Mozilla/5.0",
+                  "Chrome/122.0.0.0"
+                ]
+              },
+              {
+                "exceptionManagedRuleSets": [
+                  {
+                    "ruleGroups": [
+                      {
+                        "ruleGroupName": "BadBots",
+                        "rules": [
+                          {
+                            "ruleId": "100100"
+                          }
+                        ]
+                      }
+                    ],
+                    "ruleSetType": "Microsoft_BotManagerRuleSet",
+                    "ruleSetVersion": "1.0"
+                  }
+                ],
+                "matchVariable": "RemoteAddr",
+                "valueMatchOperator": "IPMatch",
+                "values": [
+                  "1.2.3.4",
+                  "10.0.0.1/6"
+                ]
+              }
+            ]
+          },
+          "policySettings": {
+            "customBlockResponseBody": "SGVsbG8=",
+            "customBlockResponseStatusCode": 405,
+            "fileUploadEnforcement": true,
+            "fileUploadLimitInMb": 4000,
+            "jsChallengeCookieExpirationInMins": 100,
+            "maxRequestBodySizeInKb": 2000,
+            "mode": "Detection",
+            "requestBodyCheck": true,
+            "requestBodyEnforcement": true,
+            "requestBodyInspectLimitInKB": 2000,
+            "state": "Enabled"
+          },
+          "provisioningState": "Succeeded",
+          "resourceState": "Enabled",
+          "tier": "Basic"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "WebApplicationFirewallPolicies_CreateOrUpdate",
+  "title": "Creates or updates a Basic tier WAF policy within a resource group"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/WafPolicyGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/WafPolicyGet.json
@@ -397,7 +397,8 @@
             "state": "Enabled"
           },
           "provisioningState": "Succeeded",
-          "resourceState": "Enabled"
+          "resourceState": "Enabled",
+          "tier": "Standard"
         },
         "tags": {
           "key1": "value1",

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/WafPolicyGetBasic.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/WafPolicyGetBasic.json
@@ -1,0 +1,412 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "policyName": "Policy1",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "Policy1",
+        "type": "Microsoft.Network/applicationgatewaywebapplicationfirewallpolicies",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies/Policy1",
+        "location": "WestUs",
+        "properties": {
+          "applicationGatewayForContainers": [
+            {
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ServiceNetworking/trafficControllers/agc1"
+            }
+          ],
+          "customRules": [
+            {
+              "name": "Rule1",
+              "action": "Block",
+              "matchConditions": [
+                {
+                  "matchValues": [
+                    "192.168.1.0/24",
+                    "10.0.0.0/24"
+                  ],
+                  "matchVariables": [
+                    {
+                      "selector": null,
+                      "variableName": "RemoteAddr"
+                    }
+                  ],
+                  "negationConditon": false,
+                  "operator": "IPMatch",
+                  "transforms": []
+                }
+              ],
+              "priority": 1,
+              "ruleType": "MatchRule",
+              "state": "Enabled"
+            },
+            {
+              "name": "Rule2",
+              "action": "Block",
+              "matchConditions": [
+                {
+                  "matchValues": [
+                    "192.168.1.0/24"
+                  ],
+                  "matchVariables": [
+                    {
+                      "selector": null,
+                      "variableName": "RemoteAddr"
+                    }
+                  ],
+                  "negationConditon": false,
+                  "operator": "IPMatch"
+                },
+                {
+                  "matchValues": [
+                    "Windows"
+                  ],
+                  "matchVariables": [
+                    {
+                      "selector": "UserAgent",
+                      "variableName": "RequestHeader"
+                    }
+                  ],
+                  "negationConditon": false,
+                  "operator": "Contains"
+                }
+              ],
+              "priority": 2,
+              "ruleType": "MatchRule",
+              "state": "Enabled"
+            },
+            {
+              "name": "RateLimitRule3",
+              "action": "Block",
+              "groupByUserSession": [
+                {
+                  "groupByVariables": [
+                    {
+                      "variableName": "ClientAddr"
+                    }
+                  ]
+                }
+              ],
+              "matchConditions": [
+                {
+                  "matchValues": [
+                    "192.168.1.0/24",
+                    "10.0.0.0/24"
+                  ],
+                  "matchVariables": [
+                    {
+                      "selector": null,
+                      "variableName": "RemoteAddr"
+                    }
+                  ],
+                  "negationConditon": true,
+                  "operator": "IPMatch"
+                }
+              ],
+              "priority": 3,
+              "rateLimitDuration": "OneMin",
+              "rateLimitThreshold": 10,
+              "ruleType": "RateLimitRule"
+            },
+            {
+              "name": "Rule4",
+              "action": "JSChallenge",
+              "matchConditions": [
+                {
+                  "matchValues": [
+                    "192.168.1.0/24"
+                  ],
+                  "matchVariables": [
+                    {
+                      "selector": null,
+                      "variableName": "RemoteAddr"
+                    }
+                  ],
+                  "negationConditon": false,
+                  "operator": "IPMatch"
+                },
+                {
+                  "matchValues": [
+                    "Bot"
+                  ],
+                  "matchVariables": [
+                    {
+                      "selector": "UserAgent",
+                      "variableName": "RequestHeaders"
+                    }
+                  ],
+                  "negationConditon": false,
+                  "operator": "Contains"
+                }
+              ],
+              "priority": 4,
+              "ruleType": "MatchRule",
+              "state": "Enabled"
+            }
+          ],
+          "managedRules": {
+            "exclusions": [
+              {
+                "matchVariable": "RequestHeaderNames",
+                "selector": "testHeader1",
+                "selectorMatchOperator": "Equals"
+              },
+              {
+                "matchVariable": "RequestHeaderNames",
+                "selector": "testHeader2",
+                "selectorMatchOperator": "StartsWith"
+              },
+              {
+                "matchVariable": "RequestArgValues",
+                "selector": "hello",
+                "selectorMatchOperator": "StartsWith"
+              },
+              {
+                "exclusionManagedRuleSets": [
+                  {
+                    "ruleGroups": [
+                      {
+                        "ruleGroupName": "REQUEST-930-APPLICATION-ATTACK-LFI",
+                        "rules": [
+                          {
+                            "ruleId": "930120"
+                          }
+                        ]
+                      },
+                      {
+                        "ruleGroupName": "REQUEST-932-APPLICATION-ATTACK-RCE"
+                      }
+                    ],
+                    "ruleSetType": "OWASP",
+                    "ruleSetVersion": "3.2"
+                  }
+                ],
+                "matchVariable": "RequestArgNames",
+                "selector": "hello",
+                "selectorMatchOperator": "StartsWith"
+              },
+              {
+                "exclusionManagedRuleSets": [
+                  {
+                    "ruleGroups": [],
+                    "ruleSetType": "OWASP",
+                    "ruleSetVersion": "3.1"
+                  }
+                ],
+                "matchVariable": "RequestArgNames",
+                "selector": "hello",
+                "selectorMatchOperator": "EndsWith"
+              }
+            ],
+            "managedRuleSets": [
+              {
+                "computedDisabledRules": [
+                  {
+                    "ruleGroupName": "REQUEST-942-APPLICATION-ATTACK-SQLI",
+                    "rules": [
+                      942130,
+                      942110
+                    ]
+                  },
+                  {
+                    "ruleGroupName": "REQUEST-920-PROTOCOL-ENFORCEMENT",
+                    "rules": [
+                      920100,
+                      920120
+                    ]
+                  },
+                  {
+                    "ruleGroupName": "General",
+                    "rules": [
+                      200003
+                    ]
+                  }
+                ],
+                "ruleGroupOverrides": [
+                  {
+                    "ruleGroupName": "REQUEST-942-APPLICATION-ATTACK-SQLI",
+                    "rules": [
+                      {
+                        "action": "AnomalyScoring",
+                        "ruleId": "942130",
+                        "state": "Disabled"
+                      },
+                      {
+                        "action": "AnomalyScoring",
+                        "ruleId": "942110",
+                        "state": "Disabled"
+                      },
+                      {
+                        "action": "Log",
+                        "ruleId": "942140",
+                        "state": "Enabled"
+                      }
+                    ]
+                  },
+                  {
+                    "ruleGroupName": "REQUEST-920-PROTOCOL-ENFORCEMENT",
+                    "rules": [
+                      {
+                        "action": "AnomalyScoring",
+                        "ruleId": "920100",
+                        "state": "Disabled"
+                      },
+                      {
+                        "action": "AnomalyScoring",
+                        "ruleId": "920120",
+                        "state": "Disabled"
+                      },
+                      {
+                        "action": "Block",
+                        "ruleId": "920130",
+                        "state": "Enabled"
+                      }
+                    ]
+                  }
+                ],
+                "ruleSetType": "OWASP",
+                "ruleSetVersion": "3.2"
+              },
+              {
+                "ruleGroupOverrides": [
+                  {
+                    "ruleGroupName": "UnknownBots",
+                    "rules": [
+                      {
+                        "action": "JSChallenge",
+                        "ruleId": "300700",
+                        "state": "Enabled"
+                      }
+                    ]
+                  }
+                ],
+                "ruleSetType": "Microsoft_BotManagerRuleSet",
+                "ruleSetVersion": "1.0"
+              },
+              {
+                "ruleGroupOverrides": [
+                  {
+                    "ruleGroupName": "ExcessiveRequests",
+                    "rules": [
+                      {
+                        "action": "Block",
+                        "ruleId": "500100",
+                        "sensitivity": "High",
+                        "state": "Enabled"
+                      }
+                    ]
+                  }
+                ],
+                "ruleSetType": "Microsoft_HTTPDDoSRuleSet",
+                "ruleSetVersion": "1.0"
+              }
+            ],
+            "exceptions": [
+              {
+                "exceptionManagedRuleSets": [
+                  {
+                    "ruleSetType": "OWASP",
+                    "ruleSetVersion": "3.2"
+                  }
+                ],
+                "matchVariable": "RequestURI",
+                "valueMatchOperator": "Contains",
+                "values": [
+                  "health",
+                  "account/images",
+                  "default.aspx"
+                ]
+              },
+              {
+                "exceptionManagedRuleSets": [
+                  {
+                    "ruleGroups": [
+                      {
+                        "ruleGroupName": "REQUEST-932-APPLICATION-ATTACK-RCE"
+                      }
+                    ],
+                    "ruleSetType": "OWASP",
+                    "ruleSetVersion": "3.2"
+                  }
+                ],
+                "matchVariable": "RequestHeader",
+                "selector": "User-Agent",
+                "selectorMatchOperator": "StartsWith",
+                "valueMatchOperator": "Contains",
+                "values": [
+                  "Mozilla/5.0",
+                  "Chrome/122.0.0.0"
+                ]
+              },
+              {
+                "exceptionManagedRuleSets": [
+                  {
+                    "ruleGroups": [
+                      {
+                        "ruleGroupName": "BadBots",
+                        "rules": [
+                          {
+                            "ruleId": "100100"
+                          }
+                        ]
+                      }
+                    ],
+                    "ruleSetType": "Microsoft_BotManagerRuleSet",
+                    "ruleSetVersion": "1.0"
+                  }
+                ],
+                "matchVariable": "RemoteAddr",
+                "valueMatchOperator": "IPMatch",
+                "values": [
+                  "1.2.3.4",
+                  "10.0.0.1/6"
+                ]
+              }
+            ]
+          },
+          "policySettings": {
+            "customBlockResponseBody": "SGVsbG8=",
+            "customBlockResponseStatusCode": 405,
+            "fileUploadEnforcement": true,
+            "fileUploadLimitInMb": 4000,
+            "jsChallengeCookieExpirationInMins": 100,
+            "logScrubbing": {
+              "scrubbingRules": [
+                {
+                  "matchVariable": "RequestArgNames",
+                  "selector": "test",
+                  "selectorMatchOperator": "Equals",
+                  "state": "Enabled"
+                },
+                {
+                  "matchVariable": "RequestIPAddress",
+                  "selectorMatchOperator": "EqualsAny",
+                  "state": "Enabled"
+                }
+              ],
+              "state": "Enabled"
+            },
+            "maxRequestBodySizeInKb": 2000,
+            "mode": "Prevention",
+            "requestBodyCheck": true,
+            "requestBodyEnforcement": true,
+            "requestBodyInspectLimitInKB": 2000,
+            "state": "Enabled"
+          },
+          "provisioningState": "Succeeded",
+          "resourceState": "Enabled",
+          "tier": "Basic"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "WebApplicationFirewallPolicies_Get",
+  "title": "Gets a Basic tier WAF policy within a resource group"
+}


### PR DESCRIPTION
## Summary
Adds Centurion WAF (Basic WAF v2) API contract changes to api-version 2026-01-01:

1. **Application Gateway SKU names and tiers** - adds Basic_v2 and Basic_WAF_v2 to ApplicationGatewaySkuName and ApplicationGatewayTier.
2. **Reserved capacity** - adds reservedCapacity for the Basic_v2 and Basic_WAF_v2 SKU tiers.
3. **WAF Policy tier** - adds the WebApplicationFirewallPolicyTier enum (Basic / Standard) and optional tier property on WebApplicationFirewallPolicyPropertiesFormat.
The WAF policy tier values are ordered to align generated SDK enum ordinals with Standard = 0 and Basic = 1.

All changes are authored in TypeSpec (`Network/Network/models.tsp`) and gated with `@added(Versions.v2026_01_01)`. The 2026-01-01 Swagger was regenerated with `tsp compile`, and the WAF policy get/create-or-update examples demonstrate `tier`.

Adapted from #45330 for the 2026-01-01 API version with the corrected Basic_v2/Basic_WAF_v2 SKU set.

Validation: TypeSpec compile, OAV validate-spec, and OAV validate-example pass.