### PR TITLE
Support filters in LCH LIST

### DIFF
--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/Compute/VirtualMachineScaleSetLifecycleHookEvent.tsp
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/Compute/VirtualMachineScaleSetLifecycleHookEvent.tsp
@@ -72,6 +72,14 @@ interface VirtualMachineScaleSetLifeCycleHookEvents {
    */
   list is ComputeResourceListByParent<
     VMScaleSetLifecycleHookEvent,
+    Parameters = {
+      /**
+       * The filter to apply to the operation. Allowed value is 'properties/state eq 'Active''.
+       */
+      @added(Versions.v2026_09_01)
+      @query("$filter")
+      $filter?: string;
+    },
     Response = VMScaleSetLifecycleHookEventListResult
   >;
 }

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/Compute/examples/2026-09-01/virtualMachineScaleSetExamples/VirtualMachineScaleSetLifeCycleHookEvent_List_ActiveOnly.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/Compute/examples/2026-09-01/virtualMachineScaleSetExamples/VirtualMachineScaleSetLifeCycleHookEvent_List_ActiveOnly.json
@@ -1,0 +1,46 @@
+{
+  "parameters": {
+    "subscriptionId": "2e2e3046-f85f-4966-8fd2-5fd7bf6ea717",
+    "resourceGroupName": "RG01",
+    "vmScaleSetName": "VMSS01",
+    "api-version": "2026-09-01",
+    "$filter": "properties/state eq 'Active'"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "445c0a08-cfc5-4ef6-bb89-fe77c5178628",
+            "id": "/subscriptions/2e2e3046-f85f-4966-8fd2-5fd7bf6ea717/resourceGroups/RG01/providers/Microsoft.Compute/virtualMachineScaleSets/VMSS01/lifecycleHookEvents/445c0a08-cfc5-4ef6-bb89-fe77c5178628",
+            "type": "Microsoft.Compute/virtualMachineScaleSets/lifecycleHookEvents",
+            "properties": {
+              "type": "UpgradeAutoOSRollingBatchStarting",
+              "waitUntil": "2025-05-08T10:17:55.6844555+00:00",
+              "maxWaitUntil": "2025-05-08T13:17:55.6844555+00:00",
+              "timeCreated": "2025-05-08T07:17:55.6844555+00:00",
+              "defaultAction": "Approve",
+              "targetResources": [
+                {
+                  "resource": {
+                    "id": "/subscriptions/2e2e3046-f85f-4966-8fd2-5fd7bf6ea717/resourceGroups/RG01/providers/Microsoft.Compute/virtualMachineScaleSets/VMSS01/virtualMachines/2"
+                  },
+                  "actionState": "Waiting"
+                },
+                {
+                  "resource": {
+                    "id": "/subscriptions/2e2e3046-f85f-4966-8fd2-5fd7bf6ea717/resourceGroups/RG01/providers/Microsoft.Compute/virtualMachineScaleSets/VMSS01/virtualMachines/3"
+                  },
+                  "actionState": "Waiting"
+                }
+              ],
+              "state": "Active"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "VirtualMachineScaleSetLifeCycleHookEvents_List",
+  "title": "Gets a list of the active lifecycle hook events in a virtual machine scale set."
+}

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2026-09-01/ComputeRP.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2026-09-01/ComputeRP.json
@@ -7168,6 +7168,13 @@
             "description": "The name of the VM scale set.",
             "required": true,
             "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "The filter to apply to the operation. Allowed value is 'properties/state eq 'Active''.",
+            "required": false,
+            "type": "string"
           }
         ],
         "responses": {
@@ -7187,6 +7194,9 @@
         "x-ms-examples": {
           "Gets a list of all lifecycle hook events in a virtual machine scale set.": {
             "$ref": "./examples/virtualMachineScaleSetExamples/VirtualMachineScaleSetLifeCycleHookEvent_List.json"
+          },
+          "Gets a list of the active lifecycle hook events in a virtual machine scale set.": {
+            "$ref": "./examples/virtualMachineScaleSetExamples/VirtualMachineScaleSetLifeCycleHookEvent_List_ActiveOnly.json"
           }
         },
         "x-ms-pageable": {

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2026-09-01/examples/virtualMachineScaleSetExamples/VirtualMachineScaleSetLifeCycleHookEvent_List_ActiveOnly.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2026-09-01/examples/virtualMachineScaleSetExamples/VirtualMachineScaleSetLifeCycleHookEvent_List_ActiveOnly.json
@@ -1,0 +1,46 @@
+{
+  "parameters": {
+    "subscriptionId": "2e2e3046-f85f-4966-8fd2-5fd7bf6ea717",
+    "resourceGroupName": "RG01",
+    "vmScaleSetName": "VMSS01",
+    "api-version": "2026-09-01",
+    "$filter": "properties/state eq 'Active'"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "445c0a08-cfc5-4ef6-bb89-fe77c5178628",
+            "id": "/subscriptions/2e2e3046-f85f-4966-8fd2-5fd7bf6ea717/resourceGroups/RG01/providers/Microsoft.Compute/virtualMachineScaleSets/VMSS01/lifecycleHookEvents/445c0a08-cfc5-4ef6-bb89-fe77c5178628",
+            "type": "Microsoft.Compute/virtualMachineScaleSets/lifecycleHookEvents",
+            "properties": {
+              "type": "UpgradeAutoOSRollingBatchStarting",
+              "waitUntil": "2025-05-08T10:17:55.6844555+00:00",
+              "maxWaitUntil": "2025-05-08T13:17:55.6844555+00:00",
+              "timeCreated": "2025-05-08T07:17:55.6844555+00:00",
+              "defaultAction": "Approve",
+              "targetResources": [
+                {
+                  "resource": {
+                    "id": "/subscriptions/2e2e3046-f85f-4966-8fd2-5fd7bf6ea717/resourceGroups/RG01/providers/Microsoft.Compute/virtualMachineScaleSets/VMSS01/virtualMachines/2"
+                  },
+                  "actionState": "Waiting"
+                },
+                {
+                  "resource": {
+                    "id": "/subscriptions/2e2e3046-f85f-4966-8fd2-5fd7bf6ea717/resourceGroups/RG01/providers/Microsoft.Compute/virtualMachineScaleSets/VMSS01/virtualMachines/3"
+                  },
+                  "actionState": "Waiting"
+                }
+              ],
+              "state": "Active"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "VirtualMachineScaleSetLifeCycleHookEvents_List",
+  "title": "Gets a list of the active lifecycle hook events in a virtual machine scale set."
+}


### PR DESCRIPTION
The LIST API for VMSS lifecycle hook events returns every event, both `Active` and `Completed`. A customer who only wants the events that still wait on a response must read every page and filter on the client. This PR adds an optional `$filter` query parameter so the service returns the active events only.

The parameter accepts one value:
```
GET .../virtualMachineScaleSets/{name}/lifecycleHookEvents?api-version=2026-09-01&$filter=properties/state eq 'Active'
```

`state` and the `VMScaleSetLifecycleHookEventState` enum (`Active`, `Completed`) already exist in the contract. This PR adds no new model or property.