### PR TITLE
Preserve Resources Deployments .NET API compatibility

### DIFF
--- a/specification/resources/resource-manager/Microsoft.Resources/deployments/DeploymentExtended.tsp
+++ b/specification/resources/resource-manager/Microsoft.Resources/deployments/DeploymentExtended.tsp
@@ -35,6 +35,7 @@ model DeploymentExtended
    */
   #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "For backward compatibility"
   #suppress "@azure-tools/typespec-azure-resource-manager/arm-no-record" "For backward compatibility"
+  @visibility(Lifecycle.Read)
   tags?: Record<string>;
 }
 

--- a/specification/resources/resource-manager/Microsoft.Resources/deployments/client.tsp
+++ b/specification/resources/resource-manager/Microsoft.Resources/deployments/client.tsp
@@ -148,7 +148,12 @@ using Microsoft.Resources;
 @@clientName(Deployments.exportTemplateAtScope, "ExportTemplate", "csharp");
 @@clientName(Deployments.validateAtScope, "Validate", "csharp");
 @@clientName(Deployments.checkExistenceAtScope, "CheckExistence", "csharp");
-@@alternateType(KeyVaultReference.id, armResourceIdentifier, "csharp");
+@@scope(Deployments.checkExistenceAtScope, "csharp");
+@@alternateType(
+  KeyVaultParameterReference.keyVault,
+  Azure.ResourceManager.Models.WritableSubResource,
+  "csharp"
+);
 @@clientName(
   Azure.ResourceManager.Foundations.ErrorAdditionalInfo.type,
   "ErrorAdditionalInfoType",
@@ -273,8 +278,6 @@ using Microsoft.Resources;
 @@scope(DeploymentOperationsOperationGroup.get, "!csharp");
 @@scope(DeploymentOperationsOperationGroup.list, "!csharp");
 
-@@scope(Deployments.checkExistenceAtScope, "!csharp"); // Remove this setting once https://github.com/Azure/azure-sdk-for-net/issues/58746 get fixed
-
 @@apiVersion(ProviderResourceType.apiVersions, false);
 @@apiVersion(AliasPath.apiVersions, false);
 @@responseAsBool(Deployments.checkExistenceAtScope, "javascript");
@@ -291,3 +294,9 @@ using Microsoft.Resources;
   "javascript"
 );
 @@responseAsBool(DeploymentExtendedOperationGroup.checkExistence, "javascript");
+
+namespace Azure.ResourceManager.Models {
+  model WritableSubResource {
+    id?: Azure.Core.armResourceIdentifier;
+  }
+}


### PR DESCRIPTION
## Summary
- keep deployment response tags read-only in .NET
- preserve the legacy WritableSubResource shape for Key Vault parameter references
- enable the at-scope CheckExistence operation for C# generation

SDK comparison excludes serialization members, additive APIs, and IList/IReadOnlyList differences as requested.