### PR TITLE
Fix Java deployments SDK configuration

### DIFF
--- a/specification/resources/resource-manager/Microsoft.Resources/deployments/tspconfig.yaml
+++ b/specification/resources/resource-manager/Microsoft.Resources/deployments/tspconfig.yaml
@@ -1,6 +1,6 @@
 parameters:
   "service-dir":
-    default: "sdk/resources"
+    default: "sdk/deployments"
 emit:
   - "@azure-tools/typespec-autorest"
 options:
@@ -24,6 +24,7 @@ options:
     generate-sample: true
     flavor: "azure"
   "@azure-tools/typespec-java":
+    service-dir: "sdk/resources"
     emitter-output-dir: "{output-dir}/{service-dir}/azure-resourcemanager-deployments"
     namespace: "com.azure.resourcemanager.resources.deployments"
     service-name: "Deployments" # human-readable service name, whitespace allowed

--- a/specification/resources/resource-manager/Microsoft.Resources/deployments/tspconfig.yaml
+++ b/specification/resources/resource-manager/Microsoft.Resources/deployments/tspconfig.yaml
@@ -1,6 +1,6 @@
 parameters:
   "service-dir":
-    default: "sdk/deployments"
+    default: "sdk/resources"
 emit:
   - "@azure-tools/typespec-autorest"
 options:
@@ -25,10 +25,9 @@ options:
     flavor: "azure"
   "@azure-tools/typespec-java":
     emitter-output-dir: "{output-dir}/{service-dir}/azure-resourcemanager-deployments"
-    namespace: "com.azure.resourcemanager.deployments"
+    namespace: "com.azure.resourcemanager.resources.deployments"
     service-name: "Deployments" # human-readable service name, whitespace allowed
     flavor: azure
-    use-object-for-unknown: true
   "@azure-tools/typespec-ts":
     emitter-output-dir: "{output-dir}/{service-dir}/arm-resourcesdeployments"
     service-dir: "sdk/resources"

--- a/specification/resources/resource-manager/Microsoft.Resources/deployments/tspconfig.yaml
+++ b/specification/resources/resource-manager/Microsoft.Resources/deployments/tspconfig.yaml
@@ -25,7 +25,7 @@ options:
     flavor: "azure"
   "@azure-tools/typespec-java":
     service-dir: "sdk/resources"
-    emitter-output-dir: "{output-dir}/{service-dir}/azure-resourcemanager-deployments"
+    emitter-output-dir: "{output-dir}/{service-dir}/azure-resourcemanager-resources-deployments"
     namespace: "com.azure.resourcemanager.resources.deployments"
     service-name: "Deployments" # human-readable service name, whitespace allowed
     flavor: azure


### PR DESCRIPTION
Align the Java Deployments SDK with the Resources package hierarchy:

- generate `azure-resourcemanager-resources-deployments` under `sdk/resources`
- use `com.azure.resourcemanager.resources.deployments`
- remove `use-object-for-unknown`
