### PR TITLE
ServiceBus api-version update

### DIFF
--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/tspconfig.yaml
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/tspconfig.yaml
@@ -52,7 +52,7 @@ options:
     namespace: "Azure.ResourceManager.ServiceBus"
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
     enable-wire-path-attribute: true
-    api-version: "2026-01-01"
+    api-version: "2026-07-01-preview"
   "@azure-typespec/http-client-csharp-provisioning":
     namespace: "Azure.Provisioning.ServiceBus"
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/tspconfig.yaml
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/tspconfig.yaml
@@ -52,7 +52,6 @@ options:
     namespace: "Azure.ResourceManager.ServiceBus"
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
     enable-wire-path-attribute: true
-    api-version: "2026-07-01-preview"
   "@azure-typespec/http-client-csharp-provisioning":
     namespace: "Azure.Provisioning.ServiceBus"
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"


### PR DESCRIPTION
The @azure-typespec/http-client-csharp-mgmt emitter was pinned to 2026-01-01, so Azure.ResourceManager.ServiceBus could not be regenerated at 2026-07-01-preview reproducibly. Only the C# mgmt emitter is changed; the provisioning emitter stays on 2026-01-01.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
