### PR TITLE
Pin Policy Java SDK to 2026-01-01-preview

### DIFF
--- a/specification/resources/resource-manager/Microsoft.Authorization/policy/tspconfig.yaml
+++ b/specification/resources/resource-manager/Microsoft.Authorization/policy/tspconfig.yaml
@@ -25,6 +25,7 @@ options:
     namespace: "com.azure.resourcemanager.resources.policy"
     service-name: "Policy"
     flavor: azure
+    api-version: "2026-01-01-preview"
   "@azure-tools/typespec-ts":
     compatibility-lro: true
     service-dir: "sdk/policy"


### PR DESCRIPTION
Pin the Policy Java management SDK to API version `2026-01-01-preview`.

This keeps Java regeneration for `azure-resourcemanager-resources-policy` on the API version used by Azure/azure-sdk-for-java#50248 while newer service API versions remain available to other emitters.
