### PR TITLE
Fix PrivateLinkScopes C# namespace collision

### DIFF
--- a/specification/kubernetesconfiguration/resource-manager/Microsoft.KubernetesConfiguration/privateLinkScopes/back-compatible.tsp
+++ b/specification/kubernetesconfiguration/resource-manager/Microsoft.KubernetesConfiguration/privateLinkScopes/back-compatible.tsp
@@ -43,6 +43,37 @@ using Microsoft.KubernetesConfiguration;
   "!java,!csharp"
 );
 
+@@clientLocation(
+  KubernetesConfigurationPrivateLinkScopes.get,
+  "KubernetesConfigurationPrivateLinkScopes",
+  "csharp"
+);
+@@clientLocation(
+  KubernetesConfigurationPrivateLinkScopes.createOrUpdate,
+  "KubernetesConfigurationPrivateLinkScopes",
+  "csharp"
+);
+@@clientLocation(
+  KubernetesConfigurationPrivateLinkScopes.updateTags,
+  "KubernetesConfigurationPrivateLinkScopes",
+  "csharp"
+);
+@@clientLocation(
+  KubernetesConfigurationPrivateLinkScopes.delete,
+  "KubernetesConfigurationPrivateLinkScopes",
+  "csharp"
+);
+@@clientLocation(
+  KubernetesConfigurationPrivateLinkScopes.listByResourceGroup,
+  "KubernetesConfigurationPrivateLinkScopes",
+  "csharp"
+);
+@@clientLocation(
+  KubernetesConfigurationPrivateLinkScopes.list,
+  "KubernetesConfigurationPrivateLinkScopes",
+  "csharp"
+);
+
 @@clientName(
   PrivateEndpointConnections.createOrUpdate::parameters.resource,
   "properties"

--- a/specification/kubernetesconfiguration/resource-manager/Microsoft.KubernetesConfiguration/privateLinkScopes/back-compatible.tsp
+++ b/specification/kubernetesconfiguration/resource-manager/Microsoft.KubernetesConfiguration/privateLinkScopes/back-compatible.tsp
@@ -6,12 +6,12 @@ using Microsoft.KubernetesConfiguration;
 @@clientLocation(
   KubernetesConfigurationPrivateLinkScopes.get,
   "PrivateLinkScopes",
-  "!java"
+  "!java,!csharp"
 );
 @@clientLocation(
   KubernetesConfigurationPrivateLinkScopes.createOrUpdate,
   "PrivateLinkScopes",
-  "!java"
+  "!java,!csharp"
 );
 @@clientName(
   KubernetesConfigurationPrivateLinkScopes.createOrUpdate::parameters.resource,
@@ -20,7 +20,7 @@ using Microsoft.KubernetesConfiguration;
 @@clientLocation(
   KubernetesConfigurationPrivateLinkScopes.updateTags,
   "PrivateLinkScopes",
-  "!java"
+  "!java,!csharp"
 );
 @@clientName(
   KubernetesConfigurationPrivateLinkScopes.updateTags::parameters.properties,
@@ -30,17 +30,17 @@ using Microsoft.KubernetesConfiguration;
 @@clientLocation(
   KubernetesConfigurationPrivateLinkScopes.delete,
   "PrivateLinkScopes",
-  "!java"
+  "!java,!csharp"
 );
 @@clientLocation(
   KubernetesConfigurationPrivateLinkScopes.listByResourceGroup,
   "PrivateLinkScopes",
-  "!java"
+  "!java,!csharp"
 );
 @@clientLocation(
   KubernetesConfigurationPrivateLinkScopes.list,
   "PrivateLinkScopes",
-  "!java"
+  "!java,!csharp"
 );
 
 @@clientName(

--- a/specification/kubernetesconfiguration/resource-manager/Microsoft.KubernetesConfiguration/privateLinkScopes/back-compatible.tsp
+++ b/specification/kubernetesconfiguration/resource-manager/Microsoft.KubernetesConfiguration/privateLinkScopes/back-compatible.tsp
@@ -45,32 +45,32 @@ using Microsoft.KubernetesConfiguration;
 
 @@clientLocation(
   KubernetesConfigurationPrivateLinkScopes.get,
-  "KubernetesConfigurationPrivateLinkScopes",
+  "PrivateLinkScopesOperations",
   "csharp"
 );
 @@clientLocation(
   KubernetesConfigurationPrivateLinkScopes.createOrUpdate,
-  "KubernetesConfigurationPrivateLinkScopes",
+  "PrivateLinkScopesOperations",
   "csharp"
 );
 @@clientLocation(
   KubernetesConfigurationPrivateLinkScopes.updateTags,
-  "KubernetesConfigurationPrivateLinkScopes",
+  "PrivateLinkScopesOperations",
   "csharp"
 );
 @@clientLocation(
   KubernetesConfigurationPrivateLinkScopes.delete,
-  "KubernetesConfigurationPrivateLinkScopes",
+  "PrivateLinkScopesOperations",
   "csharp"
 );
 @@clientLocation(
   KubernetesConfigurationPrivateLinkScopes.listByResourceGroup,
-  "KubernetesConfigurationPrivateLinkScopes",
+  "PrivateLinkScopesOperations",
   "csharp"
 );
 @@clientLocation(
   KubernetesConfigurationPrivateLinkScopes.list,
-  "KubernetesConfigurationPrivateLinkScopes",
+  "PrivateLinkScopesOperations",
   "csharp"
 );
 

--- a/specification/kubernetesconfiguration/resource-manager/Microsoft.KubernetesConfiguration/privateLinkScopes/client.tsp
+++ b/specification/kubernetesconfiguration/resource-manager/Microsoft.KubernetesConfiguration/privateLinkScopes/client.tsp
@@ -43,6 +43,21 @@ using Azure.ClientGenerator.Core;
   Azure.Core.uuid,
   "csharp"
 );
+@@alternateType(
+  Microsoft.KubernetesConfiguration.KubernetesConfigurationPrivateLinkScope.id,
+  Azure.Core.armResourceIdentifier,
+  "csharp"
+);
+@@alternateType(
+  Microsoft.KubernetesConfiguration.PrivateEndpointConnection.id,
+  Azure.Core.armResourceIdentifier,
+  "csharp"
+);
+@@alternateType(
+  Microsoft.KubernetesConfiguration.PrivateLinkResource.id,
+  Azure.Core.armResourceIdentifier,
+  "csharp"
+);
 @@clientName(
   Microsoft.KubernetesConfiguration,
   "KubernetesConfigurationPrivateLinkScopesMgmtClient",

--- a/specification/kubernetesconfiguration/resource-manager/Microsoft.KubernetesConfiguration/privateLinkScopes/client.tsp
+++ b/specification/kubernetesconfiguration/resource-manager/Microsoft.KubernetesConfiguration/privateLinkScopes/client.tsp
@@ -23,16 +23,6 @@ using Azure.ClientGenerator.Core;
   "KubernetesConfigurationPrivateLinkResource",
   "csharp"
 );
-@@clientName(
-  Microsoft.KubernetesConfiguration.PrivateEndpointConnections.listByPrivateLinkScope,
-  "GetPrivateEndpointConnectionsByPrivateLinkScope",
-  "csharp"
-);
-@@clientName(
-  Microsoft.KubernetesConfiguration.PrivateLinkResources.listByPrivateLinkScope,
-  "GetPrivateLinkResourcesByPrivateLinkScope",
-  "csharp"
-);
 @@alternateType(
   Microsoft.KubernetesConfiguration.KubernetesConfigurationPrivateLinkScopeProperties.clusterResourceId,
   Azure.Core.armResourceIdentifier,
@@ -46,6 +36,21 @@ using Azure.ClientGenerator.Core;
 @@alternateType(
   Azure.ResourceManager.CommonTypes.Resource.id,
   Azure.Core.armResourceIdentifier,
+  "csharp"
+);
+@@alternateType(
+  Azure.ResourceManager.CommonTypes.PrivateEndpoint.id,
+  Azure.Core.armResourceIdentifier,
+  "csharp"
+);
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Preserve the existing C# pageable collection."
+@@Legacy.markAsPageable(
+  Microsoft.KubernetesConfiguration.PrivateEndpointConnections.listByPrivateLinkScope,
+  "csharp"
+);
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Preserve the existing C# pageable collection."
+@@Legacy.markAsPageable(
+  Microsoft.KubernetesConfiguration.PrivateLinkResources.listByPrivateLinkScope,
   "csharp"
 );
 @@clientName(

--- a/specification/kubernetesconfiguration/resource-manager/Microsoft.KubernetesConfiguration/privateLinkScopes/client.tsp
+++ b/specification/kubernetesconfiguration/resource-manager/Microsoft.KubernetesConfiguration/privateLinkScopes/client.tsp
@@ -4,6 +4,11 @@ import "@azure-tools/typespec-client-generator-core";
 using Azure.ClientGenerator.Core;
 
 @@clientName(
+  Microsoft.KubernetesConfiguration.ProvisioningState,
+  "KubernetesConfigurationPrivateLinkScopeProvisioningState",
+  "csharp"
+);
+@@clientName(
   Microsoft.KubernetesConfiguration,
   "KubernetesConfigurationPrivateLinkScopesMgmtClient",
   "python"

--- a/specification/kubernetesconfiguration/resource-manager/Microsoft.KubernetesConfiguration/privateLinkScopes/client.tsp
+++ b/specification/kubernetesconfiguration/resource-manager/Microsoft.KubernetesConfiguration/privateLinkScopes/client.tsp
@@ -24,12 +24,12 @@ using Azure.ClientGenerator.Core;
   "csharp"
 );
 @@clientName(
-  Microsoft.KubernetesConfiguration.PrivateEndpointConnections.getByPrivateLinkScope,
+  Microsoft.KubernetesConfiguration.PrivateEndpointConnections.listByPrivateLinkScope,
   "GetPrivateEndpointConnectionsByPrivateLinkScope",
   "csharp"
 );
 @@clientName(
-  Microsoft.KubernetesConfiguration.PrivateLinkResources.getByPrivateLinkScope,
+  Microsoft.KubernetesConfiguration.PrivateLinkResources.listByPrivateLinkScope,
   "GetPrivateLinkResourcesByPrivateLinkScope",
   "csharp"
 );

--- a/specification/kubernetesconfiguration/resource-manager/Microsoft.KubernetesConfiguration/privateLinkScopes/client.tsp
+++ b/specification/kubernetesconfiguration/resource-manager/Microsoft.KubernetesConfiguration/privateLinkScopes/client.tsp
@@ -9,6 +9,41 @@ using Azure.ClientGenerator.Core;
   "csharp"
 );
 @@clientName(
+  Microsoft.KubernetesConfiguration.PublicNetworkAccessType,
+  "KubernetesConfigurationPrivateLinkScopePublicNetworkAccessType",
+  "csharp"
+);
+@@clientName(
+  Microsoft.KubernetesConfiguration.PrivateEndpointConnection,
+  "KubernetesConfigurationPrivateEndpointConnection",
+  "csharp"
+);
+@@clientName(
+  Microsoft.KubernetesConfiguration.PrivateLinkResource,
+  "KubernetesConfigurationPrivateLinkResource",
+  "csharp"
+);
+@@clientName(
+  Microsoft.KubernetesConfiguration.PrivateEndpointConnections.getByPrivateLinkScope,
+  "GetPrivateEndpointConnectionsByPrivateLinkScope",
+  "csharp"
+);
+@@clientName(
+  Microsoft.KubernetesConfiguration.PrivateLinkResources.getByPrivateLinkScope,
+  "GetPrivateLinkResourcesByPrivateLinkScope",
+  "csharp"
+);
+@@alternateType(
+  Microsoft.KubernetesConfiguration.KubernetesConfigurationPrivateLinkScopeProperties.clusterResourceId,
+  Azure.Core.armResourceIdentifier,
+  "csharp"
+);
+@@alternateType(
+  Microsoft.KubernetesConfiguration.KubernetesConfigurationPrivateLinkScopeProperties.privateLinkScopeId,
+  Azure.Core.uuid,
+  "csharp"
+);
+@@clientName(
   Microsoft.KubernetesConfiguration,
   "KubernetesConfigurationPrivateLinkScopesMgmtClient",
   "python"

--- a/specification/kubernetesconfiguration/resource-manager/Microsoft.KubernetesConfiguration/privateLinkScopes/client.tsp
+++ b/specification/kubernetesconfiguration/resource-manager/Microsoft.KubernetesConfiguration/privateLinkScopes/client.tsp
@@ -44,17 +44,7 @@ using Azure.ClientGenerator.Core;
   "csharp"
 );
 @@alternateType(
-  Microsoft.KubernetesConfiguration.KubernetesConfigurationPrivateLinkScope.id,
-  Azure.Core.armResourceIdentifier,
-  "csharp"
-);
-@@alternateType(
-  Microsoft.KubernetesConfiguration.PrivateEndpointConnection.id,
-  Azure.Core.armResourceIdentifier,
-  "csharp"
-);
-@@alternateType(
-  Microsoft.KubernetesConfiguration.PrivateLinkResource.id,
+  Azure.ResourceManager.CommonTypes.Resource.id,
   Azure.Core.armResourceIdentifier,
   "csharp"
 );


### PR DESCRIPTION
## Summary

- Exclude C# from the legacy PrivateLinkScopes client-location mapping to avoid a namespace/type collision.
- Rename the C# ProvisioningState model to KubernetesConfigurationPrivateLinkScopeProvisioningState.

## SDK impact

- Removes the _PrivateLinkScopes generated namespace from the provisioning SDK.
- Allows the provisioning package to remove its namespace-workaround custom types.

## Validation

- TypeSpec compilation succeeds for the PrivateLinkScopes specification.