### PR TITLE
Add AppGw Advanced Routing Rule in NRR API 2026-01-01

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/ApplicationGatewayCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/ApplicationGatewayCreate.json
@@ -11,6 +11,60 @@
       },
       "location": "eastus",
       "properties": {
+        "advancedRoutingConditionSets": [
+          {
+            "name": "advancedRoutingConditionSet1",
+            "properties": {
+              "routingConditions": [
+                {
+                  "conditionType": "Header",
+                  "propertyName": "X-Client-Tier",
+                  "propertyValues": [
+                    "premium"
+                  ]
+                },
+                {
+                  "conditionType": "Path",
+                  "propertyValueMatcher": {
+                    "ignoreCase": true,
+                    "negate": false,
+                    "pattern": "^/api/v2/.*"
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "advancedRoutingMaps": [
+          {
+            "name": "advancedRoutingMap1",
+            "properties": {
+              "advancedRoutingRules": [
+                {
+                  "name": "advancedRoutingRule1",
+                  "properties": {
+                    "advancedRoutingConditionSet": {
+                      "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/advancedRoutingConditionSets/advancedRoutingConditionSet1"
+                    },
+                    "backendAddressPool": {
+                      "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool1"
+                    },
+                    "backendHttpSettings": {
+                      "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs"
+                    },
+                    "priority": 1
+                  }
+                }
+              ],
+              "defaultBackendAddressPool": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
+              },
+              "defaultBackendHttpSettings": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs"
+              }
+            }
+          }
+        ],
         "backendAddressPools": [
           {
             "name": "appgwpool",
@@ -154,6 +208,19 @@
               },
               "ruleType": "Basic"
             }
+          },
+          {
+            "name": "appgwadvancedroutingrule",
+            "properties": {
+              "advancedRoutingMap": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/advancedRoutingMaps/advancedRoutingMap1"
+              },
+              "httpListener": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhttplistener"
+              },
+              "priority": 20,
+              "ruleType": "AdvancedRouting"
+            }
           }
         ],
         "rewriteRuleSets": [
@@ -271,6 +338,66 @@
         "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw",
         "location": "southcentralus",
         "properties": {
+          "advancedRoutingConditionSets": [
+            {
+              "name": "advancedRoutingConditionSet1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/advancedRoutingConditionSets/advancedRoutingConditionSet1",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "routingConditions": [
+                  {
+                    "conditionType": "Header",
+                    "propertyName": "X-Client-Tier",
+                    "propertyValues": [
+                      "premium"
+                    ]
+                  },
+                  {
+                    "conditionType": "Path",
+                    "propertyValueMatcher": {
+                      "ignoreCase": true,
+                      "negate": false,
+                      "pattern": "^/api/v2/.*"
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "advancedRoutingMaps": [
+            {
+              "name": "advancedRoutingMap1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/advancedRoutingMaps/advancedRoutingMap1",
+              "properties": {
+                "advancedRoutingRules": [
+                  {
+                    "name": "advancedRoutingRule1",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/advancedRoutingMaps/advancedRoutingMap1/advancedRoutingRules/advancedRoutingRule1",
+                    "properties": {
+                      "advancedRoutingConditionSet": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/advancedRoutingConditionSets/advancedRoutingConditionSet1"
+                      },
+                      "backendAddressPool": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool1"
+                      },
+                      "backendHttpSettings": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs"
+                      },
+                      "priority": 1,
+                      "provisioningState": "Succeeded"
+                    }
+                  }
+                ],
+                "defaultBackendAddressPool": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
+                },
+                "defaultBackendHttpSettings": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs"
+                },
+                "provisioningState": "Succeeded"
+              }
+            }
+          ],
           "authenticationCertificates": [],
           "backendAddressPools": [
             {
@@ -442,6 +569,21 @@
                   "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1"
                 },
                 "ruleType": "Basic"
+              }
+            },
+            {
+              "name": "appgwadvancedroutingrule",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/requestRoutingRules/appgwadvancedroutingrule",
+              "properties": {
+                "advancedRoutingMap": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/advancedRoutingMaps/advancedRoutingMap1"
+                },
+                "httpListener": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhttplistener"
+                },
+                "priority": 20,
+                "provisioningState": "Succeeded",
+                "ruleType": "AdvancedRouting"
               }
             }
           ],
@@ -547,6 +689,66 @@
         "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw",
         "location": "southcentralus",
         "properties": {
+          "advancedRoutingConditionSets": [
+            {
+              "name": "advancedRoutingConditionSet1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/advancedRoutingConditionSets/advancedRoutingConditionSet1",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "routingConditions": [
+                  {
+                    "conditionType": "Header",
+                    "propertyName": "X-Client-Tier",
+                    "propertyValues": [
+                      "premium"
+                    ]
+                  },
+                  {
+                    "conditionType": "Path",
+                    "propertyValueMatcher": {
+                      "ignoreCase": true,
+                      "negate": false,
+                      "pattern": "^/api/v2/.*"
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "advancedRoutingMaps": [
+            {
+              "name": "advancedRoutingMap1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/advancedRoutingMaps/advancedRoutingMap1",
+              "properties": {
+                "advancedRoutingRules": [
+                  {
+                    "name": "advancedRoutingRule1",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/advancedRoutingMaps/advancedRoutingMap1/advancedRoutingRules/advancedRoutingRule1",
+                    "properties": {
+                      "advancedRoutingConditionSet": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/advancedRoutingConditionSets/advancedRoutingConditionSet1"
+                      },
+                      "backendAddressPool": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool1"
+                      },
+                      "backendHttpSettings": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs"
+                      },
+                      "priority": 1,
+                      "provisioningState": "Succeeded"
+                    }
+                  }
+                ],
+                "defaultBackendAddressPool": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
+                },
+                "defaultBackendHttpSettings": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs"
+                },
+                "provisioningState": "Succeeded"
+              }
+            }
+          ],
           "authenticationCertificates": [],
           "backendAddressPools": [
             {
@@ -718,6 +920,21 @@
                   "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1"
                 },
                 "ruleType": "Basic"
+              }
+            },
+            {
+              "name": "appgwadvancedroutingrule",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/requestRoutingRules/appgwadvancedroutingrule",
+              "properties": {
+                "advancedRoutingMap": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/advancedRoutingMaps/advancedRoutingMap1"
+                },
+                "httpListener": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhttplistener"
+                },
+                "priority": 20,
+                "provisioningState": "Succeeded",
+                "ruleType": "AdvancedRouting"
               }
             }
           ],

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/ApplicationGatewayGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/ApplicationGatewayGet.json
@@ -13,6 +13,66 @@
         "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw",
         "location": "southcentralus",
         "properties": {
+          "advancedRoutingConditionSets": [
+            {
+              "name": "advancedRoutingConditionSet1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/advancedRoutingConditionSets/advancedRoutingConditionSet1",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "routingConditions": [
+                  {
+                    "conditionType": "Header",
+                    "propertyName": "X-Client-Tier",
+                    "propertyValues": [
+                      "premium"
+                    ]
+                  },
+                  {
+                    "conditionType": "Path",
+                    "propertyValueMatcher": {
+                      "ignoreCase": true,
+                      "negate": false,
+                      "pattern": "^/api/v2/.*"
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "advancedRoutingMaps": [
+            {
+              "name": "advancedRoutingMap1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/advancedRoutingMaps/advancedRoutingMap1",
+              "properties": {
+                "advancedRoutingRules": [
+                  {
+                    "name": "advancedRoutingRule1",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/advancedRoutingMaps/advancedRoutingMap1/advancedRoutingRules/advancedRoutingRule1",
+                    "properties": {
+                      "advancedRoutingConditionSet": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/advancedRoutingConditionSets/advancedRoutingConditionSet1"
+                      },
+                      "backendAddressPool": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool1"
+                      },
+                      "backendHttpSettings": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs"
+                      },
+                      "priority": 1,
+                      "provisioningState": "Succeeded"
+                    }
+                  }
+                ],
+                "defaultBackendAddressPool": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
+                },
+                "defaultBackendHttpSettings": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs"
+                },
+                "provisioningState": "Succeeded"
+              }
+            }
+          ],
           "authenticationCertificates": [],
           "backendAddressPools": [
             {
@@ -146,6 +206,23 @@
                 "provisioningState": "Succeeded",
                 "protocol": "Http"
               }
+            },
+            {
+              "name": "appgwadvroutinglistener",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwadvroutinglistener",
+              "properties": {
+                "frontendIPConfiguration": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendIPConfigurations/appgwfip"
+                },
+                "frontendPort": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendPorts/appgwfp80"
+                },
+                "hostNames": [
+                  "advanced.contoso.com"
+                ],
+                "provisioningState": "Succeeded",
+                "protocol": "Http"
+              }
             }
           ],
           "loadDistributionPolicies": [
@@ -258,6 +335,21 @@
                 "urlPathMap": {
                   "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/urlPathMaps/pathMap1"
                 }
+              }
+            },
+            {
+              "name": "appgwadvancedroutingrule",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/requestRoutingRules/appgwadvancedroutingrule",
+              "properties": {
+                "advancedRoutingMap": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/advancedRoutingMaps/advancedRoutingMap1"
+                },
+                "httpListener": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwadvroutinglistener"
+                },
+                "priority": 30,
+                "provisioningState": "Succeeded",
+                "ruleType": "AdvancedRouting"
               }
             }
           ],

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/models.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/models.tsp
@@ -563,6 +563,45 @@ union ApplicationGatewayRequestRoutingRuleType {
    * PathBasedRouting
    */
   PathBasedRouting: "PathBasedRouting",
+
+  /**
+   * AdvancedRouting
+   */
+  @added(Versions.v2026_01_01)
+  AdvancedRouting: "AdvancedRouting",
+}
+
+/**
+ * The type of request property that an advanced routing condition is evaluated against.
+ */
+@added(Versions.v2026_01_01)
+union ApplicationGatewayAdvancedRoutingConditionType {
+  string,
+
+  /**
+   * The condition is evaluated against an HTTP request header identified by propertyName.
+   */
+  Header: "Header",
+
+  /**
+   * The condition is evaluated against a query string argument identified by propertyName.
+   */
+  QueryString: "QueryString",
+
+  /**
+   * The condition is evaluated against the request path. propertyName is not applicable.
+   */
+  Path: "Path",
+
+  /**
+   * The condition is evaluated against the client IP address. propertyName and propertyValueMatcher are not applicable.
+   */
+  ClientIP: "ClientIP",
+
+  /**
+   * The condition is evaluated against the HTTP method. propertyName and propertyValueMatcher are not applicable.
+   */
+  Method: "Method",
 }
 
 /**
@@ -6406,6 +6445,12 @@ model ApplicationGatewayPropertiesFormat {
   urlPathMaps?: ApplicationGatewayUrlPathMap[];
 
   /**
+   * Advanced routing maps of the application gateway resource. For default limits, see [Application Gateway limits](https://docs.microsoft.com/azure/azure-subscription-service-limits#application-gateway-limits).
+   */
+  @added(Versions.v2026_01_01)
+  advancedRoutingMaps?: ApplicationGatewayAdvancedRoutingMap[];
+
+  /**
    * Request routing rules of the application gateway resource.
    */
   requestRoutingRules?: ApplicationGatewayRequestRoutingRule[];
@@ -6419,6 +6464,12 @@ model ApplicationGatewayPropertiesFormat {
    * Rewrite rules for the application gateway resource.
    */
   rewriteRuleSets?: ApplicationGatewayRewriteRuleSet[];
+
+  /**
+   * Advanced routing condition sets of the application gateway resource. For default limits, see [Application Gateway limits](https://docs.microsoft.com/azure/azure-subscription-service-limits#application-gateway-limits).
+   */
+  @added(Versions.v2026_01_01)
+  advancedRoutingConditionSets?: ApplicationGatewayAdvancedRoutingConditionSet[];
 
   /**
    * Redirect configurations of the application gateway resource. For default limits, see [Application Gateway limits](https://docs.microsoft.com/azure/azure-subscription-service-limits#application-gateway-limits).
@@ -7882,6 +7933,255 @@ model ApplicationGatewayPathRulePropertiesFormat {
 }
 
 /**
+ * Advanced routing map of an application gateway. Holds the advanced routing rules evaluated for requests handled by an AdvancedRouting request routing rule, along with the configuration applied when no rule matches.
+ */
+#suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "Application Gateway child resources extend SubResource for consistency with the existing resource shape"
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "This model is part of the existing Application Gateway resource type and must use legacy patterns for backward compatibility"
+@Azure.ResourceManager.Legacy.feature(Features.applicationGateway)
+@added(Versions.v2026_01_01)
+model ApplicationGatewayAdvancedRoutingMap extends SubResource {
+  /**
+   * Properties of the application gateway advanced routing map.
+   */
+  properties?: ApplicationGatewayAdvancedRoutingMapPropertiesFormat;
+
+  /**
+   * Name of the advanced routing map that is unique within an Application Gateway.
+   */
+  name?: string;
+
+  /**
+   * A unique read-only string that changes whenever the resource is updated.
+   */
+  @visibility(Lifecycle.Read)
+  etag?: string;
+
+  /**
+   * Type of the resource.
+   */
+  @visibility(Lifecycle.Read)
+  type?: string;
+}
+
+/**
+ * Properties of advanced routing map of the application gateway.
+ */
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "This model is part of the existing Application Gateway resource type and must use legacy patterns for backward compatibility"
+@Azure.ResourceManager.Legacy.feature(Features.applicationGateway)
+@added(Versions.v2026_01_01)
+model ApplicationGatewayAdvancedRoutingMapPropertiesFormat {
+  /**
+   * Default backend address pool resource of the advanced routing map. Required unless defaultRedirectConfiguration is specified.
+   */
+  defaultBackendAddressPool?: SubResource;
+
+  /**
+   * Default backend http settings resource of the advanced routing map. Required unless defaultRedirectConfiguration is specified.
+   */
+  defaultBackendHttpSettings?: SubResource;
+
+  /**
+   * Default redirect configuration resource of the advanced routing map. Cannot be combined with defaultBackendAddressPool or defaultBackendHttpSettings.
+   */
+  defaultRedirectConfiguration?: SubResource;
+
+  /**
+   * Default rewrite rule set resource of the advanced routing map.
+   */
+  defaultRewriteRuleSet?: SubResource;
+
+  /**
+   * Advanced routing rules of the advanced routing map. Each rule must specify a priority that is unique within the map.
+   */
+  advancedRoutingRules: ApplicationGatewayAdvancedRoutingRule[];
+
+  /**
+   * The provisioning state of the advanced routing map resource.
+   */
+  @visibility(Lifecycle.Read)
+  provisioningState?: ProvisioningState;
+}
+
+/**
+ * Advanced routing rule of an application gateway.
+ */
+#suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "Application Gateway child resources extend SubResource for consistency with the existing resource shape"
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "This model is part of the existing Application Gateway resource type and must use legacy patterns for backward compatibility"
+@Azure.ResourceManager.Legacy.feature(Features.applicationGateway)
+@added(Versions.v2026_01_01)
+model ApplicationGatewayAdvancedRoutingRule extends SubResource {
+  /**
+   * Properties of the application gateway advanced routing rule.
+   */
+  properties?: ApplicationGatewayAdvancedRoutingRulePropertiesFormat;
+
+  /**
+   * Name of the advanced routing rule that is unique within an advanced routing map.
+   */
+  name?: string;
+
+  /**
+   * A unique read-only string that changes whenever the resource is updated.
+   */
+  @visibility(Lifecycle.Read)
+  etag?: string;
+
+  /**
+   * Type of the resource.
+   */
+  @visibility(Lifecycle.Read)
+  type?: string;
+}
+
+/**
+ * Properties of advanced routing rule of the application gateway.
+ */
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "This model is part of the existing Application Gateway resource type and must use legacy patterns for backward compatibility"
+@Azure.ResourceManager.Legacy.feature(Features.applicationGateway)
+@added(Versions.v2026_01_01)
+model ApplicationGatewayAdvancedRoutingRulePropertiesFormat {
+  /**
+   * Priority of the advanced routing rule. Must be unique within the containing advanced routing map. Rules are evaluated in ascending priority order.
+   */
+  @maxValue(1000)
+  @minValue(1)
+  priority: int32;
+
+  /**
+   * Advanced routing condition set resource evaluated by this rule.
+   */
+  advancedRoutingConditionSet?: SubResource;
+
+  /**
+   * Backend address pool resource of the advanced routing rule. Required unless redirectConfiguration is specified.
+   */
+  backendAddressPool?: SubResource;
+
+  /**
+   * Backend http settings resource of the advanced routing rule. Required unless redirectConfiguration is specified.
+   */
+  backendHttpSettings?: SubResource;
+
+  /**
+   * Redirect configuration resource of the advanced routing rule. Cannot be combined with backendAddressPool or backendHttpSettings.
+   */
+  redirectConfiguration?: SubResource;
+
+  /**
+   * Rewrite rule set resource of the advanced routing rule.
+   */
+  rewriteRuleSet?: SubResource;
+
+  /**
+   * The provisioning state of the advanced routing rule resource.
+   */
+  @visibility(Lifecycle.Read)
+  provisioningState?: ProvisioningState;
+}
+
+/**
+ * Advanced routing condition set of an application gateway. Referenced by advanced routing rules to determine whether a request matches.
+ */
+#suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "Application Gateway child resources extend SubResource for consistency with the existing resource shape"
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "This model is part of the existing Application Gateway resource type and must use legacy patterns for backward compatibility"
+@Azure.ResourceManager.Legacy.feature(Features.applicationGateway)
+@added(Versions.v2026_01_01)
+model ApplicationGatewayAdvancedRoutingConditionSet extends SubResource {
+  /**
+   * Properties of the application gateway advanced routing condition set.
+   */
+  properties?: ApplicationGatewayAdvancedRoutingConditionSetPropertiesFormat;
+
+  /**
+   * Name of the advanced routing condition set that is unique within an Application Gateway.
+   */
+  name?: string;
+
+  /**
+   * A unique read-only string that changes whenever the resource is updated.
+   */
+  @visibility(Lifecycle.Read)
+  etag?: string;
+
+  /**
+   * Type of the resource.
+   */
+  @visibility(Lifecycle.Read)
+  type?: string;
+}
+
+/**
+ * Properties of advanced routing condition set of the application gateway.
+ */
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "This model is part of the existing Application Gateway resource type and must use legacy patterns for backward compatibility"
+@Azure.ResourceManager.Legacy.feature(Features.applicationGateway)
+@added(Versions.v2026_01_01)
+model ApplicationGatewayAdvancedRoutingConditionSetPropertiesFormat {
+  /**
+   * Routing conditions of the condition set. All conditions must be satisfied for the referencing advanced routing rule to match.
+   */
+  @identifiers(#[])
+  routingConditions: ApplicationGatewayAdvancedRoutingCondition[];
+
+  /**
+   * The provisioning state of the advanced routing condition set resource.
+   */
+  @visibility(Lifecycle.Read)
+  provisioningState?: ProvisioningState;
+}
+
+/**
+ * A condition evaluated as part of an advanced routing condition set.
+ */
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "This model is part of the existing Application Gateway resource type and must use legacy patterns for backward compatibility"
+@Azure.ResourceManager.Legacy.feature(Features.applicationGateway)
+@added(Versions.v2026_01_01)
+model ApplicationGatewayAdvancedRoutingCondition {
+  /**
+   * The type of request property the condition is evaluated against.
+   */
+  conditionType: ApplicationGatewayAdvancedRoutingConditionType;
+
+  /**
+   * Name of the request property the condition is evaluated against. Required when conditionType is Header or QueryString, and not applicable when conditionType is Path, ClientIP or Method.
+   */
+  propertyName?: string;
+
+  /**
+   * Values the request property is matched against. Exactly one of propertyValues or propertyValueMatcher must be specified.
+   */
+  propertyValues?: string[];
+
+  /**
+   * Pattern the request property is matched against. Exactly one of propertyValues or propertyValueMatcher must be specified. Not applicable when conditionType is ClientIP or Method.
+   */
+  propertyValueMatcher?: ApplicationGatewayAdvancedRoutingPropertyValueMatcher;
+}
+
+/**
+ * Matches the value of a request property against a fixed string or regular expression.
+ */
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "This model is part of the existing Application Gateway resource type and must use legacy patterns for backward compatibility"
+@Azure.ResourceManager.Legacy.feature(Features.applicationGateway)
+@added(Versions.v2026_01_01)
+model ApplicationGatewayAdvancedRoutingPropertyValueMatcher {
+  /**
+   * The pattern, either fixed string or regular expression, that the request property value is evaluated against.
+   */
+  pattern: string;
+
+  /**
+   * Setting this parameter to truth value with force the pattern to do a case in-sensitive comparison.
+   */
+  ignoreCase?: boolean = true;
+
+  /**
+   * Setting this value as truth will force to check the negation of the condition given by the user in the pattern field.
+   */
+  negate?: boolean;
+}
+
+/**
  * Request routing rule of an application gateway.
  */
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
@@ -7948,6 +8248,12 @@ model ApplicationGatewayRequestRoutingRulePropertiesFormat {
    * URL path map resource of the application gateway.
    */
   urlPathMap?: SubResource;
+
+  /**
+   * Advanced routing map resource of the application gateway.
+   */
+  @added(Versions.v2026_01_01)
+  advancedRoutingMap?: SubResource;
 
   /**
    * Rewrite Rule Set resource in Basic rule of the application gateway.

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/applicationGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/applicationGateway.json
@@ -1601,24 +1601,6 @@
         }
       ]
     },
-    "ApplicationGatewayAuthConfig": {
-      "type": "object",
-      "description": "An authentication configuration binding for an Application Gateway routing rule or routing map.",
-      "properties": {
-        "name": {
-          "type": "string",
-          "description": "The name of the auth configuration."
-        },
-        "authenticationPolicy": {
-          "$ref": "./common.json#/definitions/SubResource",
-          "description": "Reference to the authentication policy (Microsoft.Network/authenticationPolicies) resource."
-        }
-      },
-      "required": [
-        "name",
-        "authenticationPolicy"
-      ]
-    },
     "ApplicationGatewayAdvancedRoutingCondition": {
       "type": "object",
       "description": "A condition evaluated as part of an advanced routing condition set.",
@@ -1854,6 +1836,24 @@
       },
       "required": [
         "priority"
+      ]
+    },
+    "ApplicationGatewayAuthConfig": {
+      "type": "object",
+      "description": "An authentication configuration binding for an Application Gateway routing rule or routing map.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the auth configuration."
+        },
+        "authenticationPolicy": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Reference to the authentication policy (Microsoft.Network/authenticationPolicies) resource."
+        }
+      },
+      "required": [
+        "name",
+        "authenticationPolicy"
       ]
     },
     "ApplicationGatewayAuthenticationCertificate": {

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/applicationGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/applicationGateway.json
@@ -1619,6 +1619,243 @@
         "authenticationPolicy"
       ]
     },
+    "ApplicationGatewayAdvancedRoutingCondition": {
+      "type": "object",
+      "description": "A condition evaluated as part of an advanced routing condition set.",
+      "properties": {
+        "conditionType": {
+          "$ref": "./common.json#/definitions/ApplicationGatewayAdvancedRoutingConditionType",
+          "description": "The type of request property the condition is evaluated against."
+        },
+        "propertyName": {
+          "type": "string",
+          "description": "Name of the request property the condition is evaluated against. Required when conditionType is Header or QueryString, and not applicable when conditionType is Path, ClientIP or Method."
+        },
+        "propertyValues": {
+          "type": "array",
+          "description": "Values the request property is matched against. Exactly one of propertyValues or propertyValueMatcher must be specified.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "propertyValueMatcher": {
+          "$ref": "#/definitions/ApplicationGatewayAdvancedRoutingPropertyValueMatcher",
+          "description": "Pattern the request property is matched against. Exactly one of propertyValues or propertyValueMatcher must be specified. Not applicable when conditionType is ClientIP or Method."
+        }
+      },
+      "required": [
+        "conditionType"
+      ]
+    },
+    "ApplicationGatewayAdvancedRoutingConditionSet": {
+      "type": "object",
+      "description": "Advanced routing condition set of an application gateway. Referenced by advanced routing rules to determine whether a request matches.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ApplicationGatewayAdvancedRoutingConditionSetPropertiesFormat",
+          "description": "Properties of the application gateway advanced routing condition set."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the advanced routing condition set that is unique within an Application Gateway."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the resource.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "ApplicationGatewayAdvancedRoutingConditionSetPropertiesFormat": {
+      "type": "object",
+      "description": "Properties of advanced routing condition set of the application gateway.",
+      "properties": {
+        "routingConditions": {
+          "type": "array",
+          "description": "Routing conditions of the condition set. All conditions must be satisfied for the referencing advanced routing rule to match.",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayAdvancedRoutingCondition"
+          },
+          "x-ms-identifiers": []
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the advanced routing condition set resource.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "routingConditions"
+      ]
+    },
+    "ApplicationGatewayAdvancedRoutingMap": {
+      "type": "object",
+      "description": "Advanced routing map of an application gateway. Holds the advanced routing rules evaluated for requests handled by an AdvancedRouting request routing rule, along with the configuration applied when no rule matches.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ApplicationGatewayAdvancedRoutingMapPropertiesFormat",
+          "description": "Properties of the application gateway advanced routing map."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the advanced routing map that is unique within an Application Gateway."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the resource.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "ApplicationGatewayAdvancedRoutingMapPropertiesFormat": {
+      "type": "object",
+      "description": "Properties of advanced routing map of the application gateway.",
+      "properties": {
+        "defaultBackendAddressPool": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Default backend address pool resource of the advanced routing map. Required unless defaultRedirectConfiguration is specified."
+        },
+        "defaultBackendHttpSettings": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Default backend http settings resource of the advanced routing map. Required unless defaultRedirectConfiguration is specified."
+        },
+        "defaultRedirectConfiguration": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Default redirect configuration resource of the advanced routing map. Cannot be combined with defaultBackendAddressPool or defaultBackendHttpSettings."
+        },
+        "defaultRewriteRuleSet": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Default rewrite rule set resource of the advanced routing map."
+        },
+        "advancedRoutingRules": {
+          "type": "array",
+          "description": "Advanced routing rules of the advanced routing map. Each rule must specify a priority that is unique within the map.",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayAdvancedRoutingRule"
+          }
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the advanced routing map resource.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "advancedRoutingRules"
+      ]
+    },
+    "ApplicationGatewayAdvancedRoutingPropertyValueMatcher": {
+      "type": "object",
+      "description": "Matches the value of a request property against a fixed string or regular expression.",
+      "properties": {
+        "pattern": {
+          "type": "string",
+          "description": "The pattern, either fixed string or regular expression, that the request property value is evaluated against."
+        },
+        "ignoreCase": {
+          "type": "boolean",
+          "description": "Setting this parameter to truth value with force the pattern to do a case in-sensitive comparison.",
+          "default": true
+        },
+        "negate": {
+          "type": "boolean",
+          "description": "Setting this value as truth will force to check the negation of the condition given by the user in the pattern field."
+        }
+      },
+      "required": [
+        "pattern"
+      ]
+    },
+    "ApplicationGatewayAdvancedRoutingRule": {
+      "type": "object",
+      "description": "Advanced routing rule of an application gateway.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ApplicationGatewayAdvancedRoutingRulePropertiesFormat",
+          "description": "Properties of the application gateway advanced routing rule."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the advanced routing rule that is unique within an advanced routing map."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the resource.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "ApplicationGatewayAdvancedRoutingRulePropertiesFormat": {
+      "type": "object",
+      "description": "Properties of advanced routing rule of the application gateway.",
+      "properties": {
+        "priority": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Priority of the advanced routing rule. Must be unique within the containing advanced routing map. Rules are evaluated in ascending priority order.",
+          "minimum": 1,
+          "maximum": 1000
+        },
+        "advancedRoutingConditionSet": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Advanced routing condition set resource evaluated by this rule."
+        },
+        "backendAddressPool": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Backend address pool resource of the advanced routing rule. Required unless redirectConfiguration is specified."
+        },
+        "backendHttpSettings": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Backend http settings resource of the advanced routing rule. Required unless redirectConfiguration is specified."
+        },
+        "redirectConfiguration": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Redirect configuration resource of the advanced routing rule. Cannot be combined with backendAddressPool or backendHttpSettings."
+        },
+        "rewriteRuleSet": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Rewrite rule set resource of the advanced routing rule."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the advanced routing rule resource.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "priority"
+      ]
+    },
     "ApplicationGatewayAuthenticationCertificate": {
       "type": "object",
       "description": "Authentication certificates of an application gateway.",
@@ -3528,6 +3765,13 @@
             "$ref": "#/definitions/ApplicationGatewayUrlPathMap"
           }
         },
+        "advancedRoutingMaps": {
+          "type": "array",
+          "description": "Advanced routing maps of the application gateway resource. For default limits, see [Application Gateway limits](https://docs.microsoft.com/azure/azure-subscription-service-limits#application-gateway-limits).",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayAdvancedRoutingMap"
+          }
+        },
         "requestRoutingRules": {
           "type": "array",
           "description": "Request routing rules of the application gateway resource.",
@@ -3547,6 +3791,13 @@
           "description": "Rewrite rules for the application gateway resource.",
           "items": {
             "$ref": "#/definitions/ApplicationGatewayRewriteRuleSet"
+          }
+        },
+        "advancedRoutingConditionSets": {
+          "type": "array",
+          "description": "Advanced routing condition sets of the application gateway resource. For default limits, see [Application Gateway limits](https://docs.microsoft.com/azure/azure-subscription-service-limits#application-gateway-limits).",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayAdvancedRoutingConditionSet"
           }
         },
         "redirectConfigurations": {
@@ -3779,6 +4030,10 @@
         "urlPathMap": {
           "$ref": "./common.json#/definitions/SubResource",
           "description": "URL path map resource of the application gateway."
+        },
+        "advancedRoutingMap": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Advanced routing map resource of the application gateway."
         },
         "rewriteRuleSet": {
           "$ref": "./common.json#/definitions/SubResource",

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/common.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/common.json
@@ -359,6 +359,48 @@
         ]
       }
     },
+    "ApplicationGatewayAdvancedRoutingConditionType": {
+      "type": "string",
+      "description": "The type of request property that an advanced routing condition is evaluated against.",
+      "enum": [
+        "Header",
+        "QueryString",
+        "Path",
+        "ClientIP",
+        "Method"
+      ],
+      "x-ms-enum": {
+        "name": "ApplicationGatewayAdvancedRoutingConditionType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Header",
+            "value": "Header",
+            "description": "The condition is evaluated against an HTTP request header identified by propertyName."
+          },
+          {
+            "name": "QueryString",
+            "value": "QueryString",
+            "description": "The condition is evaluated against a query string argument identified by propertyName."
+          },
+          {
+            "name": "Path",
+            "value": "Path",
+            "description": "The condition is evaluated against the request path. propertyName is not applicable."
+          },
+          {
+            "name": "ClientIP",
+            "value": "ClientIP",
+            "description": "The condition is evaluated against the client IP address. propertyName and propertyValueMatcher are not applicable."
+          },
+          {
+            "name": "Method",
+            "value": "Method",
+            "description": "The condition is evaluated against the HTTP method. propertyName and propertyValueMatcher are not applicable."
+          }
+        ]
+      }
+    },
     "ApplicationGatewayBackendHealthServerHealth": {
       "type": "string",
       "description": "Health of backend server.",
@@ -772,7 +814,8 @@
       "description": "Rule type.",
       "enum": [
         "Basic",
-        "PathBasedRouting"
+        "PathBasedRouting",
+        "AdvancedRouting"
       ],
       "x-ms-enum": {
         "name": "ApplicationGatewayRequestRoutingRuleType",
@@ -787,6 +830,11 @@
             "name": "PathBasedRouting",
             "value": "PathBasedRouting",
             "description": "PathBasedRouting"
+          },
+          {
+            "name": "AdvancedRouting",
+            "value": "AdvancedRouting",
+            "description": "AdvancedRouting"
           }
         ]
       }

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/ApplicationGatewayCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/ApplicationGatewayCreate.json
@@ -11,6 +11,60 @@
       },
       "location": "eastus",
       "properties": {
+        "advancedRoutingConditionSets": [
+          {
+            "name": "advancedRoutingConditionSet1",
+            "properties": {
+              "routingConditions": [
+                {
+                  "conditionType": "Header",
+                  "propertyName": "X-Client-Tier",
+                  "propertyValues": [
+                    "premium"
+                  ]
+                },
+                {
+                  "conditionType": "Path",
+                  "propertyValueMatcher": {
+                    "ignoreCase": true,
+                    "negate": false,
+                    "pattern": "^/api/v2/.*"
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "advancedRoutingMaps": [
+          {
+            "name": "advancedRoutingMap1",
+            "properties": {
+              "advancedRoutingRules": [
+                {
+                  "name": "advancedRoutingRule1",
+                  "properties": {
+                    "advancedRoutingConditionSet": {
+                      "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/advancedRoutingConditionSets/advancedRoutingConditionSet1"
+                    },
+                    "backendAddressPool": {
+                      "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool1"
+                    },
+                    "backendHttpSettings": {
+                      "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs"
+                    },
+                    "priority": 1
+                  }
+                }
+              ],
+              "defaultBackendAddressPool": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
+              },
+              "defaultBackendHttpSettings": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs"
+              }
+            }
+          }
+        ],
         "backendAddressPools": [
           {
             "name": "appgwpool",
@@ -154,6 +208,19 @@
               },
               "ruleType": "Basic"
             }
+          },
+          {
+            "name": "appgwadvancedroutingrule",
+            "properties": {
+              "advancedRoutingMap": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/advancedRoutingMaps/advancedRoutingMap1"
+              },
+              "httpListener": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhttplistener"
+              },
+              "priority": 20,
+              "ruleType": "AdvancedRouting"
+            }
           }
         ],
         "rewriteRuleSets": [
@@ -271,6 +338,66 @@
         "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw",
         "location": "southcentralus",
         "properties": {
+          "advancedRoutingConditionSets": [
+            {
+              "name": "advancedRoutingConditionSet1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/advancedRoutingConditionSets/advancedRoutingConditionSet1",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "routingConditions": [
+                  {
+                    "conditionType": "Header",
+                    "propertyName": "X-Client-Tier",
+                    "propertyValues": [
+                      "premium"
+                    ]
+                  },
+                  {
+                    "conditionType": "Path",
+                    "propertyValueMatcher": {
+                      "ignoreCase": true,
+                      "negate": false,
+                      "pattern": "^/api/v2/.*"
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "advancedRoutingMaps": [
+            {
+              "name": "advancedRoutingMap1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/advancedRoutingMaps/advancedRoutingMap1",
+              "properties": {
+                "advancedRoutingRules": [
+                  {
+                    "name": "advancedRoutingRule1",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/advancedRoutingMaps/advancedRoutingMap1/advancedRoutingRules/advancedRoutingRule1",
+                    "properties": {
+                      "advancedRoutingConditionSet": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/advancedRoutingConditionSets/advancedRoutingConditionSet1"
+                      },
+                      "backendAddressPool": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool1"
+                      },
+                      "backendHttpSettings": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs"
+                      },
+                      "priority": 1,
+                      "provisioningState": "Succeeded"
+                    }
+                  }
+                ],
+                "defaultBackendAddressPool": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
+                },
+                "defaultBackendHttpSettings": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs"
+                },
+                "provisioningState": "Succeeded"
+              }
+            }
+          ],
           "authenticationCertificates": [],
           "backendAddressPools": [
             {
@@ -442,6 +569,21 @@
                   "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1"
                 },
                 "ruleType": "Basic"
+              }
+            },
+            {
+              "name": "appgwadvancedroutingrule",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/requestRoutingRules/appgwadvancedroutingrule",
+              "properties": {
+                "advancedRoutingMap": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/advancedRoutingMaps/advancedRoutingMap1"
+                },
+                "httpListener": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhttplistener"
+                },
+                "priority": 20,
+                "provisioningState": "Succeeded",
+                "ruleType": "AdvancedRouting"
               }
             }
           ],
@@ -547,6 +689,66 @@
         "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw",
         "location": "southcentralus",
         "properties": {
+          "advancedRoutingConditionSets": [
+            {
+              "name": "advancedRoutingConditionSet1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/advancedRoutingConditionSets/advancedRoutingConditionSet1",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "routingConditions": [
+                  {
+                    "conditionType": "Header",
+                    "propertyName": "X-Client-Tier",
+                    "propertyValues": [
+                      "premium"
+                    ]
+                  },
+                  {
+                    "conditionType": "Path",
+                    "propertyValueMatcher": {
+                      "ignoreCase": true,
+                      "negate": false,
+                      "pattern": "^/api/v2/.*"
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "advancedRoutingMaps": [
+            {
+              "name": "advancedRoutingMap1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/advancedRoutingMaps/advancedRoutingMap1",
+              "properties": {
+                "advancedRoutingRules": [
+                  {
+                    "name": "advancedRoutingRule1",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/advancedRoutingMaps/advancedRoutingMap1/advancedRoutingRules/advancedRoutingRule1",
+                    "properties": {
+                      "advancedRoutingConditionSet": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/advancedRoutingConditionSets/advancedRoutingConditionSet1"
+                      },
+                      "backendAddressPool": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool1"
+                      },
+                      "backendHttpSettings": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs"
+                      },
+                      "priority": 1,
+                      "provisioningState": "Succeeded"
+                    }
+                  }
+                ],
+                "defaultBackendAddressPool": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
+                },
+                "defaultBackendHttpSettings": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs"
+                },
+                "provisioningState": "Succeeded"
+              }
+            }
+          ],
           "authenticationCertificates": [],
           "backendAddressPools": [
             {
@@ -718,6 +920,21 @@
                   "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/rewriteRuleSets/rewriteRuleSet1"
                 },
                 "ruleType": "Basic"
+              }
+            },
+            {
+              "name": "appgwadvancedroutingrule",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/requestRoutingRules/appgwadvancedroutingrule",
+              "properties": {
+                "advancedRoutingMap": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/advancedRoutingMaps/advancedRoutingMap1"
+                },
+                "httpListener": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwhttplistener"
+                },
+                "priority": 20,
+                "provisioningState": "Succeeded",
+                "ruleType": "AdvancedRouting"
               }
             }
           ],

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/ApplicationGatewayGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/ApplicationGatewayGet.json
@@ -13,6 +13,66 @@
         "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw",
         "location": "southcentralus",
         "properties": {
+          "advancedRoutingConditionSets": [
+            {
+              "name": "advancedRoutingConditionSet1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/advancedRoutingConditionSets/advancedRoutingConditionSet1",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "routingConditions": [
+                  {
+                    "conditionType": "Header",
+                    "propertyName": "X-Client-Tier",
+                    "propertyValues": [
+                      "premium"
+                    ]
+                  },
+                  {
+                    "conditionType": "Path",
+                    "propertyValueMatcher": {
+                      "ignoreCase": true,
+                      "negate": false,
+                      "pattern": "^/api/v2/.*"
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "advancedRoutingMaps": [
+            {
+              "name": "advancedRoutingMap1",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/advancedRoutingMaps/advancedRoutingMap1",
+              "properties": {
+                "advancedRoutingRules": [
+                  {
+                    "name": "advancedRoutingRule1",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/advancedRoutingMaps/advancedRoutingMap1/advancedRoutingRules/advancedRoutingRule1",
+                    "properties": {
+                      "advancedRoutingConditionSet": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/advancedRoutingConditionSets/advancedRoutingConditionSet1"
+                      },
+                      "backendAddressPool": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool1"
+                      },
+                      "backendHttpSettings": {
+                        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs"
+                      },
+                      "priority": 1,
+                      "provisioningState": "Succeeded"
+                    }
+                  }
+                ],
+                "defaultBackendAddressPool": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendAddressPools/appgwpool"
+                },
+                "defaultBackendHttpSettings": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/backendHttpSettingsCollection/appgwbhs"
+                },
+                "provisioningState": "Succeeded"
+              }
+            }
+          ],
           "authenticationCertificates": [],
           "backendAddressPools": [
             {
@@ -146,6 +206,23 @@
                 "provisioningState": "Succeeded",
                 "protocol": "Http"
               }
+            },
+            {
+              "name": "appgwadvroutinglistener",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwadvroutinglistener",
+              "properties": {
+                "frontendIPConfiguration": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendIPConfigurations/appgwfip"
+                },
+                "frontendPort": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/frontendPorts/appgwfp80"
+                },
+                "hostNames": [
+                  "advanced.contoso.com"
+                ],
+                "provisioningState": "Succeeded",
+                "protocol": "Http"
+              }
             }
           ],
           "loadDistributionPolicies": [
@@ -258,6 +335,21 @@
                 "urlPathMap": {
                   "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/urlPathMaps/pathMap1"
                 }
+              }
+            },
+            {
+              "name": "appgwadvancedroutingrule",
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/requestRoutingRules/appgwadvancedroutingrule",
+              "properties": {
+                "advancedRoutingMap": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/advancedRoutingMaps/advancedRoutingMap1"
+                },
+                "httpListener": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/applicationGateways/appgw/httpListeners/appgwadvroutinglistener"
+                },
+                "priority": 30,
+                "provisioningState": "Succeeded",
+                "ruleType": "AdvancedRouting"
               }
             }
           ],


### PR DESCRIPTION
# Summary

Introduces Advanced Routing for Application Gateway in API version 2026-01-01: a rules engine that lets a request routing rule select a backend based on evaluated request properties (headers, query string, path, client IP, HTTP method) instead of just host/path.

Entry point is a new AdvancedRouting value on the existing ApplicationGatewayRequestRoutingRuleType enum. A rule of that type points at an advanced routing map, which owns an ordered set of rules; each rule references a condition set and a backend/redirect target, with map-level defaults for the no-match case.

All changes are authored in TypeSpec (Network/Network/models.tsp) and gated with `@added(Versions.v2026_01_01)`. The 2026-01-01 Swagger was regenerated with tsp compile, and the AppGw  get/create examples were added.