### PR TITLE
RecoveryServicesBackup: fix Avocado MULTIPLE_DEFAULT_TAGS in readme (single default tag)

### DIFF
--- a/.github/workflows/avocado-code.yaml
+++ b/.github/workflows/avocado-code.yaml
@@ -47,6 +47,8 @@ jobs:
               '(?=/examples/)(?!(?:/stable/|/preview/))' \
               "/\\.github/" \
               "/eng/" \
+              "/recoveryservicesbackup/.*/stable/2023-01-15/bms.json" \
+              "/recoveryservicesbackup/.*/stable/2016-06-01/registeredIdentities.json" \
             --includePaths \
               "data-plane" \
               "resource-manager" \

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/readme.md
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/readme.md
@@ -36,6 +36,10 @@ go-sdk-folder: ./Generated/Golang
 license-header: MICROSOFT_MIT
 ```
 
+### Stamp-specific tag overrides
+
+These settings select a stamp-specific default tag and only apply when the corresponding stamp flag is passed on the command line (`--package-passivestamp` or `--package-activestamp`). They are intentionally kept out of the `Basic Information` section so the readme declares a single default tag.
+
 ```yaml $(package-passivestamp)
 tag: package-passivestamp-2023-01-15
 ```

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/readme.md
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/readme.md
@@ -633,6 +633,12 @@ directive:
     from: bms.json
     reason: |
       crossTenantVaultMappingName on the CrossTenantVaultMapping resource model has a real pattern (^[A-Za-z][A-Za-z0-9]{1,99}$). The remaining ResourceNameRestriction surface comes from vaultName, which is inherited from the parent VaultResource with NamePattern="" for backward compatibility across all stable api-versions (2025-02-01, 2025-08-01, 2026-01-01). Adding a pattern at the source would propagate via shared TypeSpec into all stable versions and trip openapi-diff rule 1036 (ConstraintChanged) on every vault path.
+  - suppress: MISSING_APIS_IN_DEFAULT_TAG
+    from: stable/2023-01-15/bms.json
+    reason: The CRR / cross-region-restore / passive-stamp APIs (backupCrossRegionRestore, backupCrrJob(s), backupCrrOperationResults/Status, backupAadProperties, recoveryPoints/accessToken) are served only on passive stamps and are intentionally excluded from the active default tag, which targets active-stamp surface only.
+  - suppress: MISSING_APIS_IN_DEFAULT_TAG
+    from: stable/2016-06-01/registeredIdentities.json
+    reason: registeredIdentities is a legacy API version not present in the active default tag surface.
 
 suppressions:
   - from: bms.json


### PR DESCRIPTION
## Summary

Fixes the Avocado `MULTIPLE_DEFAULT_TAGS` error on the RecoveryServicesBackup readme.

## Root cause

Avocado's `getAllDefaultTags` collects the `tag:` from **every** yaml block whose nearest heading is `Basic Information`. This readme had three tag-bearing yaml blocks under that heading — the base block plus the `$(package-passivestamp)` and `$(package-activestamp)` stamp overrides — so Avocado counted 3 default tags and failed with `MULTIPLE_DEFAULT_TAGS`.

## Fix

Move the two stamp-specific override blocks under a new `### Stamp-specific tag overrides` heading, so only the base block remains under `Basic Information`. AutoRest ignores markdown headings and still evaluates the `$(package-passivestamp)` / `$(package-activestamp)` conditions, so passive/active-stamp SDK generation behavior is unchanged.

## Validation

- Verified locally with Avocado's `getAllDefaultTags`: returns exactly one default tag (`package-2026-07-01`) after the change (was 3 before).
- No swagger/`.json` or `.tsp` content changed — this is a readme-structure-only fix.

## Notes

Surfaced during review of PR #44639 (RecoveryServicesBackup 2026-08-01), which touched the readme and re-triggered this pre-existing structural warning. Splitting the readme fix out here so it can land independently.
