### PR TITLE
Add 2026-09-01 Storage DataRP API

### DIFF
--- a/specification/storage/Storage.Management/BlobAccessPointConfiguration.tsp
+++ b/specification/storage/Storage.Management/BlobAccessPointConfiguration.tsp
@@ -1,0 +1,428 @@
+import "@typespec/http";
+import "@typespec/rest";
+import "@typespec/versioning";
+import "@azure-tools/typespec-azure-core";
+import "@azure-tools/typespec-azure-resource-manager";
+
+import "./StorageAccount.tsp";
+
+using TypeSpec.Http;
+using TypeSpec.Rest;
+using TypeSpec.Versioning;
+using Azure.ResourceManager;
+
+namespace Microsoft.Storage;
+
+@added(Versions.v2026_09_01)
+@doc("The state of a Blob Access Point configuration.")
+union BlobAccessPointConfigurationState {
+  @doc("The Blob Access Point configuration is active.")
+  Active: "Active",
+
+  @doc("The Blob Access Point configuration is inactive.")
+  Inactive: "Inactive",
+
+  string,
+}
+
+@added(Versions.v2026_09_01)
+@doc("The status of the most recent connection test.")
+union BlobAccessPointConnectionTestStatus {
+  @doc("The connection test succeeded.")
+  Succeeded: "Succeeded",
+
+  @doc("The connection test failed.")
+  Failed: "Failed",
+
+  string,
+}
+
+@added(Versions.v2026_09_01)
+@doc("The type of the non-Azure S3-compatible data source exposed through the Blob Access Point.")
+union BlobAccessPointSourceType {
+  @doc("NetApp ONTAP.")
+  NetAppOntap: "NetAppOntap",
+
+  @doc("Azure NetApp Files.")
+  AzureNetAppFiles: "AzureNetAppFiles",
+
+  @doc("Dell OneFS.")
+  DellOneFs: "DellOneFs",
+
+  @doc("Qumulo S3-compatible data source.")
+  Qumulo: "Qumulo",
+
+  @doc("Commvault S3-compatible data source.")
+  Commvault: "Commvault",
+
+  @doc("Nasuni S3-compatible data source.")
+  Nasuni: "Nasuni",
+
+  @doc("Another S3-compatible data source.")
+  S3Compatible: "S3Compatible",
+
+  string,
+}
+
+@added(Versions.v2026_09_01)
+@doc("The connection type used to reach a non-Azure backing data source.")
+union BlobAccessPointConnectionType {
+  @doc("Connect directly to a public or otherwise routable endpoint.")
+  Endpoint: "Endpoint",
+
+  @doc("Connect through Azure Private Link.")
+  PrivateLink: "PrivateLink",
+
+  string,
+}
+
+@added(Versions.v2026_09_01)
+@doc("The format used by a Private Link identifier.")
+union BlobAccessPointPrivateLinkIdType {
+  @doc("The identifier is an Azure resource ID.")
+  ResourceId: "ResourceId",
+
+  @doc("The identifier is a Private Link alias.")
+  Alias: "Alias",
+
+  string,
+}
+
+@added(Versions.v2026_09_01)
+@doc("TLS certificate verification behavior.")
+union BlobAccessPointTlsVerification {
+  @doc("Verify the TLS certificate chain.")
+  Perform: "Perform",
+
+  @doc("Skip TLS certificate-chain verification. Use only when the backing source uses a certificate that cannot be validated against a trusted root. Skipping verification exposes credentials and data to an on-path attacker.")
+  Skip: "Skip",
+
+  string,
+}
+
+@added(Versions.v2026_09_01)
+@doc("How Azure Storage authenticates to a non-Azure S3-compatible source.")
+union BlobAccessPointRemoteAuthType {
+  @doc("Authenticate with an S3 access key and secret access key.")
+  AccessKey: "AccessKey",
+
+  string,
+}
+
+@added(Versions.v2026_09_01)
+@discriminator("connectionType")
+@doc("Details for connecting to a backing data source.")
+model BlobAccessPointConnectionProperties {
+  @doc("The connection type. This value determines the remaining shape of the connection object.")
+  connectionType: BlobAccessPointConnectionType;
+}
+
+@added(Versions.v2026_09_01)
+@doc("A direct endpoint connection.")
+model BlobAccessPointEndpointConnectionProperties
+  extends BlobAccessPointConnectionProperties {
+  @visibility(Lifecycle.Read)
+  connectionType: BlobAccessPointConnectionType.Endpoint;
+
+  @visibility(Lifecycle.Create, Lifecycle.Read)
+  @doc("The backing endpoint, including its protocol, host, optional port, and optional path.")
+  @minLength(4)
+  endpoint: url;
+
+  @doc("TLS certificate verification behavior. Defaults to Perform when not specified.")
+  tlsVerification?: BlobAccessPointTlsVerification;
+}
+
+@added(Versions.v2026_09_01)
+@doc("A connection established through Azure Private Link.")
+model BlobAccessPointPrivateLinkConnectionProperties
+  extends BlobAccessPointConnectionProperties {
+  @visibility(Lifecycle.Read)
+  connectionType: BlobAccessPointConnectionType.PrivateLink;
+
+  @visibility(Lifecycle.Create, Lifecycle.Read)
+  @doc("Whether privateLinkId contains an Azure resource ID or a Private Link alias.")
+  privateLinkIdType: BlobAccessPointPrivateLinkIdType;
+
+  @visibility(Lifecycle.Create, Lifecycle.Read)
+  @doc("The Azure resource ID or alias of the backing Private Link resource.")
+  privateLinkId: string;
+
+  @visibility(Lifecycle.Create, Lifecycle.Read)
+  @doc("The Private Link group ID, when required by the backing resource.")
+  privateLinkGroupId?: string;
+
+  @visibility(Lifecycle.Create, Lifecycle.Read)
+  @doc("The Azure region in which the private endpoint is provisioned.")
+  privateLinkLocation: string;
+
+  @visibility(Lifecycle.Create, Lifecycle.Read)
+  @doc("The connection request message sent to the Private Link owner.")
+  requestMessage: string;
+
+  @visibility(Lifecycle.Create, Lifecycle.Read)
+  @doc("The backing endpoint as seen by the target of the Private Link.")
+  @minLength(4)
+  endpoint: url;
+
+  @doc("TLS certificate verification behavior. Defaults to Perform when not specified.")
+  tlsVerification?: BlobAccessPointTlsVerification;
+
+  @visibility(Lifecycle.Read)
+  @doc("The name of the private endpoint created by Azure Storage.")
+  privateEndpointName?: string;
+}
+
+@added(Versions.v2026_09_01)
+@discriminator("authType")
+@doc("Authentication properties for a non-Azure S3-compatible source.")
+model BlobAccessPointRemoteAuthProperties {
+  @doc("The authentication type. This value determines the remaining shape of the authentication object.")
+  authType: BlobAccessPointRemoteAuthType;
+}
+
+@added(Versions.v2026_09_01)
+@doc("S3 access-key authentication properties.")
+model BlobAccessPointAccessKeyAuthProperties
+  extends BlobAccessPointRemoteAuthProperties {
+  @visibility(Lifecycle.Read)
+  authType: BlobAccessPointRemoteAuthType.AccessKey;
+
+  @minLength(3)
+  @doc("The access key ID.")
+  accessKeyId: string;
+
+  @visibility(Lifecycle.Create, Lifecycle.Update)
+  @secret
+  @minLength(3)
+  @doc("The secret access key. This value is never returned by read or list operations.")
+  secretAccessKey: string;
+
+  @doc("The region used by the request-signing algorithm. Defaults to 'us-east-1' when not specified.")
+  signingRegion?: string;
+
+  @doc("The host used when computing request signatures. The endpoint host is used by default.")
+  hostOverride?: string;
+}
+
+@added(Versions.v2026_09_01)
+@discriminator("sourceType")
+@doc("Information about the data source exposed through a Blob Access Point.")
+model BlobAccessPointSourceProperties {
+  @doc("The source type. This value determines the remaining shape of the source object.")
+  sourceType: BlobAccessPointSourceType;
+}
+
+/** Properties shared by every non-Azure S3-compatible backing source. */
+alias BlobAccessPointS3CompatibleSourceProperties = {
+  @doc("Details for connecting to the backing data source. The connection target is fixed when the configuration is created; only the TLS verification behavior can be changed afterwards.")
+  connection: BlobAccessPointConnectionProperties;
+
+  @doc("Details for authenticating to the backing data source.")
+  auth: BlobAccessPointRemoteAuthProperties;
+};
+
+@added(Versions.v2026_09_01)
+@doc("A NetApp ONTAP backing source.")
+model BlobAccessPointNetAppOntapSourceProperties
+  extends BlobAccessPointSourceProperties {
+  @visibility(Lifecycle.Read)
+  sourceType: BlobAccessPointSourceType.NetAppOntap;
+
+  ...BlobAccessPointS3CompatibleSourceProperties;
+}
+
+@added(Versions.v2026_09_01)
+@doc("An Azure NetApp Files backing source.")
+model BlobAccessPointAzureNetAppFilesSourceProperties
+  extends BlobAccessPointSourceProperties {
+  @visibility(Lifecycle.Read)
+  sourceType: BlobAccessPointSourceType.AzureNetAppFiles;
+
+  ...BlobAccessPointS3CompatibleSourceProperties;
+}
+
+@added(Versions.v2026_09_01)
+@doc("A Dell OneFS backing source.")
+model BlobAccessPointDellOneFsSourceProperties
+  extends BlobAccessPointSourceProperties {
+  @visibility(Lifecycle.Read)
+  sourceType: BlobAccessPointSourceType.DellOneFs;
+
+  ...BlobAccessPointS3CompatibleSourceProperties;
+}
+
+@added(Versions.v2026_09_01)
+@doc("A Qumulo backing source.")
+model BlobAccessPointQumuloSourceProperties
+  extends BlobAccessPointSourceProperties {
+  @visibility(Lifecycle.Read)
+  sourceType: BlobAccessPointSourceType.Qumulo;
+
+  ...BlobAccessPointS3CompatibleSourceProperties;
+}
+
+@added(Versions.v2026_09_01)
+@doc("A Commvault backing source.")
+model BlobAccessPointCommvaultSourceProperties
+  extends BlobAccessPointSourceProperties {
+  @visibility(Lifecycle.Read)
+  sourceType: BlobAccessPointSourceType.Commvault;
+
+  ...BlobAccessPointS3CompatibleSourceProperties;
+}
+
+@added(Versions.v2026_09_01)
+@doc("A Nasuni backing source.")
+model BlobAccessPointNasuniSourceProperties
+  extends BlobAccessPointSourceProperties {
+  @visibility(Lifecycle.Read)
+  sourceType: BlobAccessPointSourceType.Nasuni;
+
+  ...BlobAccessPointS3CompatibleSourceProperties;
+}
+
+@added(Versions.v2026_09_01)
+@doc("Another S3-compatible backing source.")
+model BlobAccessPointGenericS3SourceProperties
+  extends BlobAccessPointSourceProperties {
+  @visibility(Lifecycle.Read)
+  sourceType: BlobAccessPointSourceType.S3Compatible;
+
+  ...BlobAccessPointS3CompatibleSourceProperties;
+}
+
+@added(Versions.v2026_09_01)
+@doc("Details of a Blob Access Point configuration.")
+model BlobAccessPointConfigurationProperties {
+  @visibility(Lifecycle.Read)
+  @doc("The system-generated unique identifier of the configuration.")
+  @pattern("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+  uniqueId?: string;
+
+  @doc("The configuration state. A configuration is created in the Active state when this value is not specified.")
+  state?: BlobAccessPointConfigurationState;
+
+  @maxLength(250)
+  @doc("An arbitrary description of the Blob Access Point configuration.")
+  description?: string;
+
+  @visibility(Lifecycle.Read)
+  @doc("The status of the most recent connection test.")
+  lastConnectionTestStatus?: BlobAccessPointConnectionTestStatus;
+
+  @visibility(Lifecycle.Read)
+  @doc("The timestamp of the most recent connection test.")
+  lastConnectionTestTimestamp?: utcDateTime;
+
+  @visibility(Lifecycle.Read)
+  @doc("The normalized and redacted error from the most recent failed connection test.")
+  lastConnectionTestErrorMessage?: string;
+
+  @doc("Information about the backing data source.")
+  source: BlobAccessPointSourceProperties;
+
+  @visibility(Lifecycle.Read)
+  @doc("The status of the last operation.")
+  provisioningState?: Azure.ResourceManager.ResourceProvisioningState;
+}
+
+@added(Versions.v2026_09_01)
+@doc("The result of testing a Blob Access Point configuration connection.")
+model BlobAccessPointConnectionTestResponse {
+  @doc("The name of the request attempted against the backing data source.")
+  @minLength(1)
+  methodName: string;
+
+  @doc("A normalized and redacted error message received from the backing data source. This value is empty when the connection test succeeds.")
+  errorMessage?: string;
+
+  @doc("The request ID associated with the request sent to the backing data source for validation.")
+  @minLength(1)
+  requestId: string;
+}
+
+@added(Versions.v2026_09_01)
+@doc("The request used to test a proposed Blob Access Point configuration.")
+model BlobAccessPointProposedConnectionTestRequest {
+  @doc("Information about the backing data source whose connection is tested.")
+  source: BlobAccessPointSourceProperties;
+}
+
+@added(Versions.v2026_09_01)
+@doc("The request used to test an existing Blob Access Point configuration.")
+model BlobAccessPointConnectionTestRequest {
+  @doc("The system-generated unique identifier of the Blob Access Point configuration, as returned by a read operation. This value must match the configuration named in the request path, and is required so that a configuration which was deleted and recreated under the same name is not tested by mistake.")
+  @pattern("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+  uniqueId: string;
+}
+
+@added(Versions.v2026_09_01)
+@doc("A BlobAccessPointConfiguration is a tracked Azure resource modeled as a sub-resource of a Storage Account.")
+@parentResource(StorageAccount)
+model BlobAccessPointConfiguration is TrackedResource<
+  BlobAccessPointConfigurationProperties,
+  false
+> {
+  @doc("The name of the Blob Access Point configuration.")
+  @pattern("^[a-z0-9](?!.*--)[a-z0-9-]{1,61}[a-z0-9]$")
+  @key("blobAccessPointConfigurationName")
+  @segment("blobAccessPointConfigurations")
+  @path
+  name: string;
+}
+
+@armResourceOperations(BlobAccessPointConfiguration)
+interface BlobAccessPointConfigurations {
+  @doc("Get the specified Blob Access Point configuration.")
+  @added(Versions.v2026_09_01)
+  get is ArmResourceRead<BlobAccessPointConfiguration>;
+
+  @doc("Creates or updates a Blob Access Point configuration.")
+  @added(Versions.v2026_09_01)
+  create is ArmResourceCreateOrReplaceAsync<BlobAccessPointConfiguration>;
+
+  @doc("Update a Blob Access Point configuration.")
+  @added(Versions.v2026_09_01)
+  update is ArmResourcePatchAsync<
+    BlobAccessPointConfiguration,
+    BlobAccessPointConfigurationProperties,
+    LroHeaders = ArmCombinedLroHeaders<FinalResult = BlobAccessPointConfiguration> &
+      Azure.Core.Foundations.RetryAfterHeader
+  >;
+
+  @doc("Delete a Blob Access Point configuration.")
+  @added(Versions.v2026_09_01)
+  delete is ArmResourceDeleteWithoutOkAsync<
+    BlobAccessPointConfiguration,
+    LroHeaders = ArmCombinedLroHeaders & Azure.Core.Foundations.RetryAfterHeader
+  >;
+
+  @doc("List all Blob Access Point configurations in a Storage Account.")
+  @added(Versions.v2026_09_01)
+  listByStorageAccount is ArmResourceListByParent<BlobAccessPointConfiguration>;
+
+  @doc("Test the connection configured on an existing Blob Access Point configuration.")
+  @added(Versions.v2026_09_01)
+  testExistingConnection is ArmResourceActionAsync<
+    BlobAccessPointConfiguration,
+    BlobAccessPointConnectionTestRequest,
+    BlobAccessPointConnectionTestResponse,
+    LroHeaders = ArmCombinedLroHeaders<FinalResult = BlobAccessPointConnectionTestResponse> &
+      Azure.Core.Foundations.RetryAfterHeader
+  >;
+}
+
+@armResourceOperations(StorageAccount)
+interface BlobAccessPointConnectionTests {
+  @doc("Test a proposed Blob Access Point connection before the configuration is created. The connection is validated in the context of the storage account in the request path, so no Blob Access Point configuration needs to exist beforehand.")
+  @added(Versions.v2026_09_01)
+  @action("testBlobAccessPointConfigurationProposedConnection")
+  testProposedConnection is ArmResourceActionAsync<
+    StorageAccount,
+    BlobAccessPointProposedConnectionTestRequest,
+    BlobAccessPointConnectionTestResponse,
+    LroHeaders = ArmCombinedLroHeaders<FinalResult = BlobAccessPointConnectionTestResponse> &
+      Azure.Core.Foundations.RetryAfterHeader
+  >;
+}

--- a/specification/storage/Storage.Management/BlobAccessPointConfiguration.tsp
+++ b/specification/storage/Storage.Management/BlobAccessPointConfiguration.tsp
@@ -78,10 +78,11 @@ union BlobAccessPointConnectionType {
 
 @added(Versions.v2026_09_01)
 @doc("The format used by a Private Link identifier.")
-#suppress "@azure-tools/typespec-azure-core/no-closed-literal-union" "Only ResourceId is accepted."
 union BlobAccessPointPrivateLinkIdType {
   @doc("The identifier is an Azure resource ID.")
   ResourceId: "ResourceId",
+
+  string,
 }
 
 @added(Versions.v2026_09_01)

--- a/specification/storage/Storage.Management/BlobAccessPointConfiguration.tsp
+++ b/specification/storage/Storage.Management/BlobAccessPointConfiguration.tsp
@@ -78,14 +78,10 @@ union BlobAccessPointConnectionType {
 
 @added(Versions.v2026_09_01)
 @doc("The format used by a Private Link identifier.")
+#suppress "@azure-tools/typespec-azure-core/no-closed-literal-union" "Only ResourceId is accepted."
 union BlobAccessPointPrivateLinkIdType {
   @doc("The identifier is an Azure resource ID.")
   ResourceId: "ResourceId",
-
-  @doc("The identifier is a Private Link alias.")
-  Alias: "Alias",
-
-  string,
 }
 
 @added(Versions.v2026_09_01)
@@ -139,11 +135,11 @@ model BlobAccessPointPrivateLinkConnectionProperties
   connectionType: BlobAccessPointConnectionType.PrivateLink;
 
   @visibility(Lifecycle.Create, Lifecycle.Read)
-  @doc("Whether privateLinkId contains an Azure resource ID or a Private Link alias.")
+  @doc("Indicates that privateLinkId contains an Azure resource ID.")
   privateLinkIdType: BlobAccessPointPrivateLinkIdType;
 
   @visibility(Lifecycle.Create, Lifecycle.Read)
-  @doc("The Azure resource ID or alias of the backing Private Link resource.")
+  @doc("The Azure resource ID of the backing Private Link resource.")
   privateLinkId: string;
 
   @visibility(Lifecycle.Create, Lifecycle.Read)

--- a/specification/storage/Storage.Management/BlobAccessPointConfiguration.tsp
+++ b/specification/storage/Storage.Management/BlobAccessPointConfiguration.tsp
@@ -121,7 +121,6 @@ model BlobAccessPointConnectionProperties {
 @doc("A direct endpoint connection.")
 model BlobAccessPointEndpointConnectionProperties
   extends BlobAccessPointConnectionProperties {
-  @visibility(Lifecycle.Read)
   connectionType: BlobAccessPointConnectionType.Endpoint;
 
   @visibility(Lifecycle.Create, Lifecycle.Read)
@@ -137,7 +136,6 @@ model BlobAccessPointEndpointConnectionProperties
 @doc("A connection established through Azure Private Link.")
 model BlobAccessPointPrivateLinkConnectionProperties
   extends BlobAccessPointConnectionProperties {
-  @visibility(Lifecycle.Read)
   connectionType: BlobAccessPointConnectionType.PrivateLink;
 
   @visibility(Lifecycle.Create, Lifecycle.Read)
@@ -185,7 +183,6 @@ model BlobAccessPointRemoteAuthProperties {
 @doc("S3 access-key authentication properties.")
 model BlobAccessPointAccessKeyAuthProperties
   extends BlobAccessPointRemoteAuthProperties {
-  @visibility(Lifecycle.Read)
   authType: BlobAccessPointRemoteAuthType.AccessKey;
 
   @minLength(3)
@@ -226,9 +223,7 @@ alias BlobAccessPointS3CompatibleSourceProperties = {
 @doc("A NetApp ONTAP backing source.")
 model BlobAccessPointNetAppOntapSourceProperties
   extends BlobAccessPointSourceProperties {
-  @visibility(Lifecycle.Read)
   sourceType: BlobAccessPointSourceType.NetAppOntap;
-
   ...BlobAccessPointS3CompatibleSourceProperties;
 }
 
@@ -236,9 +231,7 @@ model BlobAccessPointNetAppOntapSourceProperties
 @doc("An Azure NetApp Files backing source.")
 model BlobAccessPointAzureNetAppFilesSourceProperties
   extends BlobAccessPointSourceProperties {
-  @visibility(Lifecycle.Read)
   sourceType: BlobAccessPointSourceType.AzureNetAppFiles;
-
   ...BlobAccessPointS3CompatibleSourceProperties;
 }
 
@@ -246,9 +239,7 @@ model BlobAccessPointAzureNetAppFilesSourceProperties
 @doc("A Dell OneFS backing source.")
 model BlobAccessPointDellOneFsSourceProperties
   extends BlobAccessPointSourceProperties {
-  @visibility(Lifecycle.Read)
   sourceType: BlobAccessPointSourceType.DellOneFs;
-
   ...BlobAccessPointS3CompatibleSourceProperties;
 }
 
@@ -256,9 +247,7 @@ model BlobAccessPointDellOneFsSourceProperties
 @doc("A Qumulo backing source.")
 model BlobAccessPointQumuloSourceProperties
   extends BlobAccessPointSourceProperties {
-  @visibility(Lifecycle.Read)
   sourceType: BlobAccessPointSourceType.Qumulo;
-
   ...BlobAccessPointS3CompatibleSourceProperties;
 }
 
@@ -266,9 +255,7 @@ model BlobAccessPointQumuloSourceProperties
 @doc("A Commvault backing source.")
 model BlobAccessPointCommvaultSourceProperties
   extends BlobAccessPointSourceProperties {
-  @visibility(Lifecycle.Read)
   sourceType: BlobAccessPointSourceType.Commvault;
-
   ...BlobAccessPointS3CompatibleSourceProperties;
 }
 
@@ -276,9 +263,7 @@ model BlobAccessPointCommvaultSourceProperties
 @doc("A Nasuni backing source.")
 model BlobAccessPointNasuniSourceProperties
   extends BlobAccessPointSourceProperties {
-  @visibility(Lifecycle.Read)
   sourceType: BlobAccessPointSourceType.Nasuni;
-
   ...BlobAccessPointS3CompatibleSourceProperties;
 }
 
@@ -286,10 +271,154 @@ model BlobAccessPointNasuniSourceProperties
 @doc("Another S3-compatible backing source.")
 model BlobAccessPointGenericS3SourceProperties
   extends BlobAccessPointSourceProperties {
-  @visibility(Lifecycle.Read)
   sourceType: BlobAccessPointSourceType.S3Compatible;
-
   ...BlobAccessPointS3CompatibleSourceProperties;
+}
+
+@added(Versions.v2026_09_01)
+@discriminator("connectionType")
+@doc("Details for connecting to a backing data source.")
+model BlobAccessPointConnectionPropertiesUpdate {
+  @doc("The connection type. This value determines the remaining shape of the connection object.")
+  connectionType: BlobAccessPointConnectionType;
+}
+
+@added(Versions.v2026_09_01)
+@doc("A direct endpoint connection.")
+model BlobAccessPointEndpointConnectionPropertiesUpdate
+  extends BlobAccessPointConnectionPropertiesUpdate {
+  connectionType: BlobAccessPointConnectionType.Endpoint;
+
+  @doc("TLS certificate verification behavior. Defaults to Perform when not specified.")
+  tlsVerification?: BlobAccessPointTlsVerification;
+}
+
+@added(Versions.v2026_09_01)
+@doc("A connection established through Azure Private Link.")
+model BlobAccessPointPrivateLinkConnectionPropertiesUpdate
+  extends BlobAccessPointConnectionPropertiesUpdate {
+  connectionType: BlobAccessPointConnectionType.PrivateLink;
+
+  @doc("TLS certificate verification behavior. Defaults to Perform when not specified.")
+  tlsVerification?: BlobAccessPointTlsVerification;
+}
+
+@added(Versions.v2026_09_01)
+@discriminator("authType")
+@doc("Authentication properties for a non-Azure S3-compatible source.")
+model BlobAccessPointRemoteAuthPropertiesUpdate {
+  @doc("The authentication type. This value determines the remaining shape of the authentication object.")
+  authType: BlobAccessPointRemoteAuthType;
+}
+
+@added(Versions.v2026_09_01)
+@doc("S3 access-key authentication properties.")
+model BlobAccessPointAccessKeyAuthPropertiesUpdate
+  extends BlobAccessPointRemoteAuthPropertiesUpdate {
+  authType: BlobAccessPointRemoteAuthType.AccessKey;
+
+  @minLength(3)
+  @doc("The access key ID.")
+  accessKeyId?: string;
+
+  @visibility(Lifecycle.Create, Lifecycle.Update)
+  @secret
+  @minLength(3)
+  @doc("The secret access key. This value is never returned by read or list operations.")
+  secretAccessKey?: string;
+
+  @doc("The region used by the request-signing algorithm. Defaults to 'us-east-1' when not specified.")
+  signingRegion?: string;
+
+  @doc("The host used when computing request signatures. The endpoint host is used by default.")
+  hostOverride?: string;
+}
+
+@added(Versions.v2026_09_01)
+@discriminator("sourceType")
+@doc("Information about the data source exposed through a Blob Access Point.")
+model BlobAccessPointSourcePropertiesUpdate {
+  @doc("The source type. This value determines the remaining shape of the source object.")
+  sourceType: BlobAccessPointSourceType;
+}
+
+/** Properties for updating a non-Azure S3-compatible backing source. */
+alias BlobAccessPointS3CompatibleSourcePropertiesUpdate = {
+  @doc("Details for connecting to the backing data source. The connection target is fixed when the configuration is created; only the TLS verification behavior can be changed afterwards.")
+  connection?: BlobAccessPointConnectionPropertiesUpdate;
+
+  @doc("Details for authenticating to the backing data source.")
+  auth?: BlobAccessPointRemoteAuthPropertiesUpdate;
+};
+
+@added(Versions.v2026_09_01)
+@doc("A NetApp ONTAP backing source.")
+model BlobAccessPointNetAppOntapSourcePropertiesUpdate
+  extends BlobAccessPointSourcePropertiesUpdate {
+  sourceType: BlobAccessPointSourceType.NetAppOntap;
+  ...BlobAccessPointS3CompatibleSourcePropertiesUpdate;
+}
+
+@added(Versions.v2026_09_01)
+@doc("An Azure NetApp Files backing source.")
+model BlobAccessPointAzureNetAppFilesSourcePropertiesUpdate
+  extends BlobAccessPointSourcePropertiesUpdate {
+  sourceType: BlobAccessPointSourceType.AzureNetAppFiles;
+  ...BlobAccessPointS3CompatibleSourcePropertiesUpdate;
+}
+
+@added(Versions.v2026_09_01)
+@doc("A Dell OneFS backing source.")
+model BlobAccessPointDellOneFsSourcePropertiesUpdate
+  extends BlobAccessPointSourcePropertiesUpdate {
+  sourceType: BlobAccessPointSourceType.DellOneFs;
+  ...BlobAccessPointS3CompatibleSourcePropertiesUpdate;
+}
+
+@added(Versions.v2026_09_01)
+@doc("A Qumulo backing source.")
+model BlobAccessPointQumuloSourcePropertiesUpdate
+  extends BlobAccessPointSourcePropertiesUpdate {
+  sourceType: BlobAccessPointSourceType.Qumulo;
+  ...BlobAccessPointS3CompatibleSourcePropertiesUpdate;
+}
+
+@added(Versions.v2026_09_01)
+@doc("A Commvault backing source.")
+model BlobAccessPointCommvaultSourcePropertiesUpdate
+  extends BlobAccessPointSourcePropertiesUpdate {
+  sourceType: BlobAccessPointSourceType.Commvault;
+  ...BlobAccessPointS3CompatibleSourcePropertiesUpdate;
+}
+
+@added(Versions.v2026_09_01)
+@doc("A Nasuni backing source.")
+model BlobAccessPointNasuniSourcePropertiesUpdate
+  extends BlobAccessPointSourcePropertiesUpdate {
+  sourceType: BlobAccessPointSourceType.Nasuni;
+  ...BlobAccessPointS3CompatibleSourcePropertiesUpdate;
+}
+
+@added(Versions.v2026_09_01)
+@doc("Another S3-compatible backing source.")
+model BlobAccessPointGenericS3SourcePropertiesUpdate
+  extends BlobAccessPointSourcePropertiesUpdate {
+  sourceType: BlobAccessPointSourceType.S3Compatible;
+  ...BlobAccessPointS3CompatibleSourcePropertiesUpdate;
+}
+
+@added(Versions.v2026_09_01)
+@doc("Details of a Blob Access Point configuration.")
+model BlobAccessPointConfigurationPropertiesUpdate {
+  @doc("The configuration state. A configuration is created in the Active state when this value is not specified.")
+  state?: BlobAccessPointConfigurationState;
+
+  @maxLength(250)
+  @doc("An arbitrary description of the Blob Access Point configuration.")
+  description?: string;
+
+  @doc("Information about the backing data source.")
+  source?: BlobAccessPointSourcePropertiesUpdate;
 }
 
 @added(Versions.v2026_09_01)
@@ -325,6 +454,15 @@ model BlobAccessPointConfigurationProperties {
   @visibility(Lifecycle.Read)
   @doc("The status of the last operation.")
   provisioningState?: Azure.ResourceManager.ResourceProvisioningState;
+}
+
+@added(Versions.v2026_09_01)
+@doc("A BlobAccessPointConfiguration is a tracked Azure resource modeled as a sub-resource of a Storage Account.")
+model BlobAccessPointConfigurationUpdate {
+  ...Azure.ResourceManager.Foundations.ArmTagsProperty;
+
+  @doc("The resource-specific properties for this resource.")
+  properties?: BlobAccessPointConfigurationPropertiesUpdate;
 }
 
 @added(Versions.v2026_09_01)
@@ -384,9 +522,9 @@ interface BlobAccessPointConfigurations {
 
   @doc("Update a Blob Access Point configuration.")
   @added(Versions.v2026_09_01)
-  update is ArmResourcePatchAsync<
+  update is ArmCustomPatchAsync<
     BlobAccessPointConfiguration,
-    BlobAccessPointConfigurationProperties,
+    PatchModel = BlobAccessPointConfigurationUpdate,
     LroHeaders = ArmCombinedLroHeaders<FinalResult = BlobAccessPointConfiguration> &
       Azure.Core.Foundations.RetryAfterHeader
   >;

--- a/specification/storage/Storage.Management/client.tsp
+++ b/specification/storage/Storage.Management/client.tsp
@@ -156,6 +156,21 @@ using Microsoft.Storage;
   "csharp"
 );
 @@clientName(
+  BlobAccessPointConnectionTestResponse,
+  "BlobAccessPointConnectionTestResult",
+  "csharp"
+);
+@@clientName(
+  BlobAccessPointProposedConnectionTestRequest,
+  "BlobAccessPointProposedConnectionTestContent",
+  "csharp"
+);
+@@clientName(
+  BlobAccessPointConnectionTestRequest,
+  "BlobAccessPointConnectionTestContent",
+  "csharp"
+);
+@@clientName(
   ActiveDirectoryProperties,
   "StorageActiveDirectoryProperties",
   "csharp"

--- a/specification/storage/Storage.Management/examples/2026-09-01/BlobAccessPointConfigurations_Create.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/BlobAccessPointConfigurations_Create.json
@@ -1,0 +1,98 @@
+{
+  "operationId": "BlobAccessPointConfigurations_Create",
+  "title": "CreateBlobAccessPointConfiguration",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "testrg",
+    "api-version": "2026-09-01",
+    "blobAccessPointConfigurationName": "testaccesspointconfig",
+    "accountName": "teststorageaccount",
+    "resource": {
+      "location": "eastus",
+      "properties": {
+        "state": "Active",
+        "description": "NetApp ONTAP S3-compatible source",
+        "source": {
+          "sourceType": "NetAppOntap",
+          "connection": {
+            "connectionType": "Endpoint",
+            "endpoint": "https://netapp.contoso.com/bucket1",
+            "tlsVerification": "Perform"
+          },
+          "auth": {
+            "authType": "AccessKey",
+            "accessKeyId": "example-access-key",
+            "secretAccessKey": "example-secret-key",
+            "signingRegion": "us-east-1"
+          }
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/storageAccounts/teststorageaccount/blobAccessPointConfigurations/testaccesspointconfig",
+        "name": "testaccesspointconfig",
+        "type": "Microsoft.Storage/storageAccounts/blobAccessPointConfigurations",
+        "location": "eastus",
+        "systemData": {
+          "createdAt": "2026-09-01T00:00:00Z"
+        },
+        "properties": {
+          "uniqueId": "11111111-2222-3333-4444-555555555555",
+          "state": "Active",
+          "description": "NetApp ONTAP S3-compatible source",
+          "source": {
+            "sourceType": "NetAppOntap",
+            "connection": {
+              "connectionType": "Endpoint",
+              "endpoint": "https://netapp.contoso.com/bucket1",
+              "tlsVerification": "Perform"
+            },
+            "auth": {
+              "authType": "AccessKey",
+              "accessKeyId": "example-access-key",
+              "signingRegion": "us-east-1"
+            }
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/storageAccounts/teststorageaccount/blobAccessPointConfigurations/testaccesspointconfig",
+        "name": "testaccesspointconfig",
+        "type": "Microsoft.Storage/storageAccounts/blobAccessPointConfigurations",
+        "location": "eastus",
+        "systemData": {
+          "createdAt": "2026-09-01T00:00:00Z"
+        },
+        "properties": {
+          "uniqueId": "11111111-2222-3333-4444-555555555555",
+          "state": "Active",
+          "description": "NetApp ONTAP S3-compatible source",
+          "source": {
+            "sourceType": "NetAppOntap",
+            "connection": {
+              "connectionType": "Endpoint",
+              "endpoint": "https://netapp.contoso.com/bucket1",
+              "tlsVerification": "Perform"
+            },
+            "auth": {
+              "authType": "AccessKey",
+              "accessKeyId": "example-access-key",
+              "signingRegion": "us-east-1"
+            }
+          },
+          "provisioningState": "Creating"
+        }
+      },
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/eastus/DataManagementRPOperationStatuses/operation-98765?api-version=2026-09-01",
+        "Retry-After": 30
+      }
+    }
+  }
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/BlobAccessPointConfigurations_Create_AzureNetAppFilesPrivateLink.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/BlobAccessPointConfigurations_Create_AzureNetAppFilesPrivateLink.json
@@ -1,0 +1,114 @@
+{
+  "operationId": "BlobAccessPointConfigurations_Create",
+  "title": "CreateBlobAccessPointConfigurationWithAzureNetAppFilesPrivateLink",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "testrg",
+    "api-version": "2026-09-01",
+    "blobAccessPointConfigurationName": "anfprivatelinkaccesspoint",
+    "accountName": "teststorageaccount",
+    "resource": {
+      "location": "eastus",
+      "properties": {
+        "state": "Active",
+        "description": "Azure NetApp Files S3-compatible source over Private Link",
+        "source": {
+          "sourceType": "AzureNetAppFiles",
+          "connection": {
+            "connectionType": "PrivateLink",
+            "privateLinkIdType": "ResourceId",
+            "privateLinkId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Network/privateLinkServices/anfpls",
+            "privateLinkGroupId": "s3",
+            "privateLinkLocation": "eastus",
+            "requestMessage": "Blob Access Point connection request for Azure NetApp Files",
+            "endpoint": "https://anf.contoso.com/bucket1",
+            "tlsVerification": "Perform"
+          },
+          "auth": {
+            "authType": "AccessKey",
+            "accessKeyId": "example-access-key",
+            "secretAccessKey": "example-secret-key",
+            "signingRegion": "us-east-1"
+          }
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/storageAccounts/teststorageaccount/blobAccessPointConfigurations/anfprivatelinkaccesspoint",
+        "name": "anfprivatelinkaccesspoint",
+        "type": "Microsoft.Storage/storageAccounts/blobAccessPointConfigurations",
+        "location": "eastus",
+        "systemData": {
+          "createdAt": "2026-09-01T00:00:00Z"
+        },
+        "properties": {
+          "uniqueId": "33333333-4444-5555-6666-777777777777",
+          "state": "Active",
+          "description": "Azure NetApp Files S3-compatible source over Private Link",
+          "source": {
+            "sourceType": "AzureNetAppFiles",
+            "connection": {
+              "connectionType": "PrivateLink",
+              "privateLinkIdType": "ResourceId",
+              "privateLinkId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Network/privateLinkServices/anfpls",
+              "privateLinkGroupId": "s3",
+              "privateLinkLocation": "eastus",
+              "requestMessage": "Blob Access Point connection request for Azure NetApp Files",
+              "endpoint": "https://anf.contoso.com/bucket1",
+              "tlsVerification": "Perform",
+              "privateEndpointName": "anfprivateendpoint"
+            },
+            "auth": {
+              "authType": "AccessKey",
+              "accessKeyId": "example-access-key",
+              "signingRegion": "us-east-1"
+            }
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/storageAccounts/teststorageaccount/blobAccessPointConfigurations/anfprivatelinkaccesspoint",
+        "name": "anfprivatelinkaccesspoint",
+        "type": "Microsoft.Storage/storageAccounts/blobAccessPointConfigurations",
+        "location": "eastus",
+        "systemData": {
+          "createdAt": "2026-09-01T00:00:00Z"
+        },
+        "properties": {
+          "uniqueId": "33333333-4444-5555-6666-777777777777",
+          "state": "Active",
+          "description": "Azure NetApp Files S3-compatible source over Private Link",
+          "source": {
+            "sourceType": "AzureNetAppFiles",
+            "connection": {
+              "connectionType": "PrivateLink",
+              "privateLinkIdType": "ResourceId",
+              "privateLinkId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Network/privateLinkServices/anfpls",
+              "privateLinkGroupId": "s3",
+              "privateLinkLocation": "eastus",
+              "requestMessage": "Blob Access Point connection request for Azure NetApp Files",
+              "endpoint": "https://anf.contoso.com/bucket1",
+              "tlsVerification": "Perform"
+            },
+            "auth": {
+              "authType": "AccessKey",
+              "accessKeyId": "example-access-key",
+              "signingRegion": "us-east-1"
+            }
+          },
+          "provisioningState": "Creating"
+        }
+      },
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/eastus/DataManagementRPOperationStatuses/operation-98765?api-version=2026-09-01",
+        "Retry-After": 30
+      }
+    }
+  }
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/BlobAccessPointConfigurations_Delete.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/BlobAccessPointConfigurations_Delete.json
@@ -1,0 +1,23 @@
+{
+  "operationId": "BlobAccessPointConfigurations_Delete",
+  "title": "DeleteBlobAccessPointConfiguration",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "testrg",
+    "accountName": "teststorageaccount",
+    "blobAccessPointConfigurationName": "testaccesspointconfig",
+    "api-version": "2026-09-01"
+  },
+  "responses": {
+    "204": {},
+    "202": {
+      "status": "Accepted",
+      "message": "The resource operation has been received and is being processed.",
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/eastus/DataManagementRPOperationStatuses/operation-98765?api-version=2026-09-01",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/eastus/DataManagementRPOperationStatuses/operation-98765?api-version=2026-09-01",
+        "Retry-After": 30
+      }
+    }
+  }
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/BlobAccessPointConfigurations_Get.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/BlobAccessPointConfigurations_Get.json
@@ -1,0 +1,45 @@
+{
+  "operationId": "BlobAccessPointConfigurations_Get",
+  "title": "GetBlobAccessPointConfiguration",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "testrg",
+    "api-version": "2026-09-01",
+    "blobAccessPointConfigurationName": "testaccesspointconfig",
+    "accountName": "teststorageaccount"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/storageAccounts/teststorageaccount/blobAccessPointConfigurations/testaccesspointconfig",
+        "name": "testaccesspointconfig",
+        "type": "Microsoft.Storage/storageAccounts/blobAccessPointConfigurations",
+        "location": "eastus",
+        "systemData": {
+          "createdAt": "2026-09-01T00:00:00Z"
+        },
+        "properties": {
+          "uniqueId": "11111111-2222-3333-4444-555555555555",
+          "state": "Active",
+          "description": "NetApp ONTAP S3-compatible source",
+          "lastConnectionTestStatus": "Succeeded",
+          "lastConnectionTestTimestamp": "2026-09-01T01:00:00Z",
+          "source": {
+            "sourceType": "NetAppOntap",
+            "connection": {
+              "connectionType": "Endpoint",
+              "endpoint": "https://netapp.contoso.com/bucket1",
+              "tlsVerification": "Perform"
+            },
+            "auth": {
+              "authType": "AccessKey",
+              "accessKeyId": "example-access-key",
+              "signingRegion": "us-east-1"
+            }
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  }
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/BlobAccessPointConfigurations_ListByStorageAccount.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/BlobAccessPointConfigurations_ListByStorageAccount.json
@@ -1,0 +1,81 @@
+{
+  "operationId": "BlobAccessPointConfigurations_ListByStorageAccount",
+  "title": "ListBlobAccessPointConfigurationsByStorageAccount",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "testrg",
+    "api-version": "2026-09-01",
+    "accountName": "teststorageaccount"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/storageAccounts/teststorageaccount/blobAccessPointConfigurations/testaccesspointconfig",
+            "name": "testaccesspointconfig",
+            "type": "Microsoft.Storage/storageAccounts/blobAccessPointConfigurations",
+            "location": "eastus",
+            "systemData": {
+              "createdAt": "2026-09-01T00:00:00Z"
+            },
+            "properties": {
+              "uniqueId": "11111111-2222-3333-4444-555555555555",
+              "state": "Active",
+              "description": "NetApp ONTAP S3-compatible source",
+              "source": {
+                "sourceType": "NetAppOntap",
+                "connection": {
+                  "connectionType": "Endpoint",
+                  "endpoint": "https://netapp.contoso.com/bucket1",
+                  "tlsVerification": "Perform"
+                },
+                "auth": {
+                  "authType": "AccessKey",
+                  "accessKeyId": "example-access-key",
+                  "signingRegion": "us-east-1"
+                }
+              },
+              "provisioningState": "Succeeded"
+            }
+          },
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/storageAccounts/teststorageaccount/blobAccessPointConfigurations/privatelinkaccesspointconfig",
+            "name": "privatelinkaccesspointconfig",
+            "type": "Microsoft.Storage/storageAccounts/blobAccessPointConfigurations",
+            "location": "eastus",
+            "systemData": {
+              "createdAt": "2026-09-01T00:00:00Z"
+            },
+            "properties": {
+              "uniqueId": "22222222-3333-4444-5555-666666666666",
+              "state": "Active",
+              "description": "Private-link-backed S3-compatible source",
+              "source": {
+                "sourceType": "DellOneFs",
+                "connection": {
+                  "connectionType": "PrivateLink",
+                  "privateLinkIdType": "ResourceId",
+                  "privateLinkId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Network/privateLinkServices/testpls",
+                  "privateLinkGroupId": "s3",
+                  "privateLinkLocation": "eastus",
+                  "requestMessage": "Blob Access Point connection request",
+                  "endpoint": "https://onefs.contoso.com/bucket2",
+                  "tlsVerification": "Perform",
+                  "privateEndpointName": "testpe"
+                },
+                "auth": {
+                  "authType": "AccessKey",
+                  "accessKeyId": "example-access-key-2",
+                  "signingRegion": "us-east-1",
+                  "hostOverride": "onefs.contoso.com"
+                }
+              },
+              "provisioningState": "Succeeded"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/BlobAccessPointConfigurations_TestExistingConnection.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/BlobAccessPointConfigurations_TestExistingConnection.json
@@ -1,0 +1,31 @@
+{
+  "operationId": "BlobAccessPointConfigurations_TestExistingConnection",
+  "title": "BlobAccessPointConfigurationTestExistingConnection",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "testrg",
+    "accountName": "teststorageaccount",
+    "api-version": "2026-09-01",
+    "blobAccessPointConfigurationName": "testaccesspointconfig",
+    "body": {
+      "uniqueId": "11111111-2222-3333-4444-555555555555"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "methodName": "List",
+        "requestId": "request-id-123"
+      }
+    },
+    "202": {
+      "status": "Accepted",
+      "message": "The resource operation has been received and is being processed.",
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/eastus/DataManagementRPOperationStatuses/operation-98765?api-version=2026-09-01",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/eastus/DataManagementRPOperationResults/operation-98765?api-version=2026-09-01",
+        "Retry-After": 30
+      }
+    }
+  }
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/BlobAccessPointConfigurations_Update.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/BlobAccessPointConfigurations_Update.json
@@ -1,0 +1,65 @@
+{
+  "operationId": "BlobAccessPointConfigurations_Update",
+  "title": "UpdateBlobAccessPointConfiguration",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "testrg",
+    "accountName": "teststorageaccount",
+    "api-version": "2026-09-01",
+    "blobAccessPointConfigurationName": "testaccesspointconfig",
+    "properties": {
+      "properties": {
+        "state": "Inactive",
+        "description": "Updated NetApp ONTAP S3-compatible source",
+        "source": {
+          "sourceType": "NetAppOntap",
+          "auth": {
+            "authType": "AccessKey",
+            "secretAccessKey": "rotated-secret-key"
+          }
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/storageAccounts/teststorageaccount/blobAccessPointConfigurations/testaccesspointconfig",
+        "name": "testaccesspointconfig",
+        "type": "Microsoft.Storage/storageAccounts/blobAccessPointConfigurations",
+        "location": "eastus",
+        "systemData": {
+          "createdAt": "2026-09-01T00:00:00Z"
+        },
+        "properties": {
+          "uniqueId": "11111111-2222-3333-4444-555555555555",
+          "state": "Inactive",
+          "description": "Updated NetApp ONTAP S3-compatible source",
+          "source": {
+            "sourceType": "NetAppOntap",
+            "connection": {
+              "connectionType": "Endpoint",
+              "endpoint": "https://netapp.contoso.com/bucket1",
+              "tlsVerification": "Perform"
+            },
+            "auth": {
+              "authType": "AccessKey",
+              "accessKeyId": "example-access-key",
+              "signingRegion": "us-east-1"
+            }
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    },
+    "202": {
+      "status": "Accepted",
+      "message": "The resource operation has been received and is being processed.",
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/eastus/DataManagementRPOperationStatuses/operation-98765?api-version=2026-09-01",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/eastus/DataManagementRPOperationStatuses/operation-98765?api-version=2026-09-01",
+        "Retry-After": 30
+      }
+    }
+  }
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/BlobAccessPointConnectionTests_TestProposedConnection.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/BlobAccessPointConnectionTests_TestProposedConnection.json
@@ -1,0 +1,48 @@
+{
+  "operationId": "BlobAccessPointConnectionTests_TestProposedConnection",
+  "title": "BlobAccessPointTestProposedConnection",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "testrg",
+    "accountName": "teststorageaccount",
+    "api-version": "2026-09-01",
+    "body": {
+      "source": {
+        "sourceType": "S3Compatible",
+        "connection": {
+          "connectionType": "PrivateLink",
+          "privateLinkIdType": "ResourceId",
+          "privateLinkId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Network/privateLinkServices/testpls",
+          "privateLinkGroupId": "s3",
+          "privateLinkLocation": "eastus",
+          "requestMessage": "Blob Access Point connection request",
+          "endpoint": "https://s3.contoso.com/bucket1",
+          "tlsVerification": "Perform"
+        },
+        "auth": {
+          "authType": "AccessKey",
+          "accessKeyId": "example-access-key",
+          "secretAccessKey": "example-secret-key",
+          "signingRegion": "us-east-1"
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "methodName": "List",
+        "requestId": "request-id-123"
+      }
+    },
+    "202": {
+      "status": "Accepted",
+      "message": "The resource operation has been received and is being processed.",
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/eastus/DataManagementRPOperationStatuses/operation-98765?api-version=2026-09-01",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/eastus/DataManagementRPOperationResults/operation-98765?api-version=2026-09-01",
+        "Retry-After": 30
+      }
+    }
+  }
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/Operations_List.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/Operations_List.json
@@ -1,0 +1,131 @@
+{
+  "operationId": "Operations_List",
+  "title": "ListOperations",
+  "parameters": {
+    "api-version": "2026-09-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Microsoft.Storage/storageAccounts/connectors/read",
+            "display": {
+              "provider": "Microsoft Storage",
+              "resource": "Storage Connector",
+              "operation": "Read Storage Connector",
+              "description": "Reads the properties of a storage connector."
+            }
+          },
+          {
+            "name": "Microsoft.Storage/storageAccounts/connectors/write",
+            "display": {
+              "provider": "Microsoft Storage",
+              "resource": "Storage Connector",
+              "operation": "Write Storage Connector",
+              "description": "Creates or updates a storage connector."
+            }
+          },
+          {
+            "name": "Microsoft.Storage/storageAccounts/connectors/delete",
+            "display": {
+              "provider": "Microsoft Storage",
+              "resource": "Storage Connector",
+              "operation": "Delete Storage Connector",
+              "description": "Deletes a storage connector."
+            }
+          },
+          {
+            "name": "Microsoft.Storage/storageAccounts/connectors/testExistingConnection/action",
+            "display": {
+              "provider": "Microsoft Storage",
+              "resource": "Storage Connector",
+              "operation": "Test Existing Connection",
+              "description": "Tests connection to an existing storage connector."
+            }
+          },
+          {
+            "name": "Microsoft.Storage/storageAccounts/dataShares/read",
+            "display": {
+              "provider": "Microsoft Storage",
+              "resource": "Storage DataShare",
+              "operation": "Read Storage DataShare",
+              "description": "Reads the properties of a storage data share."
+            }
+          },
+          {
+            "name": "Microsoft.Storage/storageAccounts/dataShares/write",
+            "display": {
+              "provider": "Microsoft Storage",
+              "resource": "Storage DataShare",
+              "operation": "Write Storage DataShare",
+              "description": "Reads the properties of a storage data share."
+            }
+          },
+          {
+            "name": "Microsoft.Storage/storageAccounts/dataShares/delete",
+            "display": {
+              "provider": "Microsoft Storage",
+              "resource": "Storage DataShare",
+              "operation": "Delete Storage DataShare",
+              "description": "Reads the properties of a storage data share."
+            }
+          },
+          {
+            "name": "Microsoft.Storage/storageAccounts/blobAccessPointConfigurations/read",
+            "display": {
+              "provider": "Microsoft Storage",
+              "resource": "Blob Access Point Configuration",
+              "operation": "Read Blob Access Point Configuration",
+              "description": "Reads Blob Access Point configuration properties."
+            }
+          },
+          {
+            "name": "Microsoft.Storage/storageAccounts/blobAccessPointConfigurations/write",
+            "display": {
+              "provider": "Microsoft Storage",
+              "resource": "Blob Access Point Configuration",
+              "operation": "Write Blob Access Point Configuration",
+              "description": "Creates or updates a Blob Access Point configuration."
+            }
+          },
+          {
+            "name": "Microsoft.Storage/storageAccounts/blobAccessPointConfigurations/delete",
+            "display": {
+              "provider": "Microsoft Storage",
+              "resource": "Blob Access Point Configuration",
+              "operation": "Delete Blob Access Point Configuration",
+              "description": "Deletes a Blob Access Point configuration."
+            }
+          },
+          {
+            "name": "Microsoft.Storage/storageAccounts/blobAccessPointConfigurations/testExistingConnection/action",
+            "display": {
+              "provider": "Microsoft Storage",
+              "resource": "Blob Access Point Configuration",
+              "operation": "Test Existing Blob Access Point Connection",
+              "description": "Tests the connection on an existing Blob Access Point configuration."
+            }
+          },
+          {
+            "name": "Microsoft.Storage/storageAccounts/testBlobAccessPointConfigurationProposedConnection/action",
+            "display": {
+              "provider": "Microsoft Storage",
+              "resource": "Blob Access Point Connection Test",
+              "operation": "Test Proposed Blob Access Point Connection",
+              "description": "Tests a proposed Blob Access Point connection before the configuration is created."
+            }
+          }
+        ]
+      }
+    },
+    "default": {
+      "body": {
+        "error": {
+          "code": "InternalServerError",
+          "message": "An unexpected error occurred."
+        }
+      }
+    }
+  }
+}

--- a/specification/storage/Storage.Management/main.tsp
+++ b/specification/storage/Storage.Management/main.tsp
@@ -38,6 +38,7 @@ import "./StorageConnector.tsp";
 import "./StorageDataShare.tsp";
 import "./StorageContextCache.tsp";
 import "./StorageContextCacheContainer.tsp";
+import "./BlobAccessPointConfiguration.tsp";
 import "./AdvancedPlatformMetrics.tsp";
 import "./routes.tsp";
 import "./client.tsp";

--- a/specification/storage/Storage.Management/models.tsp
+++ b/specification/storage/Storage.Management/models.tsp
@@ -1169,36 +1169,6 @@ union StorageConnectorDataSourceType {
   Azure_DataShare: "Azure_DataShare",
 
   /**
-   * NetApp ONTAP data source type.
-   */
-  @added(Versions.v2026_09_01)
-  NetAppOntap: "NetAppOntap",
-
-  /**
-   * Azure NetApp Files data source type.
-   */
-  @added(Versions.v2026_09_01)
-  AzureNetAppFiles: "AzureNetAppFiles",
-
-  /**
-   * Dell OneFS data source type.
-   */
-  @added(Versions.v2026_09_01)
-  DellOneFs: "DellOneFs",
-
-  /**
-   * AWS S3 data source type.
-   */
-  @added(Versions.v2026_09_01)
-  AwsS3: "AwsS3",
-
-  /**
-   * S3-compatible data source type.
-   */
-  @added(Versions.v2026_09_01)
-  S3Compatible: "S3Compatible",
-
-  /**
    * Azure DataShare data source type.
    */
   @added(Versions.v2026_09_01)

--- a/specification/storage/Storage.Management/models.tsp
+++ b/specification/storage/Storage.Management/models.tsp
@@ -1165,14 +1165,7 @@ union StorageConnectorDataSourceType {
   /**
    * Azure DataShare data source type.
    */
-  @removed(Versions.v2026_09_01)
   Azure_DataShare: "Azure_DataShare",
-
-  /**
-   * Azure DataShare data source type.
-   */
-  @added(Versions.v2026_09_01)
-  AzureDataShare: "AzureDataShare",
 
   string,
 }
@@ -6549,7 +6542,6 @@ model StorageConnectorProperties {
    * System-generated creation time of the Storage Connector in ISO 8601 date-time format (YYYY-MM-DDTHH:mm:ssZ).
    * Not a valid input parameter during creating.
    */
-  @removed(Versions.v2026_09_01)
   @visibility(Lifecycle.Read)
   creationTime?: string;
 

--- a/specification/storage/Storage.Management/models.tsp
+++ b/specification/storage/Storage.Management/models.tsp
@@ -1165,7 +1165,44 @@ union StorageConnectorDataSourceType {
   /**
    * Azure DataShare data source type.
    */
+  @removed(Versions.v2026_09_01)
   Azure_DataShare: "Azure_DataShare",
+
+  /**
+   * NetApp ONTAP data source type.
+   */
+  @added(Versions.v2026_09_01)
+  NetAppOntap: "NetAppOntap",
+
+  /**
+   * Azure NetApp Files data source type.
+   */
+  @added(Versions.v2026_09_01)
+  AzureNetAppFiles: "AzureNetAppFiles",
+
+  /**
+   * Dell OneFS data source type.
+   */
+  @added(Versions.v2026_09_01)
+  DellOneFs: "DellOneFs",
+
+  /**
+   * AWS S3 data source type.
+   */
+  @added(Versions.v2026_09_01)
+  AwsS3: "AwsS3",
+
+  /**
+   * S3-compatible data source type.
+   */
+  @added(Versions.v2026_09_01)
+  S3Compatible: "S3Compatible",
+
+  /**
+   * Azure DataShare data source type.
+   */
+  @added(Versions.v2026_09_01)
+  AzureDataShare: "AzureDataShare",
 
   string,
 }
@@ -3722,6 +3759,12 @@ model StorageDataCollaborationPolicyProperties {
    * Indicates whether storage connectors are allowed to created or managed on the storage account.
    */
   allowStorageConnectors?: boolean;
+
+  /**
+   * Indicates whether Blob Access Point configurations are allowed to be created or managed on the storage account.
+   */
+  @added(Versions.v2026_09_01)
+  allowStorageBlobAccessPointConfigurations?: boolean;
 
   /**
    * Indicates whether data shares are allowed to be created or managed on the storage account.
@@ -6536,6 +6579,7 @@ model StorageConnectorProperties {
    * System-generated creation time of the Storage Connector in ISO 8601 date-time format (YYYY-MM-DDTHH:mm:ssZ).
    * Not a valid input parameter during creating.
    */
+  @removed(Versions.v2026_09_01)
   @visibility(Lifecycle.Read)
   creationTime?: string;
 

--- a/specification/storage/cspell.yaml
+++ b/specification/storage/cspell.yaml
@@ -25,10 +25,13 @@ words:
   - mebibytes
   - messageid
   - mibps
+  - Nasuni
   - ntlm
   - numofmessages
+  - ONTAP
   - overriden
   - policyid
+  - Qumulo
   - ragrs
   - ragzrs
   - rscc

--- a/specification/storage/cspell.yaml
+++ b/specification/storage/cspell.yaml
@@ -25,13 +25,13 @@ words:
   - mebibytes
   - messageid
   - mibps
-  - Nasuni
+  - nasuni
   - ntlm
   - numofmessages
-  - ONTAP
+  - ontap
   - overriden
   - policyid
-  - Qumulo
+  - qumulo
   - ragrs
   - ragzrs
   - rscc

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/BlobAccessPointConfigurations_Create.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/BlobAccessPointConfigurations_Create.json
@@ -1,0 +1,98 @@
+{
+  "operationId": "BlobAccessPointConfigurations_Create",
+  "title": "CreateBlobAccessPointConfiguration",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "testrg",
+    "api-version": "2026-09-01",
+    "blobAccessPointConfigurationName": "testaccesspointconfig",
+    "accountName": "teststorageaccount",
+    "resource": {
+      "location": "eastus",
+      "properties": {
+        "state": "Active",
+        "description": "NetApp ONTAP S3-compatible source",
+        "source": {
+          "sourceType": "NetAppOntap",
+          "connection": {
+            "connectionType": "Endpoint",
+            "endpoint": "https://netapp.contoso.com/bucket1",
+            "tlsVerification": "Perform"
+          },
+          "auth": {
+            "authType": "AccessKey",
+            "accessKeyId": "example-access-key",
+            "secretAccessKey": "example-secret-key",
+            "signingRegion": "us-east-1"
+          }
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/storageAccounts/teststorageaccount/blobAccessPointConfigurations/testaccesspointconfig",
+        "name": "testaccesspointconfig",
+        "type": "Microsoft.Storage/storageAccounts/blobAccessPointConfigurations",
+        "location": "eastus",
+        "systemData": {
+          "createdAt": "2026-09-01T00:00:00Z"
+        },
+        "properties": {
+          "uniqueId": "11111111-2222-3333-4444-555555555555",
+          "state": "Active",
+          "description": "NetApp ONTAP S3-compatible source",
+          "source": {
+            "sourceType": "NetAppOntap",
+            "connection": {
+              "connectionType": "Endpoint",
+              "endpoint": "https://netapp.contoso.com/bucket1",
+              "tlsVerification": "Perform"
+            },
+            "auth": {
+              "authType": "AccessKey",
+              "accessKeyId": "example-access-key",
+              "signingRegion": "us-east-1"
+            }
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/storageAccounts/teststorageaccount/blobAccessPointConfigurations/testaccesspointconfig",
+        "name": "testaccesspointconfig",
+        "type": "Microsoft.Storage/storageAccounts/blobAccessPointConfigurations",
+        "location": "eastus",
+        "systemData": {
+          "createdAt": "2026-09-01T00:00:00Z"
+        },
+        "properties": {
+          "uniqueId": "11111111-2222-3333-4444-555555555555",
+          "state": "Active",
+          "description": "NetApp ONTAP S3-compatible source",
+          "source": {
+            "sourceType": "NetAppOntap",
+            "connection": {
+              "connectionType": "Endpoint",
+              "endpoint": "https://netapp.contoso.com/bucket1",
+              "tlsVerification": "Perform"
+            },
+            "auth": {
+              "authType": "AccessKey",
+              "accessKeyId": "example-access-key",
+              "signingRegion": "us-east-1"
+            }
+          },
+          "provisioningState": "Creating"
+        }
+      },
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/eastus/DataManagementRPOperationStatuses/operation-98765?api-version=2026-09-01",
+        "Retry-After": 30
+      }
+    }
+  }
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/BlobAccessPointConfigurations_Create_AzureNetAppFilesPrivateLink.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/BlobAccessPointConfigurations_Create_AzureNetAppFilesPrivateLink.json
@@ -1,0 +1,114 @@
+{
+  "operationId": "BlobAccessPointConfigurations_Create",
+  "title": "CreateBlobAccessPointConfigurationWithAzureNetAppFilesPrivateLink",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "testrg",
+    "api-version": "2026-09-01",
+    "blobAccessPointConfigurationName": "anfprivatelinkaccesspoint",
+    "accountName": "teststorageaccount",
+    "resource": {
+      "location": "eastus",
+      "properties": {
+        "state": "Active",
+        "description": "Azure NetApp Files S3-compatible source over Private Link",
+        "source": {
+          "sourceType": "AzureNetAppFiles",
+          "connection": {
+            "connectionType": "PrivateLink",
+            "privateLinkIdType": "ResourceId",
+            "privateLinkId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Network/privateLinkServices/anfpls",
+            "privateLinkGroupId": "s3",
+            "privateLinkLocation": "eastus",
+            "requestMessage": "Blob Access Point connection request for Azure NetApp Files",
+            "endpoint": "https://anf.contoso.com/bucket1",
+            "tlsVerification": "Perform"
+          },
+          "auth": {
+            "authType": "AccessKey",
+            "accessKeyId": "example-access-key",
+            "secretAccessKey": "example-secret-key",
+            "signingRegion": "us-east-1"
+          }
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/storageAccounts/teststorageaccount/blobAccessPointConfigurations/anfprivatelinkaccesspoint",
+        "name": "anfprivatelinkaccesspoint",
+        "type": "Microsoft.Storage/storageAccounts/blobAccessPointConfigurations",
+        "location": "eastus",
+        "systemData": {
+          "createdAt": "2026-09-01T00:00:00Z"
+        },
+        "properties": {
+          "uniqueId": "33333333-4444-5555-6666-777777777777",
+          "state": "Active",
+          "description": "Azure NetApp Files S3-compatible source over Private Link",
+          "source": {
+            "sourceType": "AzureNetAppFiles",
+            "connection": {
+              "connectionType": "PrivateLink",
+              "privateLinkIdType": "ResourceId",
+              "privateLinkId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Network/privateLinkServices/anfpls",
+              "privateLinkGroupId": "s3",
+              "privateLinkLocation": "eastus",
+              "requestMessage": "Blob Access Point connection request for Azure NetApp Files",
+              "endpoint": "https://anf.contoso.com/bucket1",
+              "tlsVerification": "Perform",
+              "privateEndpointName": "anfprivateendpoint"
+            },
+            "auth": {
+              "authType": "AccessKey",
+              "accessKeyId": "example-access-key",
+              "signingRegion": "us-east-1"
+            }
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/storageAccounts/teststorageaccount/blobAccessPointConfigurations/anfprivatelinkaccesspoint",
+        "name": "anfprivatelinkaccesspoint",
+        "type": "Microsoft.Storage/storageAccounts/blobAccessPointConfigurations",
+        "location": "eastus",
+        "systemData": {
+          "createdAt": "2026-09-01T00:00:00Z"
+        },
+        "properties": {
+          "uniqueId": "33333333-4444-5555-6666-777777777777",
+          "state": "Active",
+          "description": "Azure NetApp Files S3-compatible source over Private Link",
+          "source": {
+            "sourceType": "AzureNetAppFiles",
+            "connection": {
+              "connectionType": "PrivateLink",
+              "privateLinkIdType": "ResourceId",
+              "privateLinkId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Network/privateLinkServices/anfpls",
+              "privateLinkGroupId": "s3",
+              "privateLinkLocation": "eastus",
+              "requestMessage": "Blob Access Point connection request for Azure NetApp Files",
+              "endpoint": "https://anf.contoso.com/bucket1",
+              "tlsVerification": "Perform"
+            },
+            "auth": {
+              "authType": "AccessKey",
+              "accessKeyId": "example-access-key",
+              "signingRegion": "us-east-1"
+            }
+          },
+          "provisioningState": "Creating"
+        }
+      },
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/eastus/DataManagementRPOperationStatuses/operation-98765?api-version=2026-09-01",
+        "Retry-After": 30
+      }
+    }
+  }
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/BlobAccessPointConfigurations_Delete.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/BlobAccessPointConfigurations_Delete.json
@@ -1,0 +1,23 @@
+{
+  "operationId": "BlobAccessPointConfigurations_Delete",
+  "title": "DeleteBlobAccessPointConfiguration",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "testrg",
+    "accountName": "teststorageaccount",
+    "blobAccessPointConfigurationName": "testaccesspointconfig",
+    "api-version": "2026-09-01"
+  },
+  "responses": {
+    "204": {},
+    "202": {
+      "status": "Accepted",
+      "message": "The resource operation has been received and is being processed.",
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/eastus/DataManagementRPOperationStatuses/operation-98765?api-version=2026-09-01",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/eastus/DataManagementRPOperationStatuses/operation-98765?api-version=2026-09-01",
+        "Retry-After": 30
+      }
+    }
+  }
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/BlobAccessPointConfigurations_Get.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/BlobAccessPointConfigurations_Get.json
@@ -1,0 +1,45 @@
+{
+  "operationId": "BlobAccessPointConfigurations_Get",
+  "title": "GetBlobAccessPointConfiguration",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "testrg",
+    "api-version": "2026-09-01",
+    "blobAccessPointConfigurationName": "testaccesspointconfig",
+    "accountName": "teststorageaccount"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/storageAccounts/teststorageaccount/blobAccessPointConfigurations/testaccesspointconfig",
+        "name": "testaccesspointconfig",
+        "type": "Microsoft.Storage/storageAccounts/blobAccessPointConfigurations",
+        "location": "eastus",
+        "systemData": {
+          "createdAt": "2026-09-01T00:00:00Z"
+        },
+        "properties": {
+          "uniqueId": "11111111-2222-3333-4444-555555555555",
+          "state": "Active",
+          "description": "NetApp ONTAP S3-compatible source",
+          "lastConnectionTestStatus": "Succeeded",
+          "lastConnectionTestTimestamp": "2026-09-01T01:00:00Z",
+          "source": {
+            "sourceType": "NetAppOntap",
+            "connection": {
+              "connectionType": "Endpoint",
+              "endpoint": "https://netapp.contoso.com/bucket1",
+              "tlsVerification": "Perform"
+            },
+            "auth": {
+              "authType": "AccessKey",
+              "accessKeyId": "example-access-key",
+              "signingRegion": "us-east-1"
+            }
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  }
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/BlobAccessPointConfigurations_ListByStorageAccount.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/BlobAccessPointConfigurations_ListByStorageAccount.json
@@ -1,0 +1,81 @@
+{
+  "operationId": "BlobAccessPointConfigurations_ListByStorageAccount",
+  "title": "ListBlobAccessPointConfigurationsByStorageAccount",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "testrg",
+    "api-version": "2026-09-01",
+    "accountName": "teststorageaccount"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/storageAccounts/teststorageaccount/blobAccessPointConfigurations/testaccesspointconfig",
+            "name": "testaccesspointconfig",
+            "type": "Microsoft.Storage/storageAccounts/blobAccessPointConfigurations",
+            "location": "eastus",
+            "systemData": {
+              "createdAt": "2026-09-01T00:00:00Z"
+            },
+            "properties": {
+              "uniqueId": "11111111-2222-3333-4444-555555555555",
+              "state": "Active",
+              "description": "NetApp ONTAP S3-compatible source",
+              "source": {
+                "sourceType": "NetAppOntap",
+                "connection": {
+                  "connectionType": "Endpoint",
+                  "endpoint": "https://netapp.contoso.com/bucket1",
+                  "tlsVerification": "Perform"
+                },
+                "auth": {
+                  "authType": "AccessKey",
+                  "accessKeyId": "example-access-key",
+                  "signingRegion": "us-east-1"
+                }
+              },
+              "provisioningState": "Succeeded"
+            }
+          },
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/storageAccounts/teststorageaccount/blobAccessPointConfigurations/privatelinkaccesspointconfig",
+            "name": "privatelinkaccesspointconfig",
+            "type": "Microsoft.Storage/storageAccounts/blobAccessPointConfigurations",
+            "location": "eastus",
+            "systemData": {
+              "createdAt": "2026-09-01T00:00:00Z"
+            },
+            "properties": {
+              "uniqueId": "22222222-3333-4444-5555-666666666666",
+              "state": "Active",
+              "description": "Private-link-backed S3-compatible source",
+              "source": {
+                "sourceType": "DellOneFs",
+                "connection": {
+                  "connectionType": "PrivateLink",
+                  "privateLinkIdType": "ResourceId",
+                  "privateLinkId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Network/privateLinkServices/testpls",
+                  "privateLinkGroupId": "s3",
+                  "privateLinkLocation": "eastus",
+                  "requestMessage": "Blob Access Point connection request",
+                  "endpoint": "https://onefs.contoso.com/bucket2",
+                  "tlsVerification": "Perform",
+                  "privateEndpointName": "testpe"
+                },
+                "auth": {
+                  "authType": "AccessKey",
+                  "accessKeyId": "example-access-key-2",
+                  "signingRegion": "us-east-1",
+                  "hostOverride": "onefs.contoso.com"
+                }
+              },
+              "provisioningState": "Succeeded"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/BlobAccessPointConfigurations_TestExistingConnection.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/BlobAccessPointConfigurations_TestExistingConnection.json
@@ -1,0 +1,31 @@
+{
+  "operationId": "BlobAccessPointConfigurations_TestExistingConnection",
+  "title": "BlobAccessPointConfigurationTestExistingConnection",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "testrg",
+    "accountName": "teststorageaccount",
+    "api-version": "2026-09-01",
+    "blobAccessPointConfigurationName": "testaccesspointconfig",
+    "body": {
+      "uniqueId": "11111111-2222-3333-4444-555555555555"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "methodName": "List",
+        "requestId": "request-id-123"
+      }
+    },
+    "202": {
+      "status": "Accepted",
+      "message": "The resource operation has been received and is being processed.",
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/eastus/DataManagementRPOperationStatuses/operation-98765?api-version=2026-09-01",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/eastus/DataManagementRPOperationResults/operation-98765?api-version=2026-09-01",
+        "Retry-After": 30
+      }
+    }
+  }
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/BlobAccessPointConfigurations_Update.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/BlobAccessPointConfigurations_Update.json
@@ -1,0 +1,65 @@
+{
+  "operationId": "BlobAccessPointConfigurations_Update",
+  "title": "UpdateBlobAccessPointConfiguration",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "testrg",
+    "accountName": "teststorageaccount",
+    "api-version": "2026-09-01",
+    "blobAccessPointConfigurationName": "testaccesspointconfig",
+    "properties": {
+      "properties": {
+        "state": "Inactive",
+        "description": "Updated NetApp ONTAP S3-compatible source",
+        "source": {
+          "sourceType": "NetAppOntap",
+          "auth": {
+            "authType": "AccessKey",
+            "secretAccessKey": "rotated-secret-key"
+          }
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/storageAccounts/teststorageaccount/blobAccessPointConfigurations/testaccesspointconfig",
+        "name": "testaccesspointconfig",
+        "type": "Microsoft.Storage/storageAccounts/blobAccessPointConfigurations",
+        "location": "eastus",
+        "systemData": {
+          "createdAt": "2026-09-01T00:00:00Z"
+        },
+        "properties": {
+          "uniqueId": "11111111-2222-3333-4444-555555555555",
+          "state": "Inactive",
+          "description": "Updated NetApp ONTAP S3-compatible source",
+          "source": {
+            "sourceType": "NetAppOntap",
+            "connection": {
+              "connectionType": "Endpoint",
+              "endpoint": "https://netapp.contoso.com/bucket1",
+              "tlsVerification": "Perform"
+            },
+            "auth": {
+              "authType": "AccessKey",
+              "accessKeyId": "example-access-key",
+              "signingRegion": "us-east-1"
+            }
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    },
+    "202": {
+      "status": "Accepted",
+      "message": "The resource operation has been received and is being processed.",
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/eastus/DataManagementRPOperationStatuses/operation-98765?api-version=2026-09-01",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/eastus/DataManagementRPOperationStatuses/operation-98765?api-version=2026-09-01",
+        "Retry-After": 30
+      }
+    }
+  }
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/BlobAccessPointConnectionTests_TestProposedConnection.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/BlobAccessPointConnectionTests_TestProposedConnection.json
@@ -1,0 +1,48 @@
+{
+  "operationId": "BlobAccessPointConnectionTests_TestProposedConnection",
+  "title": "BlobAccessPointTestProposedConnection",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "testrg",
+    "accountName": "teststorageaccount",
+    "api-version": "2026-09-01",
+    "body": {
+      "source": {
+        "sourceType": "S3Compatible",
+        "connection": {
+          "connectionType": "PrivateLink",
+          "privateLinkIdType": "ResourceId",
+          "privateLinkId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Network/privateLinkServices/testpls",
+          "privateLinkGroupId": "s3",
+          "privateLinkLocation": "eastus",
+          "requestMessage": "Blob Access Point connection request",
+          "endpoint": "https://s3.contoso.com/bucket1",
+          "tlsVerification": "Perform"
+        },
+        "auth": {
+          "authType": "AccessKey",
+          "accessKeyId": "example-access-key",
+          "secretAccessKey": "example-secret-key",
+          "signingRegion": "us-east-1"
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "methodName": "List",
+        "requestId": "request-id-123"
+      }
+    },
+    "202": {
+      "status": "Accepted",
+      "message": "The resource operation has been received and is being processed.",
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/eastus/DataManagementRPOperationStatuses/operation-98765?api-version=2026-09-01",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/eastus/DataManagementRPOperationResults/operation-98765?api-version=2026-09-01",
+        "Retry-After": 30
+      }
+    }
+  }
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/Operations_List.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/Operations_List.json
@@ -1,0 +1,131 @@
+{
+  "operationId": "Operations_List",
+  "title": "ListOperations",
+  "parameters": {
+    "api-version": "2026-09-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Microsoft.Storage/storageAccounts/connectors/read",
+            "display": {
+              "provider": "Microsoft Storage",
+              "resource": "Storage Connector",
+              "operation": "Read Storage Connector",
+              "description": "Reads the properties of a storage connector."
+            }
+          },
+          {
+            "name": "Microsoft.Storage/storageAccounts/connectors/write",
+            "display": {
+              "provider": "Microsoft Storage",
+              "resource": "Storage Connector",
+              "operation": "Write Storage Connector",
+              "description": "Creates or updates a storage connector."
+            }
+          },
+          {
+            "name": "Microsoft.Storage/storageAccounts/connectors/delete",
+            "display": {
+              "provider": "Microsoft Storage",
+              "resource": "Storage Connector",
+              "operation": "Delete Storage Connector",
+              "description": "Deletes a storage connector."
+            }
+          },
+          {
+            "name": "Microsoft.Storage/storageAccounts/connectors/testExistingConnection/action",
+            "display": {
+              "provider": "Microsoft Storage",
+              "resource": "Storage Connector",
+              "operation": "Test Existing Connection",
+              "description": "Tests connection to an existing storage connector."
+            }
+          },
+          {
+            "name": "Microsoft.Storage/storageAccounts/dataShares/read",
+            "display": {
+              "provider": "Microsoft Storage",
+              "resource": "Storage DataShare",
+              "operation": "Read Storage DataShare",
+              "description": "Reads the properties of a storage data share."
+            }
+          },
+          {
+            "name": "Microsoft.Storage/storageAccounts/dataShares/write",
+            "display": {
+              "provider": "Microsoft Storage",
+              "resource": "Storage DataShare",
+              "operation": "Write Storage DataShare",
+              "description": "Reads the properties of a storage data share."
+            }
+          },
+          {
+            "name": "Microsoft.Storage/storageAccounts/dataShares/delete",
+            "display": {
+              "provider": "Microsoft Storage",
+              "resource": "Storage DataShare",
+              "operation": "Delete Storage DataShare",
+              "description": "Reads the properties of a storage data share."
+            }
+          },
+          {
+            "name": "Microsoft.Storage/storageAccounts/blobAccessPointConfigurations/read",
+            "display": {
+              "provider": "Microsoft Storage",
+              "resource": "Blob Access Point Configuration",
+              "operation": "Read Blob Access Point Configuration",
+              "description": "Reads Blob Access Point configuration properties."
+            }
+          },
+          {
+            "name": "Microsoft.Storage/storageAccounts/blobAccessPointConfigurations/write",
+            "display": {
+              "provider": "Microsoft Storage",
+              "resource": "Blob Access Point Configuration",
+              "operation": "Write Blob Access Point Configuration",
+              "description": "Creates or updates a Blob Access Point configuration."
+            }
+          },
+          {
+            "name": "Microsoft.Storage/storageAccounts/blobAccessPointConfigurations/delete",
+            "display": {
+              "provider": "Microsoft Storage",
+              "resource": "Blob Access Point Configuration",
+              "operation": "Delete Blob Access Point Configuration",
+              "description": "Deletes a Blob Access Point configuration."
+            }
+          },
+          {
+            "name": "Microsoft.Storage/storageAccounts/blobAccessPointConfigurations/testExistingConnection/action",
+            "display": {
+              "provider": "Microsoft Storage",
+              "resource": "Blob Access Point Configuration",
+              "operation": "Test Existing Blob Access Point Connection",
+              "description": "Tests the connection on an existing Blob Access Point configuration."
+            }
+          },
+          {
+            "name": "Microsoft.Storage/storageAccounts/testBlobAccessPointConfigurationProposedConnection/action",
+            "display": {
+              "provider": "Microsoft Storage",
+              "resource": "Blob Access Point Connection Test",
+              "operation": "Test Proposed Blob Access Point Connection",
+              "description": "Tests a proposed Blob Access Point connection before the configuration is created."
+            }
+          }
+        ]
+      }
+    },
+    "default": {
+      "body": {
+        "error": {
+          "code": "InternalServerError",
+          "message": "An unexpected error occurred."
+        }
+      }
+    }
+  }
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/openapi.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/openapi.json
@@ -9922,25 +9922,6 @@
         ]
       }
     },
-    "Azure.ResourceManager.CommonTypes.TrackedResourceUpdate": {
-      "type": "object",
-      "title": "Tracked Resource",
-      "description": "The resource model definition for an Azure Resource Manager tracked top level resource which has 'tags' and a 'location'",
-      "properties": {
-        "tags": {
-          "type": "object",
-          "description": "Resource tags.",
-          "additionalProperties": {
-            "type": "string"
-          }
-        }
-      },
-      "allOf": [
-        {
-          "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/Resource"
-        }
-      ]
-    },
     "Azure.ResourceManager.ResourceProvisioningState": {
       "type": "string",
       "description": "The provisioning state of a resource type.",
@@ -10313,16 +10294,18 @@
       "type": "object",
       "description": "A BlobAccessPointConfiguration is a tracked Azure resource modeled as a sub-resource of a Storage Account.",
       "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
         "properties": {
           "$ref": "#/definitions/BlobAccessPointConfigurationPropertiesUpdate",
           "description": "The resource-specific properties for this resource."
         }
-      },
-      "allOf": [
-        {
-          "$ref": "#/definitions/Azure.ResourceManager.CommonTypes.TrackedResourceUpdate"
-        }
-      ]
+      }
     },
     "BlobAccessPointConnectionProperties": {
       "type": "object",

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/openapi.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/openapi.json
@@ -18150,15 +18150,15 @@
       "type": "string",
       "description": "The type of the backing data source for storage connector",
       "enum": [
-        "AzureDataShare"
+        "Azure_DataShare"
       ],
       "x-ms-enum": {
         "name": "StorageConnectorDataSourceType",
         "modelAsString": true,
         "values": [
           {
-            "name": "AzureDataShare",
-            "value": "AzureDataShare",
+            "name": "Azure_DataShare",
+            "value": "Azure_DataShare",
             "description": "Azure DataShare data source type."
           }
         ]
@@ -18197,6 +18197,11 @@
               }
             ]
           }
+        },
+        "creationTime": {
+          "type": "string",
+          "description": "System-generated creation time of the Storage Connector in ISO 8601 date-time format (YYYY-MM-DDTHH:mm:ssZ).\nNot a valid input parameter during creating.",
+          "readOnly": true
         },
         "description": {
           "type": "string",

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/openapi.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/openapi.json
@@ -18150,42 +18150,12 @@
       "type": "string",
       "description": "The type of the backing data source for storage connector",
       "enum": [
-        "NetAppOntap",
-        "AzureNetAppFiles",
-        "DellOneFs",
-        "AwsS3",
-        "S3Compatible",
         "AzureDataShare"
       ],
       "x-ms-enum": {
         "name": "StorageConnectorDataSourceType",
         "modelAsString": true,
         "values": [
-          {
-            "name": "NetAppOntap",
-            "value": "NetAppOntap",
-            "description": "NetApp ONTAP data source type."
-          },
-          {
-            "name": "AzureNetAppFiles",
-            "value": "AzureNetAppFiles",
-            "description": "Azure NetApp Files data source type."
-          },
-          {
-            "name": "DellOneFs",
-            "value": "DellOneFs",
-            "description": "Dell OneFS data source type."
-          },
-          {
-            "name": "AwsS3",
-            "value": "AwsS3",
-            "description": "AWS S3 data source type."
-          },
-          {
-            "name": "S3Compatible",
-            "value": "S3Compatible",
-            "description": "S3-compatible data source type."
-          },
           {
             "name": "AzureDataShare",
             "value": "AzureDataShare",

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/openapi.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/openapi.json
@@ -10739,13 +10739,21 @@
     },
     "BlobAccessPointPrivateLinkIdType": {
       "type": "string",
+      "description": "The format used by a Private Link identifier.",
       "enum": [
         "ResourceId"
       ],
       "x-ms-enum": {
-        "modelAsString": false
-      },
-      "x-nullable": false
+        "name": "BlobAccessPointPrivateLinkIdType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "ResourceId",
+            "value": "ResourceId",
+            "description": "The identifier is an Azure resource ID."
+          }
+        ]
+      }
     },
     "BlobAccessPointProposedConnectionTestRequest": {
       "type": "object",

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/openapi.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/openapi.json
@@ -10649,7 +10649,7 @@
       "properties": {
         "privateLinkIdType": {
           "$ref": "#/definitions/BlobAccessPointPrivateLinkIdType",
-          "description": "Whether privateLinkId contains an Azure resource ID or a Private Link alias.",
+          "description": "Indicates that privateLinkId contains an Azure resource ID.",
           "x-ms-mutability": [
             "read",
             "create"
@@ -10657,7 +10657,7 @@
         },
         "privateLinkId": {
           "type": "string",
-          "description": "The Azure resource ID or alias of the backing Private Link resource.",
+          "description": "The Azure resource ID of the backing Private Link resource.",
           "x-ms-mutability": [
             "read",
             "create"
@@ -10739,27 +10739,13 @@
     },
     "BlobAccessPointPrivateLinkIdType": {
       "type": "string",
-      "description": "The format used by a Private Link identifier.",
       "enum": [
-        "ResourceId",
-        "Alias"
+        "ResourceId"
       ],
       "x-ms-enum": {
-        "name": "BlobAccessPointPrivateLinkIdType",
-        "modelAsString": true,
-        "values": [
-          {
-            "name": "ResourceId",
-            "value": "ResourceId",
-            "description": "The identifier is an Azure resource ID."
-          },
-          {
-            "name": "Alias",
-            "value": "Alias",
-            "description": "The identifier is a Private Link alias."
-          }
-        ]
-      }
+        "modelAsString": false
+      },
+      "x-nullable": false
     },
     "BlobAccessPointProposedConnectionTestRequest": {
       "type": "object",

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/openapi.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/openapi.json
@@ -118,6 +118,12 @@
       "name": "ContextCacheContainers"
     },
     {
+      "name": "BlobAccessPointConfigurations"
+    },
+    {
+      "name": "BlobAccessPointConnectionTests"
+    },
+    {
       "name": "AdvancedPlatformMetrics"
     }
   ],
@@ -149,6 +155,9 @@
           }
         },
         "x-ms-examples": {
+          "ListOperations": {
+            "$ref": "./examples/Operations_List.json"
+          },
           "OperationsList": {
             "$ref": "./examples/OperationsList.json"
           }
@@ -1941,6 +1950,457 @@
             "$ref": "./examples/AdvancedPlatformMetricsCRUD/AdvancedPlatformMetricsRules_Delete.json"
           }
         }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/blobAccessPointConfigurations": {
+      "get": {
+        "operationId": "BlobAccessPointConfigurations_ListByStorageAccount",
+        "tags": [
+          "BlobAccessPointConfigurations"
+        ],
+        "description": "List all Blob Access Point configurations in a Storage Account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/BlobAccessPointConfigurationListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ListBlobAccessPointConfigurationsByStorageAccount": {
+            "$ref": "./examples/BlobAccessPointConfigurations_ListByStorageAccount.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/blobAccessPointConfigurations/{blobAccessPointConfigurationName}": {
+      "get": {
+        "operationId": "BlobAccessPointConfigurations_Get",
+        "tags": [
+          "BlobAccessPointConfigurations"
+        ],
+        "description": "Get the specified Blob Access Point configuration.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "blobAccessPointConfigurationName",
+            "in": "path",
+            "description": "The name of the Blob Access Point configuration.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-z0-9](?!.*--)[a-z0-9-]{1,61}[a-z0-9]$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/BlobAccessPointConfiguration"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "GetBlobAccessPointConfiguration": {
+            "$ref": "./examples/BlobAccessPointConfigurations_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "BlobAccessPointConfigurations_Create",
+        "tags": [
+          "BlobAccessPointConfigurations"
+        ],
+        "description": "Creates or updates a Blob Access Point configuration.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "blobAccessPointConfigurationName",
+            "in": "path",
+            "description": "The name of the Blob Access Point configuration.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-z0-9](?!.*--)[a-z0-9-]{1,61}[a-z0-9]$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Resource create parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/BlobAccessPointConfiguration"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'BlobAccessPointConfiguration' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/BlobAccessPointConfiguration"
+            }
+          },
+          "201": {
+            "description": "Resource 'BlobAccessPointConfiguration' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/BlobAccessPointConfiguration"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "CreateBlobAccessPointConfiguration": {
+            "$ref": "./examples/BlobAccessPointConfigurations_Create.json"
+          },
+          "CreateBlobAccessPointConfigurationWithAzureNetAppFilesPrivateLink": {
+            "$ref": "./examples/BlobAccessPointConfigurations_Create_AzureNetAppFilesPrivateLink.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/BlobAccessPointConfiguration"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "BlobAccessPointConfigurations_Update",
+        "tags": [
+          "BlobAccessPointConfigurations"
+        ],
+        "description": "Update a Blob Access Point configuration.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "blobAccessPointConfigurationName",
+            "in": "path",
+            "description": "The name of the Blob Access Point configuration.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-z0-9](?!.*--)[a-z0-9-]{1,61}[a-z0-9]$"
+          },
+          {
+            "name": "properties",
+            "in": "body",
+            "description": "The resource properties to be updated.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/BlobAccessPointConfigurationUpdate"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/BlobAccessPointConfiguration"
+            }
+          },
+          "202": {
+            "description": "Resource update request accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "UpdateBlobAccessPointConfiguration": {
+            "$ref": "./examples/BlobAccessPointConfigurations_Update.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/BlobAccessPointConfiguration"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "BlobAccessPointConfigurations_Delete",
+        "tags": [
+          "BlobAccessPointConfigurations"
+        ],
+        "description": "Delete a Blob Access Point configuration.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "blobAccessPointConfigurationName",
+            "in": "path",
+            "description": "The name of the Blob Access Point configuration.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-z0-9](?!.*--)[a-z0-9-]{1,61}[a-z0-9]$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DeleteBlobAccessPointConfiguration": {
+            "$ref": "./examples/BlobAccessPointConfigurations_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/blobAccessPointConfigurations/{blobAccessPointConfigurationName}/testExistingConnection": {
+      "post": {
+        "operationId": "BlobAccessPointConfigurations_TestExistingConnection",
+        "tags": [
+          "BlobAccessPointConfigurations"
+        ],
+        "description": "Test the connection configured on an existing Blob Access Point configuration.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "blobAccessPointConfigurationName",
+            "in": "path",
+            "description": "The name of the Blob Access Point configuration.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-z0-9](?!.*--)[a-z0-9-]{1,61}[a-z0-9]$"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "The content of the action request",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/BlobAccessPointConnectionTestRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/BlobAccessPointConnectionTestResponse"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "BlobAccessPointConfigurationTestExistingConnection": {
+            "$ref": "./examples/BlobAccessPointConfigurations_TestExistingConnection.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/BlobAccessPointConnectionTestResponse"
+        },
+        "x-ms-long-running-operation": true
       }
     },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/blobServices": {
@@ -8735,6 +9195,88 @@
           }
         }
       }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/testBlobAccessPointConfigurationProposedConnection": {
+      "post": {
+        "operationId": "BlobAccessPointConnectionTests_TestProposedConnection",
+        "tags": [
+          "BlobAccessPointConnectionTests"
+        ],
+        "description": "Test a proposed Blob Access Point connection before the configuration is created. The connection is validated in the context of the storage account in the request path, so no Blob Access Point configuration needs to exist beforehand.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "The content of the action request",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/BlobAccessPointProposedConnectionTestRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/BlobAccessPointConnectionTestResponse"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "BlobAccessPointTestProposedConnection": {
+            "$ref": "./examples/BlobAccessPointConnectionTests_TestProposedConnection.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/BlobAccessPointConnectionTestResponse"
+        },
+        "x-ms-long-running-operation": true
+      }
     }
   },
   "definitions": {
@@ -9380,6 +9922,56 @@
         ]
       }
     },
+    "Azure.ResourceManager.CommonTypes.TrackedResourceUpdate": {
+      "type": "object",
+      "title": "Tracked Resource",
+      "description": "The resource model definition for an Azure Resource Manager tracked top level resource which has 'tags' and a 'location'",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/Resource"
+        }
+      ]
+    },
+    "Azure.ResourceManager.ResourceProvisioningState": {
+      "type": "string",
+      "description": "The provisioning state of a resource type.",
+      "enum": [
+        "Succeeded",
+        "Failed",
+        "Canceled"
+      ],
+      "x-ms-enum": {
+        "name": "ResourceProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Resource has been created."
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Resource creation failed."
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Resource creation was canceled."
+          }
+        ]
+      },
+      "readOnly": true
+    },
     "AzureEntityResource": {
       "type": "object",
       "title": "Entity Resource",
@@ -9421,6 +10013,979 @@
       "required": [
         "directoryServiceOptions"
       ]
+    },
+    "BlobAccessPointAccessKeyAuthProperties": {
+      "type": "object",
+      "description": "S3 access-key authentication properties.",
+      "properties": {
+        "accessKeyId": {
+          "type": "string",
+          "description": "The access key ID.",
+          "minLength": 3
+        },
+        "secretAccessKey": {
+          "type": "string",
+          "format": "password",
+          "description": "The secret access key. This value is never returned by read or list operations.",
+          "minLength": 3,
+          "x-ms-mutability": [
+            "update",
+            "create"
+          ],
+          "x-ms-secret": true
+        },
+        "signingRegion": {
+          "type": "string",
+          "description": "The region used by the request-signing algorithm. Defaults to 'us-east-1' when not specified."
+        },
+        "hostOverride": {
+          "type": "string",
+          "description": "The host used when computing request signatures. The endpoint host is used by default."
+        }
+      },
+      "required": [
+        "accessKeyId",
+        "secretAccessKey"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/BlobAccessPointRemoteAuthProperties"
+        }
+      ],
+      "x-ms-discriminator-value": "AccessKey"
+    },
+    "BlobAccessPointAccessKeyAuthPropertiesUpdate": {
+      "type": "object",
+      "description": "S3 access-key authentication properties.",
+      "properties": {
+        "accessKeyId": {
+          "type": "string",
+          "description": "The access key ID.",
+          "minLength": 3
+        },
+        "secretAccessKey": {
+          "type": "string",
+          "format": "password",
+          "description": "The secret access key. This value is never returned by read or list operations.",
+          "minLength": 3,
+          "x-ms-mutability": [
+            "update",
+            "create"
+          ],
+          "x-ms-secret": true
+        },
+        "signingRegion": {
+          "type": "string",
+          "description": "The region used by the request-signing algorithm. Defaults to 'us-east-1' when not specified."
+        },
+        "hostOverride": {
+          "type": "string",
+          "description": "The host used when computing request signatures. The endpoint host is used by default."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/BlobAccessPointRemoteAuthPropertiesUpdate"
+        }
+      ],
+      "x-ms-discriminator-value": "AccessKey"
+    },
+    "BlobAccessPointAzureNetAppFilesSourceProperties": {
+      "type": "object",
+      "description": "An Azure NetApp Files backing source.",
+      "properties": {
+        "connection": {
+          "$ref": "#/definitions/BlobAccessPointConnectionProperties",
+          "description": "Details for connecting to the backing data source. The connection target is fixed when the configuration is created; only the TLS verification behavior can be changed afterwards."
+        },
+        "auth": {
+          "$ref": "#/definitions/BlobAccessPointRemoteAuthProperties",
+          "description": "Details for authenticating to the backing data source."
+        }
+      },
+      "required": [
+        "connection",
+        "auth"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/BlobAccessPointSourceProperties"
+        }
+      ],
+      "x-ms-discriminator-value": "AzureNetAppFiles"
+    },
+    "BlobAccessPointAzureNetAppFilesSourcePropertiesUpdate": {
+      "type": "object",
+      "description": "An Azure NetApp Files backing source.",
+      "properties": {
+        "connection": {
+          "$ref": "#/definitions/BlobAccessPointConnectionPropertiesUpdate",
+          "description": "Details for connecting to the backing data source. The connection target is fixed when the configuration is created; only the TLS verification behavior can be changed afterwards."
+        },
+        "auth": {
+          "$ref": "#/definitions/BlobAccessPointRemoteAuthPropertiesUpdate",
+          "description": "Details for authenticating to the backing data source."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/BlobAccessPointSourcePropertiesUpdate"
+        }
+      ],
+      "x-ms-discriminator-value": "AzureNetAppFiles"
+    },
+    "BlobAccessPointCommvaultSourceProperties": {
+      "type": "object",
+      "description": "A Commvault backing source.",
+      "properties": {
+        "connection": {
+          "$ref": "#/definitions/BlobAccessPointConnectionProperties",
+          "description": "Details for connecting to the backing data source. The connection target is fixed when the configuration is created; only the TLS verification behavior can be changed afterwards."
+        },
+        "auth": {
+          "$ref": "#/definitions/BlobAccessPointRemoteAuthProperties",
+          "description": "Details for authenticating to the backing data source."
+        }
+      },
+      "required": [
+        "connection",
+        "auth"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/BlobAccessPointSourceProperties"
+        }
+      ],
+      "x-ms-discriminator-value": "Commvault"
+    },
+    "BlobAccessPointCommvaultSourcePropertiesUpdate": {
+      "type": "object",
+      "description": "A Commvault backing source.",
+      "properties": {
+        "connection": {
+          "$ref": "#/definitions/BlobAccessPointConnectionPropertiesUpdate",
+          "description": "Details for connecting to the backing data source. The connection target is fixed when the configuration is created; only the TLS verification behavior can be changed afterwards."
+        },
+        "auth": {
+          "$ref": "#/definitions/BlobAccessPointRemoteAuthPropertiesUpdate",
+          "description": "Details for authenticating to the backing data source."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/BlobAccessPointSourcePropertiesUpdate"
+        }
+      ],
+      "x-ms-discriminator-value": "Commvault"
+    },
+    "BlobAccessPointConfiguration": {
+      "type": "object",
+      "description": "A BlobAccessPointConfiguration is a tracked Azure resource modeled as a sub-resource of a Storage Account.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/BlobAccessPointConfigurationProperties",
+          "description": "The resource-specific properties for this resource."
+        }
+      },
+      "required": [
+        "properties"
+      ],
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/TrackedResource"
+        }
+      ]
+    },
+    "BlobAccessPointConfigurationListResult": {
+      "type": "object",
+      "description": "The response of a BlobAccessPointConfiguration list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The BlobAccessPointConfiguration items on this page",
+          "items": {
+            "$ref": "#/definitions/BlobAccessPointConfiguration"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "BlobAccessPointConfigurationProperties": {
+      "type": "object",
+      "description": "Details of a Blob Access Point configuration.",
+      "properties": {
+        "uniqueId": {
+          "type": "string",
+          "description": "The system-generated unique identifier of the configuration.",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+          "readOnly": true
+        },
+        "state": {
+          "$ref": "#/definitions/BlobAccessPointConfigurationState",
+          "description": "The configuration state. A configuration is created in the Active state when this value is not specified."
+        },
+        "description": {
+          "type": "string",
+          "description": "An arbitrary description of the Blob Access Point configuration.",
+          "maxLength": 250
+        },
+        "lastConnectionTestStatus": {
+          "$ref": "#/definitions/BlobAccessPointConnectionTestStatus",
+          "description": "The status of the most recent connection test.",
+          "readOnly": true
+        },
+        "lastConnectionTestTimestamp": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The timestamp of the most recent connection test.",
+          "readOnly": true
+        },
+        "lastConnectionTestErrorMessage": {
+          "type": "string",
+          "description": "The normalized and redacted error from the most recent failed connection test.",
+          "readOnly": true
+        },
+        "source": {
+          "$ref": "#/definitions/BlobAccessPointSourceProperties",
+          "description": "Information about the backing data source."
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/Azure.ResourceManager.ResourceProvisioningState",
+          "description": "The status of the last operation.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "source"
+      ]
+    },
+    "BlobAccessPointConfigurationPropertiesUpdate": {
+      "type": "object",
+      "description": "Details of a Blob Access Point configuration.",
+      "properties": {
+        "state": {
+          "$ref": "#/definitions/BlobAccessPointConfigurationState",
+          "description": "The configuration state. A configuration is created in the Active state when this value is not specified."
+        },
+        "description": {
+          "type": "string",
+          "description": "An arbitrary description of the Blob Access Point configuration.",
+          "maxLength": 250
+        },
+        "source": {
+          "$ref": "#/definitions/BlobAccessPointSourcePropertiesUpdate",
+          "description": "Information about the backing data source."
+        }
+      }
+    },
+    "BlobAccessPointConfigurationState": {
+      "type": "string",
+      "description": "The state of a Blob Access Point configuration.",
+      "enum": [
+        "Active",
+        "Inactive"
+      ],
+      "x-ms-enum": {
+        "name": "BlobAccessPointConfigurationState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Active",
+            "value": "Active",
+            "description": "The Blob Access Point configuration is active."
+          },
+          {
+            "name": "Inactive",
+            "value": "Inactive",
+            "description": "The Blob Access Point configuration is inactive."
+          }
+        ]
+      }
+    },
+    "BlobAccessPointConfigurationUpdate": {
+      "type": "object",
+      "description": "A BlobAccessPointConfiguration is a tracked Azure resource modeled as a sub-resource of a Storage Account.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/BlobAccessPointConfigurationPropertiesUpdate",
+          "description": "The resource-specific properties for this resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Azure.ResourceManager.CommonTypes.TrackedResourceUpdate"
+        }
+      ]
+    },
+    "BlobAccessPointConnectionProperties": {
+      "type": "object",
+      "description": "Details for connecting to a backing data source.",
+      "properties": {
+        "connectionType": {
+          "$ref": "#/definitions/BlobAccessPointConnectionType",
+          "description": "The connection type. This value determines the remaining shape of the connection object."
+        }
+      },
+      "discriminator": "connectionType",
+      "required": [
+        "connectionType"
+      ]
+    },
+    "BlobAccessPointConnectionPropertiesUpdate": {
+      "type": "object",
+      "description": "Details for connecting to a backing data source.",
+      "properties": {
+        "connectionType": {
+          "$ref": "#/definitions/BlobAccessPointConnectionType",
+          "description": "The connection type. This value determines the remaining shape of the connection object."
+        }
+      },
+      "discriminator": "connectionType",
+      "required": [
+        "connectionType"
+      ]
+    },
+    "BlobAccessPointConnectionTestRequest": {
+      "type": "object",
+      "description": "The request used to test an existing Blob Access Point configuration.",
+      "properties": {
+        "uniqueId": {
+          "type": "string",
+          "description": "The system-generated unique identifier of the Blob Access Point configuration, as returned by a read operation. This value must match the configuration named in the request path, and is required so that a configuration which was deleted and recreated under the same name is not tested by mistake.",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+        }
+      },
+      "required": [
+        "uniqueId"
+      ]
+    },
+    "BlobAccessPointConnectionTestResponse": {
+      "type": "object",
+      "description": "The result of testing a Blob Access Point configuration connection.",
+      "properties": {
+        "methodName": {
+          "type": "string",
+          "description": "The name of the request attempted against the backing data source.",
+          "minLength": 1
+        },
+        "errorMessage": {
+          "type": "string",
+          "description": "A normalized and redacted error message received from the backing data source. This value is empty when the connection test succeeds."
+        },
+        "requestId": {
+          "type": "string",
+          "description": "The request ID associated with the request sent to the backing data source for validation.",
+          "minLength": 1
+        }
+      },
+      "required": [
+        "methodName",
+        "requestId"
+      ]
+    },
+    "BlobAccessPointConnectionTestStatus": {
+      "type": "string",
+      "description": "The status of the most recent connection test.",
+      "enum": [
+        "Succeeded",
+        "Failed"
+      ],
+      "x-ms-enum": {
+        "name": "BlobAccessPointConnectionTestStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "The connection test succeeded."
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "The connection test failed."
+          }
+        ]
+      },
+      "readOnly": true
+    },
+    "BlobAccessPointConnectionType": {
+      "type": "string",
+      "description": "The connection type used to reach a non-Azure backing data source.",
+      "enum": [
+        "Endpoint",
+        "PrivateLink"
+      ],
+      "x-ms-enum": {
+        "name": "BlobAccessPointConnectionType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Endpoint",
+            "value": "Endpoint",
+            "description": "Connect directly to a public or otherwise routable endpoint."
+          },
+          {
+            "name": "PrivateLink",
+            "value": "PrivateLink",
+            "description": "Connect through Azure Private Link."
+          }
+        ]
+      }
+    },
+    "BlobAccessPointDellOneFsSourceProperties": {
+      "type": "object",
+      "description": "A Dell OneFS backing source.",
+      "properties": {
+        "connection": {
+          "$ref": "#/definitions/BlobAccessPointConnectionProperties",
+          "description": "Details for connecting to the backing data source. The connection target is fixed when the configuration is created; only the TLS verification behavior can be changed afterwards."
+        },
+        "auth": {
+          "$ref": "#/definitions/BlobAccessPointRemoteAuthProperties",
+          "description": "Details for authenticating to the backing data source."
+        }
+      },
+      "required": [
+        "connection",
+        "auth"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/BlobAccessPointSourceProperties"
+        }
+      ],
+      "x-ms-discriminator-value": "DellOneFs"
+    },
+    "BlobAccessPointDellOneFsSourcePropertiesUpdate": {
+      "type": "object",
+      "description": "A Dell OneFS backing source.",
+      "properties": {
+        "connection": {
+          "$ref": "#/definitions/BlobAccessPointConnectionPropertiesUpdate",
+          "description": "Details for connecting to the backing data source. The connection target is fixed when the configuration is created; only the TLS verification behavior can be changed afterwards."
+        },
+        "auth": {
+          "$ref": "#/definitions/BlobAccessPointRemoteAuthPropertiesUpdate",
+          "description": "Details for authenticating to the backing data source."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/BlobAccessPointSourcePropertiesUpdate"
+        }
+      ],
+      "x-ms-discriminator-value": "DellOneFs"
+    },
+    "BlobAccessPointEndpointConnectionProperties": {
+      "type": "object",
+      "description": "A direct endpoint connection.",
+      "properties": {
+        "endpoint": {
+          "type": "string",
+          "format": "uri",
+          "description": "The backing endpoint, including its protocol, host, optional port, and optional path.",
+          "minLength": 4,
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "tlsVerification": {
+          "$ref": "#/definitions/BlobAccessPointTlsVerification",
+          "description": "TLS certificate verification behavior. Defaults to Perform when not specified."
+        }
+      },
+      "required": [
+        "endpoint"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/BlobAccessPointConnectionProperties"
+        }
+      ],
+      "x-ms-discriminator-value": "Endpoint"
+    },
+    "BlobAccessPointEndpointConnectionPropertiesUpdate": {
+      "type": "object",
+      "description": "A direct endpoint connection.",
+      "properties": {
+        "tlsVerification": {
+          "$ref": "#/definitions/BlobAccessPointTlsVerification",
+          "description": "TLS certificate verification behavior. Defaults to Perform when not specified."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/BlobAccessPointConnectionPropertiesUpdate"
+        }
+      ],
+      "x-ms-discriminator-value": "Endpoint"
+    },
+    "BlobAccessPointGenericS3SourceProperties": {
+      "type": "object",
+      "description": "Another S3-compatible backing source.",
+      "properties": {
+        "connection": {
+          "$ref": "#/definitions/BlobAccessPointConnectionProperties",
+          "description": "Details for connecting to the backing data source. The connection target is fixed when the configuration is created; only the TLS verification behavior can be changed afterwards."
+        },
+        "auth": {
+          "$ref": "#/definitions/BlobAccessPointRemoteAuthProperties",
+          "description": "Details for authenticating to the backing data source."
+        }
+      },
+      "required": [
+        "connection",
+        "auth"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/BlobAccessPointSourceProperties"
+        }
+      ],
+      "x-ms-discriminator-value": "S3Compatible"
+    },
+    "BlobAccessPointGenericS3SourcePropertiesUpdate": {
+      "type": "object",
+      "description": "Another S3-compatible backing source.",
+      "properties": {
+        "connection": {
+          "$ref": "#/definitions/BlobAccessPointConnectionPropertiesUpdate",
+          "description": "Details for connecting to the backing data source. The connection target is fixed when the configuration is created; only the TLS verification behavior can be changed afterwards."
+        },
+        "auth": {
+          "$ref": "#/definitions/BlobAccessPointRemoteAuthPropertiesUpdate",
+          "description": "Details for authenticating to the backing data source."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/BlobAccessPointSourcePropertiesUpdate"
+        }
+      ],
+      "x-ms-discriminator-value": "S3Compatible"
+    },
+    "BlobAccessPointNasuniSourceProperties": {
+      "type": "object",
+      "description": "A Nasuni backing source.",
+      "properties": {
+        "connection": {
+          "$ref": "#/definitions/BlobAccessPointConnectionProperties",
+          "description": "Details for connecting to the backing data source. The connection target is fixed when the configuration is created; only the TLS verification behavior can be changed afterwards."
+        },
+        "auth": {
+          "$ref": "#/definitions/BlobAccessPointRemoteAuthProperties",
+          "description": "Details for authenticating to the backing data source."
+        }
+      },
+      "required": [
+        "connection",
+        "auth"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/BlobAccessPointSourceProperties"
+        }
+      ],
+      "x-ms-discriminator-value": "Nasuni"
+    },
+    "BlobAccessPointNasuniSourcePropertiesUpdate": {
+      "type": "object",
+      "description": "A Nasuni backing source.",
+      "properties": {
+        "connection": {
+          "$ref": "#/definitions/BlobAccessPointConnectionPropertiesUpdate",
+          "description": "Details for connecting to the backing data source. The connection target is fixed when the configuration is created; only the TLS verification behavior can be changed afterwards."
+        },
+        "auth": {
+          "$ref": "#/definitions/BlobAccessPointRemoteAuthPropertiesUpdate",
+          "description": "Details for authenticating to the backing data source."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/BlobAccessPointSourcePropertiesUpdate"
+        }
+      ],
+      "x-ms-discriminator-value": "Nasuni"
+    },
+    "BlobAccessPointNetAppOntapSourceProperties": {
+      "type": "object",
+      "description": "A NetApp ONTAP backing source.",
+      "properties": {
+        "connection": {
+          "$ref": "#/definitions/BlobAccessPointConnectionProperties",
+          "description": "Details for connecting to the backing data source. The connection target is fixed when the configuration is created; only the TLS verification behavior can be changed afterwards."
+        },
+        "auth": {
+          "$ref": "#/definitions/BlobAccessPointRemoteAuthProperties",
+          "description": "Details for authenticating to the backing data source."
+        }
+      },
+      "required": [
+        "connection",
+        "auth"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/BlobAccessPointSourceProperties"
+        }
+      ],
+      "x-ms-discriminator-value": "NetAppOntap"
+    },
+    "BlobAccessPointNetAppOntapSourcePropertiesUpdate": {
+      "type": "object",
+      "description": "A NetApp ONTAP backing source.",
+      "properties": {
+        "connection": {
+          "$ref": "#/definitions/BlobAccessPointConnectionPropertiesUpdate",
+          "description": "Details for connecting to the backing data source. The connection target is fixed when the configuration is created; only the TLS verification behavior can be changed afterwards."
+        },
+        "auth": {
+          "$ref": "#/definitions/BlobAccessPointRemoteAuthPropertiesUpdate",
+          "description": "Details for authenticating to the backing data source."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/BlobAccessPointSourcePropertiesUpdate"
+        }
+      ],
+      "x-ms-discriminator-value": "NetAppOntap"
+    },
+    "BlobAccessPointPrivateLinkConnectionProperties": {
+      "type": "object",
+      "description": "A connection established through Azure Private Link.",
+      "properties": {
+        "privateLinkIdType": {
+          "$ref": "#/definitions/BlobAccessPointPrivateLinkIdType",
+          "description": "Whether privateLinkId contains an Azure resource ID or a Private Link alias.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "privateLinkId": {
+          "type": "string",
+          "description": "The Azure resource ID or alias of the backing Private Link resource.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "privateLinkGroupId": {
+          "type": "string",
+          "description": "The Private Link group ID, when required by the backing resource.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "privateLinkLocation": {
+          "type": "string",
+          "description": "The Azure region in which the private endpoint is provisioned.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "requestMessage": {
+          "type": "string",
+          "description": "The connection request message sent to the Private Link owner.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "endpoint": {
+          "type": "string",
+          "format": "uri",
+          "description": "The backing endpoint as seen by the target of the Private Link.",
+          "minLength": 4,
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "tlsVerification": {
+          "$ref": "#/definitions/BlobAccessPointTlsVerification",
+          "description": "TLS certificate verification behavior. Defaults to Perform when not specified."
+        },
+        "privateEndpointName": {
+          "type": "string",
+          "description": "The name of the private endpoint created by Azure Storage.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "privateLinkIdType",
+        "privateLinkId",
+        "privateLinkLocation",
+        "requestMessage",
+        "endpoint"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/BlobAccessPointConnectionProperties"
+        }
+      ],
+      "x-ms-discriminator-value": "PrivateLink"
+    },
+    "BlobAccessPointPrivateLinkConnectionPropertiesUpdate": {
+      "type": "object",
+      "description": "A connection established through Azure Private Link.",
+      "properties": {
+        "tlsVerification": {
+          "$ref": "#/definitions/BlobAccessPointTlsVerification",
+          "description": "TLS certificate verification behavior. Defaults to Perform when not specified."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/BlobAccessPointConnectionPropertiesUpdate"
+        }
+      ],
+      "x-ms-discriminator-value": "PrivateLink"
+    },
+    "BlobAccessPointPrivateLinkIdType": {
+      "type": "string",
+      "description": "The format used by a Private Link identifier.",
+      "enum": [
+        "ResourceId",
+        "Alias"
+      ],
+      "x-ms-enum": {
+        "name": "BlobAccessPointPrivateLinkIdType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "ResourceId",
+            "value": "ResourceId",
+            "description": "The identifier is an Azure resource ID."
+          },
+          {
+            "name": "Alias",
+            "value": "Alias",
+            "description": "The identifier is a Private Link alias."
+          }
+        ]
+      }
+    },
+    "BlobAccessPointProposedConnectionTestRequest": {
+      "type": "object",
+      "description": "The request used to test a proposed Blob Access Point configuration.",
+      "properties": {
+        "source": {
+          "$ref": "#/definitions/BlobAccessPointSourceProperties",
+          "description": "Information about the backing data source whose connection is tested."
+        }
+      },
+      "required": [
+        "source"
+      ]
+    },
+    "BlobAccessPointQumuloSourceProperties": {
+      "type": "object",
+      "description": "A Qumulo backing source.",
+      "properties": {
+        "connection": {
+          "$ref": "#/definitions/BlobAccessPointConnectionProperties",
+          "description": "Details for connecting to the backing data source. The connection target is fixed when the configuration is created; only the TLS verification behavior can be changed afterwards."
+        },
+        "auth": {
+          "$ref": "#/definitions/BlobAccessPointRemoteAuthProperties",
+          "description": "Details for authenticating to the backing data source."
+        }
+      },
+      "required": [
+        "connection",
+        "auth"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/BlobAccessPointSourceProperties"
+        }
+      ],
+      "x-ms-discriminator-value": "Qumulo"
+    },
+    "BlobAccessPointQumuloSourcePropertiesUpdate": {
+      "type": "object",
+      "description": "A Qumulo backing source.",
+      "properties": {
+        "connection": {
+          "$ref": "#/definitions/BlobAccessPointConnectionPropertiesUpdate",
+          "description": "Details for connecting to the backing data source. The connection target is fixed when the configuration is created; only the TLS verification behavior can be changed afterwards."
+        },
+        "auth": {
+          "$ref": "#/definitions/BlobAccessPointRemoteAuthPropertiesUpdate",
+          "description": "Details for authenticating to the backing data source."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/BlobAccessPointSourcePropertiesUpdate"
+        }
+      ],
+      "x-ms-discriminator-value": "Qumulo"
+    },
+    "BlobAccessPointRemoteAuthProperties": {
+      "type": "object",
+      "description": "Authentication properties for a non-Azure S3-compatible source.",
+      "properties": {
+        "authType": {
+          "$ref": "#/definitions/BlobAccessPointRemoteAuthType",
+          "description": "The authentication type. This value determines the remaining shape of the authentication object."
+        }
+      },
+      "discriminator": "authType",
+      "required": [
+        "authType"
+      ]
+    },
+    "BlobAccessPointRemoteAuthPropertiesUpdate": {
+      "type": "object",
+      "description": "Authentication properties for a non-Azure S3-compatible source.",
+      "properties": {
+        "authType": {
+          "$ref": "#/definitions/BlobAccessPointRemoteAuthType",
+          "description": "The authentication type. This value determines the remaining shape of the authentication object."
+        }
+      },
+      "discriminator": "authType",
+      "required": [
+        "authType"
+      ]
+    },
+    "BlobAccessPointRemoteAuthType": {
+      "type": "string",
+      "description": "How Azure Storage authenticates to a non-Azure S3-compatible source.",
+      "enum": [
+        "AccessKey"
+      ],
+      "x-ms-enum": {
+        "name": "BlobAccessPointRemoteAuthType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "AccessKey",
+            "value": "AccessKey",
+            "description": "Authenticate with an S3 access key and secret access key."
+          }
+        ]
+      }
+    },
+    "BlobAccessPointSourceProperties": {
+      "type": "object",
+      "description": "Information about the data source exposed through a Blob Access Point.",
+      "properties": {
+        "sourceType": {
+          "$ref": "#/definitions/BlobAccessPointSourceType",
+          "description": "The source type. This value determines the remaining shape of the source object."
+        }
+      },
+      "discriminator": "sourceType",
+      "required": [
+        "sourceType"
+      ]
+    },
+    "BlobAccessPointSourcePropertiesUpdate": {
+      "type": "object",
+      "description": "Information about the data source exposed through a Blob Access Point.",
+      "properties": {
+        "sourceType": {
+          "$ref": "#/definitions/BlobAccessPointSourceType",
+          "description": "The source type. This value determines the remaining shape of the source object."
+        }
+      },
+      "discriminator": "sourceType",
+      "required": [
+        "sourceType"
+      ]
+    },
+    "BlobAccessPointSourceType": {
+      "type": "string",
+      "description": "The type of the non-Azure S3-compatible data source exposed through the Blob Access Point.",
+      "enum": [
+        "NetAppOntap",
+        "AzureNetAppFiles",
+        "DellOneFs",
+        "Qumulo",
+        "Commvault",
+        "Nasuni",
+        "S3Compatible"
+      ],
+      "x-ms-enum": {
+        "name": "BlobAccessPointSourceType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "NetAppOntap",
+            "value": "NetAppOntap",
+            "description": "NetApp ONTAP."
+          },
+          {
+            "name": "AzureNetAppFiles",
+            "value": "AzureNetAppFiles",
+            "description": "Azure NetApp Files."
+          },
+          {
+            "name": "DellOneFs",
+            "value": "DellOneFs",
+            "description": "Dell OneFS."
+          },
+          {
+            "name": "Qumulo",
+            "value": "Qumulo",
+            "description": "Qumulo S3-compatible data source."
+          },
+          {
+            "name": "Commvault",
+            "value": "Commvault",
+            "description": "Commvault S3-compatible data source."
+          },
+          {
+            "name": "Nasuni",
+            "value": "Nasuni",
+            "description": "Nasuni S3-compatible data source."
+          },
+          {
+            "name": "S3Compatible",
+            "value": "S3Compatible",
+            "description": "Another S3-compatible data source."
+          }
+        ]
+      }
+    },
+    "BlobAccessPointTlsVerification": {
+      "type": "string",
+      "description": "TLS certificate verification behavior.",
+      "enum": [
+        "Perform",
+        "Skip"
+      ],
+      "x-ms-enum": {
+        "name": "BlobAccessPointTlsVerification",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Perform",
+            "value": "Perform",
+            "description": "Verify the TLS certificate chain."
+          },
+          {
+            "name": "Skip",
+            "value": "Skip",
+            "description": "Skip TLS certificate-chain verification. Use only when the backing source uses a certificate that cannot be validated against a trusted root. Skipping verification exposes credentials and data to an on-path attacker."
+          }
+        ]
+      }
     },
     "BlobContainer": {
       "type": "object",
@@ -16585,15 +18150,45 @@
       "type": "string",
       "description": "The type of the backing data source for storage connector",
       "enum": [
-        "Azure_DataShare"
+        "NetAppOntap",
+        "AzureNetAppFiles",
+        "DellOneFs",
+        "AwsS3",
+        "S3Compatible",
+        "AzureDataShare"
       ],
       "x-ms-enum": {
         "name": "StorageConnectorDataSourceType",
         "modelAsString": true,
         "values": [
           {
-            "name": "Azure_DataShare",
-            "value": "Azure_DataShare",
+            "name": "NetAppOntap",
+            "value": "NetAppOntap",
+            "description": "NetApp ONTAP data source type."
+          },
+          {
+            "name": "AzureNetAppFiles",
+            "value": "AzureNetAppFiles",
+            "description": "Azure NetApp Files data source type."
+          },
+          {
+            "name": "DellOneFs",
+            "value": "DellOneFs",
+            "description": "Dell OneFS data source type."
+          },
+          {
+            "name": "AwsS3",
+            "value": "AwsS3",
+            "description": "AWS S3 data source type."
+          },
+          {
+            "name": "S3Compatible",
+            "value": "S3Compatible",
+            "description": "S3-compatible data source type."
+          },
+          {
+            "name": "AzureDataShare",
+            "value": "AzureDataShare",
             "description": "Azure DataShare data source type."
           }
         ]
@@ -16632,11 +18227,6 @@
               }
             ]
           }
-        },
-        "creationTime": {
-          "type": "string",
-          "description": "System-generated creation time of the Storage Connector in ISO 8601 date-time format (YYYY-MM-DDTHH:mm:ssZ).\nNot a valid input parameter during creating.",
-          "readOnly": true
         },
         "description": {
           "type": "string",
@@ -16777,6 +18367,10 @@
         "allowStorageConnectors": {
           "type": "boolean",
           "description": "Indicates whether storage connectors are allowed to created or managed on the storage account."
+        },
+        "allowStorageBlobAccessPointConfigurations": {
+          "type": "boolean",
+          "description": "Indicates whether Blob Access Point configurations are allowed to be created or managed on the storage account."
         },
         "allowStorageDataShares": {
           "type": "boolean",

--- a/specification/storage/resource-manager/readme.md
+++ b/specification/storage/resource-manager/readme.md
@@ -70,8 +70,12 @@ directive:
   - where:
     - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/connectors/{connectorName}"].patch.parameters[5].schema.properties.properties
     - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/dataShares/{dataShareName}"].patch.parameters[5].schema.properties.properties
+    - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/blobAccessPointConfigurations/{blobAccessPointConfigurationName}"].patch.parameters[5].schema.properties.properties
     suppress: PatchBodyParametersSchema
-    reason: We have used kind property as discriminator to support polymorphic resource and during patch also need to pass discriminator to allow patch on certain polymorphic resource type property.
+    reason: >
+      Connector and DataShare PATCH carry forward their existing polymorphic
+      discriminator requirements. Blob Access Point also requires a source
+      discriminator to select the concrete polymorphic shape being updated.
 
   - where:
     - $.definitions["Azure.Core.uuid"].format

--- a/specification/storage/resource-manager/readme.md
+++ b/specification/storage/resource-manager/readme.md
@@ -72,10 +72,7 @@ directive:
     - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/dataShares/{dataShareName}"].patch.parameters[5].schema.properties.properties
     - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/blobAccessPointConfigurations/{blobAccessPointConfigurationName}"].patch.parameters[5].schema.properties.properties
     suppress: PatchBodyParametersSchema
-    reason: >
-      Connector and DataShare PATCH carry forward their existing polymorphic
-      discriminator requirements. Blob Access Point also requires a source
-      discriminator to select the concrete polymorphic shape being updated.
+    reason: Connector and DataShare PATCH carry forward their existing polymorphic discriminator requirements. Blob Access Point also requires a source discriminator to select the concrete polymorphic shape being updated.
 
   - where:
     - $.definitions["Azure.Core.uuid"].format


### PR DESCRIPTION
## Summary
- Port the stable `2026-09-01` Storage DataRP contract from https://github.com/Azure/azure-rest-api-specs-pr/pull/29696 into the parent `Microsoft.Storage` TypeSpec project.
- Add Blob Access Point configuration CRUD/list and connection-test operations, models, client customizations, and examples.
- Apply the version-scoped Connector changes: remove `creationTime` and introduce the six camel-cased `dataSourceType` values.
- Add `allowStorageBlobAccessPointConfigurations` to the storage data collaboration policy for `2026-09-01`.
- Keep examples and suppressions scoped to DataRP resources only.

## Validation
- `npm exec --no -- tsp compile --list-files --warn-as-error .`
- `npm exec --no -- tsp compile --no-emit --warn-as-error client.tsp`
- `npx oav validate-spec specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/openapi.json -l warn`
- Targeted `oav validate-example` for all 19 DataRP operation IDs