### PR TITLE
Make VnetConnection create-or-update synchronous

### DIFF
--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/VnetConnection.tsp
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/VnetConnection.tsp
@@ -65,7 +65,7 @@ interface VnetConnections {
   get is ArmResourceRead<VnetConnection>;
 
   /** Create or update a VnetConnection. */
-  createOrUpdate is ArmResourceCreateOrReplaceAsync<VnetConnection>;
+  createOrUpdate is ArmResourceCreateOrReplaceSync<VnetConnection>;
 
   /** Delete a VnetConnection. */
   delete is ArmResourceDeleteWithoutOkAsync<

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-07-01/VnetConnections_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-07-01/VnetConnections_CreateOrUpdate.json
@@ -24,15 +24,12 @@
       }
     },
     "201": {
-      "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/operationStatuses/myVnetConnection?api-version=2026-07-01"
-      },
       "body": {
         "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myRg/providers/Microsoft.App/sandboxGroups/testgroup/vnetConnections/myVnetConnection",
         "name": "myVnetConnection",
         "type": "Microsoft.App/sandboxGroups/vnetConnections",
         "properties": {
-          "provisioningState": "InProgress",
+          "provisioningState": "Succeeded",
           "subnetId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myRg/providers/Microsoft.Network/virtualNetworks/myVnet/subnets/mySubnet"
         }
       }

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/stable/2026-07-01/examples/VnetConnections_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/stable/2026-07-01/examples/VnetConnections_CreateOrUpdate.json
@@ -24,15 +24,12 @@
       }
     },
     "201": {
-      "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.App/locations/eastus/operationStatuses/myVnetConnection?api-version=2026-07-01"
-      },
       "body": {
         "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myRg/providers/Microsoft.App/sandboxGroups/testgroup/vnetConnections/myVnetConnection",
         "name": "myVnetConnection",
         "type": "Microsoft.App/sandboxGroups/vnetConnections",
         "properties": {
-          "provisioningState": "InProgress",
+          "provisioningState": "Succeeded",
           "subnetId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myRg/providers/Microsoft.Network/virtualNetworks/myVnet/subnets/mySubnet"
         }
       }

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/stable/2026-07-01/openapi.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/stable/2026-07-01/openapi.json
@@ -8375,17 +8375,6 @@
             "description": "Resource 'VnetConnection' create operation succeeded",
             "schema": {
               "$ref": "#/definitions/VnetConnection"
-            },
-            "headers": {
-              "Azure-AsyncOperation": {
-                "type": "string",
-                "description": "A link to the status monitor"
-              },
-              "Retry-After": {
-                "type": "integer",
-                "format": "int32",
-                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
-              }
             }
           },
           "default": {
@@ -8399,12 +8388,7 @@
           "Create or update a VnetConnection": {
             "$ref": "./examples/VnetConnections_CreateOrUpdate.json"
           }
-        },
-        "x-ms-long-running-operation-options": {
-          "final-state-via": "azure-async-operation",
-          "final-state-schema": "#/definitions/VnetConnection"
-        },
-        "x-ms-long-running-operation": true
+        }
       },
       "delete": {
         "operationId": "VnetConnections_Delete",


### PR DESCRIPTION
## Summary
- change VnetConnections_CreateOrUpdate from an ARM long-running PUT to a synchronous create-or-replace operation
- remove LRO response headers and metadata from the generated 2026-07-01 OpenAPI
- regenerate the source and emitted create-or-update example with synchronous response semantics

## Validation
- azsdk_run_typespec_validation
- npx tsp compile .
- npx oav validate-example specification/app/resource-manager/Microsoft.App/ContainerApps/stable/2026-07-01/openapi.json
- ./eng/scripts/TypeSpec-Validation.ps1 -BaseCommitish upstream/release-app-Microsoft.App-stable/2026-07-01 -HeadCommitish HEAD -IgnoreCoreFiles
- TypeSpec and JSON formatting checks
- git diff --check