### PR TITLE
fix(chaos): correct the data-plane endpoint host in connection examples

### DIFF
--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-08-01-preview/Connections_CreateOrUpdate.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-08-01-preview/Connections_CreateOrUpdate.json
@@ -25,7 +25,7 @@
           "targetResourceId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.ContainerService/managedClusters/exampleCluster",
           "principalId": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
           "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
-          "dataPlaneEndpoint": "https://eastus.dp.chaos.azure.com",
+          "dataPlaneEndpoint": "https://dataplane.eastus.chaos-prod.azure.com",
           "status": "Connected",
           "provisioningState": "Succeeded"
         },

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-08-01-preview/Connections_Get.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-08-01-preview/Connections_Get.json
@@ -17,7 +17,7 @@
           "targetResourceId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.ContainerService/managedClusters/exampleCluster",
           "principalId": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
           "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
-          "dataPlaneEndpoint": "https://eastus.dp.chaos.azure.com",
+          "dataPlaneEndpoint": "https://dataplane.eastus.chaos-prod.azure.com",
           "status": "Connected",
           "provisioningState": "Succeeded"
         },

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-08-01-preview/Connections_ListAll.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-08-01-preview/Connections_ListAll.json
@@ -18,7 +18,7 @@
               "targetResourceId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.ContainerService/managedClusters/exampleCluster",
               "principalId": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
               "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
-              "dataPlaneEndpoint": "https://eastus.dp.chaos.azure.com",
+              "dataPlaneEndpoint": "https://dataplane.eastus.chaos-prod.azure.com",
               "status": "Connected",
               "provisioningState": "Succeeded"
             },

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Connections_CreateOrUpdate.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Connections_CreateOrUpdate.json
@@ -25,7 +25,7 @@
           "targetResourceId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.ContainerService/managedClusters/exampleCluster",
           "principalId": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
           "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
-          "dataPlaneEndpoint": "https://eastus.dp.chaos.azure.com",
+          "dataPlaneEndpoint": "https://dataplane.eastus.chaos-prod.azure.com",
           "status": "Connected",
           "provisioningState": "Succeeded"
         },

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Connections_Get.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Connections_Get.json
@@ -17,7 +17,7 @@
           "targetResourceId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.ContainerService/managedClusters/exampleCluster",
           "principalId": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
           "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
-          "dataPlaneEndpoint": "https://eastus.dp.chaos.azure.com",
+          "dataPlaneEndpoint": "https://dataplane.eastus.chaos-prod.azure.com",
           "status": "Connected",
           "provisioningState": "Succeeded"
         },

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Connections_ListAll.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Connections_ListAll.json
@@ -18,7 +18,7 @@
               "targetResourceId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.ContainerService/managedClusters/exampleCluster",
               "principalId": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
               "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
-              "dataPlaneEndpoint": "https://eastus.dp.chaos.azure.com",
+              "dataPlaneEndpoint": "https://dataplane.eastus.chaos-prod.azure.com",
               "status": "Connected",
               "provisioningState": "Succeeded"
             },

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/preview/2026-08-01-preview/examples/Connections_CreateOrUpdate.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/preview/2026-08-01-preview/examples/Connections_CreateOrUpdate.json
@@ -25,7 +25,7 @@
           "targetResourceId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.ContainerService/managedClusters/exampleCluster",
           "principalId": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
           "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
-          "dataPlaneEndpoint": "https://eastus.dp.chaos.azure.com",
+          "dataPlaneEndpoint": "https://dataplane.eastus.chaos-prod.azure.com",
           "status": "Connected",
           "provisioningState": "Succeeded"
         },

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/preview/2026-08-01-preview/examples/Connections_Get.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/preview/2026-08-01-preview/examples/Connections_Get.json
@@ -17,7 +17,7 @@
           "targetResourceId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.ContainerService/managedClusters/exampleCluster",
           "principalId": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
           "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
-          "dataPlaneEndpoint": "https://eastus.dp.chaos.azure.com",
+          "dataPlaneEndpoint": "https://dataplane.eastus.chaos-prod.azure.com",
           "status": "Connected",
           "provisioningState": "Succeeded"
         },

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/preview/2026-08-01-preview/examples/Connections_ListAll.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/preview/2026-08-01-preview/examples/Connections_ListAll.json
@@ -18,7 +18,7 @@
               "targetResourceId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.ContainerService/managedClusters/exampleCluster",
               "principalId": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
               "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
-              "dataPlaneEndpoint": "https://eastus.dp.chaos.azure.com",
+              "dataPlaneEndpoint": "https://dataplane.eastus.chaos-prod.azure.com",
               "status": "Connected",
               "provisioningState": "Succeeded"
             },

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Connections_CreateOrUpdate.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Connections_CreateOrUpdate.json
@@ -25,7 +25,7 @@
           "targetResourceId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.ContainerService/managedClusters/exampleCluster",
           "principalId": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
           "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
-          "dataPlaneEndpoint": "https://eastus.dp.chaos.azure.com",
+          "dataPlaneEndpoint": "https://dataplane.eastus.chaos-prod.azure.com",
           "status": "Connected",
           "provisioningState": "Succeeded"
         },

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Connections_Get.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Connections_Get.json
@@ -17,7 +17,7 @@
           "targetResourceId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.ContainerService/managedClusters/exampleCluster",
           "principalId": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
           "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
-          "dataPlaneEndpoint": "https://eastus.dp.chaos.azure.com",
+          "dataPlaneEndpoint": "https://dataplane.eastus.chaos-prod.azure.com",
           "status": "Connected",
           "provisioningState": "Succeeded"
         },

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Connections_ListAll.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Connections_ListAll.json
@@ -18,7 +18,7 @@
               "targetResourceId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.ContainerService/managedClusters/exampleCluster",
               "principalId": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
               "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
-              "dataPlaneEndpoint": "https://eastus.dp.chaos.azure.com",
+              "dataPlaneEndpoint": "https://dataplane.eastus.chaos-prod.azure.com",
               "status": "Connected",
               "provisioningState": "Succeeded"
             },


### PR DESCRIPTION
## Problem

The `workspaces/connections` examples show a `dataPlaneEndpoint` of `https://eastus.dp.chaos.azure.com`. **That host does not exist**, and a customer copying it would hit a blocking failure.

The AKS Litmus subscriber's conformance check validates the endpoint it is handed against an anchored whole-host pattern that requires a leading `dataplane` label. `eastus.dp.chaos.azure.com` has no such label, so the check throws before onboarding can proceed.

## What the real host is

Deployed infrastructure is authoritative, and three sources agree:

- the data-plane bicep builds its canonical hostname as `dataplane.${location}.chaos-${environmentLower}.azure.com`
- the Front Door config registers **exactly that string** as the custom domain — the name customers connect to, with the AFD endpoint serving only as its CNAME target
- the production EV2 configuration sets the environment to `prod` and provisions a per-region TLS certificate covering `dataplane.<region>.chaos-prod.azure.com`

So production resolves to `https://dataplane.<region>.chaos-prod.azure.com`.

## What changed

All twelve affected example files - the TypeSpec examples and the generated OpenAPI examples, for both `2026-08-01-preview` and the `2026-11-01` GA set.

Targeting the GA promotion branch specifically so **GA does not inherit the wrong host**.

## Review notes

Examples only. No schema, no TypeSpec model, no API surface change - the diff is twelve one-line value corrections.

Note that the service-side conformance validator currently accepts a bare `chaos` suffix and rejects `chaos-prod`; that is being corrected separately in the service repo, since it is the mirror image of the same defect.
