### PR TITLE
[Microsoft.AzureResilienceManagement] Model listReportDownloadUrl as an async action (2026-08-31-preview)

### DIFF
--- a/specification/azureresiliencemanagement/resource-manager/Microsoft.AzureResilienceManagement/AzureResilienceManagement/drillRun.tsp
+++ b/specification/azureresiliencemanagement/resource-manager/Microsoft.AzureResilienceManagement/AzureResilienceManagement/drillRun.tsp
@@ -190,12 +190,14 @@ interface DrillRuns {
   @armResourceAction(DrillRun)
   @post
   @doc("This returns a short-lived, read-only URL to download the report for this Drill Run. The URL expires at the returned expiryTimestamp and grants access to that single report only.")
-  listReportDownloadUrl is ArmResourceActionSync<
+  listReportDownloadUrl is ArmResourceActionAsync<
     DrillRun,
     ListReportDownloadUrlRequest,
     ListReportDownloadUrlResponse,
-    ServiceGroupParameters,
-    OptionalRequestBody = true
+    ServiceGroupAndRequestHeadersParameters,
+    LroHeaders = ArmAsyncOperationHeader &
+      ArmLroLocationHeader &
+      Azure.Core.Foundations.RetryAfterHeader
   >;
 }
 

--- a/specification/azureresiliencemanagement/resource-manager/Microsoft.AzureResilienceManagement/AzureResilienceManagement/examples/2026-08-31-preview/DrillRuns_ListReportDownloadUrl_MaximumSet_Gen.json
+++ b/specification/azureresiliencemanagement/resource-manager/Microsoft.AzureResilienceManagement/AzureResilienceManagement/examples/2026-08-31-preview/DrillRuns_ListReportDownloadUrl_MaximumSet_Gen.json
@@ -4,6 +4,7 @@
   "parameters": {
     "serviceGroupName": "sampleServiceGroupName",
     "api-version": "2026-08-31-preview",
+    "operation-id": "3f2b1c4d-5e6f-4a7b-8c9d-0e1f2a3b4c5d",
     "drillName": "drill1",
     "drillRunName": "ca92602e-53bf-43d2-ae62-d3fc940474b3",
     "body": {
@@ -11,6 +12,11 @@
     }
   },
   "responses": {
+    "202": {
+      "headers": {
+        "location": "https://contoso.com/operationstatus"
+      }
+    },
     "200": {
       "body": {
         "format": "Html",

--- a/specification/azureresiliencemanagement/resource-manager/Microsoft.AzureResilienceManagement/AzureResilienceManagement/preview/2026-08-31-preview/examples/DrillRuns_ListReportDownloadUrl_MaximumSet_Gen.json
+++ b/specification/azureresiliencemanagement/resource-manager/Microsoft.AzureResilienceManagement/AzureResilienceManagement/preview/2026-08-31-preview/examples/DrillRuns_ListReportDownloadUrl_MaximumSet_Gen.json
@@ -4,6 +4,7 @@
   "parameters": {
     "serviceGroupName": "sampleServiceGroupName",
     "api-version": "2026-08-31-preview",
+    "operation-id": "3f2b1c4d-5e6f-4a7b-8c9d-0e1f2a3b4c5d",
     "drillName": "drill1",
     "drillRunName": "ca92602e-53bf-43d2-ae62-d3fc940474b3",
     "body": {
@@ -11,6 +12,11 @@
     }
   },
   "responses": {
+    "202": {
+      "headers": {
+        "location": "https://contoso.com/operationstatus"
+      }
+    },
     "200": {
       "body": {
         "format": "Html",

--- a/specification/azureresiliencemanagement/resource-manager/Microsoft.AzureResilienceManagement/AzureResilienceManagement/preview/2026-08-31-preview/openapi.json
+++ b/specification/azureresiliencemanagement/resource-manager/Microsoft.AzureResilienceManagement/AzureResilienceManagement/preview/2026-08-31-preview/openapi.json
@@ -1118,6 +1118,9 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
+            "$ref": "#/parameters/RequiredRequestHeaders"
+          },
+          {
             "name": "drillName",
             "in": "path",
             "description": "The name of the Drill",
@@ -1137,7 +1140,7 @@
             "name": "body",
             "in": "body",
             "description": "The content of the action request",
-            "required": false,
+            "required": true,
             "schema": {
               "$ref": "#/definitions/ListReportDownloadUrlRequest"
             }
@@ -1148,6 +1151,24 @@
             "description": "Azure operation completed successfully.",
             "schema": {
               "$ref": "#/definitions/ListReportDownloadUrlResponse"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
             }
           },
           "default": {
@@ -1161,7 +1182,11 @@
           "DrillRuns_ListReportDownloadUrl_MaximumSet": {
             "$ref": "./examples/DrillRuns_ListReportDownloadUrl_MaximumSet_Gen.json"
           }
-        }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
       }
     },
     "/providers/Microsoft.Management/serviceGroups/{serviceGroupName}/providers/Microsoft.AzureResilienceManagement/drills/{drillName}/drillRuns/{drillRunName}/markAsComplete": {


### PR DESCRIPTION
# ARM (Control Plane) API Specification Update Pull Request

## Summary

Changes `listReportDownloadUrl` on `Microsoft.AzureResilienceManagement/drills/drillRuns` from a
synchronous to a long-running (async) POST action in `2026-08-31-preview`. This is a fix for a
live `412 HttpResponsePayloadAPISpecValidationFailed` — the action is currently unusable.

### Why

`drills/drillRuns` is registered in RPaaS with `enableAsyncOperation: true` and a POST
concurrency policy of `SynchronizeBeginExtension`. As a result ProviderHub routes **every** POST
action on the resource type through its async pipeline and emits `202 Accepted` with
`Location` / `Azure-AsyncOperation` headers *before* the request is ever dispatched to the RP.

`listReportDownloadUrl` was the only `ArmResourceActionSync` in the provider, so its generated
swagger declared only `200` and `default`. RPaaS response validation therefore rejected the
platform's own `202`:

```
412 HttpResponsePayloadAPISpecValidationFailed
APIValidationEngine.TraceErrorCodes: INVALID_RESPONSE_CODE
  at preview/2026-08-31-preview/openapi.json (responses block of listReportDownloadUrl)
```

Confirmed from RPaaS `Traces` telemetry (`ShouldCreateResourceManagementJob: 'True' -
isResourceManagementJobNeededForConcurrencyControl: 'True'`) and independently by the ICM
troubleshooting analysis on incident 856928156. `enableAsyncOperation` is **resource-type
scoped with no per-action override**, so the only correct fix is to declare the action async so
the contract matches the platform behaviour.

### What changed

| Change | Detail |
| --- | --- |
| `ArmResourceActionSync` → `ArmResourceActionAsync` | Adds `202` with `Azure-AsyncOperation`, `Location`, `Retry-After`; `x-ms-long-running-operation: true`; `final-state-via: location` |
| `ServiceGroupParameters` → `ServiceGroupAndRequestHeadersParameters` | Required for the async parameter set, matching the sibling `generateReport` action |
| Removed `OptionalRequestBody = true` | Body is now required — see below |

The action's contract is now identical in shape to the sibling `generateReport` action on the
same resource type, which has always been async and has always worked.

**On the body becoming required:** the ProviderHub controller emitter does not honour
`OptionalRequestBody = true` — it generates an unconditional null check that throws. An optional
body therefore meant a spec-compliant caller who omitted it received a `500` rather than the
documented response. Declaring the body required moves that rejection to ARM as a clean `400`.
This preview version has no wire callers today, so there is no compatibility impact.

No changes to any other API version, resource type, or provider.

## Purpose of this PR

  - [ ] New resource provider.
  - [ ] New API version for an existing resource provider.
  - [x] Update existing version for a new feature. (This is applicable only when you are revising a private preview API version.)
  - [ ] Update existing version to fix OpenAPI spec quality issues in S360.
  - [ ] Convert existing OpenAPI spec to TypeSpec spec.
  - [ ] Other, please clarify:

> Note: `2026-08-31-preview` is an unreleased preview version. This PR corrects the contract of an
> action introduced in that same version, before it has any callers.

## Due diligence checklist

- [x] I confirm this PR is modifying Azure Resource Manager (ARM) related specifications, and not data plane related specifications.
- [x] I have reviewed following [Resource Provider guidelines](https://aka.ms/rpguidelines), including [ARM resource provider contract](https://aka.ms/azurerpc) and [REST guidelines](https://github.com/microsoft/api-guidelines/blob/vNext/azure/Guidelines.md) (estimated time: 4 hours). I understand this is required before I can proceed to the diagram Step 2, "ARM API changes review", for this PR.
- [x] A [release plan](https://aka.ms/azsdkdocs/release-plans) has been created.