### PR TITLE
Foundry training jobs: rebase TypeSpec onto current main

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/examples/v1/Jobs_BeginCancel_MaximumSet_Gen.json
+++ b/specification/ai-foundry/data-plane/Foundry/examples/v1/Jobs_BeginCancel_MaximumSet_Gen.json
@@ -1,0 +1,18 @@
+{
+  "title": "Jobs_BeginCancel_MaximumSet",
+  "operationId": "Jobs_BeginCancel",
+  "parameters": {
+    "api-version": "v1",
+    "name": "my_training_job_01",
+    "x-ms-client-request-id": "cf35b680-dc80-4815-ab83-9364acc3bce6",
+    "Foundry-Features": "Jobs=V1Preview"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/operations/cancel-operation-id",
+        "Retry-After": "10"
+      }
+    }
+  }
+}

--- a/specification/ai-foundry/data-plane/Foundry/examples/v1/Jobs_BeginCancel_MinimumSet_Gen.json
+++ b/specification/ai-foundry/data-plane/Foundry/examples/v1/Jobs_BeginCancel_MinimumSet_Gen.json
@@ -1,0 +1,11 @@
+{
+  "title": "Jobs_BeginCancel_MinimumSet",
+  "operationId": "Jobs_BeginCancel",
+  "parameters": {
+    "api-version": "v1",
+    "name": "my_training_job_01"
+  },
+  "responses": {
+    "200": {}
+  }
+}

--- a/specification/ai-foundry/data-plane/Foundry/examples/v1/Jobs_BeginDelete_MaximumSet_Gen.json
+++ b/specification/ai-foundry/data-plane/Foundry/examples/v1/Jobs_BeginDelete_MaximumSet_Gen.json
@@ -1,0 +1,19 @@
+{
+  "title": "Jobs_BeginDelete_MaximumSet",
+  "operationId": "Jobs_BeginDelete",
+  "parameters": {
+    "api-version": "v1",
+    "name": "my_training_job_01",
+    "x-ms-client-request-id": "cf35b680-dc80-4815-ab83-9364acc3bce6",
+    "Foundry-Features": "Jobs=V1Preview"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/operations/delete-operation-id",
+        "Retry-After": "10",
+        "x-ms-async-operation-timeout": "PT1H"
+      }
+    }
+  }
+}

--- a/specification/ai-foundry/data-plane/Foundry/examples/v1/Jobs_BeginDelete_MinimumSet_Gen.json
+++ b/specification/ai-foundry/data-plane/Foundry/examples/v1/Jobs_BeginDelete_MinimumSet_Gen.json
@@ -1,0 +1,11 @@
+{
+  "title": "Jobs_BeginDelete_MinimumSet",
+  "operationId": "Jobs_BeginDelete",
+  "parameters": {
+    "api-version": "v1",
+    "name": "my_training_job_01"
+  },
+  "responses": {
+    "204": {}
+  }
+}

--- a/specification/ai-foundry/data-plane/Foundry/examples/v1/Jobs_CreateOrUpdate_MaximumSet_Gen.json
+++ b/specification/ai-foundry/data-plane/Foundry/examples/v1/Jobs_CreateOrUpdate_MaximumSet_Gen.json
@@ -1,0 +1,284 @@
+{
+  "title": "Jobs_CreateOrUpdate_MaximumSet",
+  "operationId": "Jobs_CreateOrUpdate",
+  "parameters": {
+    "api-version": "v1",
+    "name": "my_training_job_01",
+    "job": {
+      "properties": {
+        "jobType": "Command",
+        "command": "python train.py --data ${{inputs.training_data}} --output ${{outputs.model}}",
+        "environmentImageReference": "mcr.microsoft.com/azureml/openmpi4.1.0-cuda11.8-cudnn8-ubuntu22.04:latest",
+        "displayName": "My Training Job",
+        "description": "A sample command job for training",
+        "experimentName": "my-experiment",
+        "tags": {
+          "framework": "pytorch"
+        },
+        "properties": {
+          "team": "vision-research"
+        },
+        "codeId": "azureai:my-training-code:1",
+        "computeId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg/providers/Microsoft.MachineLearningServices/workspaces/my-ws/computes/my-cluster",
+        "inputs": {
+          "training_data": {
+            "jobInputType": "uri_folder",
+            "uri": "azureai://datastores/mystore/paths/data/train",
+            "mode": "ReadOnlyMount"
+          },
+          "learning_rate": {
+            "jobInputType": "literal",
+            "value": "0.001"
+          }
+        },
+        "outputs": {
+          "model": {
+            "jobOutputType": "uri_folder",
+            "mode": "ReadWriteMount",
+            "assetName": "my-trained-model",
+            "assetVersion": "1",
+            "uri": "azureai://datastores/workspaceblobstore/paths/outputs/model",
+            "baseModelId": "azureai:qwen-base-model:1",
+            "description": "Trained model output"
+          }
+        },
+        "environmentVariables": {
+          "AZUREML_DATASET_FILE": "/mnt/data/train.csv"
+        },
+        "distribution": {
+          "distributionType": "PyTorch",
+          "processCountPerInstance": 4
+        },
+        "resources": {
+          "instanceCount": 2,
+          "instanceType": "Standard_NC6s_v3",
+          "shmSize": "2g",
+          "dockerArgs": "--privileged"
+        },
+        "limits": {
+          "jobLimitsType": "Command",
+          "timeout": "PT2H30M"
+        },
+        "services": {
+          "my_ssh": {
+            "jobServiceType": "SSH",
+            "nodes": {
+              "nodesValueType": "All"
+            },
+            "properties": {
+              "sshPublicKeys": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPykbeMQW4AN94tfWncTg3qegSMi6dwvIEmrW7rWq6OV user@host"
+            }
+          }
+        },
+        "queueSettings": {
+          "jobTier": "Standard"
+        },
+        "userAssignedIdentityId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/my-identity",
+        "priority": "High",
+        "capacityUnitCount": 4,
+        "gpuCount": 4,
+        "isArchived": false
+      }
+    },
+    "Foundry-Features": "Jobs=V1Preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "my_training_job_01",
+        "name": "my_training_job_01",
+        "type": "Microsoft.MachineLearningServices/workspaces/jobs",
+        "properties": {
+          "jobType": "Command",
+          "command": "python train.py --data ${{inputs.training_data}} --output ${{outputs.model}}",
+          "environmentImageReference": "mcr.microsoft.com/azureml/openmpi4.1.0-cuda11.8-cudnn8-ubuntu22.04:latest",
+          "displayName": "My Training Job",
+          "description": "A sample command job for training",
+          "experimentName": "my-experiment",
+          "tags": {
+            "framework": "pytorch"
+          },
+          "properties": {
+            "team": "vision-research"
+          },
+          "codeId": "azureai:my-training-code:1",
+          "computeId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg/providers/Microsoft.MachineLearningServices/workspaces/my-ws/computes/my-cluster",
+          "inputs": {
+            "training_data": {
+              "jobInputType": "uri_folder",
+              "uri": "azureai://datastores/mystore/paths/data/train",
+              "mode": "ReadOnlyMount"
+            },
+            "learning_rate": {
+              "jobInputType": "literal",
+              "value": "0.001"
+            }
+          },
+          "outputs": {
+            "model": {
+              "jobOutputType": "uri_folder",
+              "mode": "ReadWriteMount",
+              "assetName": "my-trained-model",
+              "assetVersion": "1",
+              "uri": "azureai://datastores/workspaceblobstore/paths/outputs/model",
+              "baseModelId": "azureai:qwen-base-model:1",
+              "description": "Trained model output"
+            }
+          },
+          "environmentVariables": {
+            "AZUREML_DATASET_FILE": "/mnt/data/train.csv"
+          },
+          "distribution": {
+            "distributionType": "PyTorch",
+            "processCountPerInstance": 4
+          },
+          "resources": {
+            "instanceCount": 2,
+            "instanceType": "Standard_NC6s_v3",
+            "shmSize": "2g",
+            "dockerArgs": "--privileged"
+          },
+          "limits": {
+            "jobLimitsType": "Command",
+            "timeout": "PT2H30M"
+          },
+          "services": {
+            "Studio": {
+              "jobServiceType": "Studio",
+              "port": 8080,
+              "endpoint": "https://studio.example.com"
+            },
+            "Tracking": {
+              "jobServiceType": "Tracking"
+            },
+            "my_ssh": {
+              "jobServiceType": "SSH",
+              "nodes": {
+                "nodesValueType": "All"
+              },
+              "properties": {
+                "sshPublicKeys": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPykbeMQW4AN94tfWncTg3qegSMi6dwvIEmrW7rWq6OV user@host"
+              },
+              "status": "Running"
+            }
+          },
+          "queueSettings": {
+            "jobTier": "Standard"
+          },
+          "userAssignedIdentityId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/my-identity",
+          "priority": "High",
+          "capacityUnitCount": 4,
+          "gpuCount": 4,
+          "status": "Running",
+          "isArchived": false
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "user@example.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "user@example.com",
+          "lastModifiedByType": "User"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "id": "my_training_job_01",
+        "name": "my_training_job_01",
+        "type": "Microsoft.MachineLearningServices/workspaces/jobs",
+        "properties": {
+          "jobType": "Command",
+          "command": "python train.py --data ${{inputs.training_data}} --output ${{outputs.model}}",
+          "environmentImageReference": "mcr.microsoft.com/azureml/openmpi4.1.0-cuda11.8-cudnn8-ubuntu22.04:latest",
+          "displayName": "My Training Job",
+          "description": "A sample command job for training",
+          "experimentName": "my-experiment",
+          "tags": {
+            "framework": "pytorch"
+          },
+          "properties": {
+            "team": "vision-research"
+          },
+          "codeId": "azureai:my-training-code:1",
+          "computeId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg/providers/Microsoft.MachineLearningServices/workspaces/my-ws/computes/my-cluster",
+          "inputs": {
+            "training_data": {
+              "jobInputType": "uri_folder",
+              "uri": "azureai://datastores/mystore/paths/data/train",
+              "mode": "ReadOnlyMount"
+            },
+            "learning_rate": {
+              "jobInputType": "literal",
+              "value": "0.001"
+            }
+          },
+          "outputs": {
+            "model": {
+              "jobOutputType": "uri_folder",
+              "mode": "ReadWriteMount",
+              "assetName": "my-trained-model",
+              "assetVersion": "1",
+              "uri": "azureai://datastores/workspaceblobstore/paths/outputs/model",
+              "baseModelId": "azureai:qwen-base-model:1",
+              "description": "Trained model output"
+            }
+          },
+          "environmentVariables": {
+            "AZUREML_DATASET_FILE": "/mnt/data/train.csv"
+          },
+          "distribution": {
+            "distributionType": "PyTorch",
+            "processCountPerInstance": 4
+          },
+          "resources": {
+            "instanceCount": 2,
+            "instanceType": "Standard_NC6s_v3",
+            "shmSize": "2g",
+            "dockerArgs": "--privileged"
+          },
+          "limits": {
+            "jobLimitsType": "Command",
+            "timeout": "PT2H30M"
+          },
+          "services": {
+            "Studio": {
+              "jobServiceType": "Studio",
+              "port": 8080,
+              "endpoint": "https://studio.example.com"
+            },
+            "Tracking": {
+              "jobServiceType": "Tracking"
+            },
+            "my_ssh": {
+              "jobServiceType": "SSH",
+              "nodes": {
+                "nodesValueType": "All"
+              },
+              "properties": {
+                "sshPublicKeys": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPykbeMQW4AN94tfWncTg3qegSMi6dwvIEmrW7rWq6OV user@host"
+              }
+            }
+          },
+          "queueSettings": {
+            "jobTier": "Standard"
+          },
+          "userAssignedIdentityId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/my-identity",
+          "priority": "High",
+          "capacityUnitCount": 4,
+          "gpuCount": 4,
+          "status": "NotStarted",
+          "isArchived": false
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "user@example.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "user@example.com",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  }
+}

--- a/specification/ai-foundry/data-plane/Foundry/examples/v1/Jobs_CreateOrUpdate_MinimumSet_Gen.json
+++ b/specification/ai-foundry/data-plane/Foundry/examples/v1/Jobs_CreateOrUpdate_MinimumSet_Gen.json
@@ -1,0 +1,40 @@
+{
+  "title": "Jobs_CreateOrUpdate_MinimumSet",
+  "operationId": "Jobs_CreateOrUpdate",
+  "parameters": {
+    "api-version": "v1",
+    "name": "my_training_job_01",
+    "job": {
+      "properties": {
+        "jobType": "Command",
+        "command": "python train.py",
+        "environmentImageReference": "mcr.microsoft.com/azureml/openmpi4.1.0-cuda11.8-cudnn8-ubuntu22.04:latest",
+        "computeId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg/providers/Microsoft.MachineLearningServices/workspaces/my-ws/computes/my-cluster"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "my_training_job_01",
+        "properties": {
+          "jobType": "Command",
+          "command": "python train.py",
+          "environmentImageReference": "mcr.microsoft.com/azureml/openmpi4.1.0-cuda11.8-cudnn8-ubuntu22.04:latest",
+          "computeId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg/providers/Microsoft.MachineLearningServices/workspaces/my-ws/computes/my-cluster"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "my_training_job_01",
+        "properties": {
+          "jobType": "Command",
+          "command": "python train.py",
+          "environmentImageReference": "mcr.microsoft.com/azureml/openmpi4.1.0-cuda11.8-cudnn8-ubuntu22.04:latest",
+          "computeId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg/providers/Microsoft.MachineLearningServices/workspaces/my-ws/computes/my-cluster"
+        }
+      }
+    }
+  }
+}

--- a/specification/ai-foundry/data-plane/Foundry/examples/v1/Jobs_GetArtifactContentInformation_MaximumSet_Gen.json
+++ b/specification/ai-foundry/data-plane/Foundry/examples/v1/Jobs_GetArtifactContentInformation_MaximumSet_Gen.json
@@ -1,0 +1,39 @@
+{
+  "title": "Jobs_GetArtifactContentInformation_MaximumSet",
+  "operationId": "Jobs_getArtifactContentInformation",
+  "parameters": {
+    "api-version": "v1",
+    "name": "test-job-for-interactive-debugging-1",
+    "path": "user_logs",
+    "continuationToken": "",
+    "Foundry-Features": "Jobs=V1Preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "contentUri": "https://fdpcommandjobwestus2.blob.core.windows.net/test-job/user_logs/std_log.txt?sv=2024-11-04&sig=...",
+            "origin": "ExperimentRun",
+            "container": "dcid.test-job-for-interactive-debugging-1",
+            "path": "user_logs/std_log.txt",
+            "tags": {
+              "category": "log"
+            },
+            "contentLength": 204800
+          },
+          {
+            "contentUri": "https://fdpcommandjobwestus2.blob.core.windows.net/test-job/user_logs/std_err.txt?sv=2024-11-04&sig=...",
+            "origin": "ExperimentRun",
+            "container": "dcid.test-job-for-interactive-debugging-1",
+            "path": "user_logs/std_err.txt",
+            "tags": {},
+            "contentLength": 4096
+          }
+        ],
+        "continuationToken": "Mnw0fDV8Ng==",
+        "nextLink": "https://fdp-command-job-westus2.services.ai.azure.com/api/projects/fdp-command-job-westus2-proj/jobs/test-job-for-interactive-debugging-1/artifacts/contentinfo?api-version=v1&continuationToken=Mnw0fDV8Ng%3D%3D"
+      }
+    }
+  }
+}

--- a/specification/ai-foundry/data-plane/Foundry/examples/v1/Jobs_GetArtifactContentInformation_MinimumSet_Gen.json
+++ b/specification/ai-foundry/data-plane/Foundry/examples/v1/Jobs_GetArtifactContentInformation_MinimumSet_Gen.json
@@ -1,0 +1,16 @@
+{
+  "title": "Jobs_GetArtifactContentInformation_MinimumSet",
+  "operationId": "Jobs_getArtifactContentInformation",
+  "parameters": {
+    "api-version": "v1",
+    "name": "my_training_job_01",
+    "Foundry-Features": "Jobs=V1Preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": []
+      }
+    }
+  }
+}

--- a/specification/ai-foundry/data-plane/Foundry/examples/v1/Jobs_Get_MaximumSet_Gen.json
+++ b/specification/ai-foundry/data-plane/Foundry/examples/v1/Jobs_Get_MaximumSet_Gen.json
@@ -1,0 +1,98 @@
+{
+  "title": "Jobs_Get_MaximumSet",
+  "operationId": "Jobs_Get",
+  "parameters": {
+    "api-version": "v1",
+    "name": "my_training_job_01",
+    "x-ms-client-request-id": "cf35b680-dc80-4815-ab83-9364acc3bce6",
+    "Foundry-Features": "Jobs=V1Preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "my_training_job_01",
+        "name": "my_training_job_01",
+        "type": "Microsoft.MachineLearningServices/workspaces/jobs",
+        "properties": {
+          "jobType": "Command",
+          "command": "python train.py --data ${{inputs.training_data}} --output ${{outputs.model}}",
+          "environmentImageReference": "mcr.microsoft.com/azureml/openmpi4.1.0-cuda11.8-cudnn8-ubuntu22.04:latest",
+          "displayName": "My Training Job",
+          "description": "A sample command job for training",
+          "tags": {
+            "framework": "pytorch"
+          },
+          "properties": {
+            "experimentName": "my-experiment"
+          },
+          "codeId": "azureai:my-training-code:1",
+          "computeId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg/providers/Microsoft.MachineLearningServices/workspaces/my-ws/computes/my-cluster",
+          "inputs": {
+            "training_data": {
+              "jobInputType": "uri_folder",
+              "uri": "azureai://datastores/mystore/paths/data/train",
+              "mode": "ReadOnlyMount"
+            },
+            "learning_rate": {
+              "jobInputType": "literal",
+              "value": "0.001"
+            }
+          },
+          "outputs": {
+            "model": {
+              "jobOutputType": "uri_folder",
+              "mode": "ReadWriteMount",
+              "assetName": "my-trained-model",
+              "assetVersion": "1",
+              "uri": "azureai://datastores/workspaceblobstore/paths/outputs/model",
+              "baseModelId": "azureai:qwen-base-model:1",
+              "description": "Trained model output"
+            }
+          },
+          "environmentVariables": {
+            "AZUREML_DATASET_FILE": "/mnt/data/train.csv"
+          },
+          "distribution": {
+            "distributionType": "PyTorch",
+            "processCountPerInstance": 4
+          },
+          "resources": {
+            "instanceCount": 2,
+            "instanceType": "Standard_NC6s_v3",
+            "shmSize": "2g",
+            "dockerArgs": "--privileged"
+          },
+          "limits": {
+            "jobLimitsType": "Command",
+            "timeout": "PT2H30M"
+          },
+          "services": {
+            "Studio": {
+              "jobServiceType": "Studio",
+              "port": 8080,
+              "endpoint": "https://studio.example.com"
+            },
+            "Tracking": {
+              "jobServiceType": "Tracking"
+            }
+          },
+          "queueSettings": {
+            "jobTier": "Standard"
+          },
+          "userAssignedIdentityId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/my-identity",
+          "gpuCount": 4,
+          "status": "Running",
+          "isArchived": false
+        },
+        "systemData": {
+          "createdAt": "2020-01-01T12:34:56.999Z",
+          "createdBy": "user@example.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+          "lastModifiedBy": "user@example.com",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  }
+}

--- a/specification/ai-foundry/data-plane/Foundry/examples/v1/Jobs_Get_MinimumSet_Gen.json
+++ b/specification/ai-foundry/data-plane/Foundry/examples/v1/Jobs_Get_MinimumSet_Gen.json
@@ -1,0 +1,20 @@
+{
+  "title": "Jobs_Get_MinimumSet",
+  "operationId": "Jobs_Get",
+  "parameters": {
+    "api-version": "v1",
+    "name": "my_training_job_01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "my_training_job_01",
+        "properties": {
+          "jobType": "Command",
+          "command": "python train.py",
+          "environmentImageReference": "mcr.microsoft.com/azureml/openmpi4.1.0-cuda11.8-cudnn8-ubuntu22.04:latest"
+        }
+      }
+    }
+  }
+}

--- a/specification/ai-foundry/data-plane/Foundry/examples/v1/Jobs_ListArtifacts_MaximumSet_Gen.json
+++ b/specification/ai-foundry/data-plane/Foundry/examples/v1/Jobs_ListArtifacts_MaximumSet_Gen.json
@@ -1,0 +1,50 @@
+{
+  "title": "Jobs_ListArtifacts_MaximumSet",
+  "operationId": "Jobs_listArtifacts",
+  "parameters": {
+    "api-version": "v1",
+    "name": "sangeetakhan-westus2-30min-war3",
+    "path": "user_logs",
+    "pageSize": 50,
+    "continuationToken": "",
+    "Foundry-Features": "Jobs=V1Preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "artifactId": "ExperimentRun/dcid.sangeetakhan-westus2-30min-war3/user_logs/std_log.txt",
+            "origin": "ExperimentRun",
+            "container": "dcid.sangeetakhan-westus2-30min-war3",
+            "path": "user_logs/std_log.txt",
+            "etag": "\"0x8DC9A1C1F3A0F00\"",
+            "createdTime": "2026-05-13T08:01:34.1234567Z",
+            "dataPath": {
+              "dataStoreName": "workspaceartifactstore",
+              "relativePath": "ExperimentRun/dcid.sangeetakhan-westus2-30min-war3/user_logs/std_log.txt"
+            },
+            "tags": {
+              "category": "log"
+            }
+          },
+          {
+            "artifactId": "ExperimentRun/dcid.sangeetakhan-westus2-30min-war3/system_logs/lifecycler/lifecycler.log",
+            "origin": "ExperimentRun",
+            "container": "dcid.sangeetakhan-westus2-30min-war3",
+            "path": "system_logs/lifecycler/lifecycler.log",
+            "etag": "\"0x8DC9A1C20A4B100\"",
+            "createdTime": "2026-05-13T08:02:11.7654321Z",
+            "dataPath": {
+              "dataStoreName": "workspaceartifactstore",
+              "relativePath": "ExperimentRun/dcid.sangeetakhan-westus2-30min-war3/system_logs/lifecycler/lifecycler.log"
+            },
+            "tags": {}
+          }
+        ],
+        "continuationToken": "MnwxNzc4NjU4NjgxfDU=",
+        "nextLink": "https://fdp-command-job-westus2.services.ai.azure.com/api/projects/fdp-command-job-westus2-proj/jobs/sangeetakhan-westus2-30min-war3/artifacts?api-version=v1&continuationToken=MnwxNzc4NjU4NjgxfDU%3D"
+      }
+    }
+  }
+}

--- a/specification/ai-foundry/data-plane/Foundry/examples/v1/Jobs_ListArtifacts_MinimumSet_Gen.json
+++ b/specification/ai-foundry/data-plane/Foundry/examples/v1/Jobs_ListArtifacts_MinimumSet_Gen.json
@@ -1,0 +1,16 @@
+{
+  "title": "Jobs_ListArtifacts_MinimumSet",
+  "operationId": "Jobs_listArtifacts",
+  "parameters": {
+    "api-version": "v1",
+    "name": "my_training_job_01",
+    "Foundry-Features": "Jobs=V1Preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": []
+      }
+    }
+  }
+}

--- a/specification/ai-foundry/data-plane/Foundry/examples/v1/Jobs_List_MaximumSet_Gen.json
+++ b/specification/ai-foundry/data-plane/Foundry/examples/v1/Jobs_List_MaximumSet_Gen.json
@@ -1,0 +1,106 @@
+{
+  "title": "Jobs_List_MaximumSet",
+  "operationId": "Jobs_List",
+  "parameters": {
+    "api-version": "v1",
+    "jobType": "Command",
+    "tag": "framework=pytorch",
+    "listViewType": "ActiveOnly",
+    "properties": "experimentName=my-experiment",
+    "x-ms-client-request-id": "cf35b680-dc80-4815-ab83-9364acc3bce6",
+    "Foundry-Features": "Jobs=V1Preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "my_training_job_01",
+            "name": "my_training_job_01",
+            "type": "Microsoft.MachineLearningServices/workspaces/jobs",
+            "properties": {
+              "jobType": "Command",
+              "command": "python train.py --data ${{inputs.training_data}} --output ${{outputs.model}}",
+              "environmentImageReference": "mcr.microsoft.com/azureml/openmpi4.1.0-cuda11.8-cudnn8-ubuntu22.04:latest",
+              "displayName": "My Training Job",
+              "description": "A sample command job for training",
+              "tags": {
+                "framework": "pytorch"
+              },
+              "properties": {
+                "experimentName": "my-experiment"
+              },
+              "codeId": "azureai:my-training-code:1",
+              "computeId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg/providers/Microsoft.MachineLearningServices/workspaces/my-ws/computes/my-cluster",
+              "inputs": {
+                "training_data": {
+                  "jobInputType": "uri_folder",
+                  "uri": "azureai://datastores/mystore/paths/data/train",
+                  "mode": "ReadOnlyMount"
+                },
+                "learning_rate": {
+                  "jobInputType": "literal",
+                  "value": "0.001"
+                }
+              },
+              "outputs": {
+                "model": {
+                  "jobOutputType": "uri_folder",
+                  "mode": "ReadWriteMount",
+                  "assetName": "my-trained-model",
+                  "assetVersion": "1",
+                  "uri": "azureai://datastores/workspaceblobstore/paths/outputs/model",
+                  "baseModelId": "azureai:qwen-base-model:1",
+                  "description": "Trained model output"
+                }
+              },
+              "environmentVariables": {
+                "AZUREML_DATASET_FILE": "/mnt/data/train.csv"
+              },
+              "distribution": {
+                "distributionType": "PyTorch",
+                "processCountPerInstance": 4
+              },
+              "resources": {
+                "instanceCount": 2,
+                "instanceType": "Standard_NC6s_v3",
+                "shmSize": "2g",
+                "dockerArgs": "--privileged"
+              },
+              "limits": {
+                "jobLimitsType": "Command",
+                "timeout": "PT2H30M"
+              },
+              "services": {
+                "Studio": {
+                  "jobServiceType": "Studio",
+                  "port": 8080,
+                  "endpoint": "https://studio.example.com"
+                },
+                "Tracking": {
+                  "jobServiceType": "Tracking"
+                }
+              },
+              "queueSettings": {
+                "jobTier": "Standard"
+              },
+              "userAssignedIdentityId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/my-identity",
+              "gpuCount": 4,
+              "status": "Running",
+              "isArchived": false
+            },
+            "systemData": {
+              "createdAt": "2020-01-01T12:34:56.999Z",
+              "createdBy": "user@example.com",
+              "createdByType": "User",
+              "lastModifiedAt": "2020-01-01T12:34:56.999Z",
+              "lastModifiedBy": "user@example.com",
+              "lastModifiedByType": "User"
+            }
+          }
+        ],
+        "nextLink": "https://eastus.api.azureml.ms/jobs?api-version=v1&skip=100"
+      }
+    }
+  }
+}

--- a/specification/ai-foundry/data-plane/Foundry/examples/v1/Jobs_List_MinimumSet_Gen.json
+++ b/specification/ai-foundry/data-plane/Foundry/examples/v1/Jobs_List_MinimumSet_Gen.json
@@ -1,0 +1,23 @@
+{
+  "title": "Jobs_List_MinimumSet",
+  "operationId": "Jobs_List",
+  "parameters": {
+    "api-version": "v1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "my_training_job_01",
+            "properties": {
+              "jobType": "Command",
+              "command": "python train.py",
+              "environmentImageReference": "mcr.microsoft.com/azureml/openmpi4.1.0-cuda11.8-cudnn8-ubuntu22.04:latest"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/ai-foundry/data-plane/Foundry/main.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/main.tsp
@@ -19,6 +19,7 @@ import "./src/evaluations/routes.tsp";
 import "./src/evaluators/routes.tsp";
 import "./src/indexes/routes.tsp";
 import "./src/insights/routes.tsp";
+import "./src/jobs/routes.tsp";
 import "./src/managed-blueprints/routes.tsp";
 import "./src/models/routes.tsp";
 import "./src/memory-stores/routes.tsp";

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -9,6 +9,9 @@
       "name": "Agent Insight Monitors"
     },
     {
+      "name": "CommandJob"
+    },
+    {
       "name": "Responses Root",
       "description": "Responses"
     },
@@ -9327,6 +9330,569 @@
         },
         "tags": [
           "Insights"
+        ]
+      }
+    },
+    "/jobs": {
+      "get": {
+        "operationId": "Jobs_list",
+        "description": "List Jobs.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "jobType",
+            "in": "query",
+            "required": false,
+            "description": "Filter by job type (e.g. 'Command').",
+            "schema": {
+              "$ref": "#/components/schemas/JobType"
+            },
+            "explode": false
+          },
+          {
+            "name": "tag",
+            "in": "query",
+            "required": false,
+            "description": "Filter jobs by tag in the format 'key=value' (e.g., 'framework=pytorch').",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "listViewType",
+            "in": "query",
+            "required": false,
+            "description": "Specifies which view type to apply when listing jobs.",
+            "schema": {
+              "$ref": "#/components/schemas/ListViewType"
+            },
+            "explode": false
+          },
+          {
+            "name": "properties",
+            "in": "query",
+            "required": false,
+            "description": "Comma-separated user property names and optionally values. Example: prop1,prop2=value2.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Jobs=V1Preview"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedJob"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "headers": {
+              "x-ms-error-code": {
+                "required": false,
+                "description": "String error code indicating what went wrong.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "CommandJob"
+        ]
+      }
+    },
+    "/jobs/{name}": {
+      "get": {
+        "operationId": "Jobs_get",
+        "description": "Get a Job by name.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "description": "The name of the Job. This is case-sensitive.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Jobs=V1Preview"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Job"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "headers": {
+              "x-ms-error-code": {
+                "required": false,
+                "description": "String error code indicating what went wrong.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "CommandJob"
+        ]
+      },
+      "put": {
+        "operationId": "Jobs_createOrUpdate",
+        "description": "Create and execute a Job. For update case, the Tags in the definition passed in will replace Tags in the existing job.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "description": "The name of the Job. This is case-sensitive.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Jobs=V1Preview"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Job"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "The request has succeeded and a new resource has been created as a result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Job"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "headers": {
+              "x-ms-error-code": {
+                "required": false,
+                "description": "String error code indicating what went wrong.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "CommandJob"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Job"
+              }
+            }
+          },
+          "description": "The job to create or update."
+        }
+      },
+      "delete": {
+        "operationId": "Jobs_beginDelete",
+        "description": "Delete a Job by name. Returns 202 Accepted with a Location header to poll for completion, or 204 if the job does not exist.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "description": "The name of the Job. This is case-sensitive.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Jobs=V1Preview"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Response returned when a job delete operation is accepted asynchronously.",
+            "headers": {
+              "Location": {
+                "required": true,
+                "description": "URL to poll for the status of the delete operation.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Retry-After": {
+                "required": false,
+                "description": "Suggested delay in seconds before polling.",
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "There is no content to send for this request, but the headers may be useful."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "headers": {
+              "x-ms-error-code": {
+                "required": false,
+                "description": "String error code indicating what went wrong.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "CommandJob"
+        ]
+      }
+    },
+    "/jobs/{name}/artifacts": {
+      "get": {
+        "operationId": "Jobs_listArtifacts",
+        "description": "List the artifacts produced by a job, including its log files. Logs are ordinary artifacts stored under the well-known `azureml-logs/`, `user_logs/` and `system_logs/` path prefixes, so they are retrieved by filtering on `path`.",
+        "parameters": [
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Jobs=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "description": "The name of the Job.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "path",
+            "in": "query",
+            "required": false,
+            "description": "Optional artifact path or path prefix to filter by.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "continuationToken",
+            "in": "query",
+            "required": false,
+            "description": "Continuation token for the next page.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of artifacts per page.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ArtifactList"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "CommandJob"
+        ]
+      }
+    },
+    "/jobs/{name}/artifacts/contentinfo": {
+      "get": {
+        "operationId": "Jobs_getArtifactContentInformation",
+        "description": "Get content information, including a readable content URI and byte length, for the artifacts produced by a job. Use this to download artifact or log content.",
+        "parameters": [
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Jobs=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "description": "The name of the Job.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "path",
+            "in": "query",
+            "required": false,
+            "description": "Optional artifact path prefix to filter by.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "continuationToken",
+            "in": "query",
+            "required": false,
+            "description": "Continuation token for the next page.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ArtifactContentInformationList"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "CommandJob"
+        ]
+      }
+    },
+    "/jobs/{name}/cancel": {
+      "post": {
+        "operationId": "Jobs_beginCancel",
+        "description": "Cancel a Job by name. Returns 200 if cancelled immediately, or 202 Accepted with a Location header to poll for completion.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "description": "The name of the Job. This is case-sensitive.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Jobs=V1Preview"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded."
+          },
+          "202": {
+            "description": "Response returned when a job cancel operation is accepted asynchronously.",
+            "headers": {
+              "Location": {
+                "required": true,
+                "description": "URL to poll for the status of the cancel operation.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Retry-After": {
+                "required": false,
+                "description": "Suggested delay in seconds before polling.",
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "headers": {
+              "x-ms-error-code": {
+                "required": false,
+                "description": "String error code indicating what went wrong.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "CommandJob"
         ]
       }
     },
@@ -30494,6 +31060,27 @@
         ],
         "description": "Agentic identity credential definition"
       },
+      "AllNodes": {
+        "type": "object",
+        "required": [
+          "nodesValueType"
+        ],
+        "properties": {
+          "nodesValueType": {
+            "type": "string",
+            "enum": [
+              "All"
+            ],
+            "description": "Type of the Nodes value."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/NodeCollection"
+          }
+        ],
+        "description": "All nodes means the service will be running on all of the nodes of the job."
+      },
       "ApiErrorResponse": {
         "type": "object",
         "required": [
@@ -30532,6 +31119,153 @@
           }
         ],
         "description": "API Key Credential definition"
+      },
+      "Artifact": {
+        "type": "object",
+        "required": [
+          "origin",
+          "container",
+          "path"
+        ],
+        "properties": {
+          "artifactId": {
+            "type": "string",
+            "description": "The artifact id."
+          },
+          "origin": {
+            "type": "string",
+            "description": "The artifact origin."
+          },
+          "container": {
+            "type": "string",
+            "description": "The container name."
+          },
+          "path": {
+            "type": "string",
+            "description": "The artifact path."
+          },
+          "etag": {
+            "type": "string",
+            "description": "The artifact Etag."
+          },
+          "createdTime": {
+            "type": "string",
+            "format": "date-time",
+            "description": "The artifact creation time in UTC."
+          },
+          "dataPath": {
+            "$ref": "#/components/schemas/ArtifactDataPath",
+            "description": "The artifact data path."
+          },
+          "tags": {
+            "type": "object",
+            "unevaluatedProperties": {
+              "type": "string"
+            },
+            "description": "The artifact tags."
+          }
+        },
+        "description": "An artifact."
+      },
+      "ArtifactContentInformation": {
+        "type": "object",
+        "properties": {
+          "contentUri": {
+            "type": "string",
+            "format": "uri",
+            "description": "The content URI."
+          },
+          "origin": {
+            "type": "string",
+            "description": "The artifact origin."
+          },
+          "container": {
+            "type": "string",
+            "description": "The container name."
+          },
+          "path": {
+            "type": "string",
+            "description": "The artifact path."
+          },
+          "tags": {
+            "type": "object",
+            "unevaluatedProperties": {
+              "type": "string"
+            },
+            "description": "The artifact tags."
+          },
+          "contentLength": {
+            "type": "integer",
+            "format": "int64",
+            "description": "The content byte length."
+          }
+        },
+        "description": "Artifact content information."
+      },
+      "ArtifactContentInformationList": {
+        "type": "object",
+        "required": [
+          "value"
+        ],
+        "properties": {
+          "value": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ArtifactContentInformation"
+            },
+            "description": "The entries in the page."
+          },
+          "continuationToken": {
+            "type": "string",
+            "description": "Token for the next page."
+          },
+          "nextLink": {
+            "type": "string",
+            "description": "URL for the next page."
+          }
+        },
+        "description": "A page of artifact content information."
+      },
+      "ArtifactDataPath": {
+        "type": "object",
+        "properties": {
+          "dataStoreName": {
+            "type": "string",
+            "description": "The data store name."
+          },
+          "relativePath": {
+            "type": "string",
+            "description": "The relative path within the data store."
+          },
+          "sqlDataPath": {
+            "description": "SQL data path information."
+          }
+        },
+        "description": "A data store path."
+      },
+      "ArtifactList": {
+        "type": "object",
+        "required": [
+          "value"
+        ],
+        "properties": {
+          "value": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Artifact"
+            },
+            "description": "The artifacts in the page."
+          },
+          "continuationToken": {
+            "type": "string",
+            "description": "Token for the next page."
+          },
+          "nextLink": {
+            "type": "string",
+            "description": "URL for the next page."
+          }
+        },
+        "description": "A page of artifacts."
       },
       "ArtifactProfile": {
         "type": "object",
@@ -30574,6 +31308,23 @@
       "AssetId": {
         "type": "string",
         "description": "Identifier of a saved asset."
+      },
+      "AssetTypes": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "uri_file",
+              "uri_folder",
+              "safetensors_model",
+              "literal"
+            ]
+          }
+        ],
+        "description": "Type of job input/output asset."
       },
       "AttackStrategy": {
         "anyOf": [
@@ -32750,6 +33501,164 @@
         ],
         "description": "A code interpreter tool stored in a toolbox."
       },
+      "CommandJob": {
+        "type": "object",
+        "required": [
+          "jobType",
+          "command",
+          "environmentImageReference",
+          "computeId"
+        ],
+        "properties": {
+          "jobType": {
+            "type": "string",
+            "enum": [
+              "Command"
+            ],
+            "description": "Job type."
+          },
+          "command": {
+            "type": "string",
+            "description": "The command to execute on startup of the job."
+          },
+          "environmentImageReference": {
+            "type": "string",
+            "description": "ACR path of environment."
+          },
+          "displayName": {
+            "type": "string",
+            "description": "Display name of job."
+          },
+          "description": {
+            "type": "string",
+            "description": "The asset description text."
+          },
+          "experimentName": {
+            "type": "string",
+            "description": "The name of the experiment the job belongs to. If not set, the job is placed in the \"Default\" experiment."
+          },
+          "tags": {
+            "type": "object",
+            "unevaluatedProperties": {
+              "type": "string"
+            },
+            "description": "Tag dictionary. Tags can be added, removed, and updated."
+          },
+          "properties": {
+            "type": "object",
+            "unevaluatedProperties": {
+              "type": "string"
+            },
+            "description": "The asset property dictionary."
+          },
+          "codeId": {
+            "type": "string",
+            "description": "Code asset reference."
+          },
+          "computeId": {
+            "type": "string",
+            "description": "Compute resource ID."
+          },
+          "inputs": {
+            "type": "object",
+            "unevaluatedProperties": {
+              "$ref": "#/components/schemas/Input"
+            },
+            "description": "Mapping of input data bindings used in the job."
+          },
+          "outputs": {
+            "type": "object",
+            "unevaluatedProperties": {
+              "$ref": "#/components/schemas/Output"
+            },
+            "description": "Mapping of output data bindings used in the job."
+          },
+          "environmentVariables": {
+            "type": "object",
+            "unevaluatedProperties": {
+              "type": "string"
+            },
+            "description": "Environment variables included in the job."
+          },
+          "resources": {
+            "$ref": "#/components/schemas/JobResourceConfiguration",
+            "description": "Compute Resource configuration for the job."
+          },
+          "distribution": {
+            "$ref": "#/components/schemas/DistributionConfiguration",
+            "description": "Distribution configuration of the job."
+          },
+          "limits": {
+            "$ref": "#/components/schemas/CommandJobLimits",
+            "description": "Command Job limit."
+          },
+          "services": {
+            "type": "object",
+            "unevaluatedProperties": {
+              "$ref": "#/components/schemas/JobService"
+            },
+            "description": "List of job services."
+          },
+          "queueSettings": {
+            "$ref": "#/components/schemas/QueueSettings",
+            "description": "Queue settings for the job."
+          },
+          "priority": {
+            "$ref": "#/components/schemas/JobPriority",
+            "description": "User-visible scheduling priority for the job."
+          },
+          "userAssignedIdentityId": {
+            "type": "string",
+            "description": "user-assigned managed identity"
+          },
+          "capacityUnitCount": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Number of capacity units to allocate for the job. When set, the service resolves the VM SKU from the compute target and calculates the required node count automatically. Virtual cluster targets must also specify `resources.instanceType`. Valid values are 1, 2, 4, 8, or any multiple of 8 for values greater than 8. `gpuCount` takes precedence over this property when both are supplied."
+          },
+          "gpuCount": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Number of GPUs to allocate for the job. Takes precedence over `capacityUnitCount` when both are supplied, and is used to resolve a partial (sub-node) VM SKU for GPU computes. Only applies to GPU computes; CPU computes always resolve to a full-node SKU and ignore this value. Valid values are 1, 2, 4, 8, or any multiple of 8 for values greater than 8."
+          },
+          "isArchived": {
+            "type": "boolean",
+            "description": "Is the asset archived?"
+          },
+          "status": {
+            "type": "string",
+            "description": "Status of the job.",
+            "readOnly": true
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/JobProperties"
+          }
+        ],
+        "description": "Properties of a Command Job."
+      },
+      "CommandJobLimits": {
+        "type": "object",
+        "required": [
+          "jobLimitsType"
+        ],
+        "properties": {
+          "jobLimitsType": {
+            "type": "string",
+            "enum": [
+              "Command"
+            ],
+            "description": "JobLimit type."
+          },
+          "timeout": {
+            "type": "string",
+            "format": "duration",
+            "description": "The max run duration, after which the job will be cancelled."
+          }
+        },
+        "description": "Command Job limit class."
+      },
       "CompletionMessageToolCallChunk": {
         "type": "object",
         "required": [
@@ -34694,6 +35603,28 @@
             "Routines=V2Preview"
           ]
         }
+      },
+      "DistributionConfiguration": {
+        "type": "object",
+        "required": [
+          "distributionType"
+        ],
+        "properties": {
+          "distributionType": {
+            "type": "string",
+            "description": "Specifies the type of distribution framework."
+          }
+        },
+        "discriminator": {
+          "propertyName": "distributionType",
+          "mapping": {
+            "PyTorch": "#/components/schemas/PyTorchDistribution",
+            "Mpi": "#/components/schemas/MpiDistribution",
+            "TensorFlow": "#/components/schemas/TensorFlowDistribution",
+            "Ray": "#/components/schemas/RayDistribution"
+          }
+        },
+        "description": "Distribution configuration of the job."
       },
       "EndpointBasedEvaluatorDefinition": {
         "type": "object",
@@ -37667,6 +38598,49 @@
         },
         "description": "Index resource Definition"
       },
+      "Input": {
+        "type": "object",
+        "required": [
+          "jobInputType"
+        ],
+        "properties": {
+          "jobInputType": {
+            "$ref": "#/components/schemas/AssetTypes",
+            "description": "Specifies the type of job input."
+          },
+          "uri": {
+            "type": "string",
+            "description": "Input Asset URI."
+          },
+          "mode": {
+            "$ref": "#/components/schemas/InputOutputModes",
+            "description": "Input Asset Delivery Mode."
+          },
+          "value": {
+            "type": "string",
+            "description": "Literal value for literal-type inputs."
+          }
+        },
+        "description": "Job input definition."
+      },
+      "InputOutputModes": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "ReadOnlyMount",
+              "ReadWriteMount",
+              "Download",
+              "Direct",
+              "Upload"
+            ]
+          }
+        ],
+        "description": "Enum to determine the input/output data delivery mode."
+      },
       "Insight": {
         "type": "object",
         "required": [
@@ -38199,6 +39173,143 @@
         ],
         "description": "The types of parameters for red team item generation."
       },
+      "Job": {
+        "type": "object",
+        "required": [
+          "name",
+          "properties"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name of the Job. This is case-sensitive.",
+            "readOnly": true
+          },
+          "id": {
+            "type": "string",
+            "description": "The resource ID.",
+            "readOnly": true
+          },
+          "type": {
+            "type": "string",
+            "description": "The resource type.",
+            "readOnly": true
+          },
+          "properties": {
+            "$ref": "#/components/schemas/JobProperties",
+            "description": "Properties of the job."
+          },
+          "systemData": {
+            "$ref": "#/components/schemas/SystemData",
+            "description": "Metadata pertaining to creation and last modification of the resource.",
+            "readOnly": true
+          }
+        },
+        "description": "Job resource."
+      },
+      "JobPriority": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "Low",
+              "Mid",
+              "High"
+            ]
+          }
+        ],
+        "description": "User-visible scheduling priority for a job."
+      },
+      "JobProperties": {
+        "type": "object",
+        "required": [
+          "jobType"
+        ],
+        "properties": {
+          "jobType": {
+            "type": "string",
+            "description": "Job type."
+          }
+        },
+        "discriminator": {
+          "propertyName": "jobType",
+          "mapping": {
+            "Command": "#/components/schemas/CommandJob"
+          }
+        },
+        "description": "Base properties of a Job."
+      },
+      "JobResourceConfiguration": {
+        "type": "object",
+        "properties": {
+          "instanceCount": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Optional number of instances or nodes used by the compute target."
+          },
+          "instanceType": {
+            "type": "string",
+            "description": "Optional type of VM used as supported by the compute target."
+          },
+          "properties": {
+            "type": "object",
+            "unevaluatedProperties": {},
+            "description": "Additional properties bag."
+          },
+          "shmSize": {
+            "type": "string",
+            "description": "Size of the docker container's shared memory block."
+          },
+          "dockerArgs": {
+            "type": "string",
+            "description": "Extra arguments to pass to the Docker run command."
+          }
+        },
+        "description": "Compute Resource configuration for the job."
+      },
+      "JobService": {
+        "type": "object",
+        "properties": {
+          "jobServiceType": {
+            "type": "string",
+            "description": "Endpoint type."
+          },
+          "port": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Port for endpoint."
+          },
+          "endpoint": {
+            "type": "string",
+            "description": "Url for endpoint."
+          },
+          "properties": {
+            "type": "object",
+            "unevaluatedProperties": {
+              "type": "string"
+            },
+            "description": "Additional properties to set on the endpoint."
+          },
+          "nodes": {
+            "$ref": "#/components/schemas/AllNodes",
+            "description": "Nodes that user would like to start the service on."
+          },
+          "status": {
+            "type": "string",
+            "description": "Status of endpoint.",
+            "readOnly": true
+          },
+          "errorMessage": {
+            "type": "string",
+            "description": "Any error in the service.",
+            "readOnly": true
+          }
+        },
+        "description": "Job endpoint definition."
+      },
       "JobStatus": {
         "anyOf": [
           {
@@ -38216,6 +39327,36 @@
           }
         ],
         "description": "Extensible status values shared by Foundry jobs."
+      },
+      "JobType": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "Command"
+            ]
+          }
+        ],
+        "description": "Type of a job."
+      },
+      "ListViewType": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "ActiveOnly",
+              "ArchivedOnly",
+              "All"
+            ]
+          }
+        ],
+        "description": "Specifies which jobs to include in a list result based on their lifecycle state."
       },
       "LoraConfig": {
         "type": "object",
@@ -39825,6 +40966,32 @@
           ]
         }
       },
+      "MpiDistribution": {
+        "type": "object",
+        "required": [
+          "distributionType"
+        ],
+        "properties": {
+          "distributionType": {
+            "type": "string",
+            "enum": [
+              "Mpi"
+            ],
+            "description": "Specifies the type of distribution framework."
+          },
+          "processCountPerNode": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Number of processes per MPI node."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/DistributionConfiguration"
+          }
+        ],
+        "description": "MPI distribution configuration."
+      },
       "NoAuthenticationCredentials": {
         "type": "object",
         "required": [
@@ -39846,6 +41013,25 @@
           }
         ],
         "description": "Credentials that do not require authentication"
+      },
+      "NodeCollection": {
+        "type": "object",
+        "required": [
+          "nodesValueType"
+        ],
+        "properties": {
+          "nodesValueType": {
+            "type": "string",
+            "description": "Type of the Nodes value."
+          }
+        },
+        "discriminator": {
+          "propertyName": "nodesValueType",
+          "mapping": {
+            "All": "#/components/schemas/AllNodes"
+          }
+        },
+        "description": "Nodes that user would like to start the service on."
       },
       "OAuthConsentRequestOutputItem": {
         "type": "object",
@@ -77636,6 +78822,43 @@
         ],
         "description": "An OTLP (OpenTelemetry Protocol) telemetry export endpoint."
       },
+      "Output": {
+        "type": "object",
+        "required": [
+          "jobOutputType"
+        ],
+        "properties": {
+          "jobOutputType": {
+            "$ref": "#/components/schemas/AssetTypes",
+            "description": "Specifies the type of job output."
+          },
+          "mode": {
+            "$ref": "#/components/schemas/InputOutputModes",
+            "description": "Output Asset Delivery Mode."
+          },
+          "assetName": {
+            "type": "string",
+            "description": "Name of the output data asset to register."
+          },
+          "assetVersion": {
+            "type": "string",
+            "description": "Version of the output data asset to register."
+          },
+          "uri": {
+            "type": "string",
+            "description": "Output Asset URI."
+          },
+          "baseModelId": {
+            "type": "string",
+            "description": "Base model ID."
+          },
+          "description": {
+            "type": "string",
+            "description": "Description for the output."
+          }
+        },
+        "description": "Job output definition."
+      },
       "PageOrder": {
         "type": "string",
         "enum": [
@@ -77810,6 +79033,27 @@
           }
         },
         "description": "Paged collection of Insight items"
+      },
+      "PagedJob": {
+        "type": "object",
+        "required": [
+          "value"
+        ],
+        "properties": {
+          "value": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Job"
+            },
+            "description": "The Job items on this page"
+          },
+          "nextLink": {
+            "type": "string",
+            "format": "uri",
+            "description": "The link to the next page of items"
+          }
+        },
+        "description": "Paged collection of Job items"
       },
       "PagedModelVersion": {
         "type": "object",
@@ -78296,6 +79540,42 @@
         ],
         "description": "The Microsoft Agent Certification review status of the Microsoft 365 store title published for an agent."
       },
+      "PyTorchDistribution": {
+        "type": "object",
+        "required": [
+          "distributionType"
+        ],
+        "properties": {
+          "distributionType": {
+            "type": "string",
+            "enum": [
+              "PyTorch"
+            ],
+            "description": "Specifies the type of distribution framework."
+          },
+          "processCountPerInstance": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Number of processes per node."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/DistributionConfiguration"
+          }
+        ],
+        "description": "PyTorch distribution configuration."
+      },
+      "QueueSettings": {
+        "type": "object",
+        "properties": {
+          "jobTier": {
+            "type": "string",
+            "description": "Controls the compute job tier."
+          }
+        },
+        "description": "Queue settings for the job."
+      },
       "RaiConfig": {
         "type": "object",
         "required": [
@@ -78308,6 +79588,53 @@
           }
         },
         "description": "Configuration for Responsible AI (RAI) content filtering and safety features."
+      },
+      "RayDistribution": {
+        "type": "object",
+        "required": [
+          "distributionType"
+        ],
+        "properties": {
+          "distributionType": {
+            "type": "string",
+            "enum": [
+              "Ray"
+            ],
+            "description": "Specifies the type of distribution framework."
+          },
+          "port": {
+            "type": "integer",
+            "format": "int32",
+            "description": "The port of the head Ray process."
+          },
+          "address": {
+            "type": "string",
+            "description": "The address of the Ray head node."
+          },
+          "includeDashboard": {
+            "type": "boolean",
+            "description": "Whether to start the Ray dashboard GUI."
+          },
+          "dashboardPort": {
+            "type": "integer",
+            "format": "int32",
+            "description": "The port to bind the dashboard server to."
+          },
+          "headNodeAdditionalArgs": {
+            "type": "string",
+            "description": "Additional arguments passed to ray start on the head node."
+          },
+          "workerNodeAdditionalArgs": {
+            "type": "string",
+            "description": "Additional arguments passed to ray start on worker nodes."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/DistributionConfiguration"
+          }
+        ],
+        "description": "Ray distribution configuration."
       },
       "RecurrenceSchedule": {
         "type": "object",
@@ -80387,6 +81714,44 @@
         ],
         "description": "Represents the parameters for synthetic data generation item generation."
       },
+      "SystemData": {
+        "type": "object",
+        "properties": {
+          "createdBy": {
+            "type": "string",
+            "description": "The identity that created the resource.",
+            "readOnly": true
+          },
+          "createdByType": {
+            "type": "string",
+            "description": "The type of identity that created the resource.",
+            "readOnly": true
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "The timestamp of resource creation (UTC).",
+            "readOnly": true
+          },
+          "lastModifiedBy": {
+            "type": "string",
+            "description": "The identity that last modified the resource.",
+            "readOnly": true
+          },
+          "lastModifiedByType": {
+            "type": "string",
+            "description": "The type of identity that last modified the resource.",
+            "readOnly": true
+          },
+          "lastModifiedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "The timestamp of resource last modification (UTC).",
+            "readOnly": true
+          }
+        },
+        "description": "Metadata pertaining to creation and last modification of the resource."
+      },
       "Target": {
         "type": "object",
         "required": [
@@ -80720,6 +82085,37 @@
           }
         ],
         "description": "The transport protocol for telemetry export."
+      },
+      "TensorFlowDistribution": {
+        "type": "object",
+        "required": [
+          "distributionType"
+        ],
+        "properties": {
+          "distributionType": {
+            "type": "string",
+            "enum": [
+              "TensorFlow"
+            ],
+            "description": "Specifies the type of distribution framework."
+          },
+          "workerCount": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Number of workers."
+          },
+          "parameterServerCount": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Number of parameter server tasks."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/DistributionConfiguration"
+          }
+        ],
+        "description": "TensorFlow distribution configuration."
       },
       "TestingCriterionAzureAIEvaluator": {
         "type": "object",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -4,6 +4,7 @@ info:
   version: v1
 tags:
   - name: Agent Insight Monitors
+  - name: CommandJob
   - name: Responses Root
     description: Responses
   - name: Responses
@@ -6177,6 +6178,370 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Insights
+  /jobs:
+    get:
+      operationId: Jobs_list
+      description: List Jobs.
+      parameters:
+        - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
+        - name: jobType
+          in: query
+          required: false
+          description: Filter by job type (e.g. 'Command').
+          schema:
+            $ref: '#/components/schemas/JobType'
+          explode: false
+        - name: tag
+          in: query
+          required: false
+          description: Filter jobs by tag in the format 'key=value' (e.g., 'framework=pytorch').
+          schema:
+            type: string
+          explode: false
+        - name: listViewType
+          in: query
+          required: false
+          description: Specifies which view type to apply when listing jobs.
+          schema:
+            $ref: '#/components/schemas/ListViewType'
+          explode: false
+        - name: properties
+          in: query
+          required: false
+          description: 'Comma-separated user property names and optionally values. Example: prop1,prop2=value2.'
+          schema:
+            type: string
+          explode: false
+        - name: Foundry-Features
+          in: header
+          required: true
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - Jobs=V1Preview
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PagedJob'
+        default:
+          description: An unexpected error response.
+          headers:
+            x-ms-error-code:
+              required: false
+              description: String error code indicating what went wrong.
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
+      tags:
+        - CommandJob
+  /jobs/{name}:
+    get:
+      operationId: Jobs_get
+      description: Get a Job by name.
+      parameters:
+        - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
+        - name: name
+          in: path
+          required: true
+          description: The name of the Job. This is case-sensitive.
+          schema:
+            type: string
+        - name: Foundry-Features
+          in: header
+          required: true
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - Jobs=V1Preview
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Job'
+        default:
+          description: An unexpected error response.
+          headers:
+            x-ms-error-code:
+              required: false
+              description: String error code indicating what went wrong.
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
+      tags:
+        - CommandJob
+    put:
+      operationId: Jobs_createOrUpdate
+      description: Create and execute a Job. For update case, the Tags in the definition passed in will replace Tags in the existing job.
+      parameters:
+        - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
+        - name: name
+          in: path
+          required: true
+          description: The name of the Job. This is case-sensitive.
+          schema:
+            type: string
+        - name: Foundry-Features
+          in: header
+          required: true
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - Jobs=V1Preview
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Job'
+        '201':
+          description: The request has succeeded and a new resource has been created as a result.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Job'
+        default:
+          description: An unexpected error response.
+          headers:
+            x-ms-error-code:
+              required: false
+              description: String error code indicating what went wrong.
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
+      tags:
+        - CommandJob
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Job'
+        description: The job to create or update.
+    delete:
+      operationId: Jobs_beginDelete
+      description: Delete a Job by name. Returns 202 Accepted with a Location header to poll for completion, or 204 if the job does not exist.
+      parameters:
+        - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
+        - name: name
+          in: path
+          required: true
+          description: The name of the Job. This is case-sensitive.
+          schema:
+            type: string
+        - name: Foundry-Features
+          in: header
+          required: true
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - Jobs=V1Preview
+      responses:
+        '202':
+          description: Response returned when a job delete operation is accepted asynchronously.
+          headers:
+            Location:
+              required: true
+              description: URL to poll for the status of the delete operation.
+              schema:
+                type: string
+            Retry-After:
+              required: false
+              description: Suggested delay in seconds before polling.
+              schema:
+                type: integer
+                format: int32
+        '204':
+          description: There is no content to send for this request, but the headers may be useful.
+        default:
+          description: An unexpected error response.
+          headers:
+            x-ms-error-code:
+              required: false
+              description: String error code indicating what went wrong.
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
+      tags:
+        - CommandJob
+  /jobs/{name}/artifacts:
+    get:
+      operationId: Jobs_listArtifacts
+      description: List the artifacts produced by a job, including its log files. Logs are ordinary artifacts stored under the well-known `azureml-logs/`, `user_logs/` and `system_logs/` path prefixes, so they are retrieved by filtering on `path`.
+      parameters:
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+        - name: Foundry-Features
+          in: header
+          required: true
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - Jobs=V1Preview
+        - name: name
+          in: path
+          required: true
+          description: The name of the Job.
+          schema:
+            type: string
+        - name: path
+          in: query
+          required: false
+          description: Optional artifact path or path prefix to filter by.
+          schema:
+            type: string
+          explode: false
+        - name: continuationToken
+          in: query
+          required: false
+          description: Continuation token for the next page.
+          schema:
+            type: string
+          explode: false
+        - name: pageSize
+          in: query
+          required: false
+          description: Maximum number of artifacts per page.
+          schema:
+            type: integer
+            format: int32
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ArtifactList'
+      tags:
+        - CommandJob
+  /jobs/{name}/artifacts/contentinfo:
+    get:
+      operationId: Jobs_getArtifactContentInformation
+      description: Get content information, including a readable content URI and byte length, for the artifacts produced by a job. Use this to download artifact or log content.
+      parameters:
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+        - name: Foundry-Features
+          in: header
+          required: true
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - Jobs=V1Preview
+        - name: name
+          in: path
+          required: true
+          description: The name of the Job.
+          schema:
+            type: string
+        - name: path
+          in: query
+          required: false
+          description: Optional artifact path prefix to filter by.
+          schema:
+            type: string
+          explode: false
+        - name: continuationToken
+          in: query
+          required: false
+          description: Continuation token for the next page.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ArtifactContentInformationList'
+      tags:
+        - CommandJob
+  /jobs/{name}/cancel:
+    post:
+      operationId: Jobs_beginCancel
+      description: Cancel a Job by name. Returns 200 if cancelled immediately, or 202 Accepted with a Location header to poll for completion.
+      parameters:
+        - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
+        - name: name
+          in: path
+          required: true
+          description: The name of the Job. This is case-sensitive.
+          schema:
+            type: string
+        - name: Foundry-Features
+          in: header
+          required: true
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - Jobs=V1Preview
+      responses:
+        '200':
+          description: The request has succeeded.
+        '202':
+          description: Response returned when a job cancel operation is accepted asynchronously.
+          headers:
+            Location:
+              required: true
+              description: URL to poll for the status of the cancel operation.
+              schema:
+                type: string
+            Retry-After:
+              required: false
+              description: Suggested delay in seconds before polling.
+              schema:
+                type: integer
+                format: int32
+        default:
+          description: An unexpected error response.
+          headers:
+            x-ms-error-code:
+              required: false
+              description: String error code indicating what went wrong.
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
+      tags:
+        - CommandJob
   /memory_stores:
     post:
       operationId: createMemoryStore
@@ -40809,6 +41174,19 @@ components:
       allOf:
         - $ref: '#/components/schemas/BaseCredentials'
       description: Agentic identity credential definition
+    AllNodes:
+      type: object
+      required:
+        - nodesValueType
+      properties:
+        nodesValueType:
+          type: string
+          enum:
+            - All
+          description: Type of the Nodes value.
+      allOf:
+        - $ref: '#/components/schemas/NodeCollection'
+      description: All nodes means the service will be running on all of the nodes of the job.
     ApiErrorResponse:
       type: object
       required:
@@ -40835,6 +41213,113 @@ components:
       allOf:
         - $ref: '#/components/schemas/BaseCredentials'
       description: API Key Credential definition
+    Artifact:
+      type: object
+      required:
+        - origin
+        - container
+        - path
+      properties:
+        artifactId:
+          type: string
+          description: The artifact id.
+        origin:
+          type: string
+          description: The artifact origin.
+        container:
+          type: string
+          description: The container name.
+        path:
+          type: string
+          description: The artifact path.
+        etag:
+          type: string
+          description: The artifact Etag.
+        createdTime:
+          type: string
+          format: date-time
+          description: The artifact creation time in UTC.
+        dataPath:
+          $ref: '#/components/schemas/ArtifactDataPath'
+          description: The artifact data path.
+        tags:
+          type: object
+          unevaluatedProperties:
+            type: string
+          description: The artifact tags.
+      description: An artifact.
+    ArtifactContentInformation:
+      type: object
+      properties:
+        contentUri:
+          type: string
+          format: uri
+          description: The content URI.
+        origin:
+          type: string
+          description: The artifact origin.
+        container:
+          type: string
+          description: The container name.
+        path:
+          type: string
+          description: The artifact path.
+        tags:
+          type: object
+          unevaluatedProperties:
+            type: string
+          description: The artifact tags.
+        contentLength:
+          type: integer
+          format: int64
+          description: The content byte length.
+      description: Artifact content information.
+    ArtifactContentInformationList:
+      type: object
+      required:
+        - value
+      properties:
+        value:
+          type: array
+          items:
+            $ref: '#/components/schemas/ArtifactContentInformation'
+          description: The entries in the page.
+        continuationToken:
+          type: string
+          description: Token for the next page.
+        nextLink:
+          type: string
+          description: URL for the next page.
+      description: A page of artifact content information.
+    ArtifactDataPath:
+      type: object
+      properties:
+        dataStoreName:
+          type: string
+          description: The data store name.
+        relativePath:
+          type: string
+          description: The relative path within the data store.
+        sqlDataPath:
+          description: SQL data path information.
+      description: A data store path.
+    ArtifactList:
+      type: object
+      required:
+        - value
+      properties:
+        value:
+          type: array
+          items:
+            $ref: '#/components/schemas/Artifact'
+          description: The artifacts in the page.
+        continuationToken:
+          type: string
+          description: Token for the next page.
+        nextLink:
+          type: string
+          description: URL for the next page.
+      description: A page of artifacts.
     ArtifactProfile:
       type: object
       required:
@@ -40864,6 +41349,16 @@ components:
     AssetId:
       type: string
       description: Identifier of a saved asset.
+    AssetTypes:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - uri_file
+            - uri_folder
+            - safetensors_model
+            - literal
+      description: Type of job input/output asset.
     AttackStrategy:
       anyOf:
         - type: string
@@ -42389,6 +42884,121 @@ components:
       allOf:
         - $ref: '#/components/schemas/ToolboxTool'
       description: A code interpreter tool stored in a toolbox.
+    CommandJob:
+      type: object
+      required:
+        - jobType
+        - command
+        - environmentImageReference
+        - computeId
+      properties:
+        jobType:
+          type: string
+          enum:
+            - Command
+          description: Job type.
+        command:
+          type: string
+          description: The command to execute on startup of the job.
+        environmentImageReference:
+          type: string
+          description: ACR path of environment.
+        displayName:
+          type: string
+          description: Display name of job.
+        description:
+          type: string
+          description: The asset description text.
+        experimentName:
+          type: string
+          description: The name of the experiment the job belongs to. If not set, the job is placed in the "Default" experiment.
+        tags:
+          type: object
+          unevaluatedProperties:
+            type: string
+          description: Tag dictionary. Tags can be added, removed, and updated.
+        properties:
+          type: object
+          unevaluatedProperties:
+            type: string
+          description: The asset property dictionary.
+        codeId:
+          type: string
+          description: Code asset reference.
+        computeId:
+          type: string
+          description: Compute resource ID.
+        inputs:
+          type: object
+          unevaluatedProperties:
+            $ref: '#/components/schemas/Input'
+          description: Mapping of input data bindings used in the job.
+        outputs:
+          type: object
+          unevaluatedProperties:
+            $ref: '#/components/schemas/Output'
+          description: Mapping of output data bindings used in the job.
+        environmentVariables:
+          type: object
+          unevaluatedProperties:
+            type: string
+          description: Environment variables included in the job.
+        resources:
+          $ref: '#/components/schemas/JobResourceConfiguration'
+          description: Compute Resource configuration for the job.
+        distribution:
+          $ref: '#/components/schemas/DistributionConfiguration'
+          description: Distribution configuration of the job.
+        limits:
+          $ref: '#/components/schemas/CommandJobLimits'
+          description: Command Job limit.
+        services:
+          type: object
+          unevaluatedProperties:
+            $ref: '#/components/schemas/JobService'
+          description: List of job services.
+        queueSettings:
+          $ref: '#/components/schemas/QueueSettings'
+          description: Queue settings for the job.
+        priority:
+          $ref: '#/components/schemas/JobPriority'
+          description: User-visible scheduling priority for the job.
+        userAssignedIdentityId:
+          type: string
+          description: user-assigned managed identity
+        capacityUnitCount:
+          type: integer
+          format: int32
+          description: Number of capacity units to allocate for the job. When set, the service resolves the VM SKU from the compute target and calculates the required node count automatically. Virtual cluster targets must also specify `resources.instanceType`. Valid values are 1, 2, 4, 8, or any multiple of 8 for values greater than 8. `gpuCount` takes precedence over this property when both are supplied.
+        gpuCount:
+          type: integer
+          format: int32
+          description: Number of GPUs to allocate for the job. Takes precedence over `capacityUnitCount` when both are supplied, and is used to resolve a partial (sub-node) VM SKU for GPU computes. Only applies to GPU computes; CPU computes always resolve to a full-node SKU and ignore this value. Valid values are 1, 2, 4, 8, or any multiple of 8 for values greater than 8.
+        isArchived:
+          type: boolean
+          description: Is the asset archived?
+        status:
+          type: string
+          description: Status of the job.
+          readOnly: true
+      allOf:
+        - $ref: '#/components/schemas/JobProperties'
+      description: Properties of a Command Job.
+    CommandJobLimits:
+      type: object
+      required:
+        - jobLimitsType
+      properties:
+        jobLimitsType:
+          type: string
+          enum:
+            - Command
+          description: JobLimit type.
+        timeout:
+          type: string
+          format: duration
+          description: The max run duration, after which the job will be cancelled.
+      description: Command Job limit class.
     CompletionMessageToolCallChunk:
       type: object
       required:
@@ -43777,6 +44387,22 @@ components:
       x-ms-foundry-meta:
         conditional_previews:
           - Routines=V2Preview
+    DistributionConfiguration:
+      type: object
+      required:
+        - distributionType
+      properties:
+        distributionType:
+          type: string
+          description: Specifies the type of distribution framework.
+      discriminator:
+        propertyName: distributionType
+        mapping:
+          PyTorch: '#/components/schemas/PyTorchDistribution'
+          Mpi: '#/components/schemas/MpiDistribution'
+          TensorFlow: '#/components/schemas/TensorFlowDistribution'
+          Ray: '#/components/schemas/RayDistribution'
+      description: Distribution configuration of the job.
     EndpointBasedEvaluatorDefinition:
       type: object
       required:
@@ -46058,6 +46684,35 @@ components:
           ManagedAzureSearch: '#/components/schemas/ManagedAzureAISearchIndexUpdate'
           CosmosDBNoSqlVectorStore: '#/components/schemas/CosmosDBIndexUpdate'
       description: Index resource Definition
+    Input:
+      type: object
+      required:
+        - jobInputType
+      properties:
+        jobInputType:
+          $ref: '#/components/schemas/AssetTypes'
+          description: Specifies the type of job input.
+        uri:
+          type: string
+          description: Input Asset URI.
+        mode:
+          $ref: '#/components/schemas/InputOutputModes'
+          description: Input Asset Delivery Mode.
+        value:
+          type: string
+          description: Literal value for literal-type inputs.
+      description: Job input definition.
+    InputOutputModes:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - ReadOnlyMount
+            - ReadWriteMount
+            - Download
+            - Direct
+            - Upload
+      description: Enum to determine the input/output data delivery mode.
     Insight:
       type: object
       required:
@@ -46429,6 +47084,105 @@ components:
             - conversation_gen_preview
             - target_completion
       description: The types of parameters for red team item generation.
+    Job:
+      type: object
+      required:
+        - name
+        - properties
+      properties:
+        name:
+          type: string
+          description: The name of the Job. This is case-sensitive.
+          readOnly: true
+        id:
+          type: string
+          description: The resource ID.
+          readOnly: true
+        type:
+          type: string
+          description: The resource type.
+          readOnly: true
+        properties:
+          $ref: '#/components/schemas/JobProperties'
+          description: Properties of the job.
+        systemData:
+          $ref: '#/components/schemas/SystemData'
+          description: Metadata pertaining to creation and last modification of the resource.
+          readOnly: true
+      description: Job resource.
+    JobPriority:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - Low
+            - Mid
+            - High
+      description: User-visible scheduling priority for a job.
+    JobProperties:
+      type: object
+      required:
+        - jobType
+      properties:
+        jobType:
+          type: string
+          description: Job type.
+      discriminator:
+        propertyName: jobType
+        mapping:
+          Command: '#/components/schemas/CommandJob'
+      description: Base properties of a Job.
+    JobResourceConfiguration:
+      type: object
+      properties:
+        instanceCount:
+          type: integer
+          format: int32
+          description: Optional number of instances or nodes used by the compute target.
+        instanceType:
+          type: string
+          description: Optional type of VM used as supported by the compute target.
+        properties:
+          type: object
+          unevaluatedProperties: {}
+          description: Additional properties bag.
+        shmSize:
+          type: string
+          description: Size of the docker container's shared memory block.
+        dockerArgs:
+          type: string
+          description: Extra arguments to pass to the Docker run command.
+      description: Compute Resource configuration for the job.
+    JobService:
+      type: object
+      properties:
+        jobServiceType:
+          type: string
+          description: Endpoint type.
+        port:
+          type: integer
+          format: int32
+          description: Port for endpoint.
+        endpoint:
+          type: string
+          description: Url for endpoint.
+        properties:
+          type: object
+          unevaluatedProperties:
+            type: string
+          description: Additional properties to set on the endpoint.
+        nodes:
+          $ref: '#/components/schemas/AllNodes'
+          description: Nodes that user would like to start the service on.
+        status:
+          type: string
+          description: Status of endpoint.
+          readOnly: true
+        errorMessage:
+          type: string
+          description: Any error in the service.
+          readOnly: true
+      description: Job endpoint definition.
     JobStatus:
       anyOf:
         - type: string
@@ -46440,6 +47194,22 @@ components:
             - failed
             - cancelled
       description: Extensible status values shared by Foundry jobs.
+    JobType:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - Command
+      description: Type of a job.
+    ListViewType:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - ActiveOnly
+            - ArchivedOnly
+            - All
+      description: Specifies which jobs to include in a list result based on their lifecycle state.
     LoraConfig:
       type: object
       properties:
@@ -47598,6 +48368,23 @@ components:
       x-ms-foundry-meta:
         required_previews:
           - Schedules=V1Preview
+    MpiDistribution:
+      type: object
+      required:
+        - distributionType
+      properties:
+        distributionType:
+          type: string
+          enum:
+            - Mpi
+          description: Specifies the type of distribution framework.
+        processCountPerNode:
+          type: integer
+          format: int32
+          description: Number of processes per MPI node.
+      allOf:
+        - $ref: '#/components/schemas/DistributionConfiguration'
+      description: MPI distribution configuration.
     NoAuthenticationCredentials:
       type: object
       required:
@@ -47612,6 +48399,19 @@ components:
       allOf:
         - $ref: '#/components/schemas/BaseCredentials'
       description: Credentials that do not require authentication
+    NodeCollection:
+      type: object
+      required:
+        - nodesValueType
+      properties:
+        nodesValueType:
+          type: string
+          description: Type of the Nodes value.
+      discriminator:
+        propertyName: nodesValueType
+        mapping:
+          All: '#/components/schemas/AllNodes'
+      description: Nodes that user would like to start the service on.
     OAuthConsentRequestOutputItem:
       type: object
       required:
@@ -75049,6 +75849,33 @@ components:
       allOf:
         - $ref: '#/components/schemas/TelemetryEndpoint'
       description: An OTLP (OpenTelemetry Protocol) telemetry export endpoint.
+    Output:
+      type: object
+      required:
+        - jobOutputType
+      properties:
+        jobOutputType:
+          $ref: '#/components/schemas/AssetTypes'
+          description: Specifies the type of job output.
+        mode:
+          $ref: '#/components/schemas/InputOutputModes'
+          description: Output Asset Delivery Mode.
+        assetName:
+          type: string
+          description: Name of the output data asset to register.
+        assetVersion:
+          type: string
+          description: Version of the output data asset to register.
+        uri:
+          type: string
+          description: Output Asset URI.
+        baseModelId:
+          type: string
+          description: Base model ID.
+        description:
+          type: string
+          description: Description for the output.
+      description: Job output definition.
     PageOrder:
       type: string
       enum:
@@ -75174,6 +76001,21 @@ components:
           format: uri
           description: The link to the next page of items
       description: Paged collection of Insight items
+    PagedJob:
+      type: object
+      required:
+        - value
+      properties:
+        value:
+          type: array
+          items:
+            $ref: '#/components/schemas/Job'
+          description: The Job items on this page
+        nextLink:
+          type: string
+          format: uri
+          description: The link to the next page of items
+      description: Paged collection of Job items
     PagedModelVersion:
       type: object
       required:
@@ -75507,6 +76349,30 @@ components:
             - rejected
             - no_approval_needed
       description: The Microsoft Agent Certification review status of the Microsoft 365 store title published for an agent.
+    PyTorchDistribution:
+      type: object
+      required:
+        - distributionType
+      properties:
+        distributionType:
+          type: string
+          enum:
+            - PyTorch
+          description: Specifies the type of distribution framework.
+        processCountPerInstance:
+          type: integer
+          format: int32
+          description: Number of processes per node.
+      allOf:
+        - $ref: '#/components/schemas/DistributionConfiguration'
+      description: PyTorch distribution configuration.
+    QueueSettings:
+      type: object
+      properties:
+        jobTier:
+          type: string
+          description: Controls the compute job tier.
+      description: Queue settings for the job.
     RaiConfig:
       type: object
       required:
@@ -75516,6 +76382,39 @@ components:
           type: string
           description: The name of the RAI policy to apply.
       description: Configuration for Responsible AI (RAI) content filtering and safety features.
+    RayDistribution:
+      type: object
+      required:
+        - distributionType
+      properties:
+        distributionType:
+          type: string
+          enum:
+            - Ray
+          description: Specifies the type of distribution framework.
+        port:
+          type: integer
+          format: int32
+          description: The port of the head Ray process.
+        address:
+          type: string
+          description: The address of the Ray head node.
+        includeDashboard:
+          type: boolean
+          description: Whether to start the Ray dashboard GUI.
+        dashboardPort:
+          type: integer
+          format: int32
+          description: The port to bind the dashboard server to.
+        headNodeAdditionalArgs:
+          type: string
+          description: Additional arguments passed to ray start on the head node.
+        workerNodeAdditionalArgs:
+          type: string
+          description: Additional arguments passed to ray start on worker nodes.
+      allOf:
+        - $ref: '#/components/schemas/DistributionConfiguration'
+      description: Ray distribution configuration.
     RecurrenceSchedule:
       type: object
       required:
@@ -76962,6 +77861,36 @@ components:
       allOf:
         - $ref: '#/components/schemas/ItemGenerationParams'
       description: Represents the parameters for synthetic data generation item generation.
+    SystemData:
+      type: object
+      properties:
+        createdBy:
+          type: string
+          description: The identity that created the resource.
+          readOnly: true
+        createdByType:
+          type: string
+          description: The type of identity that created the resource.
+          readOnly: true
+        createdAt:
+          type: string
+          format: date-time
+          description: The timestamp of resource creation (UTC).
+          readOnly: true
+        lastModifiedBy:
+          type: string
+          description: The identity that last modified the resource.
+          readOnly: true
+        lastModifiedByType:
+          type: string
+          description: The type of identity that last modified the resource.
+          readOnly: true
+        lastModifiedAt:
+          type: string
+          format: date-time
+          description: The timestamp of resource last modification (UTC).
+          readOnly: true
+      description: Metadata pertaining to creation and last modification of the resource.
     Target:
       type: object
       required:
@@ -77183,6 +78112,27 @@ components:
             - Http
             - Grpc
       description: The transport protocol for telemetry export.
+    TensorFlowDistribution:
+      type: object
+      required:
+        - distributionType
+      properties:
+        distributionType:
+          type: string
+          enum:
+            - TensorFlow
+          description: Specifies the type of distribution framework.
+        workerCount:
+          type: integer
+          format: int32
+          description: Number of workers.
+        parameterServerCount:
+          type: integer
+          format: int32
+          description: Number of parameter server tasks.
+      allOf:
+        - $ref: '#/components/schemas/DistributionConfiguration'
+      description: TensorFlow distribution configuration.
     TestingCriterionAzureAIEvaluator:
       type: object
       required:

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -21,6 +21,9 @@
       "name": "EvaluationSuiteGenerationJobs"
     },
     {
+      "name": "CommandJob"
+    },
+    {
       "name": "Responses Root",
       "description": "Responses"
     },
@@ -13446,6 +13449,569 @@
         },
         "tags": [
           "Insights"
+        ]
+      }
+    },
+    "/jobs": {
+      "get": {
+        "operationId": "Jobs_list",
+        "description": "List Jobs.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "jobType",
+            "in": "query",
+            "required": false,
+            "description": "Filter by job type (e.g. 'Command').",
+            "schema": {
+              "$ref": "#/components/schemas/JobType"
+            },
+            "explode": false
+          },
+          {
+            "name": "tag",
+            "in": "query",
+            "required": false,
+            "description": "Filter jobs by tag in the format 'key=value' (e.g., 'framework=pytorch').",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "listViewType",
+            "in": "query",
+            "required": false,
+            "description": "Specifies which view type to apply when listing jobs.",
+            "schema": {
+              "$ref": "#/components/schemas/ListViewType"
+            },
+            "explode": false
+          },
+          {
+            "name": "properties",
+            "in": "query",
+            "required": false,
+            "description": "Comma-separated user property names and optionally values. Example: prop1,prop2=value2.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Jobs=V1Preview"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedJob"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "headers": {
+              "x-ms-error-code": {
+                "required": false,
+                "description": "String error code indicating what went wrong.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "CommandJob"
+        ]
+      }
+    },
+    "/jobs/{name}": {
+      "get": {
+        "operationId": "Jobs_get",
+        "description": "Get a Job by name.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "description": "The name of the Job. This is case-sensitive.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Jobs=V1Preview"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Job"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "headers": {
+              "x-ms-error-code": {
+                "required": false,
+                "description": "String error code indicating what went wrong.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "CommandJob"
+        ]
+      },
+      "put": {
+        "operationId": "Jobs_createOrUpdate",
+        "description": "Create and execute a Job. For update case, the Tags in the definition passed in will replace Tags in the existing job.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "description": "The name of the Job. This is case-sensitive.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Jobs=V1Preview"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Job"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "The request has succeeded and a new resource has been created as a result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Job"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "headers": {
+              "x-ms-error-code": {
+                "required": false,
+                "description": "String error code indicating what went wrong.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "CommandJob"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Job"
+              }
+            }
+          },
+          "description": "The job to create or update."
+        }
+      },
+      "delete": {
+        "operationId": "Jobs_beginDelete",
+        "description": "Delete a Job by name. Returns 202 Accepted with a Location header to poll for completion, or 204 if the job does not exist.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "description": "The name of the Job. This is case-sensitive.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Jobs=V1Preview"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Response returned when a job delete operation is accepted asynchronously.",
+            "headers": {
+              "Location": {
+                "required": true,
+                "description": "URL to poll for the status of the delete operation.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Retry-After": {
+                "required": false,
+                "description": "Suggested delay in seconds before polling.",
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "There is no content to send for this request, but the headers may be useful."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "headers": {
+              "x-ms-error-code": {
+                "required": false,
+                "description": "String error code indicating what went wrong.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "CommandJob"
+        ]
+      }
+    },
+    "/jobs/{name}/artifacts": {
+      "get": {
+        "operationId": "Jobs_listArtifacts",
+        "description": "List the artifacts produced by a job, including its log files. Logs are ordinary artifacts stored under the well-known `azureml-logs/`, `user_logs/` and `system_logs/` path prefixes, so they are retrieved by filtering on `path`.",
+        "parameters": [
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Jobs=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "description": "The name of the Job.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "path",
+            "in": "query",
+            "required": false,
+            "description": "Optional artifact path or path prefix to filter by.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "continuationToken",
+            "in": "query",
+            "required": false,
+            "description": "Continuation token for the next page.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of artifacts per page.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ArtifactList"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "CommandJob"
+        ]
+      }
+    },
+    "/jobs/{name}/artifacts/contentinfo": {
+      "get": {
+        "operationId": "Jobs_getArtifactContentInformation",
+        "description": "Get content information, including a readable content URI and byte length, for the artifacts produced by a job. Use this to download artifact or log content.",
+        "parameters": [
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Jobs=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "description": "The name of the Job.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "path",
+            "in": "query",
+            "required": false,
+            "description": "Optional artifact path prefix to filter by.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "continuationToken",
+            "in": "query",
+            "required": false,
+            "description": "Continuation token for the next page.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ArtifactContentInformationList"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "CommandJob"
+        ]
+      }
+    },
+    "/jobs/{name}/cancel": {
+      "post": {
+        "operationId": "Jobs_beginCancel",
+        "description": "Cancel a Job by name. Returns 200 if cancelled immediately, or 202 Accepted with a Location header to poll for completion.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "description": "The name of the Job. This is case-sensitive.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Jobs=V1Preview"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded."
+          },
+          "202": {
+            "description": "Response returned when a job cancel operation is accepted asynchronously.",
+            "headers": {
+              "Location": {
+                "required": true,
+                "description": "URL to poll for the status of the cancel operation.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Retry-After": {
+                "required": false,
+                "description": "Suggested delay in seconds before polling.",
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "headers": {
+              "x-ms-error-code": {
+                "required": false,
+                "description": "String error code indicating what went wrong.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "CommandJob"
         ]
       }
     },
@@ -36351,6 +36917,27 @@
         ],
         "description": "Agentic identity credential definition"
       },
+      "AllNodes": {
+        "type": "object",
+        "required": [
+          "nodesValueType"
+        ],
+        "properties": {
+          "nodesValueType": {
+            "type": "string",
+            "enum": [
+              "All"
+            ],
+            "description": "Type of the Nodes value."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/NodeCollection"
+          }
+        ],
+        "description": "All nodes means the service will be running on all of the nodes of the job."
+      },
       "ApiErrorResponse": {
         "type": "object",
         "required": [
@@ -36389,6 +36976,153 @@
           }
         ],
         "description": "API Key Credential definition"
+      },
+      "Artifact": {
+        "type": "object",
+        "required": [
+          "origin",
+          "container",
+          "path"
+        ],
+        "properties": {
+          "artifactId": {
+            "type": "string",
+            "description": "The artifact id."
+          },
+          "origin": {
+            "type": "string",
+            "description": "The artifact origin."
+          },
+          "container": {
+            "type": "string",
+            "description": "The container name."
+          },
+          "path": {
+            "type": "string",
+            "description": "The artifact path."
+          },
+          "etag": {
+            "type": "string",
+            "description": "The artifact Etag."
+          },
+          "createdTime": {
+            "type": "string",
+            "format": "date-time",
+            "description": "The artifact creation time in UTC."
+          },
+          "dataPath": {
+            "$ref": "#/components/schemas/ArtifactDataPath",
+            "description": "The artifact data path."
+          },
+          "tags": {
+            "type": "object",
+            "unevaluatedProperties": {
+              "type": "string"
+            },
+            "description": "The artifact tags."
+          }
+        },
+        "description": "An artifact."
+      },
+      "ArtifactContentInformation": {
+        "type": "object",
+        "properties": {
+          "contentUri": {
+            "type": "string",
+            "format": "uri",
+            "description": "The content URI."
+          },
+          "origin": {
+            "type": "string",
+            "description": "The artifact origin."
+          },
+          "container": {
+            "type": "string",
+            "description": "The container name."
+          },
+          "path": {
+            "type": "string",
+            "description": "The artifact path."
+          },
+          "tags": {
+            "type": "object",
+            "unevaluatedProperties": {
+              "type": "string"
+            },
+            "description": "The artifact tags."
+          },
+          "contentLength": {
+            "type": "integer",
+            "format": "int64",
+            "description": "The content byte length."
+          }
+        },
+        "description": "Artifact content information."
+      },
+      "ArtifactContentInformationList": {
+        "type": "object",
+        "required": [
+          "value"
+        ],
+        "properties": {
+          "value": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ArtifactContentInformation"
+            },
+            "description": "The entries in the page."
+          },
+          "continuationToken": {
+            "type": "string",
+            "description": "Token for the next page."
+          },
+          "nextLink": {
+            "type": "string",
+            "description": "URL for the next page."
+          }
+        },
+        "description": "A page of artifact content information."
+      },
+      "ArtifactDataPath": {
+        "type": "object",
+        "properties": {
+          "dataStoreName": {
+            "type": "string",
+            "description": "The data store name."
+          },
+          "relativePath": {
+            "type": "string",
+            "description": "The relative path within the data store."
+          },
+          "sqlDataPath": {
+            "description": "SQL data path information."
+          }
+        },
+        "description": "A data store path."
+      },
+      "ArtifactList": {
+        "type": "object",
+        "required": [
+          "value"
+        ],
+        "properties": {
+          "value": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Artifact"
+            },
+            "description": "The artifacts in the page."
+          },
+          "continuationToken": {
+            "type": "string",
+            "description": "Token for the next page."
+          },
+          "nextLink": {
+            "type": "string",
+            "description": "URL for the next page."
+          }
+        },
+        "description": "A page of artifacts."
       },
       "ArtifactProfile": {
         "type": "object",
@@ -36431,6 +37165,23 @@
       "AssetId": {
         "type": "string",
         "description": "Identifier of a saved asset."
+      },
+      "AssetTypes": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "uri_file",
+              "uri_folder",
+              "safetensors_model",
+              "literal"
+            ]
+          }
+        ],
+        "description": "Type of job input/output asset."
       },
       "AssistantMessage": {
         "type": "object",
@@ -38633,6 +39384,164 @@
         ],
         "description": "A code interpreter tool stored in a toolbox."
       },
+      "CommandJob": {
+        "type": "object",
+        "required": [
+          "jobType",
+          "command",
+          "environmentImageReference",
+          "computeId"
+        ],
+        "properties": {
+          "jobType": {
+            "type": "string",
+            "enum": [
+              "Command"
+            ],
+            "description": "Job type."
+          },
+          "command": {
+            "type": "string",
+            "description": "The command to execute on startup of the job."
+          },
+          "environmentImageReference": {
+            "type": "string",
+            "description": "ACR path of environment."
+          },
+          "displayName": {
+            "type": "string",
+            "description": "Display name of job."
+          },
+          "description": {
+            "type": "string",
+            "description": "The asset description text."
+          },
+          "experimentName": {
+            "type": "string",
+            "description": "The name of the experiment the job belongs to. If not set, the job is placed in the \"Default\" experiment."
+          },
+          "tags": {
+            "type": "object",
+            "unevaluatedProperties": {
+              "type": "string"
+            },
+            "description": "Tag dictionary. Tags can be added, removed, and updated."
+          },
+          "properties": {
+            "type": "object",
+            "unevaluatedProperties": {
+              "type": "string"
+            },
+            "description": "The asset property dictionary."
+          },
+          "codeId": {
+            "type": "string",
+            "description": "Code asset reference."
+          },
+          "computeId": {
+            "type": "string",
+            "description": "Compute resource ID."
+          },
+          "inputs": {
+            "type": "object",
+            "unevaluatedProperties": {
+              "$ref": "#/components/schemas/Input"
+            },
+            "description": "Mapping of input data bindings used in the job."
+          },
+          "outputs": {
+            "type": "object",
+            "unevaluatedProperties": {
+              "$ref": "#/components/schemas/Output"
+            },
+            "description": "Mapping of output data bindings used in the job."
+          },
+          "environmentVariables": {
+            "type": "object",
+            "unevaluatedProperties": {
+              "type": "string"
+            },
+            "description": "Environment variables included in the job."
+          },
+          "resources": {
+            "$ref": "#/components/schemas/JobResourceConfiguration",
+            "description": "Compute Resource configuration for the job."
+          },
+          "distribution": {
+            "$ref": "#/components/schemas/DistributionConfiguration",
+            "description": "Distribution configuration of the job."
+          },
+          "limits": {
+            "$ref": "#/components/schemas/CommandJobLimits",
+            "description": "Command Job limit."
+          },
+          "services": {
+            "type": "object",
+            "unevaluatedProperties": {
+              "$ref": "#/components/schemas/JobService"
+            },
+            "description": "List of job services."
+          },
+          "queueSettings": {
+            "$ref": "#/components/schemas/QueueSettings",
+            "description": "Queue settings for the job."
+          },
+          "priority": {
+            "$ref": "#/components/schemas/JobPriority",
+            "description": "User-visible scheduling priority for the job."
+          },
+          "userAssignedIdentityId": {
+            "type": "string",
+            "description": "user-assigned managed identity"
+          },
+          "capacityUnitCount": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Number of capacity units to allocate for the job. When set, the service resolves the VM SKU from the compute target and calculates the required node count automatically. Virtual cluster targets must also specify `resources.instanceType`. Valid values are 1, 2, 4, 8, or any multiple of 8 for values greater than 8. `gpuCount` takes precedence over this property when both are supplied."
+          },
+          "gpuCount": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Number of GPUs to allocate for the job. Takes precedence over `capacityUnitCount` when both are supplied, and is used to resolve a partial (sub-node) VM SKU for GPU computes. Only applies to GPU computes; CPU computes always resolve to a full-node SKU and ignore this value. Valid values are 1, 2, 4, 8, or any multiple of 8 for values greater than 8."
+          },
+          "isArchived": {
+            "type": "boolean",
+            "description": "Is the asset archived?"
+          },
+          "status": {
+            "type": "string",
+            "description": "Status of the job.",
+            "readOnly": true
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/JobProperties"
+          }
+        ],
+        "description": "Properties of a Command Job."
+      },
+      "CommandJobLimits": {
+        "type": "object",
+        "required": [
+          "jobLimitsType"
+        ],
+        "properties": {
+          "jobLimitsType": {
+            "type": "string",
+            "enum": [
+              "Command"
+            ],
+            "description": "JobLimit type."
+          },
+          "timeout": {
+            "type": "string",
+            "format": "duration",
+            "description": "The max run duration, after which the job will be cancelled."
+          }
+        },
+        "description": "Command Job limit class."
+      },
       "CompletionMessageToolCallChunk": {
         "type": "object",
         "required": [
@@ -40815,6 +41724,28 @@
             "Routines=V2Preview"
           ]
         }
+      },
+      "DistributionConfiguration": {
+        "type": "object",
+        "required": [
+          "distributionType"
+        ],
+        "properties": {
+          "distributionType": {
+            "type": "string",
+            "description": "Specifies the type of distribution framework."
+          }
+        },
+        "discriminator": {
+          "propertyName": "distributionType",
+          "mapping": {
+            "PyTorch": "#/components/schemas/PyTorchDistribution",
+            "Mpi": "#/components/schemas/MpiDistribution",
+            "TensorFlow": "#/components/schemas/TensorFlowDistribution",
+            "Ray": "#/components/schemas/RayDistribution"
+          }
+        },
+        "description": "Distribution configuration of the job."
       },
       "EndpointBasedEvaluatorDefinition": {
         "type": "object",
@@ -44664,6 +45595,31 @@
         },
         "description": "Index resource Definition"
       },
+      "Input": {
+        "type": "object",
+        "required": [
+          "jobInputType"
+        ],
+        "properties": {
+          "jobInputType": {
+            "$ref": "#/components/schemas/AssetTypes",
+            "description": "Specifies the type of job input."
+          },
+          "uri": {
+            "type": "string",
+            "description": "Input Asset URI."
+          },
+          "mode": {
+            "$ref": "#/components/schemas/InputOutputModes",
+            "description": "Input Asset Delivery Mode."
+          },
+          "value": {
+            "type": "string",
+            "description": "Literal value for literal-type inputs."
+          }
+        },
+        "description": "Job input definition."
+      },
       "InputData": {
         "type": "object",
         "required": [
@@ -44707,6 +45663,24 @@
           }
         ],
         "description": "Dataset as source for evaluation."
+      },
+      "InputOutputModes": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "ReadOnlyMount",
+              "ReadWriteMount",
+              "Download",
+              "Direct",
+              "Upload"
+            ]
+          }
+        ],
+        "description": "Enum to determine the input/output data delivery mode."
       },
       "Insight": {
         "type": "object",
@@ -45240,6 +46214,143 @@
         ],
         "description": "The types of parameters for red team item generation."
       },
+      "Job": {
+        "type": "object",
+        "required": [
+          "name",
+          "properties"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name of the Job. This is case-sensitive.",
+            "readOnly": true
+          },
+          "id": {
+            "type": "string",
+            "description": "The resource ID.",
+            "readOnly": true
+          },
+          "type": {
+            "type": "string",
+            "description": "The resource type.",
+            "readOnly": true
+          },
+          "properties": {
+            "$ref": "#/components/schemas/JobProperties",
+            "description": "Properties of the job."
+          },
+          "systemData": {
+            "$ref": "#/components/schemas/SystemData",
+            "description": "Metadata pertaining to creation and last modification of the resource.",
+            "readOnly": true
+          }
+        },
+        "description": "Job resource."
+      },
+      "JobPriority": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "Low",
+              "Mid",
+              "High"
+            ]
+          }
+        ],
+        "description": "User-visible scheduling priority for a job."
+      },
+      "JobProperties": {
+        "type": "object",
+        "required": [
+          "jobType"
+        ],
+        "properties": {
+          "jobType": {
+            "type": "string",
+            "description": "Job type."
+          }
+        },
+        "discriminator": {
+          "propertyName": "jobType",
+          "mapping": {
+            "Command": "#/components/schemas/CommandJob"
+          }
+        },
+        "description": "Base properties of a Job."
+      },
+      "JobResourceConfiguration": {
+        "type": "object",
+        "properties": {
+          "instanceCount": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Optional number of instances or nodes used by the compute target."
+          },
+          "instanceType": {
+            "type": "string",
+            "description": "Optional type of VM used as supported by the compute target."
+          },
+          "properties": {
+            "type": "object",
+            "unevaluatedProperties": {},
+            "description": "Additional properties bag."
+          },
+          "shmSize": {
+            "type": "string",
+            "description": "Size of the docker container's shared memory block."
+          },
+          "dockerArgs": {
+            "type": "string",
+            "description": "Extra arguments to pass to the Docker run command."
+          }
+        },
+        "description": "Compute Resource configuration for the job."
+      },
+      "JobService": {
+        "type": "object",
+        "properties": {
+          "jobServiceType": {
+            "type": "string",
+            "description": "Endpoint type."
+          },
+          "port": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Port for endpoint."
+          },
+          "endpoint": {
+            "type": "string",
+            "description": "Url for endpoint."
+          },
+          "properties": {
+            "type": "object",
+            "unevaluatedProperties": {
+              "type": "string"
+            },
+            "description": "Additional properties to set on the endpoint."
+          },
+          "nodes": {
+            "$ref": "#/components/schemas/AllNodes",
+            "description": "Nodes that user would like to start the service on."
+          },
+          "status": {
+            "type": "string",
+            "description": "Status of endpoint.",
+            "readOnly": true
+          },
+          "errorMessage": {
+            "type": "string",
+            "description": "Any error in the service.",
+            "readOnly": true
+          }
+        },
+        "description": "Job endpoint definition."
+      },
       "JobStatus": {
         "anyOf": [
           {
@@ -45257,6 +46368,36 @@
           }
         ],
         "description": "Extensible status values shared by Foundry jobs."
+      },
+      "JobType": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "Command"
+            ]
+          }
+        ],
+        "description": "Type of a job."
+      },
+      "ListViewType": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "ActiveOnly",
+              "ArchivedOnly",
+              "All"
+            ]
+          }
+        ],
+        "description": "Specifies which jobs to include in a list result based on their lifecycle state."
       },
       "LoraConfig": {
         "type": "object",
@@ -46954,6 +48095,32 @@
           ]
         }
       },
+      "MpiDistribution": {
+        "type": "object",
+        "required": [
+          "distributionType"
+        ],
+        "properties": {
+          "distributionType": {
+            "type": "string",
+            "enum": [
+              "Mpi"
+            ],
+            "description": "Specifies the type of distribution framework."
+          },
+          "processCountPerNode": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Number of processes per MPI node."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/DistributionConfiguration"
+          }
+        ],
+        "description": "MPI distribution configuration."
+      },
       "NoAuthenticationCredentials": {
         "type": "object",
         "required": [
@@ -46975,6 +48142,25 @@
           }
         ],
         "description": "Credentials that do not require authentication"
+      },
+      "NodeCollection": {
+        "type": "object",
+        "required": [
+          "nodesValueType"
+        ],
+        "properties": {
+          "nodesValueType": {
+            "type": "string",
+            "description": "Type of the Nodes value."
+          }
+        },
+        "discriminator": {
+          "propertyName": "nodesValueType",
+          "mapping": {
+            "All": "#/components/schemas/AllNodes"
+          }
+        },
+        "description": "Nodes that user would like to start the service on."
       },
       "OAuthConsentRequestOutputItem": {
         "type": "object",
@@ -85545,6 +86731,43 @@
         ],
         "description": "An OTLP (OpenTelemetry Protocol) telemetry export endpoint."
       },
+      "Output": {
+        "type": "object",
+        "required": [
+          "jobOutputType"
+        ],
+        "properties": {
+          "jobOutputType": {
+            "$ref": "#/components/schemas/AssetTypes",
+            "description": "Specifies the type of job output."
+          },
+          "mode": {
+            "$ref": "#/components/schemas/InputOutputModes",
+            "description": "Output Asset Delivery Mode."
+          },
+          "assetName": {
+            "type": "string",
+            "description": "Name of the output data asset to register."
+          },
+          "assetVersion": {
+            "type": "string",
+            "description": "Version of the output data asset to register."
+          },
+          "uri": {
+            "type": "string",
+            "description": "Output Asset URI."
+          },
+          "baseModelId": {
+            "type": "string",
+            "description": "Base model ID."
+          },
+          "description": {
+            "type": "string",
+            "description": "Description for the output."
+          }
+        },
+        "description": "Job output definition."
+      },
       "PageOrder": {
         "type": "string",
         "enum": [
@@ -85761,6 +86984,27 @@
           }
         },
         "description": "Paged collection of Insight items"
+      },
+      "PagedJob": {
+        "type": "object",
+        "required": [
+          "value"
+        ],
+        "properties": {
+          "value": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Job"
+            },
+            "description": "The Job items on this page"
+          },
+          "nextLink": {
+            "type": "string",
+            "format": "uri",
+            "description": "The link to the next page of items"
+          }
+        },
+        "description": "Paged collection of Job items"
       },
       "PagedManagedAgentIdentityBlueprint": {
         "type": "object",
@@ -86303,6 +87547,42 @@
         ],
         "description": "The Microsoft Agent Certification review status of the Microsoft 365 store title published for an agent."
       },
+      "PyTorchDistribution": {
+        "type": "object",
+        "required": [
+          "distributionType"
+        ],
+        "properties": {
+          "distributionType": {
+            "type": "string",
+            "enum": [
+              "PyTorch"
+            ],
+            "description": "Specifies the type of distribution framework."
+          },
+          "processCountPerInstance": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Number of processes per node."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/DistributionConfiguration"
+          }
+        ],
+        "description": "PyTorch distribution configuration."
+      },
+      "QueueSettings": {
+        "type": "object",
+        "properties": {
+          "jobTier": {
+            "type": "string",
+            "description": "Controls the compute job tier."
+          }
+        },
+        "description": "Queue settings for the job."
+      },
       "RaiConfig": {
         "type": "object",
         "required": [
@@ -86315,6 +87595,53 @@
           }
         },
         "description": "Configuration for Responsible AI (RAI) content filtering and safety features."
+      },
+      "RayDistribution": {
+        "type": "object",
+        "required": [
+          "distributionType"
+        ],
+        "properties": {
+          "distributionType": {
+            "type": "string",
+            "enum": [
+              "Ray"
+            ],
+            "description": "Specifies the type of distribution framework."
+          },
+          "port": {
+            "type": "integer",
+            "format": "int32",
+            "description": "The port of the head Ray process."
+          },
+          "address": {
+            "type": "string",
+            "description": "The address of the Ray head node."
+          },
+          "includeDashboard": {
+            "type": "boolean",
+            "description": "Whether to start the Ray dashboard GUI."
+          },
+          "dashboardPort": {
+            "type": "integer",
+            "format": "int32",
+            "description": "The port to bind the dashboard server to."
+          },
+          "headNodeAdditionalArgs": {
+            "type": "string",
+            "description": "Additional arguments passed to ray start on the head node."
+          },
+          "workerNodeAdditionalArgs": {
+            "type": "string",
+            "description": "Additional arguments passed to ray start on worker nodes."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/DistributionConfiguration"
+          }
+        ],
+        "description": "Ray distribution configuration."
       },
       "RecurrenceSchedule": {
         "type": "object",
@@ -88394,6 +89721,44 @@
         ],
         "description": "Represents the parameters for synthetic data generation item generation."
       },
+      "SystemData": {
+        "type": "object",
+        "properties": {
+          "createdBy": {
+            "type": "string",
+            "description": "The identity that created the resource.",
+            "readOnly": true
+          },
+          "createdByType": {
+            "type": "string",
+            "description": "The type of identity that created the resource.",
+            "readOnly": true
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "The timestamp of resource creation (UTC).",
+            "readOnly": true
+          },
+          "lastModifiedBy": {
+            "type": "string",
+            "description": "The identity that last modified the resource.",
+            "readOnly": true
+          },
+          "lastModifiedByType": {
+            "type": "string",
+            "description": "The type of identity that last modified the resource.",
+            "readOnly": true
+          },
+          "lastModifiedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "The timestamp of resource last modification (UTC).",
+            "readOnly": true
+          }
+        },
+        "description": "Metadata pertaining to creation and last modification of the resource."
+      },
       "SystemMessage": {
         "type": "object",
         "required": [
@@ -88753,6 +90118,37 @@
           }
         ],
         "description": "The transport protocol for telemetry export."
+      },
+      "TensorFlowDistribution": {
+        "type": "object",
+        "required": [
+          "distributionType"
+        ],
+        "properties": {
+          "distributionType": {
+            "type": "string",
+            "enum": [
+              "TensorFlow"
+            ],
+            "description": "Specifies the type of distribution framework."
+          },
+          "workerCount": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Number of workers."
+          },
+          "parameterServerCount": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Number of parameter server tasks."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/DistributionConfiguration"
+          }
+        ],
+        "description": "TensorFlow distribution configuration."
       },
       "TestingCriterionAzureAIEvaluator": {
         "type": "object",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -8,6 +8,7 @@ tags:
   - name: Agent Conversations
   - name: AgentServer Task Storage
   - name: EvaluationSuiteGenerationJobs
+  - name: CommandJob
   - name: Responses Root
     description: Responses
   - name: Responses
@@ -8995,6 +8996,370 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Insights
+  /jobs:
+    get:
+      operationId: Jobs_list
+      description: List Jobs.
+      parameters:
+        - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
+        - name: jobType
+          in: query
+          required: false
+          description: Filter by job type (e.g. 'Command').
+          schema:
+            $ref: '#/components/schemas/JobType'
+          explode: false
+        - name: tag
+          in: query
+          required: false
+          description: Filter jobs by tag in the format 'key=value' (e.g., 'framework=pytorch').
+          schema:
+            type: string
+          explode: false
+        - name: listViewType
+          in: query
+          required: false
+          description: Specifies which view type to apply when listing jobs.
+          schema:
+            $ref: '#/components/schemas/ListViewType'
+          explode: false
+        - name: properties
+          in: query
+          required: false
+          description: 'Comma-separated user property names and optionally values. Example: prop1,prop2=value2.'
+          schema:
+            type: string
+          explode: false
+        - name: Foundry-Features
+          in: header
+          required: true
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - Jobs=V1Preview
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PagedJob'
+        default:
+          description: An unexpected error response.
+          headers:
+            x-ms-error-code:
+              required: false
+              description: String error code indicating what went wrong.
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
+      tags:
+        - CommandJob
+  /jobs/{name}:
+    get:
+      operationId: Jobs_get
+      description: Get a Job by name.
+      parameters:
+        - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
+        - name: name
+          in: path
+          required: true
+          description: The name of the Job. This is case-sensitive.
+          schema:
+            type: string
+        - name: Foundry-Features
+          in: header
+          required: true
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - Jobs=V1Preview
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Job'
+        default:
+          description: An unexpected error response.
+          headers:
+            x-ms-error-code:
+              required: false
+              description: String error code indicating what went wrong.
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
+      tags:
+        - CommandJob
+    put:
+      operationId: Jobs_createOrUpdate
+      description: Create and execute a Job. For update case, the Tags in the definition passed in will replace Tags in the existing job.
+      parameters:
+        - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
+        - name: name
+          in: path
+          required: true
+          description: The name of the Job. This is case-sensitive.
+          schema:
+            type: string
+        - name: Foundry-Features
+          in: header
+          required: true
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - Jobs=V1Preview
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Job'
+        '201':
+          description: The request has succeeded and a new resource has been created as a result.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Job'
+        default:
+          description: An unexpected error response.
+          headers:
+            x-ms-error-code:
+              required: false
+              description: String error code indicating what went wrong.
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
+      tags:
+        - CommandJob
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Job'
+        description: The job to create or update.
+    delete:
+      operationId: Jobs_beginDelete
+      description: Delete a Job by name. Returns 202 Accepted with a Location header to poll for completion, or 204 if the job does not exist.
+      parameters:
+        - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
+        - name: name
+          in: path
+          required: true
+          description: The name of the Job. This is case-sensitive.
+          schema:
+            type: string
+        - name: Foundry-Features
+          in: header
+          required: true
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - Jobs=V1Preview
+      responses:
+        '202':
+          description: Response returned when a job delete operation is accepted asynchronously.
+          headers:
+            Location:
+              required: true
+              description: URL to poll for the status of the delete operation.
+              schema:
+                type: string
+            Retry-After:
+              required: false
+              description: Suggested delay in seconds before polling.
+              schema:
+                type: integer
+                format: int32
+        '204':
+          description: There is no content to send for this request, but the headers may be useful.
+        default:
+          description: An unexpected error response.
+          headers:
+            x-ms-error-code:
+              required: false
+              description: String error code indicating what went wrong.
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
+      tags:
+        - CommandJob
+  /jobs/{name}/artifacts:
+    get:
+      operationId: Jobs_listArtifacts
+      description: List the artifacts produced by a job, including its log files. Logs are ordinary artifacts stored under the well-known `azureml-logs/`, `user_logs/` and `system_logs/` path prefixes, so they are retrieved by filtering on `path`.
+      parameters:
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+        - name: Foundry-Features
+          in: header
+          required: true
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - Jobs=V1Preview
+        - name: name
+          in: path
+          required: true
+          description: The name of the Job.
+          schema:
+            type: string
+        - name: path
+          in: query
+          required: false
+          description: Optional artifact path or path prefix to filter by.
+          schema:
+            type: string
+          explode: false
+        - name: continuationToken
+          in: query
+          required: false
+          description: Continuation token for the next page.
+          schema:
+            type: string
+          explode: false
+        - name: pageSize
+          in: query
+          required: false
+          description: Maximum number of artifacts per page.
+          schema:
+            type: integer
+            format: int32
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ArtifactList'
+      tags:
+        - CommandJob
+  /jobs/{name}/artifacts/contentinfo:
+    get:
+      operationId: Jobs_getArtifactContentInformation
+      description: Get content information, including a readable content URI and byte length, for the artifacts produced by a job. Use this to download artifact or log content.
+      parameters:
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+        - name: Foundry-Features
+          in: header
+          required: true
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - Jobs=V1Preview
+        - name: name
+          in: path
+          required: true
+          description: The name of the Job.
+          schema:
+            type: string
+        - name: path
+          in: query
+          required: false
+          description: Optional artifact path prefix to filter by.
+          schema:
+            type: string
+          explode: false
+        - name: continuationToken
+          in: query
+          required: false
+          description: Continuation token for the next page.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ArtifactContentInformationList'
+      tags:
+        - CommandJob
+  /jobs/{name}/cancel:
+    post:
+      operationId: Jobs_beginCancel
+      description: Cancel a Job by name. Returns 200 if cancelled immediately, or 202 Accepted with a Location header to poll for completion.
+      parameters:
+        - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
+        - name: name
+          in: path
+          required: true
+          description: The name of the Job. This is case-sensitive.
+          schema:
+            type: string
+        - name: Foundry-Features
+          in: header
+          required: true
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - Jobs=V1Preview
+      responses:
+        '200':
+          description: The request has succeeded.
+        '202':
+          description: Response returned when a job cancel operation is accepted asynchronously.
+          headers:
+            Location:
+              required: true
+              description: URL to poll for the status of the cancel operation.
+              schema:
+                type: string
+            Retry-After:
+              required: false
+              description: Suggested delay in seconds before polling.
+              schema:
+                type: integer
+                format: int32
+        default:
+          description: An unexpected error response.
+          headers:
+            x-ms-error-code:
+              required: false
+              description: String error code indicating what went wrong.
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
+      tags:
+        - CommandJob
   /managedAgentIdentityBlueprints:
     get:
       operationId: ManagedAgentIdentityBlueprints_listManagedAgentIdentityBlueprints
@@ -44845,6 +45210,19 @@ components:
       allOf:
         - $ref: '#/components/schemas/BaseCredentials'
       description: Agentic identity credential definition
+    AllNodes:
+      type: object
+      required:
+        - nodesValueType
+      properties:
+        nodesValueType:
+          type: string
+          enum:
+            - All
+          description: Type of the Nodes value.
+      allOf:
+        - $ref: '#/components/schemas/NodeCollection'
+      description: All nodes means the service will be running on all of the nodes of the job.
     ApiErrorResponse:
       type: object
       required:
@@ -44871,6 +45249,113 @@ components:
       allOf:
         - $ref: '#/components/schemas/BaseCredentials'
       description: API Key Credential definition
+    Artifact:
+      type: object
+      required:
+        - origin
+        - container
+        - path
+      properties:
+        artifactId:
+          type: string
+          description: The artifact id.
+        origin:
+          type: string
+          description: The artifact origin.
+        container:
+          type: string
+          description: The container name.
+        path:
+          type: string
+          description: The artifact path.
+        etag:
+          type: string
+          description: The artifact Etag.
+        createdTime:
+          type: string
+          format: date-time
+          description: The artifact creation time in UTC.
+        dataPath:
+          $ref: '#/components/schemas/ArtifactDataPath'
+          description: The artifact data path.
+        tags:
+          type: object
+          unevaluatedProperties:
+            type: string
+          description: The artifact tags.
+      description: An artifact.
+    ArtifactContentInformation:
+      type: object
+      properties:
+        contentUri:
+          type: string
+          format: uri
+          description: The content URI.
+        origin:
+          type: string
+          description: The artifact origin.
+        container:
+          type: string
+          description: The container name.
+        path:
+          type: string
+          description: The artifact path.
+        tags:
+          type: object
+          unevaluatedProperties:
+            type: string
+          description: The artifact tags.
+        contentLength:
+          type: integer
+          format: int64
+          description: The content byte length.
+      description: Artifact content information.
+    ArtifactContentInformationList:
+      type: object
+      required:
+        - value
+      properties:
+        value:
+          type: array
+          items:
+            $ref: '#/components/schemas/ArtifactContentInformation'
+          description: The entries in the page.
+        continuationToken:
+          type: string
+          description: Token for the next page.
+        nextLink:
+          type: string
+          description: URL for the next page.
+      description: A page of artifact content information.
+    ArtifactDataPath:
+      type: object
+      properties:
+        dataStoreName:
+          type: string
+          description: The data store name.
+        relativePath:
+          type: string
+          description: The relative path within the data store.
+        sqlDataPath:
+          description: SQL data path information.
+      description: A data store path.
+    ArtifactList:
+      type: object
+      required:
+        - value
+      properties:
+        value:
+          type: array
+          items:
+            $ref: '#/components/schemas/Artifact'
+          description: The artifacts in the page.
+        continuationToken:
+          type: string
+          description: Token for the next page.
+        nextLink:
+          type: string
+          description: URL for the next page.
+      description: A page of artifacts.
     ArtifactProfile:
       type: object
       required:
@@ -44900,6 +45385,16 @@ components:
     AssetId:
       type: string
       description: Identifier of a saved asset.
+    AssetTypes:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - uri_file
+            - uri_folder
+            - safetensors_model
+            - literal
+      description: Type of job input/output asset.
     AssistantMessage:
       type: object
       required:
@@ -46442,6 +46937,121 @@ components:
       allOf:
         - $ref: '#/components/schemas/ToolboxTool'
       description: A code interpreter tool stored in a toolbox.
+    CommandJob:
+      type: object
+      required:
+        - jobType
+        - command
+        - environmentImageReference
+        - computeId
+      properties:
+        jobType:
+          type: string
+          enum:
+            - Command
+          description: Job type.
+        command:
+          type: string
+          description: The command to execute on startup of the job.
+        environmentImageReference:
+          type: string
+          description: ACR path of environment.
+        displayName:
+          type: string
+          description: Display name of job.
+        description:
+          type: string
+          description: The asset description text.
+        experimentName:
+          type: string
+          description: The name of the experiment the job belongs to. If not set, the job is placed in the "Default" experiment.
+        tags:
+          type: object
+          unevaluatedProperties:
+            type: string
+          description: Tag dictionary. Tags can be added, removed, and updated.
+        properties:
+          type: object
+          unevaluatedProperties:
+            type: string
+          description: The asset property dictionary.
+        codeId:
+          type: string
+          description: Code asset reference.
+        computeId:
+          type: string
+          description: Compute resource ID.
+        inputs:
+          type: object
+          unevaluatedProperties:
+            $ref: '#/components/schemas/Input'
+          description: Mapping of input data bindings used in the job.
+        outputs:
+          type: object
+          unevaluatedProperties:
+            $ref: '#/components/schemas/Output'
+          description: Mapping of output data bindings used in the job.
+        environmentVariables:
+          type: object
+          unevaluatedProperties:
+            type: string
+          description: Environment variables included in the job.
+        resources:
+          $ref: '#/components/schemas/JobResourceConfiguration'
+          description: Compute Resource configuration for the job.
+        distribution:
+          $ref: '#/components/schemas/DistributionConfiguration'
+          description: Distribution configuration of the job.
+        limits:
+          $ref: '#/components/schemas/CommandJobLimits'
+          description: Command Job limit.
+        services:
+          type: object
+          unevaluatedProperties:
+            $ref: '#/components/schemas/JobService'
+          description: List of job services.
+        queueSettings:
+          $ref: '#/components/schemas/QueueSettings'
+          description: Queue settings for the job.
+        priority:
+          $ref: '#/components/schemas/JobPriority'
+          description: User-visible scheduling priority for the job.
+        userAssignedIdentityId:
+          type: string
+          description: user-assigned managed identity
+        capacityUnitCount:
+          type: integer
+          format: int32
+          description: Number of capacity units to allocate for the job. When set, the service resolves the VM SKU from the compute target and calculates the required node count automatically. Virtual cluster targets must also specify `resources.instanceType`. Valid values are 1, 2, 4, 8, or any multiple of 8 for values greater than 8. `gpuCount` takes precedence over this property when both are supplied.
+        gpuCount:
+          type: integer
+          format: int32
+          description: Number of GPUs to allocate for the job. Takes precedence over `capacityUnitCount` when both are supplied, and is used to resolve a partial (sub-node) VM SKU for GPU computes. Only applies to GPU computes; CPU computes always resolve to a full-node SKU and ignore this value. Valid values are 1, 2, 4, 8, or any multiple of 8 for values greater than 8.
+        isArchived:
+          type: boolean
+          description: Is the asset archived?
+        status:
+          type: string
+          description: Status of the job.
+          readOnly: true
+      allOf:
+        - $ref: '#/components/schemas/JobProperties'
+      description: Properties of a Command Job.
+    CommandJobLimits:
+      type: object
+      required:
+        - jobLimitsType
+      properties:
+        jobLimitsType:
+          type: string
+          enum:
+            - Command
+          description: JobLimit type.
+        timeout:
+          type: string
+          format: duration
+          description: The max run duration, after which the job will be cancelled.
+      description: Command Job limit class.
     CompletionMessageToolCallChunk:
       type: object
       required:
@@ -47997,6 +48607,22 @@ components:
       x-ms-foundry-meta:
         conditional_previews:
           - Routines=V2Preview
+    DistributionConfiguration:
+      type: object
+      required:
+        - distributionType
+      properties:
+        distributionType:
+          type: string
+          description: Specifies the type of distribution framework.
+      discriminator:
+        propertyName: distributionType
+        mapping:
+          PyTorch: '#/components/schemas/PyTorchDistribution'
+          Mpi: '#/components/schemas/MpiDistribution'
+          TensorFlow: '#/components/schemas/TensorFlowDistribution'
+          Ray: '#/components/schemas/RayDistribution'
+      description: Distribution configuration of the job.
     EndpointBasedEvaluatorDefinition:
       type: object
       required:
@@ -50937,6 +51563,24 @@ components:
           ManagedAzureSearch: '#/components/schemas/ManagedAzureAISearchIndexUpdate'
           CosmosDBNoSqlVectorStore: '#/components/schemas/CosmosDBIndexUpdate'
       description: Index resource Definition
+    Input:
+      type: object
+      required:
+        - jobInputType
+      properties:
+        jobInputType:
+          $ref: '#/components/schemas/AssetTypes'
+          description: Specifies the type of job input.
+        uri:
+          type: string
+          description: Input Asset URI.
+        mode:
+          $ref: '#/components/schemas/InputOutputModes'
+          description: Input Asset Delivery Mode.
+        value:
+          type: string
+          description: Literal value for literal-type inputs.
+      description: Job input definition.
     InputData:
       type: object
       required:
@@ -50966,6 +51610,17 @@ components:
       allOf:
         - $ref: '#/components/schemas/InputData'
       description: Dataset as source for evaluation.
+    InputOutputModes:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - ReadOnlyMount
+            - ReadWriteMount
+            - Download
+            - Direct
+            - Upload
+      description: Enum to determine the input/output data delivery mode.
     Insight:
       type: object
       required:
@@ -51337,6 +51992,105 @@ components:
             - conversation_gen_preview
             - target_completion
       description: The types of parameters for red team item generation.
+    Job:
+      type: object
+      required:
+        - name
+        - properties
+      properties:
+        name:
+          type: string
+          description: The name of the Job. This is case-sensitive.
+          readOnly: true
+        id:
+          type: string
+          description: The resource ID.
+          readOnly: true
+        type:
+          type: string
+          description: The resource type.
+          readOnly: true
+        properties:
+          $ref: '#/components/schemas/JobProperties'
+          description: Properties of the job.
+        systemData:
+          $ref: '#/components/schemas/SystemData'
+          description: Metadata pertaining to creation and last modification of the resource.
+          readOnly: true
+      description: Job resource.
+    JobPriority:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - Low
+            - Mid
+            - High
+      description: User-visible scheduling priority for a job.
+    JobProperties:
+      type: object
+      required:
+        - jobType
+      properties:
+        jobType:
+          type: string
+          description: Job type.
+      discriminator:
+        propertyName: jobType
+        mapping:
+          Command: '#/components/schemas/CommandJob'
+      description: Base properties of a Job.
+    JobResourceConfiguration:
+      type: object
+      properties:
+        instanceCount:
+          type: integer
+          format: int32
+          description: Optional number of instances or nodes used by the compute target.
+        instanceType:
+          type: string
+          description: Optional type of VM used as supported by the compute target.
+        properties:
+          type: object
+          unevaluatedProperties: {}
+          description: Additional properties bag.
+        shmSize:
+          type: string
+          description: Size of the docker container's shared memory block.
+        dockerArgs:
+          type: string
+          description: Extra arguments to pass to the Docker run command.
+      description: Compute Resource configuration for the job.
+    JobService:
+      type: object
+      properties:
+        jobServiceType:
+          type: string
+          description: Endpoint type.
+        port:
+          type: integer
+          format: int32
+          description: Port for endpoint.
+        endpoint:
+          type: string
+          description: Url for endpoint.
+        properties:
+          type: object
+          unevaluatedProperties:
+            type: string
+          description: Additional properties to set on the endpoint.
+        nodes:
+          $ref: '#/components/schemas/AllNodes'
+          description: Nodes that user would like to start the service on.
+        status:
+          type: string
+          description: Status of endpoint.
+          readOnly: true
+        errorMessage:
+          type: string
+          description: Any error in the service.
+          readOnly: true
+      description: Job endpoint definition.
     JobStatus:
       anyOf:
         - type: string
@@ -51348,6 +52102,22 @@ components:
             - failed
             - cancelled
       description: Extensible status values shared by Foundry jobs.
+    JobType:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - Command
+      description: Type of a job.
+    ListViewType:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - ActiveOnly
+            - ArchivedOnly
+            - All
+      description: Specifies which jobs to include in a list result based on their lifecycle state.
     LoraConfig:
       type: object
       properties:
@@ -52569,6 +53339,23 @@ components:
       x-ms-foundry-meta:
         required_previews:
           - Schedules=V1Preview
+    MpiDistribution:
+      type: object
+      required:
+        - distributionType
+      properties:
+        distributionType:
+          type: string
+          enum:
+            - Mpi
+          description: Specifies the type of distribution framework.
+        processCountPerNode:
+          type: integer
+          format: int32
+          description: Number of processes per MPI node.
+      allOf:
+        - $ref: '#/components/schemas/DistributionConfiguration'
+      description: MPI distribution configuration.
     NoAuthenticationCredentials:
       type: object
       required:
@@ -52583,6 +53370,19 @@ components:
       allOf:
         - $ref: '#/components/schemas/BaseCredentials'
       description: Credentials that do not require authentication
+    NodeCollection:
+      type: object
+      required:
+        - nodesValueType
+      properties:
+        nodesValueType:
+          type: string
+          description: Type of the Nodes value.
+      discriminator:
+        propertyName: nodesValueType
+        mapping:
+          All: '#/components/schemas/AllNodes'
+      description: Nodes that user would like to start the service on.
     OAuthConsentRequestOutputItem:
       type: object
       required:
@@ -80561,6 +81361,33 @@ components:
       allOf:
         - $ref: '#/components/schemas/TelemetryEndpoint'
       description: An OTLP (OpenTelemetry Protocol) telemetry export endpoint.
+    Output:
+      type: object
+      required:
+        - jobOutputType
+      properties:
+        jobOutputType:
+          $ref: '#/components/schemas/AssetTypes'
+          description: Specifies the type of job output.
+        mode:
+          $ref: '#/components/schemas/InputOutputModes'
+          description: Output Asset Delivery Mode.
+        assetName:
+          type: string
+          description: Name of the output data asset to register.
+        assetVersion:
+          type: string
+          description: Version of the output data asset to register.
+        uri:
+          type: string
+          description: Output Asset URI.
+        baseModelId:
+          type: string
+          description: Base model ID.
+        description:
+          type: string
+          description: Description for the output.
+      description: Job output definition.
     PageOrder:
       type: string
       enum:
@@ -80716,6 +81543,21 @@ components:
           format: uri
           description: The link to the next page of items
       description: Paged collection of Insight items
+    PagedJob:
+      type: object
+      required:
+        - value
+      properties:
+        value:
+          type: array
+          items:
+            $ref: '#/components/schemas/Job'
+          description: The Job items on this page
+        nextLink:
+          type: string
+          format: uri
+          description: The link to the next page of items
+      description: Paged collection of Job items
     PagedManagedAgentIdentityBlueprint:
       type: object
       required:
@@ -81087,6 +81929,30 @@ components:
             - rejected
             - no_approval_needed
       description: The Microsoft Agent Certification review status of the Microsoft 365 store title published for an agent.
+    PyTorchDistribution:
+      type: object
+      required:
+        - distributionType
+      properties:
+        distributionType:
+          type: string
+          enum:
+            - PyTorch
+          description: Specifies the type of distribution framework.
+        processCountPerInstance:
+          type: integer
+          format: int32
+          description: Number of processes per node.
+      allOf:
+        - $ref: '#/components/schemas/DistributionConfiguration'
+      description: PyTorch distribution configuration.
+    QueueSettings:
+      type: object
+      properties:
+        jobTier:
+          type: string
+          description: Controls the compute job tier.
+      description: Queue settings for the job.
     RaiConfig:
       type: object
       required:
@@ -81096,6 +81962,39 @@ components:
           type: string
           description: The name of the RAI policy to apply.
       description: Configuration for Responsible AI (RAI) content filtering and safety features.
+    RayDistribution:
+      type: object
+      required:
+        - distributionType
+      properties:
+        distributionType:
+          type: string
+          enum:
+            - Ray
+          description: Specifies the type of distribution framework.
+        port:
+          type: integer
+          format: int32
+          description: The port of the head Ray process.
+        address:
+          type: string
+          description: The address of the Ray head node.
+        includeDashboard:
+          type: boolean
+          description: Whether to start the Ray dashboard GUI.
+        dashboardPort:
+          type: integer
+          format: int32
+          description: The port to bind the dashboard server to.
+        headNodeAdditionalArgs:
+          type: string
+          description: Additional arguments passed to ray start on the head node.
+        workerNodeAdditionalArgs:
+          type: string
+          description: Additional arguments passed to ray start on worker nodes.
+      allOf:
+        - $ref: '#/components/schemas/DistributionConfiguration'
+      description: Ray distribution configuration.
     RecurrenceSchedule:
       type: object
       required:
@@ -82542,6 +83441,36 @@ components:
       allOf:
         - $ref: '#/components/schemas/ItemGenerationParams'
       description: Represents the parameters for synthetic data generation item generation.
+    SystemData:
+      type: object
+      properties:
+        createdBy:
+          type: string
+          description: The identity that created the resource.
+          readOnly: true
+        createdByType:
+          type: string
+          description: The type of identity that created the resource.
+          readOnly: true
+        createdAt:
+          type: string
+          format: date-time
+          description: The timestamp of resource creation (UTC).
+          readOnly: true
+        lastModifiedBy:
+          type: string
+          description: The identity that last modified the resource.
+          readOnly: true
+        lastModifiedByType:
+          type: string
+          description: The type of identity that last modified the resource.
+          readOnly: true
+        lastModifiedAt:
+          type: string
+          format: date-time
+          description: The timestamp of resource last modification (UTC).
+          readOnly: true
+      description: Metadata pertaining to creation and last modification of the resource.
     SystemMessage:
       type: object
       required:
@@ -82780,6 +83709,27 @@ components:
             - Http
             - Grpc
       description: The transport protocol for telemetry export.
+    TensorFlowDistribution:
+      type: object
+      required:
+        - distributionType
+      properties:
+        distributionType:
+          type: string
+          enum:
+            - TensorFlow
+          description: Specifies the type of distribution framework.
+        workerCount:
+          type: integer
+          format: int32
+          description: Number of workers.
+        parameterServerCount:
+          type: integer
+          format: int32
+          description: Number of parameter server tasks.
+      allOf:
+        - $ref: '#/components/schemas/DistributionConfiguration'
+      description: TensorFlow distribution configuration.
     TestingCriterionAzureAIEvaluator:
       type: object
       required:

--- a/specification/ai-foundry/data-plane/Foundry/src/common/servicepatterns.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/common/servicepatterns.tsp
@@ -114,6 +114,7 @@ union FoundryFeaturesOptInKeys {
   models_v1_preview: "Models=V1Preview",
   agents_optimization_v2_preview: "AgentsOptimization=V2Preview",
   model_router_controls_v1_preview: "ModelRouterControls=V1Preview",
+  jobs_v1_preview: "Jobs=V1Preview",
 }
 
 alias WithRequiredFoundryPreviewHeader<RequiredPreviewOptInHeader extends

--- a/specification/ai-foundry/data-plane/Foundry/src/jobs/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/jobs/models.tsp
@@ -1,0 +1,507 @@
+import "../common/models.tsp";
+import "../common/service.tsp";
+import "../common/servicepatterns.tsp";
+
+using TypeSpec.Http;
+using Azure.ClientGenerator.Core;
+
+namespace Azure.AI.Projects;
+
+#suppress "@azure-tools/typespec-azure-core/no-string-discriminator" "Use an extensible union instead of a plain string"
+@doc("Distribution configuration of the job.")
+@discriminator("distributionType")
+model DistributionConfiguration {
+  @doc("Specifies the type of distribution framework.")
+  distributionType: string;
+}
+
+@doc("PyTorch distribution configuration.")
+model PyTorchDistribution extends DistributionConfiguration {
+  @doc("Specifies the type of distribution framework.")
+  distributionType: "PyTorch";
+
+  @doc("Number of processes per node.")
+  processCountPerInstance?: int32;
+}
+
+@doc("MPI distribution configuration.")
+model MpiDistribution extends DistributionConfiguration {
+  @doc("Specifies the type of distribution framework.")
+  distributionType: "Mpi";
+
+  @doc("Number of processes per MPI node.")
+  processCountPerNode?: int32;
+}
+
+@doc("TensorFlow distribution configuration.")
+model TensorFlowDistribution extends DistributionConfiguration {
+  @doc("Specifies the type of distribution framework.")
+  distributionType: "TensorFlow";
+
+  @doc("Number of workers.")
+  workerCount?: int32;
+
+  @doc("Number of parameter server tasks.")
+  parameterServerCount?: int32;
+}
+
+@doc("Ray distribution configuration.")
+model RayDistribution extends DistributionConfiguration {
+  @doc("Specifies the type of distribution framework.")
+  distributionType: "Ray";
+
+  @doc("The port of the head Ray process.")
+  port?: int32;
+
+  @doc("The address of the Ray head node.")
+  address?: string;
+
+  @doc("Whether to start the Ray dashboard GUI.")
+  includeDashboard?: boolean;
+
+  @doc("The port to bind the dashboard server to.")
+  dashboardPort?: int32;
+
+  @doc("Additional arguments passed to ray start on the head node.")
+  headNodeAdditionalArgs?: string;
+
+  @doc("Additional arguments passed to ray start on worker nodes.")
+  workerNodeAdditionalArgs?: string;
+}
+
+@doc("Enum to determine the input/output data delivery mode.")
+union InputOutputModes {
+  string,
+
+  @doc("Read-only mount mode.")
+  ReadOnlyMount: "ReadOnlyMount",
+
+  @doc("Read-write mount mode.")
+  ReadWriteMount: "ReadWriteMount",
+
+  @doc("Download mode.")
+  Download: "Download",
+
+  @doc("Direct mode.")
+  Direct: "Direct",
+
+  @doc("Upload mode.")
+  Upload: "Upload",
+}
+
+@doc("Type of job input/output asset.")
+union AssetTypes {
+  string,
+
+  @doc("URI file asset.")
+  UriFile: "uri_file",
+
+  @doc("URI folder asset.")
+  UriFolder: "uri_folder",
+
+  @doc("Safetensors model asset.")
+  SafetensorsModel: "safetensors_model",
+
+  @doc("Literal value (inputs only).")
+  Literal: "literal",
+}
+
+@doc("Job input definition.")
+model Input {
+  @doc("Specifies the type of job input.")
+  @encodedName("application/json", "jobInputType")
+  type: AssetTypes;
+
+  @doc("Input Asset URI.")
+  @encodedName("application/json", "uri")
+  path?: string;
+
+  @doc("Input Asset Delivery Mode.")
+  mode?: InputOutputModes;
+
+  @doc("Literal value for literal-type inputs.")
+  value?: string;
+}
+
+@doc("Job output definition.")
+model Output {
+  @doc("Specifies the type of job output.")
+  @encodedName("application/json", "jobOutputType")
+  type: AssetTypes;
+
+  @doc("Output Asset Delivery Mode.")
+  mode?: InputOutputModes;
+
+  @doc("Name of the output data asset to register.")
+  assetName?: string;
+
+  @doc("Version of the output data asset to register.")
+  assetVersion?: string;
+
+  @doc("Output Asset URI.")
+  uri?: string;
+
+  @doc("Base model ID.")
+  baseModelId?: string;
+
+  @doc("Description for the output.")
+  description?: string;
+}
+
+#suppress "@azure-tools/typespec-azure-core/no-string-discriminator" "Use an extensible union instead of a plain string"
+@doc("Nodes that user would like to start the service on.")
+@discriminator("nodesValueType")
+model NodeCollection {
+  @doc("Type of the Nodes value.")
+  nodesValueType: string;
+}
+
+@doc("All nodes means the service will be running on all of the nodes of the job.")
+model AllNodes extends NodeCollection {
+  @doc("Type of the Nodes value.")
+  nodesValueType: "All";
+}
+
+@doc("Job endpoint definition.")
+model JobService {
+  @doc("Endpoint type.")
+  jobServiceType?: string;
+
+  @doc("Port for endpoint.")
+  port?: int32;
+
+  @doc("Url for endpoint.")
+  endpoint?: string;
+
+  @doc("Additional properties to set on the endpoint.")
+  properties?: Record<string>;
+
+  @doc("Nodes that user would like to start the service on.")
+  nodes?: AllNodes;
+
+  @doc("Status of endpoint.")
+  @visibility(Lifecycle.Read)
+  status?: string;
+
+  @doc("Any error in the service.")
+  @visibility(Lifecycle.Read)
+  errorMessage?: string;
+}
+
+@doc("Compute Resource configuration for the job.")
+model JobResourceConfiguration {
+  @doc("Optional number of instances or nodes used by the compute target.")
+  instanceCount?: int32;
+
+  @doc("Optional type of VM used as supported by the compute target.")
+  instanceType?: string;
+
+  @doc("Additional properties bag.")
+  properties?: Record<unknown>;
+
+  @doc("Size of the docker container's shared memory block.")
+  shmSize?: string;
+
+  @doc("Extra arguments to pass to the Docker run command.")
+  dockerArgs?: string;
+}
+
+@doc("Command Job limit class.")
+model CommandJobLimits {
+  @doc("JobLimit type.")
+  jobLimitsType: "Command";
+
+  @doc("The max run duration, after which the job will be cancelled.")
+  timeout?: duration;
+}
+
+@doc("Queue settings for the job.")
+model QueueSettings {
+  @doc("Controls the compute job tier.")
+  jobTier?: string;
+}
+
+@doc("User-visible scheduling priority for a job.")
+union JobPriority {
+  string,
+
+  @doc("Low scheduling priority.")
+  Low: "Low",
+
+  @doc("Medium scheduling priority.")
+  Mid: "Mid",
+
+  @doc("High scheduling priority.")
+  High: "High",
+}
+
+@doc("Metadata pertaining to creation and last modification of the resource.")
+model SystemData {
+  @doc("The identity that created the resource.")
+  @visibility(Lifecycle.Read)
+  createdBy?: string;
+
+  @doc("The type of identity that created the resource.")
+  @visibility(Lifecycle.Read)
+  createdByType?: string;
+
+  @doc("The timestamp of resource creation (UTC).")
+  @visibility(Lifecycle.Read)
+  createdAt?: utcDateTime;
+
+  @doc("The identity that last modified the resource.")
+  @visibility(Lifecycle.Read)
+  lastModifiedBy?: string;
+
+  @doc("The type of identity that last modified the resource.")
+  @visibility(Lifecycle.Read)
+  lastModifiedByType?: string;
+
+  @doc("The timestamp of resource last modification (UTC).")
+  @visibility(Lifecycle.Read)
+  lastModifiedAt?: utcDateTime;
+}
+
+@doc("Type of a job.")
+union JobType {
+  string,
+
+  @doc("Command job.")
+  Command: "Command",
+}
+
+#suppress "@azure-tools/typespec-azure-core/no-string-discriminator" "Use an extensible union instead of a plain string"
+@doc("Base properties of a Job.")
+@discriminator("jobType")
+model JobProperties {
+  @doc("Job type.")
+  jobType: string;
+}
+
+@doc("Properties of a Command Job.")
+model CommandJob extends JobProperties {
+  @doc("Job type.")
+  jobType: "Command";
+
+  @doc("The command to execute on startup of the job.")
+  command: string;
+
+  @doc("ACR path of environment.")
+  environmentImageReference: string;
+
+  @doc("Display name of job.")
+  displayName?: string;
+
+  @doc("The asset description text.")
+  description?: string;
+
+  @doc("The name of the experiment the job belongs to. If not set, the job is placed in the \"Default\" experiment.")
+  experimentName?: string;
+
+  @doc("Tag dictionary. Tags can be added, removed, and updated.")
+  tags?: Record<string>;
+
+  @doc("The asset property dictionary.")
+  properties?: Record<string>;
+
+  @doc("Code asset reference.")
+  @encodedName("application/json", "codeId")
+  code?: string;
+
+  @doc("Compute resource ID.")
+  @encodedName("application/json", "computeId")
+  compute: string;
+
+  @doc("Mapping of input data bindings used in the job.")
+  inputs?: Record<Input>;
+
+  @doc("Mapping of output data bindings used in the job.")
+  outputs?: Record<Output>;
+
+  @doc("Environment variables included in the job.")
+  environmentVariables?: Record<string>;
+
+  @doc("Compute Resource configuration for the job.")
+  resources?: JobResourceConfiguration;
+
+  @doc("Distribution configuration of the job.")
+  distribution?: DistributionConfiguration;
+
+  @doc("Command Job limit.")
+  limits?: CommandJobLimits;
+
+  @doc("List of job services.")
+  services?: Record<JobService>;
+
+  @doc("Queue settings for the job.")
+  queueSettings?: QueueSettings;
+
+  @doc("User-visible scheduling priority for the job.")
+  priority?: JobPriority;
+
+  @doc("user-assigned managed identity")
+  userAssignedIdentityId?: string;
+
+  @doc("Number of capacity units to allocate for the job. When set, the service resolves the VM SKU from the compute target and calculates the required node count automatically. Virtual cluster targets must also specify `resources.instanceType`. Valid values are 1, 2, 4, 8, or any multiple of 8 for values greater than 8. `gpuCount` takes precedence over this property when both are supplied.")
+  capacityUnitCount?: int32;
+
+  @doc("Number of GPUs to allocate for the job. Takes precedence over `capacityUnitCount` when both are supplied, and is used to resolve a partial (sub-node) VM SKU for GPU computes. Only applies to GPU computes; CPU computes always resolve to a full-node SKU and ignore this value. Valid values are 1, 2, 4, 8, or any multiple of 8 for values greater than 8.")
+  gpuCount?: int32;
+
+  @doc("Is the asset archived?")
+  isArchived?: boolean;
+
+  @doc("Status of the job.")
+  @visibility(Lifecycle.Read)
+  status?: string;
+}
+
+@doc("Job resource.")
+@Rest.resource("jobs")
+model Job {
+  @doc("The name of the Job. This is case-sensitive.")
+  @key("name")
+  @visibility(Lifecycle.Read)
+  name: string;
+
+  @doc("The resource ID.")
+  @visibility(Lifecycle.Read)
+  id?: string;
+
+  @doc("The resource type.")
+  @visibility(Lifecycle.Read)
+  type?: string;
+
+  @doc("Properties of the job.")
+  properties: JobProperties;
+
+  @doc("Metadata pertaining to creation and last modification of the resource.")
+  @visibility(Lifecycle.Read)
+  systemData?: SystemData;
+}
+
+@doc("Response returned when a job delete operation is accepted asynchronously.")
+@clientName("JobDeleteAcceptedResult", "csharp")
+model JobDeleteAcceptedResponse {
+  @statusCode statusCode: 202;
+
+  @doc("URL to poll for the status of the delete operation.")
+  @header("Location")
+  location: string;
+
+  @doc("Suggested delay in seconds before polling.")
+  @header("Retry-After")
+  retryAfter?: int32;
+}
+
+@doc("Response returned when a job cancel operation is accepted asynchronously.")
+@clientName("JobCancelAcceptedResult", "csharp")
+model JobCancelAcceptedResponse {
+  @statusCode statusCode: 202;
+
+  @doc("URL to poll for the status of the cancel operation.")
+  @header("Location")
+  location: string;
+
+  @doc("Suggested delay in seconds before polling.")
+  @header("Retry-After")
+  retryAfter?: int32;
+}
+
+@doc("Specifies which jobs to include in a list result based on their lifecycle state.")
+union ListViewType {
+  string,
+
+  @doc("Show only active (non-archived) jobs.")
+  ActiveOnly: "ActiveOnly",
+
+  @doc("Show only archived jobs.")
+  ArchivedOnly: "ArchivedOnly",
+
+  @doc("Show all jobs regardless of archived state.")
+  All: "All",
+}
+
+@doc("A data store path.")
+model ArtifactDataPath {
+  @doc("The data store name.")
+  dataStoreName?: string;
+
+  @doc("The relative path within the data store.")
+  relativePath?: string;
+
+  @doc("SQL data path information.")
+  sqlDataPath?: unknown;
+}
+
+@doc("An artifact.")
+model Artifact {
+  @doc("The artifact id.")
+  artifactId?: string;
+
+  @doc("The artifact origin.")
+  origin: string;
+
+  @doc("The container name.")
+  container: string;
+
+  @doc("The artifact path.")
+  path: string;
+
+  @doc("The artifact Etag.")
+  etag?: string;
+
+  @doc("The artifact creation time in UTC.")
+  createdTime?: utcDateTime;
+
+  @doc("The artifact data path.")
+  dataPath?: ArtifactDataPath;
+
+  @doc("The artifact tags.")
+  tags?: Record<string>;
+}
+
+@doc("A page of artifacts.")
+model ArtifactList {
+  @doc("The artifacts in the page.")
+  value: Artifact[];
+
+  @doc("Token for the next page.")
+  continuationToken?: string;
+
+  @doc("URL for the next page.")
+  nextLink?: string;
+}
+
+@doc("Artifact content information.")
+model ArtifactContentInformation {
+  @doc("The content URI.")
+  contentUri?: url;
+
+  @doc("The artifact origin.")
+  origin?: string;
+
+  @doc("The container name.")
+  container?: string;
+
+  @doc("The artifact path.")
+  path?: string;
+
+  @doc("The artifact tags.")
+  tags?: Record<string>;
+
+  @doc("The content byte length.")
+  contentLength?: int64;
+}
+
+@doc("A page of artifact content information.")
+model ArtifactContentInformationList {
+  @doc("The entries in the page.")
+  value: ArtifactContentInformation[];
+
+  @doc("Token for the next page.")
+  continuationToken?: string;
+
+  @doc("URL for the next page.")
+  nextLink?: string;
+}

--- a/specification/ai-foundry/data-plane/Foundry/src/jobs/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/jobs/routes.tsp
@@ -1,0 +1,141 @@
+import "./models.tsp";
+import "../common/models.tsp";
+import "../common/servicepatterns.tsp";
+
+using TypeSpec.Http;
+using TypeSpec.Rest;
+using Azure.Core.Traits;
+
+namespace Azure.AI.Projects;
+
+alias JobsPreviewHeader = WithRequiredFoundryPreviewHeader<FoundryFeaturesOptInKeys.jobs_v1_preview>;
+
+alias JobsFilterQueryParams = {
+  @doc("Filter by job type (e.g. 'Command').")
+  @query
+  jobType?: JobType;
+
+  @doc("Filter jobs by tag in the format 'key=value' (e.g., 'framework=pytorch').")
+  @query
+  tag?: string;
+
+  @doc("Specifies which view type to apply when listing jobs.")
+  @query
+  listViewType?: ListViewType;
+
+  @doc("Comma-separated user property names and optionally values. Example: prop1,prop2=value2.")
+  @query
+  properties?: string;
+};
+
+alias JobOperations = FoundryAzureOperations<{}>;
+
+@tag("CommandJob")
+interface Jobs {
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "We need explicit definition for header support"
+  @doc("List Jobs.")
+  @Rest.listsResource(Job)
+  list is Azure.Core.Foundations.ResourceList<
+    Job,
+    JobsFilterQueryParams & JobsPreviewHeader,
+    Azure.Core.Page<Job>
+  >;
+
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "We need explicit definition for header support"
+  @doc("Get a Job by name.")
+  @get
+  get is Azure.Core.Foundations.ResourceOperation<
+    Job,
+    {
+      ...JobsPreviewHeader;
+    },
+    Azure.Core.Foundations.ResourceOkResponse<Job>
+  >;
+
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Artifact sub-resource path; cannot be expressed with standard resource operations."
+  @doc("List the artifacts produced by a job, including its log files. Logs are ordinary artifacts stored under the well-known `azureml-logs/`, `user_logs/` and `system_logs/` path prefixes, so they are retrieved by filtering on `path`.")
+  @route("/jobs/{name}/artifacts")
+  @get
+  listArtifacts(
+    ...FoundryDataPlaneApiVersionParameter,
+    ...JobsPreviewHeader,
+
+    @doc("The name of the Job.")
+    @path
+    name: string,
+
+    @doc("Optional artifact path or path prefix to filter by.")
+    @query
+    path?: string,
+
+    @doc("Continuation token for the next page.")
+    @query
+    continuationToken?: string,
+
+    @doc("Maximum number of artifacts per page.")
+    @query
+    pageSize?: int32,
+  ): ArtifactList;
+
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Artifact sub-resource path; cannot be expressed with standard resource operations."
+  @doc("Get content information, including a readable content URI and byte length, for the artifacts produced by a job. Use this to download artifact or log content.")
+  @route("/jobs/{name}/artifacts/contentinfo")
+  @get
+  getArtifactContentInformation(
+    ...FoundryDataPlaneApiVersionParameter,
+    ...JobsPreviewHeader,
+
+    @doc("The name of the Job.")
+    @path
+    name: string,
+
+    @doc("Optional artifact path prefix to filter by.")
+    @query
+    path?: string,
+
+    @doc("Continuation token for the next page.")
+    @query
+    continuationToken?: string,
+  ): ArtifactContentInformationList;
+
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "PUT create-or-update pattern required by the Job API wire format"
+  @doc("Create and execute a Job. For update case, the Tags in the definition passed in will replace Tags in the existing job.")
+  @put
+  createOrUpdate is Azure.Core.Foundations.ResourceOperation<
+    Job,
+    {
+      ...JobsPreviewHeader;
+
+      @doc("The job to create or update.")
+      @bodyRoot
+      job: Job;
+    },
+    Azure.Core.Foundations.ResourceCreatedOrOkResponse<Job>
+  >;
+
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "LRO delete returns 202 with Location header for polling, or 204 when job not found"
+  #suppress "@azure-tools/typespec-azure-core/no-response-body" "Delete LRO returns 202 with Location header, 204 with no body"
+  @doc("Delete a Job by name. Returns 202 Accepted with a Location header to poll for completion, or 204 if the job does not exist.")
+  @delete
+  beginDelete is Azure.Core.Foundations.ResourceOperation<
+    Job,
+    {
+      ...JobsPreviewHeader;
+    },
+    JobDeleteAcceptedResponse | Http.NoContentResponse
+  >;
+
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "LRO cancel returns 200 synchronously or 202 with Location header for async polling"
+  #suppress "@azure-tools/typespec-azure-core/no-response-body" "Cancel LRO returns 200 or 202 with Location header, no body"
+  @doc("Cancel a Job by name. Returns 200 if cancelled immediately, or 202 Accepted with a Location header to poll for completion.")
+  @post
+  @Rest.action("cancel")
+  @actionSeparator("/")
+  beginCancel is Azure.Core.Foundations.ResourceOperation<
+    Job,
+    {
+      ...JobsPreviewHeader;
+    },
+    Http.OkResponse | JobCancelAcceptedResponse
+  >;
+} // interface Jobs

--- a/specification/ai-foundry/data-plane/Foundry/src/sdk-csharp-azure-ai-projects/client.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/sdk-csharp-azure-ai-projects/client.tsp
@@ -15,6 +15,7 @@ import "../schedules/routes.tsp";
 import "../memory-stores/routes.tsp";
 import "../routines/routes.tsp";
 import "../data_generation_jobs/routes.tsp";
+import "../jobs/routes.tsp";
 import "../toolboxes/models.tsp";
 import "../agents/models.tsp";
 import "../skills/models.tsp";
@@ -307,3 +308,9 @@ namespace Azure.AI.Projects;
 );
 @@clientName(RoutineActionType, "RoutineActionKind");
 @@clientName(RoutineTriggerType, "RoutineTriggerKind");
+
+// --------------------------------------------------------------------------------
+// Jobs (Foundry training jobs) sub-client
+// --------------------------------------------------------------------------------
+// C# model-suffix renames are declared inline in ../jobs/models.tsp via
+// @clientName(..., "csharp") so that the root main.tsp compile is also clean.

--- a/specification/ai-foundry/data-plane/Foundry/src/sdk-csharp-azure-ai-projects/tspconfig.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/src/sdk-csharp-azure-ai-projects/tspconfig.yaml
@@ -33,6 +33,7 @@ options:
       - specification/ai-foundry/data-plane/Foundry/src/agents-session-files
       - specification/ai-foundry/data-plane/Foundry/src/managed-blueprints
       - specification/ai-foundry/data-plane/Foundry/src/agents-optimization
+      - specification/ai-foundry/data-plane/Foundry/src/jobs
 imports:
   - "@azure-tools/typespec-azure-core"
   - "@azure-tools/typespec-azure-core/experimental"

--- a/specification/ai-foundry/data-plane/Foundry/src/sdk-python-js-azure-ai-projects/client.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/sdk-python-js-azure-ai-projects/client.tsp
@@ -29,6 +29,7 @@ import "../toolboxes/routes.tsp";
 import "../skills/routes.tsp";
 import "../agents-session-files/routes.tsp";
 import "../data_generation_jobs/routes.tsp";
+import "../jobs/routes.tsp";
 //import "../evaluation-suites/routes.tsp";
 import "../agents-optimization/routes.tsp";
 
@@ -557,3 +558,17 @@ model AIProjectClientOptions {
   },
   "python"
 );
+
+// --------------------------------------------------------------------------------
+// Jobs (Foundry training jobs) sub-client
+// --------------------------------------------------------------------------------
+@@clientName(Jobs.get, "get", "python");
+@@clientName(Jobs.list, "list", "python");
+@@clientName(Jobs.createOrUpdate, "create_or_update", "python");
+@@clientName(Jobs.beginDelete, "begin_delete", "python");
+@@clientName(Jobs.beginCancel, "begin_cancel", "python");
+
+// Artifact reads (including log files) are not part of the initial public SDK
+// surface. They remain in the REST contract; the SDK shape is a follow-up.
+@@access(Jobs.listArtifacts, Access.internal);
+@@access(Jobs.getArtifactContentInformation, Access.internal);

--- a/specification/ai-foundry/data-plane/Foundry/src/sdk-python-js-azure-ai-projects/tspconfig.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/src/sdk-python-js-azure-ai-projects/tspconfig.yaml
@@ -41,6 +41,7 @@ options:
       - specification/ai-foundry/data-plane/Foundry/src/evaluators
       - specification/ai-foundry/data-plane/Foundry/src/indexes
       - specification/ai-foundry/data-plane/Foundry/src/insights
+      - specification/ai-foundry/data-plane/Foundry/src/jobs
       - specification/ai-foundry/data-plane/Foundry/src/memory-stores
       - specification/ai-foundry/data-plane/Foundry/src/models
       - specification/ai-foundry/data-plane/Foundry/src/openai


### PR DESCRIPTION
# Data Plane API Specification Update Pull Request

> [!TIP]
> Overwhelmed by all this guidance? See the `Getting help` section at the bottom of this PR description.

Adds the **Foundry training jobs** data-plane surface (`Azure.AI.Projects.Jobs`) under `specification/ai-foundry/data-plane/Foundry/src/jobs/`.

This surface has never existed in `main`. Training is currently the only major Foundry area with no public API contract — agents, datasets, evaluations, deployments, indexes, models, routines, schedules, skills and toolboxes are all already published. The service behind it is shipping today via the Foundry Management Front End, so the REST contract is the remaining gap for SDK generation and public REST reference docs.

Two earlier attempts (#42790, #45258) were never merged and targeted `feature/foundry-staging` / `feature/foundry-release`. The work was ported by hand onto current `main` — it could not be rebased or cherry-picked, because `main` had since moved `servicepatterns.tsp` into `src/common/` and split the root `client.tsp` into per-SDK `src/sdk-*/client.tsp` files. The OpenAPI artifacts were regenerated from current `main`, so the emitted diff is **purely additive (+10,778 / −0)**.

> [!IMPORTANT]
> **Reviewers — please see `Open design questions` below before approving.** This PR is the mechanical port of the contract. Five run-history operations inherited from the earlier draft have **no public route behind them today**, and I am proposing to remove them. I would like that decision confirmed in review rather than shipped by default.

## PR review workflow diagram

Please understand this diagram before proceeding. It explains how to get your PR approved & merged.

![spec_pr_review_workflow_diagram](https://github.com/Azure/azure-rest-api-specs/assets/4429827/5bb5e7ce-8aff-4dbb-a3f8-0d9b68fef5b1)

## API Info: The Basics

Most of the information about your service should be captured in the issue that serves as your [*API Spec engagement record*](https://aka.ms/azsdk/onboarding/restapischedule).

* Link to API Spec engagement record issue: _to be added — an engagement record has not yet been filed for this surface; tracked internally as ADO Feature 5423549 (`[PuPr blocker] Foundry Training SDK/API review and sign off`)._

Is this review for (select one):

- [ ] a private preview
- [x] a public preview
- [ ] GA release

All new operations are gated behind the standard Foundry preview opt-in header `Foundry-Features: Jobs=V1Preview`, registered as `jobs_v1_preview` in `FoundryFeaturesOptInKeys`.

### Change Scope

<sup>This section will help us focus on the specific parts of your API that are new or have been modified. <br/>Please share a link to the design document for the new APIs, a link to the previous API Spec document (if applicable), and the root paths that have been updated. </sup>
* Design Document: _to be added — the written spec (per the 1DP spec template) is in progress and will be linked before the review slot._
* Previous API Spec Doc: **N/A — this is a new surface.** No training-jobs contract has ever been merged to `main`. The prior unmerged drafts, for historical context only, are #42790 and #45258.
* Updated paths: all paths below are **new**; no existing path is modified or removed.

| Verb | Path | Operation ID |
|---|---|---|
| GET | `/jobs` | `Jobs_list` |
| PUT | `/jobs/{name}` | `Jobs_createOrUpdate` |
| GET | `/jobs/{name}` | `Jobs_get` |
| DELETE | `/jobs/{name}` | `Jobs_beginDelete` |
| POST | `/jobs/{name}/cancel` | `Jobs_beginCancel` |
| GET | `/jobs/{name}/history/runs/{runId}` | `Jobs_getRun` ⚠️ |
| GET | `/jobs/{name}/history/runs/{runId}/details` | `Jobs_getRunDetails` ⚠️ |
| GET | `/jobs/{name}/history/runs/{runId}/serviceinstances/{nodeId}` | `Jobs_showServices` ⚠️ |
| GET | `/jobs/{name}/history/experimentids/{experimentId}/runs/{runId}/artifacts` | `Jobs_listArtifacts` ⚠️ |
| GET | `/jobs/{name}/history/experimentids/{experimentId}/runs/{runId}/artifacts/prefix/contentinfo` | `Jobs_getArtifactContentInformation` ⚠️ |

⚠️ = proposed for removal, see below.

### Open design questions for the review

<details open>
  <summary><b>1. The five run-history operations have no public route behind them (proposed: remove)</b></summary>

The `/jobs/{name}/history/...` operations were inherited from the earlier draft. The public Front End exposes **only** the five CRUD + cancel operations; there is no public route for run history, service instances, artifacts, or metrics. They are marked `@access(Access.internal)` so they do not reach the SDKs, but they *do* land in the public REST spec and the generated reference docs.

Publishing them would also conflict with the 1DP requirement to verify the service answers these operations in production on the public endpoint, which it does not.

**Proposal: drop all five from this surface** and reintroduce them later if and when real routes exist. Flagging rather than silently deleting, because the draft's authors may have intended them for a scenario I am not aware of.
</details>

<details open>
  <summary><b>2. How interactive service endpoints should be surfaced</b></summary>

For multi-node training jobs, the Front End today returns only the lead-node representative on `GET /jobs/{name}`. The per-node service-instance route exists internally but is not public. The two options are (a) keep the inline lead-node representation, or (b) add a genuine public per-node route. This is unresolved on the service side and is the main reason the run-history block above is still present in this diff.
</details>

<details>
  <summary><b>3. Contract alignment still to come (follow-up)</b></summary>

This PR ports the draft's contract shape as-is. Aligning it to the shipped Front End contract is a deliberate follow-up, pending the questions above. Known deltas: `experimentName`, `capacityUnitCount`, `priority` and a read-only `parameters` are supported by the service but absent here; `command`, `environmentImageReference` and `computeId` are marked required here but are optional or conditional in the service; and output delivery modes are a strict subset of input modes.
</details>

<details>
  <summary><b>Implementation notes for spec-repo reviewers</b></summary>

* **The regenerated `openapi3` artifacts contain only the jobs additions.** Compiling current `main` produces an unrelated `+94/−631` (json) and `+83/−428` (yaml) delta against its own checked-in artifacts — i.e. `main`'s generated files are already stale with respect to their sources. That pre-existing drift was deliberately kept out of this PR rather than silently absorbed into it, and is worth fixing separately.
* **The `openapi3` YAML files are intentionally left as emitter output.** `Swagger-Prettier-Check` only inspects changed `*.json` files (`Get-ChangedSwaggerFiles` filters on `.EndsWith(".json")`), and running Prettier across the YAML would reflow roughly 5.5k lines of unrelated existing content.
* **`src/jobs` is registered in `additionalDirectories`** for the Python/JS and C# project SDK configs. `tsp-client` copies each `sdk-*` folder in isolation, so a sibling directory that is imported but not declared there fails to resolve during SDK generation even though the in-repo compile succeeds.
* **No suppressions were added.** The `csharp-model-suffix` lint on the five `*Response` models is resolved with inline `@clientName(..., "csharp")` rather than a `#suppress`, since the "kept for backward compatibility" rationale used elsewhere in this area does not apply to a brand-new API.

Verification performed: `compile_all.ps1` passes all 8 targets with 0 errors and 0 warnings; `tsp format` reports every touched `.tsp` unchanged; `prettier --check` passes on all changed `.json` files; the isolated per-SDK folder copy that `tsp-client` performs compiles cleanly; and both emitted documents parse and contain the 8 new `/jobs` paths alongside `main`'s existing surface.
</details>

### Viewing API changes

For convenient view of the API changes made by this PR, refer to the URLs provided in the table 
in the `Generated ApiView` comment added to this PR. You can use ApiView to show API versions diff. 

### Suppressing failures

If one or multiple validation error/warning suppression(s) is detected in your PR, please follow the 
[Swagger-Suppression-Process](https://aka.ms/pr-suppressions) 
to get approval.

No suppressions are introduced by this PR.

### Release planner

A [release plan](https://aka.ms/azsdkdocs/release-plans) should have been created. If not, please create one as it will help guide you through the REST API and SDK creation process. 

## ❔Got questions? Need additional info?? We are here to help!

<details>
  <summary> Contact us!</summary>

The [Azure API Review Board](https://aka.ms/azsdk/onboarding/restapischedule) is dedicated to helping you create amazing APIs. You can read about our mission and learn more about our process on our [wiki](https://aka.ms/azsdk/onboarding/restapischedule).
* 💬 [Teams Channel](https://teams.microsoft.com/l/channel/19%3a3ebb18fded0e47938f998e196a52952f%40thread.tacv2/General?groupId=1a10b50c-e870-4fe0-8483-bf5542a8d2d8&tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47)
* 💌 [email](mailto://azureapirbcore@microsoft.com)

</details>

<details>
  <summary>Click here for links to tools, specs, guidelines & other good stuff</summary>

### Tooling

 * [Open API validation tools](https://aka.ms/swaggertools) were run on this PR. Go here to see [how to fix errors](https://aka.ms/ci-fix)
 * [Spectral Linting](https://github.com/Azure/azure-api-style-guide/blob/main/README.md)

### Guidelines & Specifications

 * [Azure REST API Guidelines](https://aka.ms/azapi/guidelines)
 * [OpenAPI Style Guidelines](https://aka.ms/azapi/style)
 * [Azure Breaking Change Policy](https://aka.ms/AzBreakingChangesPolicy)

### Helpful Links

 * [Schedule a data plane REST API spec review](https://aka.ms/azsdk/onboarding/restapischedule)

</details>

## Getting help

- First, please carefully read through this PR description, from top to bottom.
- If you don't have permissions to remove or add labels to the PR, request `write access` per [aka.ms/azsdk/access#request-access-to-rest-api-or-sdk-repositories](https://aka.ms/azsdk/access#request-access-to-rest-api-or-sdk-repositories) 
- To understand what you must do next to merge this PR, see the `Next Steps to Merge` comment. It will appear within few minutes of submitting this PR and will continue to be up-to-date with current PR state.
- For guidance on fixing this PR CI check failures, see the hyperlinks provided in given failure 
  and https://aka.ms/ci-fix.
- If the PR CI checks appear to be stuck in `queued` state, please add a comment with contents `/azp run`.
  This should result in a new comment denoting a `PR validation pipeline` has started and the checks should be updated after few minutes.
- If the help provided by the previous points is not enough, post to https://aka.ms/azsdk/support/specreview-channel and link to this PR.

AB#5423549
