### PR TITLE
Add managed LoRA adapter deployment APIs

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -38250,6 +38250,49 @@
         ],
         "description": "FileDatasetVersion Definition"
       },
+      "FoundryModelArtifactAccess": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "Standard",
+              "Protected"
+            ]
+          }
+        ],
+        "description": "The customer-visible artifact access policy for a model version.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "Models=V1Preview"
+          ]
+        }
+      },
+      "FoundryModelArtifactDigest": {
+        "type": "object",
+        "required": [
+          "algorithm",
+          "value"
+        ],
+        "properties": {
+          "algorithm": {
+            "$ref": "#/components/schemas/FoundryModelDigestAlgorithm",
+            "description": "Digest algorithm."
+          },
+          "value": {
+            "type": "string",
+            "description": "Lowercase hexadecimal digest value."
+          }
+        },
+        "description": "Service-computed digest for a protected model artifact.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "Models=V1Preview"
+          ]
+        }
+      },
       "FoundryModelArtifactProfileCategory": {
         "anyOf": [
           {
@@ -38288,6 +38331,104 @@
           }
         ],
         "description": "Signals detected in the model artifact.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "Models=V1Preview"
+          ]
+        }
+      },
+      "FoundryModelDigestAlgorithm": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "SHA256"
+            ]
+          }
+        ],
+        "description": "Digest algorithms used to bind registered metadata to an artifact.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "Models=V1Preview"
+          ]
+        }
+      },
+      "FoundryModelProtection": {
+        "type": "object",
+        "required": [
+          "artifactAccess"
+        ],
+        "properties": {
+          "artifactAccess": {
+            "$ref": "#/components/schemas/FoundryModelArtifactAccess",
+            "description": "The customer-visible artifact access policy."
+          },
+          "establishedBy": {
+            "$ref": "#/components/schemas/FoundryModelProtectionEstablishedBy",
+            "description": "The service workflow that established protection."
+          }
+        },
+        "description": "Safe, service-authenticated protection metadata for a model version.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "Models=V1Preview"
+          ]
+        }
+      },
+      "FoundryModelProtectionEstablishedBy": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "FoundryFineTuning"
+            ]
+          }
+        ],
+        "description": "Service workflows that can establish protected artifact access.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "Models=V1Preview"
+          ]
+        }
+      },
+      "FoundryModelServingMetadata": {
+        "type": "object",
+        "required": [
+          "baseModelId",
+          "artifactDigest",
+          "adapterFormat"
+        ],
+        "properties": {
+          "baseModelId": {
+            "type": "string",
+            "description": "Exact base-model asset ID used to produce this model version."
+          },
+          "artifactDigest": {
+            "$ref": "#/components/schemas/FoundryModelArtifactDigest",
+            "description": "Service-computed digest binding this registration to its artifact."
+          },
+          "adapterFormat": {
+            "type": "string",
+            "enum": [
+              "PeftLora"
+            ],
+            "description": "Adapter serialization and runtime format."
+          },
+          "compatibleRuntimeFamilies": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Runtime families with which registration has established compatibility."
+          }
+        },
+        "description": "Serving metadata authenticated by Project Models registration.",
         "x-ms-foundry-meta": {
           "required_previews": [
             "Models=V1Preview"
@@ -40503,7 +40644,6 @@
       "ModelVersion": {
         "type": "object",
         "required": [
-          "blobUri",
           "name",
           "version"
         ],
@@ -40540,6 +40680,16 @@
               "$ref": "#/components/schemas/FoundryModelWarning"
             },
             "description": "Service-computed advisory warnings derived from the artifact profile.",
+            "readOnly": true
+          },
+          "protection": {
+            "$ref": "#/components/schemas/FoundryModelProtection",
+            "description": "Safe protection metadata for this model artifact.",
+            "readOnly": true
+          },
+          "servingMetadata": {
+            "$ref": "#/components/schemas/FoundryModelServingMetadata",
+            "description": "Service-authenticated artifact identity and serving compatibility.",
             "readOnly": true
           },
           "id": {

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -46551,6 +46551,33 @@ components:
       allOf:
         - $ref: '#/components/schemas/DatasetVersionUpdate'
       description: FileDatasetVersion Definition
+    FoundryModelArtifactAccess:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - Standard
+            - Protected
+      description: The customer-visible artifact access policy for a model version.
+      x-ms-foundry-meta:
+        required_previews:
+          - Models=V1Preview
+    FoundryModelArtifactDigest:
+      type: object
+      required:
+        - algorithm
+        - value
+      properties:
+        algorithm:
+          $ref: '#/components/schemas/FoundryModelDigestAlgorithm'
+          description: Digest algorithm.
+        value:
+          type: string
+          description: Lowercase hexadecimal digest value.
+      description: Service-computed digest for a protected model artifact.
+      x-ms-foundry-meta:
+        required_previews:
+          - Models=V1Preview
     FoundryModelArtifactProfileCategory:
       anyOf:
         - type: string
@@ -46574,6 +46601,68 @@ components:
             - NativeBinary
             - UnknownFormat
       description: Signals detected in the model artifact.
+      x-ms-foundry-meta:
+        required_previews:
+          - Models=V1Preview
+    FoundryModelDigestAlgorithm:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - SHA256
+      description: Digest algorithms used to bind registered metadata to an artifact.
+      x-ms-foundry-meta:
+        required_previews:
+          - Models=V1Preview
+    FoundryModelProtection:
+      type: object
+      required:
+        - artifactAccess
+      properties:
+        artifactAccess:
+          $ref: '#/components/schemas/FoundryModelArtifactAccess'
+          description: The customer-visible artifact access policy.
+        establishedBy:
+          $ref: '#/components/schemas/FoundryModelProtectionEstablishedBy'
+          description: The service workflow that established protection.
+      description: Safe, service-authenticated protection metadata for a model version.
+      x-ms-foundry-meta:
+        required_previews:
+          - Models=V1Preview
+    FoundryModelProtectionEstablishedBy:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - FoundryFineTuning
+      description: Service workflows that can establish protected artifact access.
+      x-ms-foundry-meta:
+        required_previews:
+          - Models=V1Preview
+    FoundryModelServingMetadata:
+      type: object
+      required:
+        - baseModelId
+        - artifactDigest
+        - adapterFormat
+      properties:
+        baseModelId:
+          type: string
+          description: Exact base-model asset ID used to produce this model version.
+        artifactDigest:
+          $ref: '#/components/schemas/FoundryModelArtifactDigest'
+          description: Service-computed digest binding this registration to its artifact.
+        adapterFormat:
+          type: string
+          enum:
+            - PeftLora
+          description: Adapter serialization and runtime format.
+        compatibleRuntimeFamilies:
+          type: array
+          items:
+            type: string
+          description: Runtime families with which registration has established compatibility.
+      description: Serving metadata authenticated by Project Models registration.
       x-ms-foundry-meta:
         required_previews:
           - Models=V1Preview
@@ -48103,7 +48192,6 @@ components:
     ModelVersion:
       type: object
       required:
-        - blobUri
         - name
         - version
       properties:
@@ -48132,6 +48220,14 @@ components:
           items:
             $ref: '#/components/schemas/FoundryModelWarning'
           description: Service-computed advisory warnings derived from the artifact profile.
+          readOnly: true
+        protection:
+          $ref: '#/components/schemas/FoundryModelProtection'
+          description: Safe protection metadata for this model artifact.
+          readOnly: true
+        servingMetadata:
+          $ref: '#/components/schemas/FoundryModelServingMetadata'
+          description: Service-authenticated artifact identity and serving compatibility.
           readOnly: true
         id:
           type: string

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -42526,6 +42526,49 @@
         ],
         "description": "FileDatasetVersion Definition"
       },
+      "FoundryModelArtifactAccess": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "Standard",
+              "Protected"
+            ]
+          }
+        ],
+        "description": "The customer-visible artifact access policy for a model version.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "Models=V1Preview"
+          ]
+        }
+      },
+      "FoundryModelArtifactDigest": {
+        "type": "object",
+        "required": [
+          "algorithm",
+          "value"
+        ],
+        "properties": {
+          "algorithm": {
+            "$ref": "#/components/schemas/FoundryModelDigestAlgorithm",
+            "description": "Digest algorithm."
+          },
+          "value": {
+            "type": "string",
+            "description": "Lowercase hexadecimal digest value."
+          }
+        },
+        "description": "Service-computed digest for a protected model artifact.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "Models=V1Preview"
+          ]
+        }
+      },
       "FoundryModelArtifactProfileCategory": {
         "anyOf": [
           {
@@ -42564,6 +42607,104 @@
           }
         ],
         "description": "Signals detected in the model artifact.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "Models=V1Preview"
+          ]
+        }
+      },
+      "FoundryModelDigestAlgorithm": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "SHA256"
+            ]
+          }
+        ],
+        "description": "Digest algorithms used to bind registered metadata to an artifact.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "Models=V1Preview"
+          ]
+        }
+      },
+      "FoundryModelProtection": {
+        "type": "object",
+        "required": [
+          "artifactAccess"
+        ],
+        "properties": {
+          "artifactAccess": {
+            "$ref": "#/components/schemas/FoundryModelArtifactAccess",
+            "description": "The customer-visible artifact access policy."
+          },
+          "establishedBy": {
+            "$ref": "#/components/schemas/FoundryModelProtectionEstablishedBy",
+            "description": "The service workflow that established protection."
+          }
+        },
+        "description": "Safe, service-authenticated protection metadata for a model version.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "Models=V1Preview"
+          ]
+        }
+      },
+      "FoundryModelProtectionEstablishedBy": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "FoundryFineTuning"
+            ]
+          }
+        ],
+        "description": "Service workflows that can establish protected artifact access.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "Models=V1Preview"
+          ]
+        }
+      },
+      "FoundryModelServingMetadata": {
+        "type": "object",
+        "required": [
+          "baseModelId",
+          "artifactDigest",
+          "adapterFormat"
+        ],
+        "properties": {
+          "baseModelId": {
+            "type": "string",
+            "description": "Exact base-model asset ID used to produce this model version."
+          },
+          "artifactDigest": {
+            "$ref": "#/components/schemas/FoundryModelArtifactDigest",
+            "description": "Service-computed digest binding this registration to its artifact."
+          },
+          "adapterFormat": {
+            "type": "string",
+            "enum": [
+              "PeftLora"
+            ],
+            "description": "Adapter serialization and runtime format."
+          },
+          "compatibleRuntimeFamilies": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Runtime families with which registration has established compatibility."
+          }
+        },
+        "description": "Serving metadata authenticated by Project Models registration.",
         "x-ms-foundry-meta": {
           "required_previews": [
             "Models=V1Preview"
@@ -44936,7 +45077,6 @@
       "ModelVersion": {
         "type": "object",
         "required": [
-          "blobUri",
           "name",
           "version"
         ],
@@ -44973,6 +45113,16 @@
               "$ref": "#/components/schemas/FoundryModelWarning"
             },
             "description": "Service-computed advisory warnings derived from the artifact profile.",
+            "readOnly": true
+          },
+          "protection": {
+            "$ref": "#/components/schemas/FoundryModelProtection",
+            "description": "Safe protection metadata for this model artifact.",
+            "readOnly": true
+          },
+          "servingMetadata": {
+            "$ref": "#/components/schemas/FoundryModelServingMetadata",
+            "description": "Service-authenticated artifact identity and serving compatibility.",
             "readOnly": true
           },
           "id": {

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -49491,6 +49491,33 @@ components:
       allOf:
         - $ref: '#/components/schemas/DatasetVersionUpdate'
       description: FileDatasetVersion Definition
+    FoundryModelArtifactAccess:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - Standard
+            - Protected
+      description: The customer-visible artifact access policy for a model version.
+      x-ms-foundry-meta:
+        required_previews:
+          - Models=V1Preview
+    FoundryModelArtifactDigest:
+      type: object
+      required:
+        - algorithm
+        - value
+      properties:
+        algorithm:
+          $ref: '#/components/schemas/FoundryModelDigestAlgorithm'
+          description: Digest algorithm.
+        value:
+          type: string
+          description: Lowercase hexadecimal digest value.
+      description: Service-computed digest for a protected model artifact.
+      x-ms-foundry-meta:
+        required_previews:
+          - Models=V1Preview
     FoundryModelArtifactProfileCategory:
       anyOf:
         - type: string
@@ -49514,6 +49541,68 @@ components:
             - NativeBinary
             - UnknownFormat
       description: Signals detected in the model artifact.
+      x-ms-foundry-meta:
+        required_previews:
+          - Models=V1Preview
+    FoundryModelDigestAlgorithm:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - SHA256
+      description: Digest algorithms used to bind registered metadata to an artifact.
+      x-ms-foundry-meta:
+        required_previews:
+          - Models=V1Preview
+    FoundryModelProtection:
+      type: object
+      required:
+        - artifactAccess
+      properties:
+        artifactAccess:
+          $ref: '#/components/schemas/FoundryModelArtifactAccess'
+          description: The customer-visible artifact access policy.
+        establishedBy:
+          $ref: '#/components/schemas/FoundryModelProtectionEstablishedBy'
+          description: The service workflow that established protection.
+      description: Safe, service-authenticated protection metadata for a model version.
+      x-ms-foundry-meta:
+        required_previews:
+          - Models=V1Preview
+    FoundryModelProtectionEstablishedBy:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - FoundryFineTuning
+      description: Service workflows that can establish protected artifact access.
+      x-ms-foundry-meta:
+        required_previews:
+          - Models=V1Preview
+    FoundryModelServingMetadata:
+      type: object
+      required:
+        - baseModelId
+        - artifactDigest
+        - adapterFormat
+      properties:
+        baseModelId:
+          type: string
+          description: Exact base-model asset ID used to produce this model version.
+        artifactDigest:
+          $ref: '#/components/schemas/FoundryModelArtifactDigest'
+          description: Service-computed digest binding this registration to its artifact.
+        adapterFormat:
+          type: string
+          enum:
+            - PeftLora
+          description: Adapter serialization and runtime format.
+        compatibleRuntimeFamilies:
+          type: array
+          items:
+            type: string
+          description: Runtime families with which registration has established compatibility.
+      description: Serving metadata authenticated by Project Models registration.
       x-ms-foundry-meta:
         required_previews:
           - Models=V1Preview
@@ -51151,7 +51240,6 @@ components:
     ModelVersion:
       type: object
       required:
-        - blobUri
         - name
         - version
       properties:
@@ -51180,6 +51268,14 @@ components:
           items:
             $ref: '#/components/schemas/FoundryModelWarning'
           description: Service-computed advisory warnings derived from the artifact profile.
+          readOnly: true
+        protection:
+          $ref: '#/components/schemas/FoundryModelProtection'
+          description: Safe protection metadata for this model artifact.
+          readOnly: true
+        servingMetadata:
+          $ref: '#/components/schemas/FoundryModelServingMetadata'
+          description: Service-authenticated artifact identity and serving compatibility.
           readOnly: true
         id:
           type: string

--- a/specification/ai-foundry/data-plane/Foundry/src/models/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/models/models.tsp
@@ -97,12 +97,78 @@ model FoundryModelWarning {
   message?: string;
 }
 
+@doc("The customer-visible artifact access policy for a model version.")
+@extension("x-ms-foundry-meta", ModelsRequiredPreviews)
+union FoundryModelArtifactAccess {
+  string,
+
+  @doc("The artifact follows the standard Project Models access policy.")
+  Standard: "Standard",
+
+  @doc("The artifact cannot be downloaded, exported, copied, or addressed through customer-visible storage credentials.")
+  Protected: "Protected",
+}
+
+@doc("Service workflows that can establish protected artifact access.")
+@extension("x-ms-foundry-meta", ModelsRequiredPreviews)
+union FoundryModelProtectionEstablishedBy {
+  string,
+
+  @doc("Protection was established by the Foundry fine-tuning service.")
+  FoundryFineTuning: "FoundryFineTuning",
+}
+
+@doc("Digest algorithms used to bind registered metadata to an artifact.")
+@extension("x-ms-foundry-meta", ModelsRequiredPreviews)
+union FoundryModelDigestAlgorithm {
+  string,
+
+  @doc("SHA-256 digest.")
+  Sha256: "SHA256",
+}
+
+@doc("Service-computed digest for a protected model artifact.")
+@extension("x-ms-foundry-meta", ModelsRequiredPreviews)
+model FoundryModelArtifactDigest {
+  @doc("Digest algorithm.")
+  algorithm: FoundryModelDigestAlgorithm;
+
+  @doc("Lowercase hexadecimal digest value.")
+  value: string;
+}
+
+@doc("Serving metadata authenticated by Project Models registration.")
+@extension("x-ms-foundry-meta", ModelsRequiredPreviews)
+model FoundryModelServingMetadata {
+  @doc("Exact base-model asset ID used to produce this model version.")
+  baseModelId: string;
+
+  @doc("Service-computed digest binding this registration to its artifact.")
+  artifactDigest: FoundryModelArtifactDigest;
+
+  @doc("Adapter serialization and runtime format.")
+  adapterFormat: "PeftLora";
+
+  @doc("Runtime families with which registration has established compatibility.")
+  compatibleRuntimeFamilies?: string[];
+}
+
+@doc("Safe, service-authenticated protection metadata for a model version.")
+@extension("x-ms-foundry-meta", ModelsRequiredPreviews)
+model FoundryModelProtection {
+  @doc("The customer-visible artifact access policy.")
+  artifactAccess: FoundryModelArtifactAccess;
+
+  @doc("The service workflow that established protection.")
+  establishedBy?: FoundryModelProtectionEstablishedBy;
+}
+
 @doc("Model Version Definition")
 @Rest.resource("models")
 @extension("x-ms-foundry-meta", ModelsRequiredPreviews)
 model ModelVersion {
   @doc("URI of the model artifact in blob storage")
-  blobUri: url;
+  blobUri?: url;
 
   @doc("The weight type of the model")
   weightType?: FoundryModelWeightType;
@@ -125,6 +191,14 @@ model ModelVersion {
   @doc("Service-computed advisory warnings derived from the artifact profile.")
   @visibility(Lifecycle.Read)
   warnings?: FoundryModelWarning[];
+
+  @doc("Safe protection metadata for this model artifact.")
+  @visibility(Lifecycle.Read)
+  protection?: FoundryModelProtection;
+
+  @doc("Service-authenticated artifact identity and serving compatibility.")
+  @visibility(Lifecycle.Read)
+  servingMetadata?: FoundryModelServingMetadata;
 
   ...AssetBase;
 }

--- a/specification/cognitiveservices/CognitiveServices.Management/AdapterDeployment.tsp
+++ b/specification/cognitiveservices/CognitiveServices.Management/AdapterDeployment.tsp
@@ -1,0 +1,417 @@
+import "@azure-tools/typespec-azure-core";
+import "@azure-tools/typespec-azure-resource-manager";
+import "@typespec/http";
+import "@typespec/openapi";
+import "@typespec/rest";
+import "@typespec/versioning";
+import "./models.tsp";
+import "./Account.tsp";
+import "./ManagedComputeDeployment.tsp";
+
+using Azure.ResourceManager;
+using TypeSpec.Http;
+using TypeSpec.OpenAPI;
+using TypeSpec.Rest;
+using TypeSpec.Versioning;
+
+namespace Microsoft.CognitiveServices;
+
+/**
+ * An independently managed LoRA adapter attached to a Managed Compute
+ * deployment.
+ */
+@added(Versions.v2026_07_15_preview)
+@parentResource(Account)
+model AdapterDeployment
+  is Azure.ResourceManager.ProxyResource<AdapterDeploymentProperties> {
+  ...ResourceNameParameter<
+    Resource = AdapterDeployment,
+    KeyName = "adapterDeploymentName",
+    SegmentName = "adapterDeployments",
+    NamePattern = "^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$"
+  >;
+
+  /**
+   * Resource tags used for organization and governance.
+   */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "The account child supports independent tags."
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-no-record" "Resource tags are extensible key-value pairs."
+  tags?: Record<string>;
+
+  /** The concurrency token for this adapter deployment. */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "Cognitive Services uses the lowercase etag envelope property."
+  @visibility(Lifecycle.Read)
+  etag?: string;
+}
+
+/** Properties of an adapter deployment. */
+@added(Versions.v2026_07_15_preview)
+model AdapterDeploymentProperties {
+  /**
+   * The Project Models version produced by Foundry fine-tuning. Updating this
+   * value starts rolling replacement of the active adapter generation.
+   */
+  sourceModelId: string;
+
+  /**
+   * The immutable ARM ID of the compatible Managed Compute deployment.
+   */
+  targetDeploymentId: Azure.Core.armResourceIdentifier<[
+    {
+      type: "Microsoft.CognitiveServices/accounts/managedComputeDeployments";
+    }
+  ]>;
+
+  /**
+   * The source model version currently admitted for inference. During
+   * replacement this remains the prior generation until atomic cutover.
+   */
+  @visibility(Lifecycle.Read)
+  activeSourceModelId?: string;
+
+  /** The provisioning state of the adapter deployment. */
+  @visibility(Lifecycle.Read)
+  provisioningState?: AdapterDeploymentProvisioningState;
+
+  /** Whether the adapter can currently serve inference requests. */
+  @visibility(Lifecycle.Read)
+  servingState?: AdapterDeploymentServingState;
+
+  /** Service-authenticated validation results for the active generation. */
+  @visibility(Lifecycle.Read)
+  validation?: AdapterDeploymentValidation;
+
+  /** Revocation details when security policy has disabled this adapter. */
+  @visibility(Lifecycle.Read)
+  revocation?: AdapterDeploymentRevocation;
+
+  /** Information about the most recently requested lifecycle operation. */
+  @visibility(Lifecycle.Read)
+  lastOperation?: AdapterDeploymentLastOperation;
+}
+
+/** Provisioning states for an adapter deployment resource. */
+@added(Versions.v2026_07_15_preview)
+union AdapterDeploymentProvisioningState {
+  string,
+
+  /** The create request was accepted. */
+  Accepted: "Accepted",
+
+  /** The initial adapter generation is being prepared. */
+  Creating: "Creating",
+
+  /** A replacement generation is being prepared. */
+  Updating: "Updating",
+
+  /** The active generation is ready across every healthy parent replica. */
+  Succeeded: "Succeeded",
+
+  /** The latest lifecycle operation failed. */
+  Failed: "Failed",
+
+  /** The latest lifecycle operation was canceled. */
+  Canceled: "Canceled",
+
+  /** The adapter is draining and being removed. */
+  Deleting: "Deleting",
+}
+
+/** Serving availability independent of the latest management operation. */
+@added(Versions.v2026_07_15_preview)
+union AdapterDeploymentServingState {
+  string,
+
+  /** No generation has been admitted for inference. */
+  NotReady: "NotReady",
+
+  /** The active generation is available for inference. */
+  Ready: "Ready",
+
+  /** The service is restoring the active generation on one or more replicas. */
+  Reconciling: "Reconciling",
+
+  /** Security policy has removed the adapter from routing. */
+  Revoked: "Revoked",
+}
+
+/** Adapter format values validated by the serving runtime. */
+@added(Versions.v2026_07_15_preview)
+union AdapterDeploymentFormat {
+  string,
+
+  /** Hugging Face PEFT LoRA adapter format. */
+  PeftLora: "PeftLora",
+}
+
+/** Service-authenticated validation results for the active adapter generation. */
+@added(Versions.v2026_07_15_preview)
+model AdapterDeploymentValidation {
+  /** Source model version for which these values were validated. */
+  sourceModelId: string;
+
+  /** Exact base-model asset ID recorded on the adapter source. */
+  sourceBaseModelId: string;
+
+  /** Exact base-model asset ID served by the parent deployment. */
+  targetBaseModelId: string;
+
+  /** Adapter serialization and runtime format. */
+  adapterFormat: AdapterDeploymentFormat;
+
+  /** Validated LoRA rank. */
+  rank: int32;
+
+  /** Validated base-model modules modified by the adapter. */
+  targetModules: string[];
+
+  /** Capacity values evaluated when admitting this generation. */
+  capacity: AdapterDeploymentCapacityValidation;
+
+  /** Time at which the service completed this validation. */
+  validatedAt: utcDateTime;
+}
+
+/** Capacity values evaluated for adapter admission. */
+@added(Versions.v2026_07_15_preview)
+model AdapterDeploymentCapacityValidation {
+  /** Maximum active adapters supported by the target runtime and fleet. */
+  adapterCountLimit: int32;
+
+  /** Number of active adapters after admitting this generation. */
+  adapterCountAfterAdmission: int32;
+
+  /** Maximum LoRA rank supported by the target runtime. */
+  rankLimit: int32;
+
+  /** Service-estimated memory required by this adapter, in bytes. */
+  estimatedAdapterMemoryBytes: int64;
+
+  /** Adapter memory available before this generation was admitted, in bytes. */
+  availableAdapterMemoryBytes: int64;
+}
+
+/** Safe customer-visible details for an administrative revocation. */
+@added(Versions.v2026_07_15_preview)
+model AdapterDeploymentRevocation {
+  /** Stable policy or security reason code. */
+  reasonCode: string;
+
+  /** Time at which the adapter was removed from routing. */
+  revokedAt: utcDateTime;
+
+  /** Safe support and audit correlation identifier. */
+  correlationId: string;
+}
+
+/** Lifecycle operation types reported by an adapter deployment. */
+@added(Versions.v2026_07_15_preview)
+union AdapterDeploymentOperationType {
+  string,
+
+  /** Initial adapter deployment creation. */
+  Create: "Create",
+
+  /** Replacement of the active source model version. */
+  Replace: "Replace",
+
+  /** Adapter deployment deletion. */
+  Delete: "Delete",
+}
+
+/** Lifecycle operation states reported by an adapter deployment. */
+@added(Versions.v2026_07_15_preview)
+union AdapterDeploymentOperationState {
+  string,
+
+  /** The operation request was accepted. */
+  Accepted: "Accepted",
+
+  /** The operation is running. */
+  Running: "Running",
+
+  /** The operation completed successfully. */
+  Succeeded: "Succeeded",
+
+  /** The operation failed. */
+  Failed: "Failed",
+
+  /** The operation was canceled. */
+  Canceled: "Canceled",
+}
+
+/** Rollback outcomes for a failed or canceled replacement. */
+@added(Versions.v2026_07_15_preview)
+union AdapterDeploymentRollbackResult {
+  string,
+
+  /** No rollback was required. */
+  NotRequired: "NotRequired",
+
+  /** Rollback completed successfully. */
+  Succeeded: "Succeeded",
+
+  /** Rollback failed. */
+  Failed: "Failed",
+}
+
+/** Safe domain error details returned for adapter deployment failures. */
+@added(Versions.v2026_07_15_preview)
+model AdapterDeploymentErrorDetail {
+  /** Stable machine-readable error code. */
+  code: string;
+
+  /** Safe customer-facing error message. */
+  message: string;
+
+  /** Request property or resource targeted by the error. */
+  target?: string;
+
+  /** Nested safe error details. */
+  @identifiers(#[])
+  details?: AdapterDeploymentErrorDetail[];
+}
+
+/** The most recently requested adapter lifecycle operation. */
+@added(Versions.v2026_07_15_preview)
+model AdapterDeploymentLastOperation {
+  /** The type of lifecycle operation. */
+  type: AdapterDeploymentOperationType;
+
+  /** The current or terminal operation state. */
+  status: AdapterDeploymentOperationState;
+
+  /** The source requested by a create or replacement operation. */
+  requestedSourceModelId?: string;
+
+  /** A safe identifier used to correlate logs and support requests. */
+  correlationId: string;
+
+  /** The time at which the operation started. */
+  startedAt: utcDateTime;
+
+  /** The time at which the operation reached a terminal state. */
+  completedAt?: utcDateTime;
+
+  /** The rollback result when a replacement does not complete successfully. */
+  rollbackResult?: AdapterDeploymentRollbackResult;
+
+  /** Safe error details when the operation failed. */
+  error?: AdapterDeploymentErrorDetail;
+}
+
+/** Parameters used to filter adapter deployments. */
+@added(Versions.v2026_07_15_preview)
+model AdapterDeploymentListParameters {
+  /**
+   * Filters by target deployment, source model version, provisioning state,
+   * or a supported conjunction of those predicates.
+   */
+  @query("$filter")
+  filter?: string;
+}
+
+/** A paginated collection of adapter deployments. */
+@added(Versions.v2026_07_15_preview)
+model AdapterDeploymentListResult {
+  /** Adapter deployments in this page. */
+  @pageItems
+  @visibility(Lifecycle.Read)
+  value: AdapterDeployment[];
+
+  /** URL used to retrieve the next page, when one exists. */
+  @nextLink
+  nextLink?: url;
+}
+
+/** The result of requesting cancellation of an adapter operation. */
+@added(Versions.v2026_07_15_preview)
+model AdapterDeploymentCancelResult {
+  /** The resulting state of the operation targeted by cancellation. */
+  status: AdapterDeploymentOperationState;
+
+  /** The operation type targeted by cancellation. */
+  operationType: AdapterDeploymentOperationType;
+
+  /** The source generation that remains active after cancellation. */
+  activeSourceModelId?: string;
+
+  /** The staged source generation removed by cancellation. */
+  canceledSourceModelId?: string;
+
+  /** A safe identifier used to correlate logs and support requests. */
+  correlationId: string;
+}
+
+/** Standard conditional headers accepted by adapter PUT operations. */
+alias AdapterDeploymentPutConditions = {
+  /** Applies replacement only when the current resource ETag matches. */
+  @header("If-Match")
+  ifMatch?: string;
+
+  /** Use `*` for create-only behavior. */
+  @header("If-None-Match")
+  ifNoneMatch?: string;
+};
+
+/** Conditional header required when deleting an adapter deployment. */
+alias AdapterDeploymentDeleteConditions = {
+  /** Applies deletion only when the current resource ETag matches. */
+  @header("If-Match")
+  ifMatch?: string;
+};
+
+@added(Versions.v2026_07_15_preview)
+@armResourceOperations
+interface AdapterDeployments {
+  /** Gets an adapter deployment by name. */
+  get is ArmResourceRead<AdapterDeployment>;
+
+  /** Creates an adapter deployment or replaces its source model version. */
+  createOrUpdate is ArmResourceCreateOrReplaceAsync<
+    AdapterDeployment,
+    Parameters = AdapterDeploymentPutConditions
+  >;
+
+  /** Lists adapter deployments associated with the Cognitive Services account. */
+  list is ArmResourceListByParent<
+    AdapterDeployment,
+    Parameters = AdapterDeploymentListParameters,
+    Response = ArmResponse<AdapterDeploymentListResult>
+  >;
+
+  /** Cancels an in-progress create or replacement before atomic cutover. */
+  cancel is ArmResourceActionAsync<
+    AdapterDeployment,
+    void,
+    Response = ArmResponse<AdapterDeploymentCancelResult>,
+    LroHeaders = Azure.Core.Foundations.RetryAfterHeader &
+      ArmLroLocationHeader<
+        Azure.Core.StatusMonitorPollingOptions<ArmOperationStatus>,
+        AdapterDeploymentCancelResult,
+        string
+      >
+  >;
+
+  /** Drains requests and deletes an adapter deployment. */
+  delete is ArmResourceDeleteWithoutOkAsync<
+    AdapterDeployment,
+    Parameters = AdapterDeploymentDeleteConditions,
+    LroHeaders = ArmCombinedLroHeaders<ArmOperationStatus, void> &
+      Azure.Core.Foundations.RetryAfterHeader
+  >;
+}
+
+@@doc(
+  AdapterDeployment.name,
+  "The account-unique adapter deployment name and inference identity."
+);
+@@doc(
+  AdapterDeployment.properties,
+  "Properties of the Cognitive Services adapter deployment."
+);
+@@encodedName(AdapterDeployment.etag, "application/json", "etag");
+@@doc(
+  AdapterDeployments.createOrUpdate::parameters.resource,
+  "The complete adapter deployment resource to create or replace."
+);

--- a/specification/cognitiveservices/CognitiveServices.Management/main.tsp
+++ b/specification/cognitiveservices/CognitiveServices.Management/main.tsp
@@ -39,6 +39,7 @@ import "./ManagedNetworkSettingsPropertiesBasicResource.tsp";
 import "./AgentApplication.tsp";
 import "./AgentDeploymentResource.tsp";
 import "./ManagedComputeDeployment.tsp";
+import "./AdapterDeployment.tsp";
 import "./ComputeOperation.tsp";
 import "./ManagedComputeUsages.tsp";
 import "./Compute.tsp";

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-07-15-preview/cognitiveservices.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-07-15-preview/cognitiveservices.json
@@ -127,6 +127,9 @@
       "name": "ManagedComputeDeployments"
     },
     {
+      "name": "AdapterDeployments"
+    },
+    {
       "name": "ComputeOperations"
     },
     {
@@ -2008,6 +2011,354 @@
         },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/adapterDeployments": {
+      "get": {
+        "operationId": "AdapterDeployments_List",
+        "tags": [
+          "AdapterDeployments"
+        ],
+        "description": "Lists adapter deployments associated with the Cognitive Services account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "$ref": "#/parameters/AdapterDeploymentListParameters"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AdapterDeploymentListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/adapterDeployments/{adapterDeploymentName}": {
+      "get": {
+        "operationId": "AdapterDeployments_Get",
+        "tags": [
+          "AdapterDeployments"
+        ],
+        "description": "Gets an adapter deployment by name.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "adapterDeploymentName",
+            "in": "path",
+            "description": "The account-unique adapter deployment name and inference identity.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AdapterDeployment"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "AdapterDeployments_CreateOrUpdate",
+        "tags": [
+          "AdapterDeployments"
+        ],
+        "description": "Creates an adapter deployment or replaces its source model version.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "adapterDeploymentName",
+            "in": "path",
+            "description": "The account-unique adapter deployment name and inference identity.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "Applies replacement only when the current resource ETag matches.",
+            "required": false,
+            "type": "string",
+            "x-ms-client-name": "ifMatch"
+          },
+          {
+            "name": "If-None-Match",
+            "in": "header",
+            "description": "Use `*` for create-only behavior.",
+            "required": false,
+            "type": "string",
+            "x-ms-client-name": "ifNoneMatch"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "The complete adapter deployment resource to create or replace.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/AdapterDeployment"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'AdapterDeployment' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/AdapterDeployment"
+            }
+          },
+          "201": {
+            "description": "Resource 'AdapterDeployment' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/AdapterDeployment"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/AdapterDeployment"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "AdapterDeployments_Delete",
+        "tags": [
+          "AdapterDeployments"
+        ],
+        "description": "Drains requests and deletes an adapter deployment.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "adapterDeploymentName",
+            "in": "path",
+            "description": "The account-unique adapter deployment name and inference identity.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "Applies deletion only when the current resource ETag matches.",
+            "required": false,
+            "type": "string",
+            "x-ms-client-name": "ifMatch"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/adapterDeployments/{adapterDeploymentName}/cancel": {
+      "post": {
+        "operationId": "AdapterDeployments_Cancel",
+        "tags": [
+          "AdapterDeployments"
+        ],
+        "description": "Cancels an in-progress create or replacement before atomic cutover.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "adapterDeploymentName",
+            "in": "path",
+            "description": "The account-unique adapter deployment name and inference identity.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AdapterDeploymentCancelResult"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/AdapterDeploymentCancelResult"
         },
         "x-ms-long-running-operation": true
       }
@@ -12080,6 +12431,546 @@
         ]
       }
     },
+    "AdapterDeployment": {
+      "type": "object",
+      "description": "An independently managed LoRA adapter attached to a Managed Compute\ndeployment.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/AdapterDeploymentProperties",
+          "description": "Properties of the Cognitive Services adapter deployment."
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags used for organization and governance.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "etag": {
+          "type": "string",
+          "description": "The concurrency token for this adapter deployment.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "AdapterDeploymentCancelResult": {
+      "type": "object",
+      "description": "The result of requesting cancellation of an adapter operation.",
+      "properties": {
+        "status": {
+          "$ref": "#/definitions/AdapterDeploymentOperationState",
+          "description": "The resulting state of the operation targeted by cancellation."
+        },
+        "operationType": {
+          "$ref": "#/definitions/AdapterDeploymentOperationType",
+          "description": "The operation type targeted by cancellation."
+        },
+        "activeSourceModelId": {
+          "type": "string",
+          "description": "The source generation that remains active after cancellation."
+        },
+        "canceledSourceModelId": {
+          "type": "string",
+          "description": "The staged source generation removed by cancellation."
+        },
+        "correlationId": {
+          "type": "string",
+          "description": "A safe identifier used to correlate logs and support requests."
+        }
+      },
+      "required": [
+        "status",
+        "operationType",
+        "correlationId"
+      ]
+    },
+    "AdapterDeploymentCapacityValidation": {
+      "type": "object",
+      "description": "Capacity values evaluated for adapter admission.",
+      "properties": {
+        "adapterCountLimit": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum active adapters supported by the target runtime and fleet."
+        },
+        "adapterCountAfterAdmission": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of active adapters after admitting this generation."
+        },
+        "rankLimit": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum LoRA rank supported by the target runtime."
+        },
+        "estimatedAdapterMemoryBytes": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Service-estimated memory required by this adapter, in bytes."
+        },
+        "availableAdapterMemoryBytes": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Adapter memory available before this generation was admitted, in bytes."
+        }
+      },
+      "required": [
+        "adapterCountLimit",
+        "adapterCountAfterAdmission",
+        "rankLimit",
+        "estimatedAdapterMemoryBytes",
+        "availableAdapterMemoryBytes"
+      ]
+    },
+    "AdapterDeploymentErrorDetail": {
+      "type": "object",
+      "description": "Safe domain error details returned for adapter deployment failures.",
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "Stable machine-readable error code."
+        },
+        "message": {
+          "type": "string",
+          "description": "Safe customer-facing error message."
+        },
+        "target": {
+          "type": "string",
+          "description": "Request property or resource targeted by the error."
+        },
+        "details": {
+          "type": "array",
+          "description": "Nested safe error details.",
+          "items": {
+            "$ref": "#/definitions/AdapterDeploymentErrorDetail"
+          },
+          "x-ms-identifiers": []
+        }
+      },
+      "required": [
+        "code",
+        "message"
+      ]
+    },
+    "AdapterDeploymentFormat": {
+      "type": "string",
+      "description": "Adapter format values validated by the serving runtime.",
+      "enum": [
+        "PeftLora"
+      ],
+      "x-ms-enum": {
+        "name": "AdapterDeploymentFormat",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "PeftLora",
+            "value": "PeftLora",
+            "description": "Hugging Face PEFT LoRA adapter format."
+          }
+        ]
+      }
+    },
+    "AdapterDeploymentLastOperation": {
+      "type": "object",
+      "description": "The most recently requested adapter lifecycle operation.",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/AdapterDeploymentOperationType",
+          "description": "The type of lifecycle operation."
+        },
+        "status": {
+          "$ref": "#/definitions/AdapterDeploymentOperationState",
+          "description": "The current or terminal operation state."
+        },
+        "requestedSourceModelId": {
+          "type": "string",
+          "description": "The source requested by a create or replacement operation."
+        },
+        "correlationId": {
+          "type": "string",
+          "description": "A safe identifier used to correlate logs and support requests."
+        },
+        "startedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The time at which the operation started."
+        },
+        "completedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The time at which the operation reached a terminal state."
+        },
+        "rollbackResult": {
+          "$ref": "#/definitions/AdapterDeploymentRollbackResult",
+          "description": "The rollback result when a replacement does not complete successfully."
+        },
+        "error": {
+          "$ref": "#/definitions/AdapterDeploymentErrorDetail",
+          "description": "Safe error details when the operation failed."
+        }
+      },
+      "required": [
+        "type",
+        "status",
+        "correlationId",
+        "startedAt"
+      ]
+    },
+    "AdapterDeploymentListResult": {
+      "type": "object",
+      "description": "A paginated collection of adapter deployments.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "Adapter deployments in this page.",
+          "items": {
+            "$ref": "#/definitions/AdapterDeployment"
+          },
+          "readOnly": true
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "URL used to retrieve the next page, when one exists."
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "AdapterDeploymentOperationState": {
+      "type": "string",
+      "description": "Lifecycle operation states reported by an adapter deployment.",
+      "enum": [
+        "Accepted",
+        "Running",
+        "Succeeded",
+        "Failed",
+        "Canceled"
+      ],
+      "x-ms-enum": {
+        "name": "AdapterDeploymentOperationState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Accepted",
+            "value": "Accepted",
+            "description": "The operation request was accepted."
+          },
+          {
+            "name": "Running",
+            "value": "Running",
+            "description": "The operation is running."
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "The operation completed successfully."
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "The operation failed."
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "The operation was canceled."
+          }
+        ]
+      },
+      "readOnly": true
+    },
+    "AdapterDeploymentOperationType": {
+      "type": "string",
+      "description": "Lifecycle operation types reported by an adapter deployment.",
+      "enum": [
+        "Create",
+        "Replace",
+        "Delete"
+      ],
+      "x-ms-enum": {
+        "name": "AdapterDeploymentOperationType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Create",
+            "value": "Create",
+            "description": "Initial adapter deployment creation."
+          },
+          {
+            "name": "Replace",
+            "value": "Replace",
+            "description": "Replacement of the active source model version."
+          },
+          {
+            "name": "Delete",
+            "value": "Delete",
+            "description": "Adapter deployment deletion."
+          }
+        ]
+      }
+    },
+    "AdapterDeploymentProperties": {
+      "type": "object",
+      "description": "Properties of an adapter deployment.",
+      "properties": {
+        "sourceModelId": {
+          "type": "string",
+          "description": "The Project Models version produced by Foundry fine-tuning. Updating this\nvalue starts rolling replacement of the active adapter generation."
+        },
+        "targetDeploymentId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The immutable ARM ID of the compatible Managed Compute deployment.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.CognitiveServices/accounts/managedComputeDeployments"
+              }
+            ]
+          }
+        },
+        "activeSourceModelId": {
+          "type": "string",
+          "description": "The source model version currently admitted for inference. During\nreplacement this remains the prior generation until atomic cutover.",
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/AdapterDeploymentProvisioningState",
+          "description": "The provisioning state of the adapter deployment.",
+          "readOnly": true
+        },
+        "servingState": {
+          "$ref": "#/definitions/AdapterDeploymentServingState",
+          "description": "Whether the adapter can currently serve inference requests.",
+          "readOnly": true
+        },
+        "validation": {
+          "$ref": "#/definitions/AdapterDeploymentValidation",
+          "description": "Service-authenticated validation results for the active generation.",
+          "readOnly": true
+        },
+        "revocation": {
+          "$ref": "#/definitions/AdapterDeploymentRevocation",
+          "description": "Revocation details when security policy has disabled this adapter.",
+          "readOnly": true
+        },
+        "lastOperation": {
+          "$ref": "#/definitions/AdapterDeploymentLastOperation",
+          "description": "Information about the most recently requested lifecycle operation.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "sourceModelId",
+        "targetDeploymentId"
+      ]
+    },
+    "AdapterDeploymentProvisioningState": {
+      "type": "string",
+      "description": "Provisioning states for an adapter deployment resource.",
+      "enum": [
+        "Accepted",
+        "Creating",
+        "Updating",
+        "Succeeded",
+        "Failed",
+        "Canceled",
+        "Deleting"
+      ],
+      "x-ms-enum": {
+        "name": "AdapterDeploymentProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Accepted",
+            "value": "Accepted",
+            "description": "The create request was accepted."
+          },
+          {
+            "name": "Creating",
+            "value": "Creating",
+            "description": "The initial adapter generation is being prepared."
+          },
+          {
+            "name": "Updating",
+            "value": "Updating",
+            "description": "A replacement generation is being prepared."
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "The active generation is ready across every healthy parent replica."
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "The latest lifecycle operation failed."
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "The latest lifecycle operation was canceled."
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "The adapter is draining and being removed."
+          }
+        ]
+      },
+      "readOnly": true
+    },
+    "AdapterDeploymentRevocation": {
+      "type": "object",
+      "description": "Safe customer-visible details for an administrative revocation.",
+      "properties": {
+        "reasonCode": {
+          "type": "string",
+          "description": "Stable policy or security reason code."
+        },
+        "revokedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Time at which the adapter was removed from routing."
+        },
+        "correlationId": {
+          "type": "string",
+          "description": "Safe support and audit correlation identifier."
+        }
+      },
+      "required": [
+        "reasonCode",
+        "revokedAt",
+        "correlationId"
+      ]
+    },
+    "AdapterDeploymentRollbackResult": {
+      "type": "string",
+      "description": "Rollback outcomes for a failed or canceled replacement.",
+      "enum": [
+        "NotRequired",
+        "Succeeded",
+        "Failed"
+      ],
+      "x-ms-enum": {
+        "name": "AdapterDeploymentRollbackResult",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "NotRequired",
+            "value": "NotRequired",
+            "description": "No rollback was required."
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Rollback completed successfully."
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Rollback failed."
+          }
+        ]
+      },
+      "readOnly": true
+    },
+    "AdapterDeploymentServingState": {
+      "type": "string",
+      "description": "Serving availability independent of the latest management operation.",
+      "enum": [
+        "NotReady",
+        "Ready",
+        "Reconciling",
+        "Revoked"
+      ],
+      "x-ms-enum": {
+        "name": "AdapterDeploymentServingState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "NotReady",
+            "value": "NotReady",
+            "description": "No generation has been admitted for inference."
+          },
+          {
+            "name": "Ready",
+            "value": "Ready",
+            "description": "The active generation is available for inference."
+          },
+          {
+            "name": "Reconciling",
+            "value": "Reconciling",
+            "description": "The service is restoring the active generation on one or more replicas."
+          },
+          {
+            "name": "Revoked",
+            "value": "Revoked",
+            "description": "Security policy has removed the adapter from routing."
+          }
+        ]
+      }
+    },
+    "AdapterDeploymentValidation": {
+      "type": "object",
+      "description": "Service-authenticated validation results for the active adapter generation.",
+      "properties": {
+        "sourceModelId": {
+          "type": "string",
+          "description": "Source model version for which these values were validated."
+        },
+        "sourceBaseModelId": {
+          "type": "string",
+          "description": "Exact base-model asset ID recorded on the adapter source."
+        },
+        "targetBaseModelId": {
+          "type": "string",
+          "description": "Exact base-model asset ID served by the parent deployment."
+        },
+        "adapterFormat": {
+          "$ref": "#/definitions/AdapterDeploymentFormat",
+          "description": "Adapter serialization and runtime format."
+        },
+        "rank": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Validated LoRA rank."
+        },
+        "targetModules": {
+          "type": "array",
+          "description": "Validated base-model modules modified by the adapter.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "capacity": {
+          "$ref": "#/definitions/AdapterDeploymentCapacityValidation",
+          "description": "Capacity values evaluated when admitting this generation."
+        },
+        "validatedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Time at which the service completed this validation."
+        }
+      },
+      "required": [
+        "sourceModelId",
+        "sourceBaseModelId",
+        "targetBaseModelId",
+        "adapterFormat",
+        "rank",
+        "targetModules",
+        "capacity",
+        "validatedAt"
+      ]
+    },
     "AgentApplication": {
       "type": "object",
       "description": "Agent Application resource",
@@ -21445,5 +22336,15 @@
       ]
     }
   },
-  "parameters": {}
+  "parameters": {
+    "AdapterDeploymentListParameters": {
+      "name": "$filter",
+      "in": "query",
+      "description": "Filters by target deployment, source model version, provisioning state,\nor a supported conjunction of those predicates.",
+      "required": false,
+      "type": "string",
+      "x-ms-parameter-location": "method",
+      "x-ms-client-name": "filter"
+    }
+  }
 }


### PR DESCRIPTION
## Summary

- adds `Microsoft.CognitiveServices/accounts/adapterDeployments` as an account-level ARM child resource for attaching protected LoRA model versions to Managed Compute deployments
- adds asynchronous create/replace, get, list, cancel, and delete operations with ETag conditions, pagination, lifecycle state, validation, capacity, rollback, and revocation metadata
- extends Foundry Project Models with protected-artifact access, digest, and serving-compatibility metadata, and permits protected model versions to omit `blobUri`
- updates the generated 2026-07-15-preview management OpenAPI and Foundry OpenAPI 3 artifacts

The existing chat-completions contract is unchanged: callers select the parent Managed Compute deployment through its route and select the adapter deployment through the existing `model` field. No adapter-specific inference route or request field is introduced.

## Validation

- `tsv specification/cognitiveservices/CognitiveServices.Management`
- `tsv specification/ai-foundry/data-plane/Foundry`