### PR TITLE
[Microsoft.App] Add Azure Files managed identity authentication

### DIFF
--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedEnvironmentsStorages_CreateOrUpdate_Identity.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedEnvironmentsStorages_CreateOrUpdate_Identity.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "managedEnv",
+    "resourceGroupName": "examplerg",
+    "storageEnvelope": {
+      "properties": {
+        "azureFile": {
+          "accessMode": "ReadWrite",
+          "accountName": "account1",
+          "identity": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity",
+          "shareName": "share1"
+        }
+      }
+    },
+    "storageName": "storage1",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {}
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/managedEnv/storages/storage1",
+        "name": "storage1",
+        "type": "Microsoft.App/managedEnvironments/storages",
+        "properties": {
+          "azureFile": {
+            "accountName": "account1",
+            "shareName": "share1",
+            "accessMode": "ReadWrite",
+            "identity": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "ManagedEnvironmentsStorages_CreateOrUpdate",
+  "title": "Create an environment storage with managed identity"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedEnvironmentsStorages_Get_Identity.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedEnvironmentsStorages_Get_Identity.json
@@ -1,0 +1,28 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "managedEnv",
+    "resourceGroupName": "examplerg",
+    "storageName": "storage1",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/managedEnv/storages/storage1",
+        "name": "storage1",
+        "type": "Microsoft.App/managedEnvironments/storages",
+        "properties": {
+          "azureFile": {
+            "accountName": "account1",
+            "shareName": "share1",
+            "accessMode": "ReadWrite",
+            "identity": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "ManagedEnvironmentsStorages_Get",
+  "title": "Get an environment storage with managed identity"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedEnvironmentsStorages_List_Identity.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedEnvironmentsStorages_List_Identity.json
@@ -1,0 +1,31 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "managedEnv",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/managedEnv/storages/storage1",
+            "name": "storage1",
+            "type": "Microsoft.App/managedEnvironments/storages",
+            "properties": {
+              "azureFile": {
+                "accountName": "account1",
+                "shareName": "share1",
+                "accessMode": "ReadWrite",
+                "identity": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity"
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ManagedEnvironmentsStorages_List",
+  "title": "List environment storages with managed identity"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/models.tsp
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/models.tsp
@@ -2463,6 +2463,12 @@ model ConnectedEnvironmentStorageProperties {
  */
 model AzureFileProperties {
   /**
+   * Resource ID of a managed identity to authenticate with Azure File, or System to use a system-assigned identity.
+   */
+  @added(Versions.v2026_03_02_preview)
+  identity?: string;
+
+  /**
    * Storage account name for azure file.
    */
   accountName?: string;

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedEnvironmentsStorages_CreateOrUpdate_Identity.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedEnvironmentsStorages_CreateOrUpdate_Identity.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "managedEnv",
+    "resourceGroupName": "examplerg",
+    "storageEnvelope": {
+      "properties": {
+        "azureFile": {
+          "accessMode": "ReadWrite",
+          "accountName": "account1",
+          "identity": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity",
+          "shareName": "share1"
+        }
+      }
+    },
+    "storageName": "storage1",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {}
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/managedEnv/storages/storage1",
+        "name": "storage1",
+        "type": "Microsoft.App/managedEnvironments/storages",
+        "properties": {
+          "azureFile": {
+            "accountName": "account1",
+            "shareName": "share1",
+            "accessMode": "ReadWrite",
+            "identity": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "ManagedEnvironmentsStorages_CreateOrUpdate",
+  "title": "Create an environment storage with managed identity"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedEnvironmentsStorages_Get_Identity.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedEnvironmentsStorages_Get_Identity.json
@@ -1,0 +1,28 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "managedEnv",
+    "resourceGroupName": "examplerg",
+    "storageName": "storage1",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/managedEnv/storages/storage1",
+        "name": "storage1",
+        "type": "Microsoft.App/managedEnvironments/storages",
+        "properties": {
+          "azureFile": {
+            "accountName": "account1",
+            "shareName": "share1",
+            "accessMode": "ReadWrite",
+            "identity": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "ManagedEnvironmentsStorages_Get",
+  "title": "Get an environment storage with managed identity"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedEnvironmentsStorages_List_Identity.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedEnvironmentsStorages_List_Identity.json
@@ -1,0 +1,31 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "managedEnv",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/managedEnv/storages/storage1",
+            "name": "storage1",
+            "type": "Microsoft.App/managedEnvironments/storages",
+            "properties": {
+              "azureFile": {
+                "accountName": "account1",
+                "shareName": "share1",
+                "accessMode": "ReadWrite",
+                "identity": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity"
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ManagedEnvironmentsStorages_List",
+  "title": "List environment storages with managed identity"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/openapi.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/openapi.json
@@ -10511,6 +10511,9 @@
           }
         },
         "x-ms-examples": {
+          "List environment storages with managed identity": {
+            "$ref": "./examples/ManagedEnvironmentsStorages_List_Identity.json"
+          },
           "List environments storages by subscription": {
             "$ref": "./examples/ManagedEnvironmentsStorages_List.json"
           }
@@ -10566,6 +10569,9 @@
           }
         },
         "x-ms-examples": {
+          "Get an environment storage with managed identity": {
+            "$ref": "./examples/ManagedEnvironmentsStorages_Get_Identity.json"
+          },
           "get a environments storage": {
             "$ref": "./examples/ManagedEnvironmentsStorages_Get.json"
           },
@@ -10637,6 +10643,9 @@
           }
         },
         "x-ms-examples": {
+          "Create an environment storage with managed identity": {
+            "$ref": "./examples/ManagedEnvironmentsStorages_CreateOrUpdate_Identity.json"
+          },
           "Create or update environments storage": {
             "$ref": "./examples/ManagedEnvironmentsStorages_CreateOrUpdate.json"
           },
@@ -11805,6 +11814,10 @@
       "type": "object",
       "description": "Azure File Properties.",
       "properties": {
+        "identity": {
+          "type": "string",
+          "description": "Resource ID of a managed identity to authenticate with Azure File, or System to use a system-assigned identity."
+        },
         "accountName": {
           "type": "string",
           "description": "Storage account name for azure file."


### PR DESCRIPTION
# ARM (Control Plane) API Specification Update Pull Request

## Purpose of this PR

- [ ] New resource provider.
- [ ] New API version for an existing resource provider.
- [x] Update existing version for a new feature. This change targets the private preview `2026-03-02-preview` API.
- [ ] Update existing version to fix OpenAPI spec quality issues in S360.
- [ ] Convert existing OpenAPI spec to TypeSpec spec.
- [ ] Other, please clarify.

## Summary

- Adds optional `AzureFileProperties.identity` support for authenticating Azure Files with a user-assigned identity resource ID or `System`.
- Gates the property to `2026-03-02-preview` with `@added`.
- Adds dedicated PUT, GET, and LIST examples while preserving the existing account-key and Key Vault examples.
- Keeps this PR identity-only. Baseline validation fixes for #45788 remain with the release PR owner.

## Validation

- `npx tsp compile specification/app/resource-manager/Microsoft.App/ContainerApps/main.tsp`
- `npx tsp format --check specification/app/resource-manager/Microsoft.App/ContainerApps/models.tsp`
- Prettier check for all changed JSON files
- `npx oav validate-example specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/openapi.json --logLevel warn`
- `npx oav validate-spec specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/openapi.json --logLevel warn`

## Due diligence checklist

- [x] I confirm this PR modifies Azure Resource Manager specifications, not data-plane specifications.
- [ ] I have reviewed the ARM resource provider contract and REST guidelines.
- [ ] A release plan has been created.

## Additional information

This PR is based directly on `release-app-Microsoft.App-preview/2026-03-02-preview`. It does not change `main.tsp`, `readme.md`, prior API versions, suppressions, or unrelated preview surfaces.