### PR TITLE
Add 2026-09-01 API version

### DIFF
--- a/specification/storage/Storage.Management/examples/2026-09-01/AdvancedPlatformMetricsCRUD/AdvancedPlatformMetricsRules_CreateOrUpdate_AllContainers.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/AdvancedPlatformMetricsCRUD/AdvancedPlatformMetricsRules_CreateOrUpdate_AllContainers.json
@@ -1,0 +1,59 @@
+{
+  "operationId": "AdvancedPlatformMetrics_CreateOrUpdate",
+  "title": "AdvancedPlatformMetricsRules_CreateOrUpdate_AllContainers - Create advanced platform metrics rule with all containers filter",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "res6977",
+    "accountName": "sto2527",
+    "advancedPlatformMetricsRuleType": "ContainerLevelCapacityMetrics",
+    "api-version": "2026-09-01",
+    "resource": {
+      "properties": {
+        "enabled": true,
+        "ruleConfig": {
+          "filterType": "AllContainersFilter"
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res6977/providers/Microsoft.Storage/storageAccounts/sto2527/advancedPlatformMetrics/ContainerLevelCapacityMetrics",
+        "name": "DefaultAdvancedPlatformMetricsRule",
+        "type": "Microsoft.Storage/storageAccounts/advancedPlatformMetrics",
+        "properties": {
+          "ruleType": "ContainerLevelCapacityMetrics",
+          "enabled": true,
+          "lastModifiedTime": "2025-01-01T11:00:00.0000000Z",
+          "metricsEmitted": [
+            "ContainerUsedSize",
+            "ContainerBlobCount"
+          ],
+          "ruleConfig": {
+            "filterType": "AllContainersFilter"
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res6977/providers/Microsoft.Storage/storageAccounts/sto2527/advancedPlatformMetrics/ContainerLevelCapacityMetrics",
+        "name": "DefaultAdvancedPlatformMetricsRule",
+        "type": "Microsoft.Storage/storageAccounts/advancedPlatformMetrics",
+        "properties": {
+          "ruleType": "ContainerLevelCapacityMetrics",
+          "enabled": true,
+          "lastModifiedTime": "2025-01-01T11:00:00.0000000Z",
+          "metricsEmitted": [
+            "ContainerUsedSize",
+            "ContainerBlobCount"
+          ],
+          "ruleConfig": {
+            "filterType": "AllContainersFilter"
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/AdvancedPlatformMetricsCRUD/AdvancedPlatformMetricsRules_CreateOrUpdate_ContainerList.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/AdvancedPlatformMetricsCRUD/AdvancedPlatformMetricsRules_CreateOrUpdate_ContainerList.json
@@ -1,0 +1,74 @@
+{
+  "operationId": "AdvancedPlatformMetrics_CreateOrUpdate",
+  "title": "AdvancedPlatformMetricsRules_CreateOrUpdate_ContainerList - Create advanced platform metrics rule with container list filter",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "res6977",
+    "accountName": "sto2527",
+    "advancedPlatformMetricsRuleType": "ContainerLevelCapacityMetrics",
+    "api-version": "2026-09-01",
+    "resource": {
+      "properties": {
+        "enabled": true,
+        "ruleConfig": {
+          "filterType": "ContainerListFilter",
+          "filterValues": [
+            "container1",
+            "container2",
+            "container3"
+          ]
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res6977/providers/Microsoft.Storage/storageAccounts/sto2527/advancedPlatformMetrics/ContainerLevelCapacityMetrics",
+        "name": "DefaultAdvancedPlatformMetricsRule",
+        "type": "Microsoft.Storage/storageAccounts/advancedPlatformMetrics",
+        "properties": {
+          "ruleType": "ContainerLevelCapacityMetrics",
+          "enabled": true,
+          "lastModifiedTime": "2025-01-01T11:00:00.0000000Z",
+          "metricsEmitted": [
+            "ContainerUsedSize",
+            "ContainerBlobCount"
+          ],
+          "ruleConfig": {
+            "filterType": "ContainerListFilter",
+            "filterValues": [
+              "container1",
+              "container2",
+              "container3"
+            ]
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res6977/providers/Microsoft.Storage/storageAccounts/sto2527/advancedPlatformMetrics/ContainerLevelCapacityMetrics",
+        "name": "DefaultAdvancedPlatformMetricsRule",
+        "type": "Microsoft.Storage/storageAccounts/advancedPlatformMetrics",
+        "properties": {
+          "ruleType": "ContainerLevelCapacityMetrics",
+          "enabled": true,
+          "lastModifiedTime": "2025-01-01T11:00:00.0000000Z",
+          "metricsEmitted": [
+            "ContainerUsedSize",
+            "ContainerBlobCount"
+          ],
+          "ruleConfig": {
+            "filterType": "ContainerListFilter",
+            "filterValues": [
+              "container1",
+              "container2",
+              "container3"
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/AdvancedPlatformMetricsCRUD/AdvancedPlatformMetricsRules_CreateOrUpdate_ContainerPrefix.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/AdvancedPlatformMetricsCRUD/AdvancedPlatformMetricsRules_CreateOrUpdate_ContainerPrefix.json
@@ -1,0 +1,71 @@
+{
+  "operationId": "AdvancedPlatformMetrics_CreateOrUpdate",
+  "title": "AdvancedPlatformMetricsRules_CreateOrUpdate_ContainerPrefix - Create advanced platform metrics rule with container prefix filter",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "res6977",
+    "accountName": "sto2527",
+    "advancedPlatformMetricsRuleType": "ContainerLevelCapacityMetrics",
+    "api-version": "2026-09-01",
+    "resource": {
+      "properties": {
+        "enabled": true,
+        "ruleConfig": {
+          "filterType": "ContainerPrefixFilter",
+          "filterValues": [
+            "logs",
+            "data"
+          ]
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res6977/providers/Microsoft.Storage/storageAccounts/sto2527/advancedPlatformMetrics/ContainerLevelCapacityMetrics",
+        "name": "DefaultAdvancedPlatformMetricsRule",
+        "type": "Microsoft.Storage/storageAccounts/advancedPlatformMetrics",
+        "properties": {
+          "ruleType": "ContainerLevelCapacityMetrics",
+          "enabled": true,
+          "lastModifiedTime": "2025-01-01T11:00:00.0000000Z",
+          "metricsEmitted": [
+            "ContainerUsedSize",
+            "ContainerBlobCount"
+          ],
+          "ruleConfig": {
+            "filterType": "ContainerPrefixFilter",
+            "filterValues": [
+              "logs",
+              "data"
+            ]
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res6977/providers/Microsoft.Storage/storageAccounts/sto2527/advancedPlatformMetrics/ContainerLevelCapacityMetrics",
+        "name": "DefaultAdvancedPlatformMetricsRule",
+        "type": "Microsoft.Storage/storageAccounts/advancedPlatformMetrics",
+        "properties": {
+          "ruleType": "ContainerLevelCapacityMetrics",
+          "enabled": true,
+          "lastModifiedTime": "2025-01-01T11:00:00.0000000Z",
+          "metricsEmitted": [
+            "ContainerUsedSize",
+            "ContainerBlobCount"
+          ],
+          "ruleConfig": {
+            "filterType": "ContainerPrefixFilter",
+            "filterValues": [
+              "logs",
+              "data"
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/AdvancedPlatformMetricsCRUD/AdvancedPlatformMetricsRules_Delete.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/AdvancedPlatformMetricsCRUD/AdvancedPlatformMetricsRules_Delete.json
@@ -1,0 +1,15 @@
+{
+  "operationId": "AdvancedPlatformMetrics_Delete",
+  "title": "AdvancedPlatformMetricsRules_Delete - Delete advanced platform metrics rule",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "res6977",
+    "accountName": "sto2527",
+    "advancedPlatformMetricsRuleType": "ContainerLevelCapacityMetrics",
+    "api-version": "2026-09-01"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  }
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/AdvancedPlatformMetricsCRUD/AdvancedPlatformMetricsRules_Get.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/AdvancedPlatformMetricsCRUD/AdvancedPlatformMetricsRules_Get.json
@@ -1,0 +1,32 @@
+{
+  "operationId": "AdvancedPlatformMetrics_Get",
+  "title": "AdvancedPlatformMetricsRules_Get - Get advanced platform metrics rule",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "res6977",
+    "accountName": "sto2527",
+    "advancedPlatformMetricsRuleType": "ContainerLevelCapacityMetrics",
+    "api-version": "2026-09-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res6977/providers/Microsoft.Storage/storageAccounts/sto2527/advancedPlatformMetrics/ContainerLevelCapacityMetrics",
+        "name": "DefaultAdvancedPlatformMetricsRule",
+        "type": "Microsoft.Storage/storageAccounts/advancedPlatformMetrics",
+        "properties": {
+          "ruleType": "ContainerLevelCapacityMetrics",
+          "enabled": true,
+          "lastModifiedTime": "2025-01-01T11:00:00.0000000Z",
+          "metricsEmitted": [
+            "ContainerUsedSize",
+            "ContainerBlobCount"
+          ],
+          "ruleConfig": {
+            "filterType": "AllContainersFilter"
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/AdvancedPlatformMetricsCRUD/AdvancedPlatformMetricsRules_List.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/AdvancedPlatformMetricsCRUD/AdvancedPlatformMetricsRules_List.json
@@ -1,0 +1,35 @@
+{
+  "operationId": "AdvancedPlatformMetrics_List",
+  "title": "AdvancedPlatformMetricsRules_List - List advanced platform metrics rules",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "res6977",
+    "accountName": "sto2527",
+    "api-version": "2026-09-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res6977/providers/Microsoft.Storage/storageAccounts/sto2527/advancedPlatformMetrics/ContainerLevelCapacityMetrics",
+            "name": "DefaultAdvancedPlatformMetricsRule",
+            "type": "Microsoft.Storage/storageAccounts/advancedPlatformMetrics",
+            "properties": {
+              "ruleType": "ContainerLevelCapacityMetrics",
+              "enabled": true,
+              "lastModifiedTime": "2025-01-01T11:00:00.0000000Z",
+              "metricsEmitted": [
+                "ContainerUsedSize",
+                "ContainerBlobCount"
+              ],
+              "ruleConfig": {
+                "filterType": "AllContainersFilter"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/BlobContainersClearLegalHold.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/BlobContainersClearLegalHold.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "LegalHold": {
+      "tags": [
+        "tag1",
+        "tag2",
+        "tag3"
+      ]
+    },
+    "accountName": "sto7280",
+    "api-version": "2026-09-01",
+    "containerName": "container8723",
+    "monitor": "true",
+    "resourceGroupName": "res4303",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "hasLegalHold": false,
+        "tags": []
+      }
+    }
+  },
+  "operationId": "BlobContainers_ClearLegalHold",
+  "title": "ClearLegalHoldContainers"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/BlobContainersDelete.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/BlobContainersDelete.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "accountName": "sto4506",
+    "api-version": "2026-09-01",
+    "containerName": "container9689",
+    "monitor": "true",
+    "resourceGroupName": "res4079",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "BlobContainers_Delete",
+  "title": "DeleteContainers"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/BlobContainersDeleteImmutabilityPolicy.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/BlobContainersDeleteImmutabilityPolicy.json
@@ -1,0 +1,28 @@
+{
+  "parameters": {
+    "If-Match": "8d59f81a7fa7be0",
+    "accountName": "sto9621",
+    "api-version": "2026-09-01",
+    "containerName": "container4910",
+    "immutabilityPolicyName": "default",
+    "monitor": "true",
+    "resourceGroupName": "res1581",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.Storage/storageAccounts/blobServices/containers/immutabilityPolicies",
+        "etag": "\"8d59f81a87b40c0\"",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res1581/providers/Microsoft.Storage/storageAccounts/sto9621/blobServices/default/containers/container4910/immutabilityPolicies/default",
+        "properties": {
+          "immutabilityPeriodSinceCreationInDays": 0,
+          "state": "Unlocked"
+        }
+      }
+    }
+  },
+  "operationId": "BlobContainers_DeleteImmutabilityPolicy",
+  "title": "DeleteImmutabilityPolicy"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/BlobContainersExtendImmutabilityPolicy.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/BlobContainersExtendImmutabilityPolicy.json
@@ -1,0 +1,32 @@
+{
+  "parameters": {
+    "If-Match": "8d59f830d0c3bf9",
+    "accountName": "sto232",
+    "api-version": "2026-09-01",
+    "containerName": "container5023",
+    "monitor": "true",
+    "parameters": {
+      "properties": {
+        "immutabilityPeriodSinceCreationInDays": 100
+      }
+    },
+    "resourceGroupName": "res6238",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.Storage/storageAccounts/blobServices/containers/immutabilityPolicies",
+        "etag": "\"8d57a8b2ff50332\"",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res6238/providers/Microsoft.Storage/storageAccounts/sto232/blobServices/default/containers/container5023/immutabilityPolicies/default",
+        "properties": {
+          "immutabilityPeriodSinceCreationInDays": 100,
+          "state": "Locked"
+        }
+      }
+    }
+  },
+  "operationId": "BlobContainers_ExtendImmutabilityPolicy",
+  "title": "ExtendImmutabilityPolicy"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/BlobContainersGet.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/BlobContainersGet.json
@@ -1,0 +1,83 @@
+{
+  "parameters": {
+    "accountName": "sto6217",
+    "api-version": "2026-09-01",
+    "containerName": "container1634",
+    "monitor": "true",
+    "resourceGroupName": "res9871",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "container1634",
+        "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
+        "etag": "\"0x8D592D74CC20EBA\"",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9871/providers/Microsoft.Storage/storageAccounts/sto6217/blobServices/default/containers/container1634",
+        "properties": {
+          "hasImmutabilityPolicy": true,
+          "hasLegalHold": true,
+          "immutabilityPolicy": {
+            "etag": "\"8d592d74cb3011a\"",
+            "properties": {
+              "immutabilityPeriodSinceCreationInDays": 100,
+              "state": "Locked"
+            },
+            "updateHistory": [
+              {
+                "immutabilityPeriodSinceCreationInDays": 3,
+                "objectIdentifier": "ce7cd28a-fc25-4bf1-8fb9-e1b9833ffd4b",
+                "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
+                "timestamp": "2018-03-26T05:06:11.431403Z",
+                "update": "put"
+              },
+              {
+                "immutabilityPeriodSinceCreationInDays": 3,
+                "objectIdentifier": "ce7cd28a-fc25-4bf1-8fb9-e1b9833ffd4b",
+                "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
+                "timestamp": "2018-03-26T05:06:13.0907641Z",
+                "update": "lock"
+              },
+              {
+                "immutabilityPeriodSinceCreationInDays": 100,
+                "objectIdentifier": "ce7cd28a-fc25-4bf1-8fb9-e1b9833ffd4b",
+                "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
+                "timestamp": "2018-03-26T05:06:14.7097716Z",
+                "update": "extend"
+              }
+            ]
+          },
+          "lastModifiedTime": "2018-03-26T05:06:14Z",
+          "leaseState": "Available",
+          "leaseStatus": "Unlocked",
+          "legalHold": {
+            "hasLegalHold": true,
+            "tags": [
+              {
+                "objectIdentifier": "ce7cd28a-fc25-4bf1-8fb9-e1b9833ffd4b",
+                "tag": "tag1",
+                "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
+                "timestamp": "2018-03-26T05:06:09.6964643Z"
+              },
+              {
+                "objectIdentifier": "ce7cd28a-fc25-4bf1-8fb9-e1b9833ffd4b",
+                "tag": "tag2",
+                "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
+                "timestamp": "2018-03-26T05:06:09.6964643Z"
+              },
+              {
+                "objectIdentifier": "ce7cd28a-fc25-4bf1-8fb9-e1b9833ffd4b",
+                "tag": "tag3",
+                "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
+                "timestamp": "2018-03-26T05:06:09.6964643Z"
+              }
+            ]
+          },
+          "publicAccess": "None"
+        }
+      }
+    }
+  },
+  "operationId": "BlobContainers_Get",
+  "title": "GetContainers"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/BlobContainersGetImmutabilityPolicy.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/BlobContainersGetImmutabilityPolicy.json
@@ -1,0 +1,28 @@
+{
+  "parameters": {
+    "accountName": "sto9177",
+    "api-version": "2026-09-01",
+    "containerName": "container3489",
+    "immutabilityPolicyName": "default",
+    "monitor": "true",
+    "resourceGroupName": "res5221",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.Storage/storageAccounts/blobServices/containers/immutabilityPolicies",
+        "etag": "\"8d59f828e64b75c\"",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res5221/providers/Microsoft.Storage/storageAccounts/sto9177/blobServices/default/containers/container3489/immutabilityPolicies/default",
+        "properties": {
+          "allowProtectedAppendWrites": true,
+          "immutabilityPeriodSinceCreationInDays": 5,
+          "state": "Unlocked"
+        }
+      }
+    }
+  },
+  "operationId": "BlobContainers_GetImmutabilityPolicy",
+  "title": "GetImmutabilityPolicy"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/BlobContainersGetWithAllowProtectedAppendWritesAll.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/BlobContainersGetWithAllowProtectedAppendWritesAll.json
@@ -1,0 +1,91 @@
+{
+  "parameters": {
+    "accountName": "sto6217",
+    "api-version": "2026-09-01",
+    "containerName": "container1634",
+    "monitor": "true",
+    "resourceGroupName": "res9871",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "container1634",
+        "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
+        "etag": "\"0x8D592D74CC20EBA\"",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9871/providers/Microsoft.Storage/storageAccounts/sto6217/blobServices/default/containers/container1634",
+        "properties": {
+          "hasImmutabilityPolicy": true,
+          "hasLegalHold": true,
+          "immutabilityPolicy": {
+            "etag": "\"8d592d74cb3011a\"",
+            "properties": {
+              "allowProtectedAppendWritesAll": true,
+              "immutabilityPeriodSinceCreationInDays": 100,
+              "state": "Locked"
+            },
+            "updateHistory": [
+              {
+                "allowProtectedAppendWritesAll": true,
+                "immutabilityPeriodSinceCreationInDays": 3,
+                "objectIdentifier": "ce7cd28a-fc25-4bf1-8fb9-e1b9833ffd4b",
+                "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
+                "timestamp": "2018-03-26T05:06:11.431403Z",
+                "update": "put"
+              },
+              {
+                "allowProtectedAppendWritesAll": true,
+                "immutabilityPeriodSinceCreationInDays": 3,
+                "objectIdentifier": "ce7cd28a-fc25-4bf1-8fb9-e1b9833ffd4b",
+                "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
+                "timestamp": "2018-03-26T05:06:13.0907641Z",
+                "update": "lock"
+              },
+              {
+                "allowProtectedAppendWritesAll": true,
+                "immutabilityPeriodSinceCreationInDays": 100,
+                "objectIdentifier": "ce7cd28a-fc25-4bf1-8fb9-e1b9833ffd4b",
+                "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
+                "timestamp": "2018-03-26T05:06:14.7097716Z",
+                "update": "extend"
+              }
+            ]
+          },
+          "lastModifiedTime": "2018-03-26T05:06:14Z",
+          "leaseState": "Available",
+          "leaseStatus": "Unlocked",
+          "legalHold": {
+            "hasLegalHold": true,
+            "protectedAppendWritesHistory": {
+              "allowProtectedAppendWritesAll": true,
+              "timestamp": "2022-09-01T01:58:44.5044483Z"
+            },
+            "tags": [
+              {
+                "objectIdentifier": "ce7cd28a-fc25-4bf1-8fb9-e1b9833ffd4b",
+                "tag": "tag1",
+                "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
+                "timestamp": "2018-03-26T05:06:09.6964643Z"
+              },
+              {
+                "objectIdentifier": "ce7cd28a-fc25-4bf1-8fb9-e1b9833ffd4b",
+                "tag": "tag2",
+                "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
+                "timestamp": "2018-03-26T05:06:09.6964643Z"
+              },
+              {
+                "objectIdentifier": "ce7cd28a-fc25-4bf1-8fb9-e1b9833ffd4b",
+                "tag": "tag3",
+                "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
+                "timestamp": "2018-03-26T05:06:09.6964643Z"
+              }
+            ]
+          },
+          "publicAccess": "None"
+        }
+      }
+    }
+  },
+  "operationId": "BlobContainers_Get",
+  "title": "GetBlobContainersGetWithAllowProtectedAppendWritesAll"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/BlobContainersLease_Acquire.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/BlobContainersLease_Acquire.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "accountName": "sto328",
+    "api-version": "2026-09-01",
+    "containerName": "container6185",
+    "monitor": "true",
+    "parameters": {
+      "action": "Acquire",
+      "breakPeriod": null,
+      "leaseDuration": -1,
+      "leaseId": null,
+      "proposedLeaseId": null
+    },
+    "resourceGroupName": "res3376",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "leaseId": "8698f513-fa75-44a1-b8eb-30ba336af27d"
+      }
+    }
+  },
+  "operationId": "BlobContainers_Lease",
+  "title": "Acquire a lease on a container"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/BlobContainersLease_Break.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/BlobContainersLease_Break.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "accountName": "sto328",
+    "api-version": "2026-09-01",
+    "containerName": "container6185",
+    "monitor": "true",
+    "parameters": {
+      "action": "Break",
+      "breakPeriod": null,
+      "leaseDuration": null,
+      "leaseId": "8698f513-fa75-44a1-b8eb-30ba336af27d",
+      "proposedLeaseId": null
+    },
+    "resourceGroupName": "res3376",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "leaseTimeSeconds": "0"
+      }
+    }
+  },
+  "operationId": "BlobContainers_Lease",
+  "title": "Break a lease on a container"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/BlobContainersList.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/BlobContainersList.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "accountName": "sto1590",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res9290",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://sto1590endpoint/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res9290/providers/Microsoft.Storage/storageAccounts/sto1590/blobServices/default/containers?api-version=2022-09-01&$maxpagesize=2&$skipToken=/sto1590/container5103",
+        "value": [
+          {
+            "name": "container1644",
+            "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
+            "etag": "\"0x8D589847D51C7DE\"",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res9290/providers/Microsoft.Storage/storageAccounts/sto1590/blobServices/default/containers/container1644",
+            "properties": {
+              "hasImmutabilityPolicy": false,
+              "hasLegalHold": false,
+              "lastModifiedTime": "2018-03-14T08:20:47Z",
+              "leaseState": "Available",
+              "leaseStatus": "Unlocked",
+              "publicAccess": "Container"
+            }
+          },
+          {
+            "name": "container4052",
+            "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
+            "etag": "\"0x8D589847DAB5AF9\"",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res9290/providers/Microsoft.Storage/storageAccounts/sto1590/blobServices/default/containers/container4052",
+            "properties": {
+              "hasImmutabilityPolicy": false,
+              "hasLegalHold": false,
+              "lastModifiedTime": "2018-03-14T08:20:47Z",
+              "leaseState": "Available",
+              "leaseStatus": "Unlocked",
+              "publicAccess": "None"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "BlobContainers_List",
+  "title": "ListContainers"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/BlobContainersLockImmutabilityPolicy.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/BlobContainersLockImmutabilityPolicy.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "If-Match": "8d59f825b721dd3",
+    "accountName": "sto5009",
+    "api-version": "2026-09-01",
+    "containerName": "container1631",
+    "monitor": "true",
+    "resourceGroupName": "res2702",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.Storage/storageAccounts/blobServices/containers/immutabilityPolicies",
+        "etag": "\"8d57a8a5edb084a\"",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res2702/providers/Microsoft.Storage/storageAccounts/sto5009/blobServices/default/containers/container1631/immutabilityPolicies/default",
+        "properties": {
+          "immutabilityPeriodSinceCreationInDays": 3,
+          "state": "Locked"
+        }
+      }
+    }
+  },
+  "operationId": "BlobContainers_LockImmutabilityPolicy",
+  "title": "LockImmutabilityPolicy"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/BlobContainersPatch.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/BlobContainersPatch.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "accountName": "sto328",
+    "api-version": "2026-09-01",
+    "blobContainer": {
+      "properties": {
+        "metadata": {
+          "metadata": "true"
+        },
+        "publicAccess": "Container"
+      }
+    },
+    "containerName": "container6185",
+    "monitor": "true",
+    "resourceGroupName": "res3376",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "container6185",
+        "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res3376/providers/Microsoft.Storage/storageAccounts/sto328/blobServices/default/containers/container6185",
+        "properties": {
+          "hasImmutabilityPolicy": false,
+          "hasLegalHold": false,
+          "metadata": {
+            "metadata": "true"
+          },
+          "publicAccess": "Container"
+        }
+      }
+    }
+  },
+  "operationId": "BlobContainers_Update",
+  "title": "UpdateContainers"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/BlobContainersPut.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/BlobContainersPut.json
@@ -1,0 +1,29 @@
+{
+  "parameters": {
+    "accountName": "sto328",
+    "api-version": "2026-09-01",
+    "blobContainer": {},
+    "containerName": "container6185",
+    "monitor": "true",
+    "resourceGroupName": "res3376",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "container6185",
+        "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res3376/providers/Microsoft.Storage/storageAccounts/sto328/blobServices/default/containers/container6185"
+      }
+    },
+    "201": {
+      "body": {
+        "name": "container6185",
+        "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res3376/providers/Microsoft.Storage/storageAccounts/sto328/blobServices/default/containers/container6185"
+      }
+    }
+  },
+  "operationId": "BlobContainers_Create",
+  "title": "PutContainers"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/BlobContainersPutDefaultEncryptionScope.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/BlobContainersPutDefaultEncryptionScope.json
@@ -1,0 +1,42 @@
+{
+  "parameters": {
+    "accountName": "sto328",
+    "api-version": "2026-09-01",
+    "blobContainer": {
+      "properties": {
+        "defaultEncryptionScope": "encryptionscope185",
+        "denyEncryptionScopeOverride": true
+      }
+    },
+    "containerName": "container6185",
+    "monitor": "true",
+    "resourceGroupName": "res3376",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "container6185",
+        "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res3376/providers/Microsoft.Storage/storageAccounts/sto328/blobServices/default/containers/container6185",
+        "properties": {
+          "defaultEncryptionScope": "encryptionscope185",
+          "denyEncryptionScopeOverride": true
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "container6185",
+        "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res3376/providers/Microsoft.Storage/storageAccounts/sto328/blobServices/default/containers/container6185",
+        "properties": {
+          "defaultEncryptionScope": "encryptionscope185",
+          "denyEncryptionScopeOverride": true
+        }
+      }
+    }
+  },
+  "operationId": "BlobContainers_Create",
+  "title": "PutContainerWithDefaultEncryptionScope"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/BlobContainersPutImmutabilityPolicy.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/BlobContainersPutImmutabilityPolicy.json
@@ -1,0 +1,34 @@
+{
+  "parameters": {
+    "accountName": "sto7069",
+    "api-version": "2026-09-01",
+    "containerName": "container6397",
+    "immutabilityPolicyName": "default",
+    "monitor": "true",
+    "parameters": {
+      "properties": {
+        "allowProtectedAppendWrites": true,
+        "immutabilityPeriodSinceCreationInDays": 3
+      }
+    },
+    "resourceGroupName": "res1782",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.Storage/storageAccounts/blobServices/containers/immutabilityPolicies",
+        "etag": "\"8d59f830cb130e5\"",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res1782/providers/Microsoft.Storage/storageAccounts/sto7069/blobServices/default/containers/container6397/immutabilityPolicies/default",
+        "properties": {
+          "allowProtectedAppendWrites": true,
+          "immutabilityPeriodSinceCreationInDays": 3,
+          "state": "Unlocked"
+        }
+      }
+    }
+  },
+  "operationId": "BlobContainers_CreateOrUpdateImmutabilityPolicy",
+  "title": "CreateOrUpdateImmutabilityPolicy"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/BlobContainersPutImmutabilityPolicyAllowProtectedAppendWritesAll.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/BlobContainersPutImmutabilityPolicyAllowProtectedAppendWritesAll.json
@@ -1,0 +1,34 @@
+{
+  "parameters": {
+    "accountName": "sto7069",
+    "api-version": "2026-09-01",
+    "containerName": "container6397",
+    "immutabilityPolicyName": "default",
+    "monitor": "true",
+    "parameters": {
+      "properties": {
+        "allowProtectedAppendWritesAll": true,
+        "immutabilityPeriodSinceCreationInDays": 3
+      }
+    },
+    "resourceGroupName": "res1782",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.Storage/storageAccounts/blobServices/containers/immutabilityPolicies",
+        "etag": "\"8d59f830cb130e5\"",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res1782/providers/Microsoft.Storage/storageAccounts/sto7069/blobServices/default/containers/container6397/immutabilityPolicies/default",
+        "properties": {
+          "allowProtectedAppendWritesAll": true,
+          "immutabilityPeriodSinceCreationInDays": 3,
+          "state": "Unlocked"
+        }
+      }
+    }
+  },
+  "operationId": "BlobContainers_CreateOrUpdateImmutabilityPolicy",
+  "title": "CreateOrUpdateImmutabilityPolicyWithAllowProtectedAppendWritesAll"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/BlobContainersPutObjectLevelWorm.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/BlobContainersPutObjectLevelWorm.json
@@ -1,0 +1,45 @@
+{
+  "parameters": {
+    "accountName": "sto328",
+    "api-version": "2026-09-01",
+    "blobContainer": {
+      "properties": {
+        "immutableStorageWithVersioning": {
+          "enabled": true
+        }
+      }
+    },
+    "containerName": "container6185",
+    "monitor": "true",
+    "resourceGroupName": "res3376",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "container6185",
+        "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res3376/providers/Microsoft.Storage/storageAccounts/sto328/blobServices/default/containers/container6185",
+        "properties": {
+          "immutableStorageWithVersioning": {
+            "enabled": true
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "container6185",
+        "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res3376/providers/Microsoft.Storage/storageAccounts/sto328/blobServices/default/containers/container6185",
+        "properties": {
+          "immutableStorageWithVersioning": {
+            "enabled": true
+          }
+        }
+      }
+    }
+  },
+  "operationId": "BlobContainers_Create",
+  "title": "PutContainerWithObjectLevelWorm"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/BlobContainersSetLegalHold.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/BlobContainersSetLegalHold.json
@@ -1,0 +1,31 @@
+{
+  "parameters": {
+    "LegalHold": {
+      "tags": [
+        "tag1",
+        "tag2",
+        "tag3"
+      ]
+    },
+    "accountName": "sto7280",
+    "api-version": "2026-09-01",
+    "containerName": "container8723",
+    "monitor": "true",
+    "resourceGroupName": "res4303",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "hasLegalHold": true,
+        "tags": [
+          "tag1",
+          "tag2",
+          "tag3"
+        ]
+      }
+    }
+  },
+  "operationId": "BlobContainers_SetLegalHold",
+  "title": "SetLegalHoldContainers"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/BlobContainersSetLegalHoldAllowProtectedAppendWritesAll.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/BlobContainersSetLegalHoldAllowProtectedAppendWritesAll.json
@@ -1,0 +1,33 @@
+{
+  "parameters": {
+    "LegalHold": {
+      "allowProtectedAppendWritesAll": true,
+      "tags": [
+        "tag1",
+        "tag2",
+        "tag3"
+      ]
+    },
+    "accountName": "sto7280",
+    "api-version": "2026-09-01",
+    "containerName": "container8723",
+    "monitor": "true",
+    "resourceGroupName": "res4303",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "allowProtectedAppendWritesAll": true,
+        "hasLegalHold": true,
+        "tags": [
+          "tag1",
+          "tag2",
+          "tag3"
+        ]
+      }
+    }
+  },
+  "operationId": "BlobContainers_SetLegalHold",
+  "title": "SetLegalHoldContainersWithAllowProtectedAppendWritesAll"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/BlobRangesRestore.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/BlobRangesRestore.json
@@ -1,0 +1,66 @@
+{
+  "parameters": {
+    "accountName": "sto4445",
+    "api-version": "2026-09-01",
+    "parameters": {
+      "blobRanges": [
+        {
+          "endRange": "container/blobpath2",
+          "startRange": "container/blobpath1"
+        },
+        {
+          "endRange": "",
+          "startRange": "container2/blobpath3"
+        }
+      ],
+      "timeToRestore": "2019-04-20T15:30:00.0000000Z"
+    },
+    "resourceGroupName": "res9101",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "parameters": {
+          "blobRanges": [
+            {
+              "endRange": "container/blobpath2",
+              "startRange": "container/blobpath1"
+            },
+            {
+              "endRange": "",
+              "startRange": "container2/blobpath3"
+            }
+          ],
+          "timeToRestore": "2019-04-20T15:30:00.0000000Z"
+        },
+        "restoreId": "{restore_id}",
+        "status": "Succeeded"
+      }
+    },
+    "202": {
+      "body": {
+        "parameters": {
+          "blobRanges": [
+            {
+              "endRange": "container/blobpath2",
+              "startRange": "container/blobpath1"
+            },
+            {
+              "endRange": "",
+              "startRange": "container2/blobpath3"
+            }
+          ],
+          "timeToRestore": "2019-04-20T15:30:00.0000000Z"
+        },
+        "restoreId": "{restore_id}",
+        "status": "InProgress"
+      },
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.Storage/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2022-09-01"
+      }
+    }
+  },
+  "operationId": "StorageAccounts_RestoreBlobRanges",
+  "title": "BlobRangesRestore"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/BlobServicesGet.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/BlobServicesGet.json
@@ -1,0 +1,103 @@
+{
+  "parameters": {
+    "BlobServicesName": "default",
+    "accountName": "sto8607",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res4410",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.Storage/storageAccounts/blobServices",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res4410/providers/Microsoft.Storage/storageAccounts/sto8607/blobServices/default",
+        "properties": {
+          "changeFeed": {
+            "enabled": true,
+            "retentionInDays": 7
+          },
+          "cors": {
+            "corsRules": [
+              {
+                "allowedHeaders": [
+                  "x-ms-meta-abc",
+                  "x-ms-meta-data*",
+                  "x-ms-meta-target*"
+                ],
+                "allowedMethods": [
+                  "GET",
+                  "HEAD",
+                  "POST",
+                  "OPTIONS",
+                  "MERGE",
+                  "PUT"
+                ],
+                "allowedOrigins": [
+                  "http://www.contoso.com",
+                  "http://www.fabrikam.com"
+                ],
+                "exposedHeaders": [
+                  "x-ms-meta-*"
+                ],
+                "maxAgeInSeconds": 100
+              },
+              {
+                "allowedHeaders": [
+                  "*"
+                ],
+                "allowedMethods": [
+                  "GET"
+                ],
+                "allowedOrigins": [
+                  "*"
+                ],
+                "exposedHeaders": [
+                  "*"
+                ],
+                "maxAgeInSeconds": 2
+              },
+              {
+                "allowedHeaders": [
+                  "x-ms-meta-12345675754564*"
+                ],
+                "allowedMethods": [
+                  "GET",
+                  "PUT"
+                ],
+                "allowedOrigins": [
+                  "http://www.abc23.com",
+                  "https://www.fabrikam.com/*"
+                ],
+                "exposedHeaders": [
+                  "x-ms-meta-abc",
+                  "x-ms-meta-data*",
+                  "x -ms-meta-target*"
+                ],
+                "maxAgeInSeconds": 2000
+              }
+            ]
+          },
+          "defaultServiceVersion": "2017-07-29",
+          "deleteRetentionPolicy": {
+            "days": 300,
+            "enabled": true
+          },
+          "isVersioningEnabled": true,
+          "staticWebsite": {
+            "enabled": true,
+            "indexDocument": "home.html",
+            "errorDocument404Path": "site/errors/not-found.html"
+          }
+        },
+        "sku": {
+          "name": "Standard_GRS",
+          "tier": "Standard"
+        }
+      }
+    }
+  },
+  "operationId": "BlobServices_GetServiceProperties",
+  "title": "GetBlobServices"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/BlobServicesList.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/BlobServicesList.json
@@ -1,0 +1,106 @@
+{
+  "parameters": {
+    "accountName": "sto8607",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res4410",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "default",
+            "type": "Microsoft.Storage/storageAccounts/blobServices",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/res4410/providers/Microsoft.Storage/storageAccounts/sto8607/blobServices/default",
+            "properties": {
+              "changeFeed": {
+                "enabled": true,
+                "retentionInDays": 7
+              },
+              "cors": {
+                "corsRules": [
+                  {
+                    "allowedHeaders": [
+                      "x-ms-meta-abc",
+                      "x-ms-meta-data*",
+                      "x-ms-meta-target*"
+                    ],
+                    "allowedMethods": [
+                      "GET",
+                      "HEAD",
+                      "POST",
+                      "OPTIONS",
+                      "MERGE",
+                      "PUT"
+                    ],
+                    "allowedOrigins": [
+                      "http://www.contoso.com",
+                      "http://www.fabrikam.com"
+                    ],
+                    "exposedHeaders": [
+                      "x-ms-meta-*"
+                    ],
+                    "maxAgeInSeconds": 100
+                  },
+                  {
+                    "allowedHeaders": [
+                      "*"
+                    ],
+                    "allowedMethods": [
+                      "GET"
+                    ],
+                    "allowedOrigins": [
+                      "*"
+                    ],
+                    "exposedHeaders": [
+                      "*"
+                    ],
+                    "maxAgeInSeconds": 2
+                  },
+                  {
+                    "allowedHeaders": [
+                      "x-ms-meta-12345675754564*"
+                    ],
+                    "allowedMethods": [
+                      "GET",
+                      "PUT"
+                    ],
+                    "allowedOrigins": [
+                      "http://www.abc23.com",
+                      "https://www.fabrikam.com/*"
+                    ],
+                    "exposedHeaders": [
+                      "x-ms-meta-abc",
+                      "x-ms-meta-data*",
+                      "x -ms-meta-target*"
+                    ],
+                    "maxAgeInSeconds": 2000
+                  }
+                ]
+              },
+              "defaultServiceVersion": "2017-07-29",
+              "deleteRetentionPolicy": {
+                "days": 300,
+                "enabled": true
+              },
+              "isVersioningEnabled": true,
+              "staticWebsite": {
+                "enabled": true,
+                "indexDocument": "home.html",
+                "errorDocument404Path": "site/errors/not-found.html"
+              }
+            },
+            "sku": {
+              "name": "Standard_GRS",
+              "tier": "Standard"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "BlobServices_List",
+  "title": "ListBlobServices"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/BlobServicesPut.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/BlobServicesPut.json
@@ -1,0 +1,183 @@
+{
+  "parameters": {
+    "BlobServicesName": "default",
+    "accountName": "sto8607",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "parameters": {
+      "properties": {
+        "changeFeed": {
+          "enabled": true,
+          "retentionInDays": 7
+        },
+        "cors": {
+          "corsRules": [
+            {
+              "allowedHeaders": [
+                "x-ms-meta-abc",
+                "x-ms-meta-data*",
+                "x-ms-meta-target*"
+              ],
+              "allowedMethods": [
+                "GET",
+                "HEAD",
+                "POST",
+                "OPTIONS",
+                "MERGE",
+                "PUT"
+              ],
+              "allowedOrigins": [
+                "http://www.contoso.com",
+                "http://www.fabrikam.com"
+              ],
+              "exposedHeaders": [
+                "x-ms-meta-*"
+              ],
+              "maxAgeInSeconds": 100
+            },
+            {
+              "allowedHeaders": [
+                "*"
+              ],
+              "allowedMethods": [
+                "GET"
+              ],
+              "allowedOrigins": [
+                "*"
+              ],
+              "exposedHeaders": [
+                "*"
+              ],
+              "maxAgeInSeconds": 2
+            },
+            {
+              "allowedHeaders": [
+                "x-ms-meta-12345675754564*"
+              ],
+              "allowedMethods": [
+                "GET",
+                "PUT"
+              ],
+              "allowedOrigins": [
+                "http://www.abc23.com",
+                "https://www.fabrikam.com/*"
+              ],
+              "exposedHeaders": [
+                "x-ms-meta-abc",
+                "x-ms-meta-data*",
+                "x -ms-meta-target*"
+              ],
+              "maxAgeInSeconds": 2000
+            }
+          ]
+        },
+        "defaultServiceVersion": "2017-07-29",
+        "deleteRetentionPolicy": {
+          "days": 300,
+          "enabled": true
+        },
+        "isVersioningEnabled": true,
+        "staticWebsite": {
+          "enabled": true,
+          "indexDocument": "home.html",
+          "errorDocument404Path": "site/errors/not-found.html"
+        }
+      }
+    },
+    "resourceGroupName": "res4410",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.Storage/storageAccounts/blobServices",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res4410/providers/Microsoft.Storage/storageAccounts/sto8607/blobServices/default",
+        "properties": {
+          "changeFeed": {
+            "enabled": true,
+            "retentionInDays": 7
+          },
+          "cors": {
+            "corsRules": [
+              {
+                "allowedHeaders": [
+                  "x-ms-meta-abc",
+                  "x-ms-meta-data*",
+                  "x-ms-meta-target*"
+                ],
+                "allowedMethods": [
+                  "GET",
+                  "HEAD",
+                  "POST",
+                  "OPTIONS",
+                  "MERGE",
+                  "PUT"
+                ],
+                "allowedOrigins": [
+                  "http://www.contoso.com",
+                  "http://www.fabrikam.com"
+                ],
+                "exposedHeaders": [
+                  "x-ms-meta-*"
+                ],
+                "maxAgeInSeconds": 100
+              },
+              {
+                "allowedHeaders": [
+                  "*"
+                ],
+                "allowedMethods": [
+                  "GET"
+                ],
+                "allowedOrigins": [
+                  "*"
+                ],
+                "exposedHeaders": [
+                  "*"
+                ],
+                "maxAgeInSeconds": 2
+              },
+              {
+                "allowedHeaders": [
+                  "x-ms-meta-12345675754564*"
+                ],
+                "allowedMethods": [
+                  "GET",
+                  "PUT"
+                ],
+                "allowedOrigins": [
+                  "http://www.abc23.com",
+                  "https://www.fabrikam.com/*"
+                ],
+                "exposedHeaders": [
+                  "x-ms-meta-abc",
+                  "x-ms-meta-data*",
+                  "x -ms-meta-target*"
+                ],
+                "maxAgeInSeconds": 2000
+              }
+            ]
+          },
+          "defaultServiceVersion": "2017-07-29",
+          "deleteRetentionPolicy": {
+            "days": 300,
+            "enabled": true
+          },
+          "isVersioningEnabled": true,
+          "staticWebsite": {
+            "enabled": true,
+            "indexDocument": "home.html",
+            "errorDocument404Path": "site/errors/not-found.html"
+          }
+        },
+        "sku": {
+          "name": "Standard_GRS",
+          "tier": "Standard"
+        }
+      }
+    }
+  },
+  "operationId": "BlobServices_SetServiceProperties",
+  "title": "PutBlobServices"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/BlobServicesPutAllowPermanentDelete.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/BlobServicesPutAllowPermanentDelete.json
@@ -1,0 +1,39 @@
+{
+  "parameters": {
+    "BlobServicesName": "default",
+    "accountName": "sto8607",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "parameters": {
+      "properties": {
+        "deleteRetentionPolicy": {
+          "allowPermanentDelete": true,
+          "days": 300,
+          "enabled": true
+        },
+        "isVersioningEnabled": true
+      }
+    },
+    "resourceGroupName": "res4410",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.Storage/storageAccounts/blobServices",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res4410/providers/Microsoft.Storage/storageAccounts/sto8607/blobServices/default",
+        "properties": {
+          "deleteRetentionPolicy": {
+            "allowPermanentDelete": true,
+            "days": 300,
+            "enabled": true
+          },
+          "isVersioningEnabled": true
+        }
+      }
+    }
+  },
+  "operationId": "BlobServices_SetServiceProperties",
+  "title": "BlobServicesPutAllowPermanentDelete"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/BlobServicesPutLastAccessTimeBasedTracking.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/BlobServicesPutLastAccessTimeBasedTracking.json
@@ -1,0 +1,43 @@
+{
+  "parameters": {
+    "BlobServicesName": "default",
+    "accountName": "sto8607",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "parameters": {
+      "properties": {
+        "lastAccessTimeTrackingPolicy": {
+          "name": "AccessTimeTracking",
+          "blobType": [
+            "blockBlob"
+          ],
+          "enable": true,
+          "trackingGranularityInDays": 1
+        }
+      }
+    },
+    "resourceGroupName": "res4410",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.Storage/storageAccounts/blobServices",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res4410/providers/Microsoft.Storage/storageAccounts/sto8607/blobServices/default",
+        "properties": {
+          "lastAccessTimeTrackingPolicy": {
+            "name": "AccessTimeTracking",
+            "blobType": [
+              "blockBlob"
+            ],
+            "enable": true,
+            "trackingGranularityInDays": 1
+          }
+        }
+      }
+    }
+  },
+  "operationId": "BlobServices_SetServiceProperties",
+  "title": "BlobServicesPutLastAccessTimeBasedTracking"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/DeletedAccountGet.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/DeletedAccountGet.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "api-version": "2026-09-01",
+    "deletedAccountName": "sto1125",
+    "location": "eastus",
+    "monitor": "true",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto1125",
+        "type": "Microsoft.Storage/deletedAccounts",
+        "id": "/subscriptions/{subscription-id}/providers/Microsoft.Storage/locations/eastus/deletedAccounts/sto1125",
+        "properties": {
+          "creationTime": "2020-08-17T03:35:37.4588848Z",
+          "deletionTime": "2020-08-17T04:41:37.3442475Z",
+          "location": "eastus",
+          "restoreReference": "sto1125|2020-08-17T03:35:37.4588848Z",
+          "storageAccountResourceId": "/subscriptions/{subscription-id}/resourceGroups/sto/providers/Microsoft.Storage/storageAccounts/sto1125"
+        }
+      }
+    }
+  },
+  "operationId": "DeletedAccounts_Get",
+  "title": "DeletedAccountGet"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/DeletedAccountList.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/DeletedAccountList.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "sto1125",
+            "type": "Microsoft.Storage/deletedAccounts",
+            "id": "/subscriptions/{subscription-id}/providers/Microsoft.Storage/locations/eastus/deletedAccounts/sto1125",
+            "properties": {
+              "creationTime": "2020-08-17T03:35:37.4588848Z",
+              "deletionTime": "2020-08-17T04:41:37.3442475Z",
+              "location": "eastus",
+              "restoreReference": "sto1125|2020-08-17T03:35:37.4588848Z",
+              "storageAccountResourceId": "/subscriptions/{subscription-id}/resourceGroups/sto/providers/Microsoft.Storage/storageAccounts/sto1125"
+            }
+          },
+          {
+            "name": "sto1126",
+            "type": "Microsoft.Storage/deletedAccounts",
+            "id": "/subscriptions/{subscription-id}/providers/Microsoft.Storage/locations/eastus/deletedAccounts/sto1126",
+            "properties": {
+              "creationTime": "2020-08-19T15:10:21.5902165Z",
+              "deletionTime": "2020-08-20T06:11:55.1957302Z",
+              "location": "eastus",
+              "restoreReference": "sto1126|2020-08-17T03:35:37.4588848Z",
+              "storageAccountResourceId": "/subscriptions/{subscription-id}/resourceGroups/sto/providers/Microsoft.Storage/storageAccounts/sto1126"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "DeletedAccounts_List",
+  "title": "DeletedAccountList"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/DeletedBlobContainersList.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/DeletedBlobContainersList.json
@@ -1,0 +1,52 @@
+{
+  "parameters": {
+    "$include": "deleted",
+    "accountName": "sto1590",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res9290",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "container1644",
+            "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
+            "etag": "\"0x8D589847D51C7DE\"",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/res9290/providers/Microsoft.Storage/storageAccounts/sto1590/blobServices/default/containers/container1644",
+            "properties": {
+              "hasImmutabilityPolicy": false,
+              "hasLegalHold": false,
+              "lastModifiedTime": "2018-03-14T08:20:47Z",
+              "leaseState": "Available",
+              "leaseStatus": "Unlocked",
+              "publicAccess": "Container"
+            }
+          },
+          {
+            "name": "container4052",
+            "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
+            "etag": "\"0x8D589847DAB5AF9\"",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/res9290/providers/Microsoft.Storage/storageAccounts/sto1590/blobServices/default/containers/container4052",
+            "properties": {
+              "deleted": true,
+              "deletedTime": "2019-12-14T08:20:47Z",
+              "hasImmutabilityPolicy": false,
+              "hasLegalHold": false,
+              "lastModifiedTime": "2018-03-14T08:20:47Z",
+              "leaseState": "Expired",
+              "leaseStatus": "Unlocked",
+              "publicAccess": "None",
+              "remainingRetentionDays": 30,
+              "version": "1234567890"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "BlobContainers_List",
+  "title": "ListDeletedContainers"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/DeletedFileSharesList.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/DeletedFileSharesList.json
@@ -1,0 +1,44 @@
+{
+  "parameters": {
+    "$expand": "deleted",
+    "accountName": "sto1590",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res9290",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "share1644",
+            "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+            "etag": "\"0x8D589847D51C7DE\"",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/res9290/providers/Microsoft.Storage/storageAccounts/sto1590/fileServices/default/shares/share1644_1234567890",
+            "properties": {
+              "deleted": true,
+              "deletedTime": "2019-12-14T08:20:47Z",
+              "lastModifiedTime": "2019-05-14T08:20:47Z",
+              "remainingRetentionDays": 30,
+              "shareQuota": 1024,
+              "version": "1234567890"
+            }
+          },
+          {
+            "name": "share4052",
+            "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+            "etag": "\"0x8D589847DAB5AF9\"",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/res9290/providers/Microsoft.Storage/storageAccounts/sto1590/fileServices/default/shares/share4052",
+            "properties": {
+              "lastModifiedTime": "2019-05-14T08:20:47Z",
+              "shareQuota": 1024
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "FileShares_List",
+  "title": "ListDeletedShares"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/FileServicesGet.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/FileServicesGet.json
@@ -1,0 +1,88 @@
+{
+  "parameters": {
+    "FileServicesName": "default",
+    "accountName": "sto8607",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res4410",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.Storage/storageAccounts/fileServices",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res4410/providers/Microsoft.Storage/storageAccounts/sto8607/fileServices/default",
+        "properties": {
+          "cors": {
+            "corsRules": [
+              {
+                "allowedHeaders": [
+                  "x-ms-meta-abc",
+                  "x-ms-meta-data*",
+                  "x-ms-meta-target*"
+                ],
+                "allowedMethods": [
+                  "GET",
+                  "HEAD",
+                  "POST",
+                  "OPTIONS",
+                  "MERGE",
+                  "PUT"
+                ],
+                "allowedOrigins": [
+                  "http://www.contoso.com",
+                  "http://www.fabrikam.com"
+                ],
+                "exposedHeaders": [
+                  "x-ms-meta-*"
+                ],
+                "maxAgeInSeconds": 100
+              },
+              {
+                "allowedHeaders": [
+                  "*"
+                ],
+                "allowedMethods": [
+                  "GET"
+                ],
+                "allowedOrigins": [
+                  "*"
+                ],
+                "exposedHeaders": [
+                  "*"
+                ],
+                "maxAgeInSeconds": 2
+              },
+              {
+                "allowedHeaders": [
+                  "x-ms-meta-12345675754564*"
+                ],
+                "allowedMethods": [
+                  "GET",
+                  "PUT"
+                ],
+                "allowedOrigins": [
+                  "http://www.abc23.com",
+                  "https://www.fabrikam.com/*"
+                ],
+                "exposedHeaders": [
+                  "x-ms-meta-abc",
+                  "x-ms-meta-data*",
+                  "x-ms-meta-target*"
+                ],
+                "maxAgeInSeconds": 2000
+              }
+            ]
+          }
+        },
+        "sku": {
+          "name": "Standard_GRS",
+          "tier": "Standard"
+        }
+      }
+    }
+  },
+  "operationId": "FileServices_GetServiceProperties",
+  "title": "GetFileServices"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/FileServicesGetUsage.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/FileServicesGetUsage.json
@@ -1,0 +1,65 @@
+{
+  "parameters": {
+    "FileServicesName": "default",
+    "accountName": "sto8607",
+    "api-version": "2026-09-01",
+    "fileServiceUsagesName": "default",
+    "monitor": "true",
+    "resourceGroupName": "res4410",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.Storage/storageAccounts/fileServices/usages",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/res4410/providers/Microsoft.Storage/storageAccounts/sto8607/fileServices/default/usages/default",
+        "properties": {
+          "burstingConstants": {
+            "burstFloorIOPS": 10000,
+            "burstIOScalar": 3,
+            "burstTimeframeSeconds": 3600
+          },
+          "fileShareLimits": {
+            "maxProvisionedBandwidthMiBPerSec": 10340,
+            "maxProvisionedIOPS": 102400,
+            "maxProvisionedStorageGiB": 262144,
+            "minProvisionedBandwidthMiBPerSec": 125,
+            "minProvisionedIOPS": 3000,
+            "minProvisionedStorageGiB": 32,
+            "guardrailIOScalar": 5,
+            "guardrailBandwidthScalar": 5
+          },
+          "fileShareRecommendations": {
+            "bandwidthScalar": 0.1,
+            "baseBandwidthMiBPerSec": 125,
+            "baseIOPS": 3000,
+            "ioScalar": 1
+          },
+          "storageAccountLimits": {
+            "maxFileShares": 50,
+            "maxProvisionedBandwidthMiBPerSec": 10340,
+            "maxProvisionedIOPS": 102400,
+            "maxProvisionedStorageGiB": 262144
+          },
+          "storageAccountUsage": {
+            "liveShares": {
+              "fileShareCount": 2,
+              "provisionedBandwidthMiBPerSec": 258,
+              "provisionedIOPS": 6064,
+              "provisionedStorageGiB": 64
+            },
+            "softDeletedShares": {
+              "fileShareCount": 1,
+              "provisionedBandwidthMiBPerSec": 125,
+              "provisionedIOPS": 3000,
+              "provisionedStorageGiB": 100
+            }
+          }
+        }
+      }
+    }
+  },
+  "operationId": "FileServices_GetServiceUsage",
+  "title": "GetFileServiceUsage"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/FileServicesList.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/FileServicesList.json
@@ -1,0 +1,91 @@
+{
+  "parameters": {
+    "accountName": "sto1590",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res9290",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "default",
+            "type": "Microsoft.Storage/storageAccounts/fileServices",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/res4410/providers/Microsoft.Storage/storageAccounts/sto8607/fileServices/default",
+            "properties": {
+              "cors": {
+                "corsRules": [
+                  {
+                    "allowedHeaders": [
+                      "x-ms-meta-abc",
+                      "x-ms-meta-data*",
+                      "x-ms-meta-target*"
+                    ],
+                    "allowedMethods": [
+                      "GET",
+                      "HEAD",
+                      "POST",
+                      "OPTIONS",
+                      "MERGE",
+                      "PUT"
+                    ],
+                    "allowedOrigins": [
+                      "http://www.contoso.com",
+                      "http://www.fabrikam.com"
+                    ],
+                    "exposedHeaders": [
+                      "x-ms-meta-*"
+                    ],
+                    "maxAgeInSeconds": 100
+                  },
+                  {
+                    "allowedHeaders": [
+                      "*"
+                    ],
+                    "allowedMethods": [
+                      "GET"
+                    ],
+                    "allowedOrigins": [
+                      "*"
+                    ],
+                    "exposedHeaders": [
+                      "*"
+                    ],
+                    "maxAgeInSeconds": 2
+                  },
+                  {
+                    "allowedHeaders": [
+                      "x-ms-meta-12345675754564*"
+                    ],
+                    "allowedMethods": [
+                      "GET",
+                      "PUT"
+                    ],
+                    "allowedOrigins": [
+                      "http://www.abc23.com",
+                      "https://www.fabrikam.com/*"
+                    ],
+                    "exposedHeaders": [
+                      "x-ms-meta-abc",
+                      "x-ms-meta-data*",
+                      "x-ms-meta-target*"
+                    ],
+                    "maxAgeInSeconds": 2000
+                  }
+                ]
+              }
+            },
+            "sku": {
+              "name": "Standard_GRS",
+              "tier": "Standard"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "FileServices_List",
+  "title": "ListFileServices"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/FileServicesListUsages.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/FileServicesListUsages.json
@@ -1,0 +1,68 @@
+{
+  "parameters": {
+    "FileServicesName": "default",
+    "accountName": "sto8607",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res4410",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "default",
+            "type": "Microsoft.Storage/storageAccounts/fileServices/usages",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/res4410/providers/Microsoft.Storage/storageAccounts/sto8607/fileServices/default/usages/default",
+            "properties": {
+              "burstingConstants": {
+                "burstFloorIOPS": 10000,
+                "burstIOScalar": 3,
+                "burstTimeframeSeconds": 3600
+              },
+              "fileShareLimits": {
+                "maxProvisionedBandwidthMiBPerSec": 10340,
+                "maxProvisionedIOPS": 102400,
+                "maxProvisionedStorageGiB": 262144,
+                "minProvisionedBandwidthMiBPerSec": 125,
+                "minProvisionedIOPS": 3000,
+                "minProvisionedStorageGiB": 32,
+                "guardrailIOScalar": 5,
+                "guardrailBandwidthScalar": 5
+              },
+              "fileShareRecommendations": {
+                "bandwidthScalar": 0.1,
+                "baseBandwidthMiBPerSec": 125,
+                "baseIOPS": 3000,
+                "ioScalar": 1
+              },
+              "storageAccountLimits": {
+                "maxFileShares": 50,
+                "maxProvisionedBandwidthMiBPerSec": 10340,
+                "maxProvisionedIOPS": 102400,
+                "maxProvisionedStorageGiB": 262144
+              },
+              "storageAccountUsage": {
+                "liveShares": {
+                  "fileShareCount": 2,
+                  "provisionedBandwidthMiBPerSec": 258,
+                  "provisionedIOPS": 6064,
+                  "provisionedStorageGiB": 64
+                },
+                "softDeletedShares": {
+                  "fileShareCount": 1,
+                  "provisionedBandwidthMiBPerSec": 125,
+                  "provisionedIOPS": 3000,
+                  "provisionedStorageGiB": 100
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "FileServices_ListServiceUsages",
+  "title": "ListFileServiceUsages"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/FileServicesPut.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/FileServicesPut.json
@@ -1,0 +1,153 @@
+{
+  "parameters": {
+    "FileServicesName": "default",
+    "accountName": "sto8607",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "parameters": {
+      "properties": {
+        "cors": {
+          "corsRules": [
+            {
+              "allowedHeaders": [
+                "x-ms-meta-abc",
+                "x-ms-meta-data*",
+                "x-ms-meta-target*"
+              ],
+              "allowedMethods": [
+                "GET",
+                "HEAD",
+                "POST",
+                "OPTIONS",
+                "MERGE",
+                "PUT"
+              ],
+              "allowedOrigins": [
+                "http://www.contoso.com",
+                "http://www.fabrikam.com"
+              ],
+              "exposedHeaders": [
+                "x-ms-meta-*"
+              ],
+              "maxAgeInSeconds": 100
+            },
+            {
+              "allowedHeaders": [
+                "*"
+              ],
+              "allowedMethods": [
+                "GET"
+              ],
+              "allowedOrigins": [
+                "*"
+              ],
+              "exposedHeaders": [
+                "*"
+              ],
+              "maxAgeInSeconds": 2
+            },
+            {
+              "allowedHeaders": [
+                "x-ms-meta-12345675754564*"
+              ],
+              "allowedMethods": [
+                "GET",
+                "PUT"
+              ],
+              "allowedOrigins": [
+                "http://www.abc23.com",
+                "https://www.fabrikam.com/*"
+              ],
+              "exposedHeaders": [
+                "x-ms-meta-abc",
+                "x-ms-meta-data*",
+                "x-ms-meta-target*"
+              ],
+              "maxAgeInSeconds": 2000
+            }
+          ]
+        }
+      }
+    },
+    "resourceGroupName": "res4410",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.Storage/storageAccounts/fileServices",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res4410/providers/Microsoft.Storage/storageAccounts/sto8607/fileServices/default",
+        "properties": {
+          "cors": {
+            "corsRules": [
+              {
+                "allowedHeaders": [
+                  "x-ms-meta-abc",
+                  "x-ms-meta-data*",
+                  "x-ms-meta-target*"
+                ],
+                "allowedMethods": [
+                  "GET",
+                  "HEAD",
+                  "POST",
+                  "OPTIONS",
+                  "MERGE",
+                  "PUT"
+                ],
+                "allowedOrigins": [
+                  "http://www.contoso.com",
+                  "http://www.fabrikam.com"
+                ],
+                "exposedHeaders": [
+                  "x-ms-meta-*"
+                ],
+                "maxAgeInSeconds": 100
+              },
+              {
+                "allowedHeaders": [
+                  "*"
+                ],
+                "allowedMethods": [
+                  "GET"
+                ],
+                "allowedOrigins": [
+                  "*"
+                ],
+                "exposedHeaders": [
+                  "*"
+                ],
+                "maxAgeInSeconds": 2
+              },
+              {
+                "allowedHeaders": [
+                  "x-ms-meta-12345675754564*"
+                ],
+                "allowedMethods": [
+                  "GET",
+                  "PUT"
+                ],
+                "allowedOrigins": [
+                  "http://www.abc23.com",
+                  "https://www.fabrikam.com/*"
+                ],
+                "exposedHeaders": [
+                  "x-ms-meta-abc",
+                  "x-ms-meta-data*",
+                  "x-ms-meta-target*"
+                ],
+                "maxAgeInSeconds": 2000
+              }
+            ]
+          }
+        },
+        "sku": {
+          "name": "Standard_GRS",
+          "tier": "Standard"
+        }
+      }
+    }
+  },
+  "operationId": "FileServices_SetServiceProperties",
+  "title": "PutFileServices"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/FileServicesPut_EnableSMBMultichannel.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/FileServicesPut_EnableSMBMultichannel.json
@@ -1,0 +1,45 @@
+{
+  "parameters": {
+    "FileServicesName": "default",
+    "accountName": "sto8607",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "parameters": {
+      "properties": {
+        "protocolSettings": {
+          "smb": {
+            "multichannel": {
+              "enabled": true
+            }
+          }
+        }
+      }
+    },
+    "resourceGroupName": "res4410",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.Storage/storageAccounts/fileServices",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res4410/providers/Microsoft.Storage/storageAccounts/sto8607/fileServices/default",
+        "properties": {
+          "protocolSettings": {
+            "smb": {
+              "multichannel": {
+                "enabled": true
+              }
+            }
+          }
+        },
+        "sku": {
+          "name": "Premium_LRS",
+          "tier": "Premium"
+        }
+      }
+    }
+  },
+  "operationId": "FileServices_SetServiceProperties",
+  "title": "PutFileServices_EnableSMBMultichannel"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/FileServicesPut_EnableSecureSmbFeatures.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/FileServicesPut_EnableSecureSmbFeatures.json
@@ -1,0 +1,47 @@
+{
+  "parameters": {
+    "FileServicesName": "default",
+    "accountName": "sto8607",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "parameters": {
+      "properties": {
+        "protocolSettings": {
+          "smb": {
+            "authenticationMethods": "NTLMv2;Kerberos",
+            "channelEncryption": "AES-128-CCM;AES-128-GCM;AES-256-GCM",
+            "kerberosTicketEncryption": "RC4-HMAC;AES-256",
+            "versions": "SMB2.1;SMB3.0;SMB3.1.1"
+          }
+        }
+      }
+    },
+    "resourceGroupName": "res4410",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.Storage/storageAccounts/fileServices",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res4410/providers/Microsoft.Storage/storageAccounts/sto8607/fileServices/default",
+        "properties": {
+          "protocolSettings": {
+            "smb": {
+              "authenticationMethods": "NTLMv2;Kerberos",
+              "channelEncryption": "AES-128-CCM;AES-128-GCM;AES-256-GCM",
+              "kerberosTicketEncryption": "RC4-HMAC;AES-256",
+              "versions": "SMB2.1;SMB3.0;SMB3.1.1"
+            }
+          }
+        },
+        "sku": {
+          "name": "Premium_LRS",
+          "tier": "Premium"
+        }
+      }
+    }
+  },
+  "operationId": "FileServices_SetServiceProperties",
+  "title": "PutFileServices_EnableSecureSmbFeatures"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/FileServicesPut_EncryptionInTransitRequired.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/FileServicesPut_EncryptionInTransitRequired.json
@@ -1,0 +1,55 @@
+{
+  "parameters": {
+    "FileServicesName": "default",
+    "accountName": "sto8607",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "parameters": {
+      "properties": {
+        "protocolSettings": {
+          "nfs": {
+            "encryptionInTransit": {
+              "required": true
+            }
+          },
+          "smb": {
+            "encryptionInTransit": {
+              "required": true
+            }
+          }
+        }
+      }
+    },
+    "resourceGroupName": "res4410",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.Storage/storageAccounts/fileServices",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res4410/providers/Microsoft.Storage/storageAccounts/sto8607/fileServices/default",
+        "properties": {
+          "protocolSettings": {
+            "nfs": {
+              "encryptionInTransit": {
+                "required": true
+              }
+            },
+            "smb": {
+              "encryptionInTransit": {
+                "required": true
+              }
+            }
+          }
+        },
+        "sku": {
+          "name": "Premium_LRS",
+          "tier": "Premium"
+        }
+      }
+    }
+  },
+  "operationId": "FileServices_SetServiceProperties",
+  "title": "PutFileServices_EncryptionInTransitRequired"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/FileShareAclsPatch.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/FileShareAclsPatch.json
@@ -1,0 +1,47 @@
+{
+  "parameters": {
+    "accountName": "sto328",
+    "api-version": "2026-09-01",
+    "fileShare": {
+      "properties": {
+        "signedIdentifiers": [
+          {
+            "accessPolicy": {
+              "expiryTime": "2021-05-01T08:49:37.0000000Z",
+              "permission": "rwd",
+              "startTime": "2021-04-01T08:49:37.0000000Z"
+            },
+            "id": "MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI"
+          }
+        ]
+      }
+    },
+    "monitor": "true",
+    "resourceGroupName": "res3376",
+    "shareName": "share6185",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "share6185",
+        "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res3376/providers/Microsoft.Storage/storageAccounts/sto328/fileServices/default/shares/share6185",
+        "properties": {
+          "signedIdentifiers": [
+            {
+              "accessPolicy": {
+                "expiryTime": "2021-05-01T08:49:37.0000000Z",
+                "permission": "rwd",
+                "startTime": "2021-04-01T08:49:37.0000000Z"
+              },
+              "id": "MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "FileShares_Update",
+  "title": "UpdateShareAcls"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/FileShareSnapshotsList.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/FileShareSnapshotsList.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "$expand": "snapshots",
+    "accountName": "sto1590",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res9290",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "share4052",
+            "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+            "etag": "\"0x8D589847DAB5AF9\"",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/res9290/providers/Microsoft.Storage/storageAccounts/sto1590/fileServices/default/shares/share4052",
+            "properties": {
+              "lastModifiedTime": "2020-10-26T05:47:05.0000000Z",
+              "shareQuota": 1024
+            }
+          },
+          {
+            "name": "share4052",
+            "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+            "etag": "\"0x8D589847DAB5AF9\"",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/res9290/providers/Microsoft.Storage/storageAccounts/sto1590/fileServices/default/shares/share4052",
+            "properties": {
+              "lastModifiedTime": "2020-10-26T05:47:05.0000000Z",
+              "shareQuota": 1024,
+              "snapshotTime": "2020-10-26T05:48:07.0000000Z"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "FileShares_List",
+  "title": "ListShareSnapshots"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/FileSharesDelete.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/FileSharesDelete.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "accountName": "sto4506",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res4079",
+    "shareName": "share9689",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "FileShares_Delete",
+  "title": "DeleteShares"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/FileSharesGet.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/FileSharesGet.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "accountName": "sto6217",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res9871",
+    "shareName": "share1634",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "share1634",
+        "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+        "etag": "\"0x8D592D74CC20EBA\"",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9871/providers/Microsoft.Storage/storageAccounts/sto6217/fileServices/default/shares/share1634",
+        "properties": {
+          "lastModifiedTime": "2019-05-26T05:06:14Z",
+          "shareQuota": 1024
+        }
+      }
+    }
+  },
+  "operationId": "FileShares_Get",
+  "title": "GetShares"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/FileSharesGet_PaidBursting.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/FileSharesGet_PaidBursting.json
@@ -1,0 +1,31 @@
+{
+  "parameters": {
+    "accountName": "sto6217",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res9871",
+    "shareName": "share1634",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "share1634",
+        "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+        "etag": "\"0x8D592D74CC20EBA\"",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9871/providers/Microsoft.Storage/storageAccounts/sto6217/fileServices/default/shares/share1634",
+        "properties": {
+          "fileSharePaidBursting": {
+            "paidBurstingEnabled": true,
+            "paidBurstingMaxBandwidthMibps": 10340,
+            "paidBurstingMaxIops": 102400
+          },
+          "lastModifiedTime": "2019-05-26T05:06:14Z",
+          "shareQuota": 1024
+        }
+      }
+    }
+  },
+  "operationId": "FileShares_Get",
+  "title": "GetSharePaidBursting"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/FileSharesGet_ProvisionedV2.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/FileSharesGet_ProvisionedV2.json
@@ -1,0 +1,33 @@
+{
+  "parameters": {
+    "accountName": "sto6217",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res9871",
+    "shareName": "share1634",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "share1634",
+        "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+        "etag": "\"0x8D592D74CC20EBA\"",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9871/providers/Microsoft.Storage/storageAccounts/sto6217/fileServices/default/shares/share1634",
+        "properties": {
+          "includedBurstIops": 15000,
+          "lastModifiedTime": "2024-10-25T01:50:50.0000000Z",
+          "maxBurstCreditsForIops": 36000000,
+          "nextAllowedProvisionedBandwidthDowngradeTime": "Fri, 25 Oct 2024 01:48:09 GMT",
+          "nextAllowedProvisionedIopsDowngradeTime": "Fri, 25 Oct 2024 01:48:09 GMT",
+          "nextAllowedQuotaDowngradeTime": "Sat, 26 Oct 2024 01:50:50 GMT",
+          "provisionedBandwidthMibps": 200,
+          "provisionedIops": 5000,
+          "shareQuota": 100
+        }
+      }
+    }
+  },
+  "operationId": "FileShares_Get",
+  "title": "GetShareProvisionedV2"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/FileSharesGet_Stats.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/FileSharesGet_Stats.json
@@ -1,0 +1,28 @@
+{
+  "parameters": {
+    "$expand": "stats",
+    "accountName": "sto6217",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res9871",
+    "shareName": "share1634",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "share1634",
+        "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+        "etag": "\"0x8D592D74CC20EBA\"",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9871/providers/Microsoft.Storage/storageAccounts/sto6217/fileServices/default/shares/share1634",
+        "properties": {
+          "lastModifiedTime": "2019-05-26T05:06:14Z",
+          "shareQuota": 1024,
+          "shareUsageBytes": 652945
+        }
+      }
+    }
+  },
+  "operationId": "FileShares_Get",
+  "title": "GetShareStats"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/FileSharesLease_Acquire.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/FileSharesLease_Acquire.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "accountName": "sto328",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "parameters": {
+      "action": "Acquire",
+      "breakPeriod": null,
+      "leaseDuration": -1,
+      "leaseId": null,
+      "proposedLeaseId": null
+    },
+    "resourceGroupName": "res3376",
+    "shareName": "share124",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "leaseId": "8698f513-fa75-44a1-b8eb-30ba336af27d"
+      }
+    }
+  },
+  "operationId": "FileShares_Lease",
+  "title": "Acquire a lease on a share"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/FileSharesLease_Break.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/FileSharesLease_Break.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "accountName": "sto328",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "parameters": {
+      "action": "Break",
+      "breakPeriod": null,
+      "leaseDuration": null,
+      "leaseId": "8698f513-fa75-44a1-b8eb-30ba336af27d",
+      "proposedLeaseId": null
+    },
+    "resourceGroupName": "res3376",
+    "shareName": "share12",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "leaseTimeSeconds": "0"
+      }
+    }
+  },
+  "operationId": "FileShares_Lease",
+  "title": "Break a lease on a share"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/FileSharesList.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/FileSharesList.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "accountName": "sto1590",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res9290",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://sto1590endpoint/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res9290/providers/Microsoft.Storage/storageAccounts/sto1590/fileServices/default/shares?api-version=2022-09-01&$maxpagesize=2&$skipToken=/sto1590/share5103",
+        "value": [
+          {
+            "name": "share1644",
+            "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+            "etag": "\"0x8D589847D51C7DE\"",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res9290/providers/Microsoft.Storage/storageAccounts/sto1590/fileServices/default/shares/share1644",
+            "properties": {
+              "lastModifiedTime": "2019-05-14T08:20:47Z",
+              "shareQuota": 1024
+            }
+          },
+          {
+            "name": "share4052",
+            "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+            "etag": "\"0x8D589847DAB5AF9\"",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res9290/providers/Microsoft.Storage/storageAccounts/sto1590/fileServices/default/shares/share4052",
+            "properties": {
+              "lastModifiedTime": "2019-05-14T08:20:47Z",
+              "shareQuota": 1024
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "FileShares_List",
+  "title": "ListShares"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/FileSharesList_PaidBursting.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/FileSharesList_PaidBursting.json
@@ -1,0 +1,50 @@
+{
+  "parameters": {
+    "accountName": "sto1590",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res9290",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://sto1590endpoint/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res9290/providers/Microsoft.Storage/storageAccounts/sto1590/fileServices/default/shares?api-version=2022-09-01&$maxpagesize=2&$skipToken=/sto1590/share5103",
+        "value": [
+          {
+            "name": "share1644",
+            "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+            "etag": "\"0x8D589847D51C7DE\"",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res9290/providers/Microsoft.Storage/storageAccounts/sto1590/fileServices/default/shares/share1644",
+            "properties": {
+              "fileSharePaidBursting": {
+                "paidBurstingEnabled": true,
+                "paidBurstingMaxBandwidthMibps": 10340,
+                "paidBurstingMaxIops": 102400
+              },
+              "lastModifiedTime": "2019-05-14T08:20:47Z",
+              "shareQuota": 1024
+            }
+          },
+          {
+            "name": "share4052",
+            "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+            "etag": "\"0x8D589847DAB5AF9\"",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res9290/providers/Microsoft.Storage/storageAccounts/sto1590/fileServices/default/shares/share4052",
+            "properties": {
+              "fileSharePaidBursting": {
+                "paidBurstingEnabled": true,
+                "paidBurstingMaxBandwidthMibps": 10340,
+                "paidBurstingMaxIops": 102400
+              },
+              "lastModifiedTime": "2019-05-14T08:20:47Z",
+              "shareQuota": 1024
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "FileShares_List",
+  "title": "ListSharesPaidBursting"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/FileSharesList_ProvisionedV2.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/FileSharesList_ProvisionedV2.json
@@ -1,0 +1,54 @@
+{
+  "parameters": {
+    "accountName": "sto1590",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res9290",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://sto1590endpoint/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res9290/providers/Microsoft.Storage/storageAccounts/sto1590/fileServices/default/shares?api-version=2022-09-01&$maxpagesize=2&$skipToken=/sto1590/share5103",
+        "value": [
+          {
+            "name": "share1644",
+            "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+            "etag": "\"0x8D589847D51C7DE\"",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res9290/providers/Microsoft.Storage/storageAccounts/sto1590/fileServices/default/shares/share1644",
+            "properties": {
+              "includedBurstIops": 15000,
+              "lastModifiedTime": "2024-10-25T01:50:50.0000000Z",
+              "maxBurstCreditsForIops": 36000000,
+              "nextAllowedProvisionedBandwidthDowngradeTime": "Fri, 25 Oct 2024 01:48:09 GMT",
+              "nextAllowedProvisionedIopsDowngradeTime": "Fri, 25 Oct 2024 01:48:09 GMT",
+              "nextAllowedQuotaDowngradeTime": "Sat, 26 Oct 2024 01:50:50 GMT",
+              "provisionedBandwidthMibps": 200,
+              "provisionedIops": 5000,
+              "shareQuota": 100
+            }
+          },
+          {
+            "name": "share4052",
+            "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+            "etag": "\"0x8D589847DAB5AF9\"",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res9290/providers/Microsoft.Storage/storageAccounts/sto1590/fileServices/default/shares/share4052",
+            "properties": {
+              "includedBurstIops": 15000,
+              "lastModifiedTime": "2024-10-25T01:50:50.0000000Z",
+              "maxBurstCreditsForIops": 36000000,
+              "nextAllowedProvisionedBandwidthDowngradeTime": "Fri, 25 Oct 2024 01:48:09 GMT",
+              "nextAllowedProvisionedIopsDowngradeTime": "Fri, 25 Oct 2024 01:48:09 GMT",
+              "nextAllowedQuotaDowngradeTime": "Sat, 26 Oct 2024 01:50:50 GMT",
+              "provisionedBandwidthMibps": 200,
+              "provisionedIops": 5000,
+              "shareQuota": 100
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "FileShares_List",
+  "title": "ListSharesProvisionedV2"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/FileSharesPatch.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/FileSharesPatch.json
@@ -1,0 +1,33 @@
+{
+  "parameters": {
+    "accountName": "sto328",
+    "api-version": "2026-09-01",
+    "fileShare": {
+      "properties": {
+        "metadata": {
+          "type": "image"
+        }
+      }
+    },
+    "monitor": "true",
+    "resourceGroupName": "res3376",
+    "shareName": "share6185",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "share6185",
+        "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res3376/providers/Microsoft.Storage/storageAccounts/sto328/fileServices/default/shares/share6185",
+        "properties": {
+          "metadata": {
+            "type": "image"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "FileShares_Update",
+  "title": "UpdateShares"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/FileSharesPatch_PaidBursting.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/FileSharesPatch_PaidBursting.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "accountName": "sto328",
+    "api-version": "2026-09-01",
+    "fileShare": {
+      "properties": {
+        "fileSharePaidBursting": {
+          "paidBurstingEnabled": true,
+          "paidBurstingMaxBandwidthMibps": 10340,
+          "paidBurstingMaxIops": 102400
+        }
+      }
+    },
+    "monitor": "true",
+    "resourceGroupName": "res3376",
+    "shareName": "share6185",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "share6185",
+        "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res3376/providers/Microsoft.Storage/storageAccounts/sto328/fileServices/default/shares/share6185",
+        "properties": {
+          "fileSharePaidBursting": {
+            "paidBurstingEnabled": true,
+            "paidBurstingMaxBandwidthMibps": 10340,
+            "paidBurstingMaxIops": 102400
+          }
+        }
+      }
+    }
+  },
+  "operationId": "FileShares_Update",
+  "title": "UpdateSharePaidBursting"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/FileSharesPatch_ProvisionedV2.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/FileSharesPatch_ProvisionedV2.json
@@ -1,0 +1,38 @@
+{
+  "parameters": {
+    "accountName": "sto328",
+    "api-version": "2026-09-01",
+    "fileShare": {
+      "properties": {
+        "provisionedBandwidthMibps": 200,
+        "provisionedIops": 5000,
+        "shareQuota": 100
+      }
+    },
+    "monitor": "true",
+    "resourceGroupName": "res3376",
+    "shareName": "share6185",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "share6185",
+        "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res3376/providers/Microsoft.Storage/storageAccounts/sto328/fileServices/default/shares/share6185",
+        "properties": {
+          "includedBurstIops": 15000,
+          "maxBurstCreditsForIops": 36000000,
+          "nextAllowedProvisionedBandwidthDowngradeTime": "Fri, 25 Oct 2024 01:48:09 GMT",
+          "nextAllowedProvisionedIopsDowngradeTime": "Fri, 25 Oct 2024 01:48:09 GMT",
+          "nextAllowedQuotaDowngradeTime": "Sat, 26 Oct 2024 01:50:50 GMT",
+          "provisionedBandwidthMibps": 200,
+          "provisionedIops": 5000,
+          "shareQuota": 100
+        }
+      }
+    }
+  },
+  "operationId": "FileShares_Update",
+  "title": "UpdateShareProvisionedV2"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/FileSharesPut.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/FileSharesPut.json
@@ -1,0 +1,29 @@
+{
+  "parameters": {
+    "accountName": "sto328",
+    "api-version": "2026-09-01",
+    "fileShare": {},
+    "monitor": "true",
+    "resourceGroupName": "res3376",
+    "shareName": "share6185",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "share6185",
+        "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res3376/providers/Microsoft.Storage/storageAccounts/sto328/fileServices/default/shares/share6185"
+      }
+    },
+    "201": {
+      "body": {
+        "name": "share6185",
+        "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res3376/providers/Microsoft.Storage/storageAccounts/sto328/fileServices/default/shares/share6185"
+      }
+    }
+  },
+  "operationId": "FileShares_Create",
+  "title": "PutShares"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/FileSharesPut_AccessTier.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/FileSharesPut_AccessTier.json
@@ -1,0 +1,39 @@
+{
+  "parameters": {
+    "accountName": "sto666",
+    "api-version": "2026-09-01",
+    "fileShare": {
+      "properties": {
+        "accessTier": "Hot"
+      }
+    },
+    "monitor": "true",
+    "resourceGroupName": "res346",
+    "shareName": "share1235",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "share1235",
+        "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res346/providers/Microsoft.Storage/storageAccounts/sto666/fileServices/default/shares/share1235",
+        "properties": {
+          "accessTier": "Hot"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "share1235",
+        "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res346/providers/Microsoft.Storage/storageAccounts/sto666/fileServices/default/shares/share1235",
+        "properties": {
+          "accessTier": "Hot"
+        }
+      }
+    }
+  },
+  "operationId": "FileShares_Create",
+  "title": "PutShares with Access Tier"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/FileSharesPut_NFS.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/FileSharesPut_NFS.json
@@ -1,0 +1,39 @@
+{
+  "parameters": {
+    "accountName": "sto666",
+    "api-version": "2026-09-01",
+    "fileShare": {
+      "properties": {
+        "enabledProtocols": "NFS"
+      }
+    },
+    "monitor": "true",
+    "resourceGroupName": "res346",
+    "shareName": "share1235",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "share1235",
+        "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res346/providers/Microsoft.Storage/storageAccounts/sto666/fileServices/default/shares/share1235",
+        "properties": {
+          "enabledProtocols": "NFS"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "share1235",
+        "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res346/providers/Microsoft.Storage/storageAccounts/sto666/fileServices/default/shares/share1235",
+        "properties": {
+          "enabledProtocols": "NFS"
+        }
+      }
+    }
+  },
+  "operationId": "FileShares_Create",
+  "title": "Create NFS Shares"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/FileSharesPut_PaidBursting.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/FileSharesPut_PaidBursting.json
@@ -1,0 +1,51 @@
+{
+  "parameters": {
+    "accountName": "sto666",
+    "api-version": "2026-09-01",
+    "fileShare": {
+      "properties": {
+        "fileSharePaidBursting": {
+          "paidBurstingEnabled": true,
+          "paidBurstingMaxBandwidthMibps": 10340,
+          "paidBurstingMaxIops": 102400
+        }
+      }
+    },
+    "monitor": "true",
+    "resourceGroupName": "res346",
+    "shareName": "share1235",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "share1235",
+        "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res346/providers/Microsoft.Storage/storageAccounts/sto666/fileServices/default/shares/share1235",
+        "properties": {
+          "fileSharePaidBursting": {
+            "paidBurstingEnabled": true,
+            "paidBurstingMaxBandwidthMibps": 10340,
+            "paidBurstingMaxIops": 102400
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "share1235",
+        "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res346/providers/Microsoft.Storage/storageAccounts/sto666/fileServices/default/shares/share1235",
+        "properties": {
+          "fileSharePaidBursting": {
+            "paidBurstingEnabled": true,
+            "paidBurstingMaxBandwidthMibps": 10340,
+            "paidBurstingMaxIops": 102400
+          }
+        }
+      }
+    }
+  },
+  "operationId": "FileShares_Create",
+  "title": "PutShares with Paid Bursting"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/FileSharesPut_ProvisionedV2.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/FileSharesPut_ProvisionedV2.json
@@ -1,0 +1,49 @@
+{
+  "parameters": {
+    "accountName": "sto666",
+    "api-version": "2026-09-01",
+    "fileShare": {
+      "properties": {
+        "provisionedBandwidthMibps": 200,
+        "provisionedIops": 5000,
+        "shareQuota": 100
+      }
+    },
+    "monitor": "true",
+    "resourceGroupName": "res346",
+    "shareName": "share1235",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "share1235",
+        "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res346/providers/Microsoft.Storage/storageAccounts/sto666/fileServices/default/shares/share1235",
+        "properties": {
+          "includedBurstIops": 15000,
+          "maxBurstCreditsForIops": 36000000,
+          "provisionedBandwidthMibps": 200,
+          "provisionedIops": 5000,
+          "shareQuota": 100
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "share1235",
+        "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res346/providers/Microsoft.Storage/storageAccounts/sto666/fileServices/default/shares/share1235",
+        "properties": {
+          "includedBurstIops": 15000,
+          "maxBurstCreditsForIops": 36000000,
+          "provisionedBandwidthMibps": 200,
+          "provisionedIops": 5000,
+          "shareQuota": 100
+        }
+      }
+    }
+  },
+  "operationId": "FileShares_Create",
+  "title": "PutSharesProvisionedV2"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/FileSharesRestore.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/FileSharesRestore.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "accountName": "sto328",
+    "api-version": "2026-09-01",
+    "deletedShare": {
+      "deletedShareName": "share1249",
+      "deletedShareVersion": "1234567890"
+    },
+    "monitor": "true",
+    "resourceGroupName": "res3376",
+    "shareName": "share1249",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {}
+  },
+  "operationId": "FileShares_Restore",
+  "title": "RestoreShares"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/LocalUserCreate.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/LocalUserCreate.json
@@ -1,0 +1,72 @@
+{
+  "parameters": {
+    "accountName": "sto2527",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "properties": {
+      "properties": {
+        "allowAclAuthorization": true,
+        "groupId": 2000,
+        "hasSshPassword": true,
+        "homeDirectory": "homedirectory",
+        "permissionScopes": [
+          {
+            "permissions": "rwd",
+            "resourceName": "share1",
+            "service": "file"
+          },
+          {
+            "permissions": "rw",
+            "resourceName": "share2",
+            "service": "file"
+          }
+        ],
+        "sshAuthorizedKeys": [
+          {
+            "description": "key name",
+            "key": "ssh-rsa keykeykeykeykey="
+          }
+        ]
+      }
+    },
+    "resourceGroupName": "res6977",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "username": "user1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "user1",
+        "type": "Microsoft.Storage/storageAccounts/localUsers",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res6977/providers/Microsoft.Storage/storageAccounts/sto2527/loalUsers/user1",
+        "properties": {
+          "allowAclAuthorization": true,
+          "groupId": 2000,
+          "homeDirectory": "homedirectory",
+          "permissionScopes": [
+            {
+              "permissions": "rwd",
+              "resourceName": "share1",
+              "service": "file"
+            },
+            {
+              "permissions": "rw",
+              "resourceName": "share2",
+              "service": "file"
+            }
+          ],
+          "sid": "S-1-2-0-125132-153423-36235-1000",
+          "sshAuthorizedKeys": [
+            {
+              "description": "key name",
+              "key": "ssh-rsa keykeykeykeykey="
+            }
+          ],
+          "userId": 1000
+        }
+      }
+    }
+  },
+  "operationId": "LocalUsers_CreateOrUpdate",
+  "title": "CreateLocalUser"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/LocalUserCreateNFSv3Enabled.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/LocalUserCreateNFSv3Enabled.json
@@ -1,0 +1,62 @@
+{
+  "parameters": {
+    "accountName": "sto2527",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "properties": {
+      "properties": {
+        "extendedGroups": [
+          1001,
+          1005,
+          2005
+        ],
+        "isNFSv3Enabled": true
+      }
+    },
+    "resourceGroupName": "res6977",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "username": "user1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "user1",
+        "type": "Microsoft.Storage/storageAccounts/localUsers",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res6977/providers/Microsoft.Storage/storageAccounts/sto2527/loalUsers/user1",
+        "properties": {
+          "allowAclAuthorization": true,
+          "extendedGroups": [
+            1001,
+            1005,
+            2005
+          ],
+          "groupId": 2000,
+          "homeDirectory": "homedirectory",
+          "isNFSv3Enabled": true,
+          "permissionScopes": [
+            {
+              "permissions": "rwd",
+              "resourceName": "share1",
+              "service": "file"
+            },
+            {
+              "permissions": "rw",
+              "resourceName": "share2",
+              "service": "file"
+            }
+          ],
+          "sid": "S-1-2-0-125132-153423-36235-1000",
+          "sshAuthorizedKeys": [
+            {
+              "description": "key name",
+              "key": "ssh-rsa keykeykeykeykey="
+            }
+          ],
+          "userId": 1000
+        }
+      }
+    }
+  },
+  "operationId": "LocalUsers_CreateOrUpdate",
+  "title": "CreateNFSv3EnabledLocalUser"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/LocalUserDelete.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/LocalUserDelete.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "accountName": "sto2527",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res6977",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "username": "user1"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "LocalUsers_Delete",
+  "title": "DeleteLocalUser"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/LocalUserGet.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/LocalUserGet.json
@@ -1,0 +1,49 @@
+{
+  "parameters": {
+    "accountName": "sto2527",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res6977",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "username": "user1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "user1",
+        "type": "Microsoft.Storage/storageAccounts/localUsers",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res6977/providers/Microsoft.Storage/storageAccounts/sto2527/loalUsers/user1",
+        "properties": {
+          "allowAclAuthorization": true,
+          "extendedGroups": [
+            1001,
+            1005,
+            2005
+          ],
+          "groupId": 2000,
+          "hasSharedKey": true,
+          "hasSshKey": true,
+          "hasSshPassword": true,
+          "homeDirectory": "homedirectory",
+          "isNFSv3Enabled": true,
+          "permissionScopes": [
+            {
+              "permissions": "rwd",
+              "resourceName": "share1",
+              "service": "file"
+            },
+            {
+              "permissions": "rw",
+              "resourceName": "share2",
+              "service": "file"
+            }
+          ],
+          "sid": "S-1-2-0-125132-153423-36235-1000",
+          "userId": 1000
+        }
+      }
+    }
+  },
+  "operationId": "LocalUsers_Get",
+  "title": "GetLocalUser"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/LocalUserListKeys.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/LocalUserListKeys.json
@@ -1,0 +1,25 @@
+{
+  "parameters": {
+    "accountName": "sto2527",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res6977",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "username": "user1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "sharedKey": "<REDACTED>",
+        "sshAuthorizedKeys": [
+          {
+            "description": "key name",
+            "key": "ssh-rsa keykeykeykeykew="
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "LocalUsers_ListKeys",
+  "title": "ListLocalUserKeys"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/LocalUserRegeneratePassword.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/LocalUserRegeneratePassword.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "accountName": "sto2527",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res6977",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "username": "user1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "sshPassword": "<REDACTED>"
+      }
+    }
+  },
+  "operationId": "LocalUsers_RegeneratePassword",
+  "title": "RegenerateLocalUserPassword"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/LocalUserUpdate.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/LocalUserUpdate.json
@@ -1,0 +1,53 @@
+{
+  "parameters": {
+    "accountName": "sto2527",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "properties": {
+      "properties": {
+        "allowAclAuthorization": false,
+        "extendedGroups": [
+          1001,
+          1005,
+          2005
+        ],
+        "groupId": 3000,
+        "hasSharedKey": false,
+        "hasSshKey": false,
+        "hasSshPassword": false,
+        "homeDirectory": "homedirectory2",
+        "isNFSv3Enabled": true
+      }
+    },
+    "resourceGroupName": "res6977",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "username": "user1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "user1",
+        "type": "Microsoft.Storage/storageAccounts/localUsers",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res6977/providers/Microsoft.Storage/storageAccounts/sto2527/loalUsers/user1",
+        "properties": {
+          "allowAclAuthorization": false,
+          "extendedGroups": [
+            1001,
+            1005,
+            2005
+          ],
+          "groupId": 3000,
+          "hasSharedKey": false,
+          "hasSshKey": false,
+          "hasSshPassword": false,
+          "homeDirectory": "homedirectory2",
+          "isNFSv3Enabled": true,
+          "sid": "S-1-2-0-3528686663-1788730862-2791910117-1000",
+          "userId": 1000
+        }
+      }
+    }
+  },
+  "operationId": "LocalUsers_CreateOrUpdate",
+  "title": "UpdateLocalUser"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/LocalUsersList.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/LocalUsersList.json
@@ -1,0 +1,68 @@
+{
+  "parameters": {
+    "accountName": "sto2527",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res6977",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": null,
+        "value": [
+          {
+            "name": "user1",
+            "type": "Microsoft.Storage/storageAccounts/localUsers",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/res6977/providers/Microsoft.Storage/storageAccounts/sto2527/loalUsers/user1",
+            "properties": {
+              "allowAclAuthorization": true,
+              "groupId": 2000,
+              "hasSharedKey": true,
+              "hasSshKey": true,
+              "hasSshPassword": true,
+              "homeDirectory": "homedirectory",
+              "permissionScopes": [
+                {
+                  "permissions": "rwd",
+                  "resourceName": "share1",
+                  "service": "file"
+                },
+                {
+                  "permissions": "rw",
+                  "resourceName": "share2",
+                  "service": "file"
+                }
+              ],
+              "sid": "S-1-2-0-125132-153423-36235-1000",
+              "userId": 1000
+            }
+          },
+          {
+            "name": "user2",
+            "type": "Microsoft.Storage/storageAccounts/localUsers",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/res9290/providers/Microsoft.Storage/storageAccounts/sto1590/loalUsers/user2",
+            "properties": {
+              "allowAclAuthorization": true,
+              "groupId": 2000,
+              "hasSharedKey": true,
+              "hasSshKey": false,
+              "hasSshPassword": true,
+              "permissionScopes": [
+                {
+                  "permissions": "rw",
+                  "resourceName": "resourcename",
+                  "service": "blob"
+                }
+              ],
+              "sid": "S-1-2-0-533672-235636-66334-1001",
+              "userId": 1001
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "LocalUsers_List",
+  "title": "ListLocalUsers"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/LocalUsersListNFSv3Enabled.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/LocalUsersListNFSv3Enabled.json
@@ -1,0 +1,80 @@
+{
+  "parameters": {
+    "$include": "nfsv3",
+    "accountName": "sto2527",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res6977",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "user1",
+            "type": "Microsoft.Storage/storageAccounts/localUsers",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/res6977/providers/Microsoft.Storage/storageAccounts/sto2527/loalUsers/user1",
+            "properties": {
+              "allowAclAuthorization": true,
+              "extendedGroups": [
+                1001,
+                1005,
+                2005
+              ],
+              "groupId": 2000,
+              "hasSharedKey": true,
+              "hasSshKey": true,
+              "hasSshPassword": true,
+              "homeDirectory": "homedirectory",
+              "isNFSv3Enabled": true,
+              "permissionScopes": [
+                {
+                  "permissions": "rwd",
+                  "resourceName": "share1",
+                  "service": "file"
+                },
+                {
+                  "permissions": "rw",
+                  "resourceName": "share2",
+                  "service": "file"
+                }
+              ],
+              "sid": "S-1-2-0-125132-153423-36235-1000",
+              "userId": 1000
+            }
+          },
+          {
+            "name": "user2",
+            "type": "Microsoft.Storage/storageAccounts/localUsers",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/res9290/providers/Microsoft.Storage/storageAccounts/sto1590/loalUsers/user2",
+            "properties": {
+              "allowAclAuthorization": true,
+              "extendedGroups": [
+                1001,
+                1005,
+                2005
+              ],
+              "groupId": 2000,
+              "hasSharedKey": true,
+              "hasSshKey": false,
+              "hasSshPassword": true,
+              "isNFSv3Enabled": true,
+              "permissionScopes": [
+                {
+                  "permissions": "rw",
+                  "resourceName": "resourcename",
+                  "service": "blob"
+                }
+              ],
+              "sid": "S-1-2-0-533672-235636-66334-1001",
+              "userId": 1001
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "LocalUsers_List",
+  "title": "ListNFSv3EnabledLocalUsers"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/NetworkSecurityPerimeterConfigurationGet.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/NetworkSecurityPerimeterConfigurationGet.json
@@ -1,0 +1,64 @@
+{
+  "parameters": {
+    "accountName": "sto8607",
+    "api-version": "2026-09-01",
+    "networkSecurityPerimeterConfigurationName": "dbedb4e0-40e6-4145-81f3-f1314c150774.resourceAssociation1",
+    "resourceGroupName": "res4410",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "dbedb4e0-40e6-4145-81f3-f1314c150774.resourceAssociation1",
+        "type": "Microsoft.Storage/storageAccounts/networkSecurityPerimeterConfigurations",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/res4410/providers/Microsoft.Storage/storageAccounts/sto8607/networkSecurityPerimeterConfigurations/dbedb4e0-40e6-4145-81f3-f1314c150774.resourceAssociation1",
+        "properties": {
+          "networkSecurityPerimeter": {
+            "id": "/subscriptions/dbedb4e0-40e6-4145-81f3-f1314c150774/resourceGroups/res4794/providers/Microsoft.Network/networkSecurityPerimeters/nsp1",
+            "location": "East US",
+            "perimeterGuid": "ce2d5953-5c15-40ca-9d51-cc3f4a63b0f5"
+          },
+          "profile": {
+            "name": "profile1",
+            "accessRules": [
+              {
+                "name": "allowedSubscriptions",
+                "properties": {
+                  "direction": "Inbound",
+                  "subscriptions": [
+                    {
+                      "id": "/subscriptions/dbedb4e0-40e6-4145-81f3-f1314c150774"
+                    }
+                  ]
+                }
+              }
+            ],
+            "accessRulesVersion": 10,
+            "diagnosticSettingsVersion": 5,
+            "enabledLogCategories": [
+              "NspPublicInboundPerimeterRulesAllowed",
+              "NspPublicInboundPerimeterRulesDenied"
+            ]
+          },
+          "provisioningIssues": [
+            {
+              "name": "ConfigurationPropagationFailure",
+              "properties": {
+                "description": "Failed to update Network Security Perimeter association.",
+                "issueType": "ConfigurationPropagationFailure",
+                "severity": "Error"
+              }
+            }
+          ],
+          "provisioningState": "Succeeded",
+          "resourceAssociation": {
+            "name": "resourceAssociation1",
+            "accessMode": "Enforced"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeterConfigurations_Get",
+  "title": "NetworkSecurityPerimeterConfigurationGet"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/NetworkSecurityPerimeterConfigurationList.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/NetworkSecurityPerimeterConfigurationList.json
@@ -1,0 +1,56 @@
+{
+  "parameters": {
+    "accountName": "sto8607",
+    "api-version": "2026-09-01",
+    "resourceGroupName": "res4410",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "dbedb4e0-40e6-4145-81f3-f1314c150774.resourceAssociation1",
+            "type": "Microsoft.Storage/storageAccounts/networkSecurityPerimeterConfigurations",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/res4410/providers/Microsoft.Storage/storageAccounts/sto8607/networkSecurityPerimeterConfigurations/dbedb4e0-40e6-4145-81f3-f1314c150774.resourceAssociation1",
+            "properties": {
+              "networkSecurityPerimeter": {
+                "id": "/subscriptions/dbedb4e0-40e6-4145-81f3-f1314c150774/resourceGroups/res4794/providers/Microsoft.Network/networkSecurityPerimeters/nsp1",
+                "location": "East US",
+                "perimeterGuid": "ce2d5953-5c15-40ca-9d51-cc3f4a63b0f5"
+              },
+              "profile": {
+                "name": "profile1",
+                "accessRules": [
+                  {
+                    "name": "inVpnRule",
+                    "properties": {
+                      "addressPrefixes": [
+                        "148.0.0.0/8",
+                        "152.4.6.0/24"
+                      ],
+                      "direction": "Inbound"
+                    }
+                  }
+                ],
+                "accessRulesVersion": 10,
+                "diagnosticSettingsVersion": 5,
+                "enabledLogCategories": [
+                  "NspPublicInboundPerimeterRulesAllowed",
+                  "NspPublicInboundPerimeterRulesDenied"
+                ]
+              },
+              "provisioningState": "Succeeded",
+              "resourceAssociation": {
+                "name": "association1",
+                "accessMode": "Enforced"
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeterConfigurations_List",
+  "title": "NetworkSecurityPerimeterConfigurationList"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/NetworkSecurityPerimeterConfigurationReconcile.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/NetworkSecurityPerimeterConfigurationReconcile.json
@@ -1,0 +1,18 @@
+{
+  "parameters": {
+    "accountName": "sto8607",
+    "api-version": "2026-09-01",
+    "networkSecurityPerimeterConfigurationName": "dbedb4e0-40e6-4145-81f3-f1314c150774.resourceAssociation1",
+    "resourceGroupName": "res4410",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://endpoint:port/subscriptions/00000000-1111-2222-3333-444444444444/providers/Microsoft.Storage/locations/{location}/asyncoperations/{operationid}?monitor=true&api-version=2022-09-01"
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeterConfigurations_Reconcile",
+  "title": "NetworkSecurityPerimeterConfigurationReconcile"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/NfsV3AccountCreate.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/NfsV3AccountCreate.json
@@ -1,0 +1,65 @@
+{
+  "parameters": {
+    "accountName": "sto4445",
+    "api-version": "2026-09-01",
+    "parameters": {
+      "kind": "BlockBlobStorage",
+      "location": "eastus",
+      "properties": {
+        "enableExtendedGroups": true,
+        "isHnsEnabled": true,
+        "isNfsV3Enabled": true,
+        "networkAcls": {
+          "bypass": "AzureServices",
+          "defaultAction": "Allow",
+          "ipRules": [],
+          "virtualNetworkRules": [
+            {
+              "id": "/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.Network/virtualNetworks/net123/subnets/subnet12"
+            }
+          ]
+        },
+        "supportsHttpsTrafficOnly": false
+      },
+      "sku": {
+        "name": "Premium_LRS"
+      }
+    },
+    "resourceGroupName": "res9101",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto4445",
+        "type": "Microsoft.Storage/storageAccounts",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.Storage/storageAccounts/sto4445",
+        "kind": "BlockBlobStorage",
+        "location": "eastus",
+        "properties": {
+          "enableExtendedGroups": true,
+          "isHnsEnabled": true,
+          "isNfsV3Enabled": true,
+          "networkAcls": {
+            "bypass": "AzureServices",
+            "defaultAction": "Allow",
+            "ipRules": [],
+            "virtualNetworkRules": [
+              {
+                "id": "/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.Network/virtualNetworks/net123/subnets/subnet12"
+              }
+            ]
+          },
+          "supportsHttpsTrafficOnly": false
+        },
+        "sku": {
+          "name": "Premium_LRS",
+          "tier": "Premium"
+        }
+      }
+    },
+    "202": {}
+  },
+  "operationId": "StorageAccounts_Create",
+  "title": "NfsV3AccountCreate"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/ObjectLevelWormContainerMigration.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/ObjectLevelWormContainerMigration.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "accountName": "sto7069",
+    "api-version": "2026-09-01",
+    "containerName": "container6397",
+    "immutabilityPolicyName": "default",
+    "monitor": "true",
+    "resourceGroupName": "res1782",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "https://endpoint:port/subscriptions/{subscription-id}/providers/Microsoft.Storage/locations/{location}/asyncoperations/{operationid}?monitor=true&api-version=2022-09-01"
+      }
+    }
+  },
+  "operationId": "BlobContainers_ObjectLevelWorm",
+  "title": "VersionLevelWormContainerMigration"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/OperationsList.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/OperationsList.json
@@ -1,0 +1,475 @@
+{
+  "parameters": {
+    "api-version": "2026-09-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Microsoft.Storage/storageAccounts/write",
+            "display": {
+              "description": "Creates a storage account with the specified parameters or update the properties or tags or adds custom domain for the specified storage account.",
+              "operation": "Create/Update Storage Account",
+              "provider": "Microsoft Storage",
+              "resource": "Storage Accounts"
+            }
+          },
+          {
+            "name": "Microsoft.Storage/storageAccounts/delete",
+            "display": {
+              "description": "Deletes an existing storage account.",
+              "operation": "Delete Storage Account",
+              "provider": "Microsoft Storage",
+              "resource": "Storage Accounts"
+            }
+          },
+          {
+            "name": "Microsoft.Storage/storageAccounts/listkeys/action",
+            "display": {
+              "description": "Returns the access keys for the specified storage account.",
+              "operation": "List Storage Account Keys",
+              "provider": "Microsoft Storage",
+              "resource": "Storage Accounts"
+            }
+          },
+          {
+            "name": "Microsoft.Storage/storageAccounts/regeneratekey/action",
+            "display": {
+              "description": "Regenerates the access keys for the specified storage account.",
+              "operation": "Regenerate Storage Account Keys",
+              "provider": "Microsoft Storage",
+              "resource": "Storage Accounts"
+            }
+          },
+          {
+            "name": "Microsoft.Storage/checknameavailability/read",
+            "display": {
+              "description": "Checks that account name is valid and is not in use.",
+              "operation": "Check Name Availability",
+              "provider": "Microsoft Storage",
+              "resource": "Name Availability"
+            }
+          },
+          {
+            "name": "Microsoft.Storage/storageAccounts/read",
+            "display": {
+              "description": "Returns the list of storage accounts or gets the properties for the specified storage account.",
+              "operation": "List/Get Storage Account(s)",
+              "provider": "Microsoft Storage",
+              "resource": "Storage Accounts"
+            }
+          },
+          {
+            "name": "Microsoft.Storage/usages/read",
+            "display": {
+              "description": "Returns the limit and the current usage count for resources in the specified subscription",
+              "operation": "Get Subscription Usages",
+              "provider": "Microsoft Storage",
+              "resource": "Usage Metrics"
+            }
+          },
+          {
+            "name": "Microsoft.Storage/storageAccounts/listAccountSas/action",
+            "display": {
+              "description": "Returns the Account SAS token for the specified storage account.",
+              "operation": "Returns Storage Account SAS Token",
+              "provider": "Microsoft Storage",
+              "resource": "Storage Account SAS Token"
+            }
+          },
+          {
+            "name": "Microsoft.Storage/storageAccounts/listServiceSas/action",
+            "display": {
+              "description": "Storage Service SAS Token",
+              "operation": "Returns Storage Service SAS Token",
+              "provider": "Microsoft Storage",
+              "resource": "Returns the Service SAS token for the specified storage account."
+            }
+          },
+          {
+            "name": "Microsoft.Storage/locations/deleteVirtualNetworkOrSubnets/action",
+            "display": {
+              "description": "Notifies Microsoft.Storage that virtual network or subnet is being deleted",
+              "operation": "Delete virtual network or subnets notifications",
+              "provider": "Microsoft Storage",
+              "resource": "Location"
+            }
+          },
+          {
+            "name": "Microsoft.Storage/operations/read",
+            "display": {
+              "description": "Polls the status of an asynchronous operation.",
+              "operation": "Poll Asynchronous Operation",
+              "provider": "Microsoft Storage",
+              "resource": "Operations"
+            }
+          },
+          {
+            "name": "Microsoft.Storage/register/action",
+            "display": {
+              "description": "Registers the subscription for the storage resource provider and enables the creation of storage accounts.",
+              "operation": "Registers the Storage Resource Provider",
+              "provider": "Microsoft Storage",
+              "resource": "Storage Resource Provider"
+            }
+          },
+          {
+            "name": "Microsoft.Storage/skus/read",
+            "display": {
+              "description": "Lists the Skus supported by Microsoft.Storage.",
+              "operation": "List Skus",
+              "provider": "Microsoft Storage",
+              "resource": "Skus"
+            }
+          },
+          {
+            "name": "Microsoft.Storage/storageAccounts/services/diagnosticSettings/write",
+            "display": {
+              "description": "Create/Update storage account diagnostic settings.",
+              "operation": "Create/Update Diagnostic Settings",
+              "provider": "Microsoft Storage",
+              "resource": "Storage Accounts"
+            }
+          },
+          {
+            "name": "Microsoft.Storage/storageAccounts/providers/Microsoft.Insights/metricDefinitions/read",
+            "display": {
+              "description": "Get list of Microsoft Storage Metrics definitions.",
+              "operation": "Get list of Microsoft Storage Metrics definitions",
+              "provider": "Microsoft Storage",
+              "resource": "Storage Accounts"
+            },
+            "origin": "system",
+            "properties": {
+              "serviceSpecification": {
+                "metricSpecifications": [
+                  {
+                    "name": "UsedCapacity",
+                    "aggregationType": "Average",
+                    "category": "Capacity",
+                    "displayDescription": "Account used capacity",
+                    "displayName": "Used capacity",
+                    "fillGapWithZero": false,
+                    "resourceIdDimensionNameOverride": "AccountResourceId",
+                    "unit": "Bytes"
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "name": "Microsoft.Storage/storageAccounts/providers/Microsoft.Insights/diagnosticSettings/read",
+            "display": {
+              "description": "Gets the diagnostic setting for the resource.",
+              "operation": "Read diagnostic setting",
+              "provider": "Microsoft Storage",
+              "resource": "Storage Accounts"
+            },
+            "origin": "system"
+          },
+          {
+            "name": "Microsoft.Storage/storageAccounts/providers/Microsoft.Insights/diagnosticSettings/write",
+            "display": {
+              "description": "Creates or updates the diagnostic setting for the resource.",
+              "operation": "Write diagnostic setting",
+              "provider": "Microsoft Storage",
+              "resource": "Storage Accounts"
+            },
+            "origin": "system"
+          },
+          {
+            "name": "Microsoft.Storage/storageAccounts/blobServices/providers/Microsoft.Insights/metricDefinitions/read",
+            "display": {
+              "description": "Get list of Microsoft Storage Metrics definitions.",
+              "operation": "Get list of Microsoft Storage Metrics definitions",
+              "provider": "Microsoft Storage",
+              "resource": "Blob service"
+            },
+            "origin": "system",
+            "properties": {
+              "serviceSpecification": {
+                "metricSpecifications": [
+                  {
+                    "name": "BlobCapacity",
+                    "aggregationType": "Average",
+                    "category": "Capacity",
+                    "dimensions": [
+                      {
+                        "name": "BlobType",
+                        "displayName": "Blob type"
+                      }
+                    ],
+                    "displayDescription": "The amount of storage used by the storage account’s Blob service in bytes.",
+                    "displayName": "Blob Capacity",
+                    "fillGapWithZero": false,
+                    "unit": "Bytes"
+                  },
+                  {
+                    "name": "BlobCount",
+                    "aggregationType": "Average",
+                    "category": "Capacity",
+                    "dimensions": [
+                      {
+                        "name": "BlobType",
+                        "displayName": "Blob type"
+                      }
+                    ],
+                    "displayDescription": "The number of Blob in the storage account’s Blob service.",
+                    "displayName": "Blob Count",
+                    "fillGapWithZero": false,
+                    "unit": "Count"
+                  },
+                  {
+                    "name": "ContainerCount",
+                    "aggregationType": "Average",
+                    "category": "Capacity",
+                    "displayDescription": "The number of containers in the storage account’s Blob service.",
+                    "displayName": "Blob Container Count",
+                    "fillGapWithZero": false,
+                    "unit": "Count"
+                  },
+                  {
+                    "name": "BlobProvisionedSize",
+                    "aggregationType": "Average",
+                    "category": "Capacity",
+                    "dimensions": [
+                      {
+                        "name": "BlobType",
+                        "displayName": "Blob type"
+                      }
+                    ],
+                    "displayDescription": "The amount of storage provisioned in the storage account’s Blob service in bytes.",
+                    "displayName": "Blob Provisioned Size",
+                    "fillGapWithZero": false,
+                    "unit": "Bytes"
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "name": "Microsoft.Storage/storageAccounts/blobServices/providers/Microsoft.Insights/diagnosticSettings/read",
+            "display": {
+              "description": "Gets the diagnostic setting for the resource.",
+              "operation": "Read diagnostic setting",
+              "provider": "Microsoft Storage",
+              "resource": "Blob service"
+            },
+            "origin": "system"
+          },
+          {
+            "name": "Microsoft.Storage/storageAccounts/blobServices/providers/Microsoft.Insights/diagnosticSettings/write",
+            "display": {
+              "description": "Creates or updates the diagnostic setting for the resource.",
+              "operation": "Write diagnostic setting",
+              "provider": "Microsoft Storage",
+              "resource": "Blob service"
+            },
+            "origin": "system"
+          },
+          {
+            "name": "Microsoft.Storage/storageAccounts/tableServices/providers/Microsoft.Insights/metricDefinitions/read",
+            "display": {
+              "description": "Get list of Microsoft Storage Metrics definitions.",
+              "operation": "Get list of Microsoft Storage Metrics definitions",
+              "provider": "Microsoft Storage",
+              "resource": "Table service"
+            },
+            "origin": "system",
+            "properties": {
+              "serviceSpecification": {
+                "metricSpecifications": [
+                  {
+                    "name": "TableCapacity",
+                    "aggregationType": "Average",
+                    "category": "Capacity",
+                    "displayDescription": "The amount of storage used by the storage account’s Table service in bytes.",
+                    "displayName": "Table Capacity",
+                    "fillGapWithZero": false,
+                    "unit": "Bytes"
+                  },
+                  {
+                    "name": "TableCount",
+                    "aggregationType": "Average",
+                    "category": "Capacity",
+                    "displayDescription": "The number of table in the storage account’s Table service.",
+                    "displayName": "Table Count",
+                    "fillGapWithZero": false,
+                    "unit": "Count"
+                  },
+                  {
+                    "name": "TableEntityCount",
+                    "aggregationType": "Average",
+                    "category": "Capacity",
+                    "displayDescription": "The number of table entities in the storage account’s Table service.",
+                    "displayName": "Table Entity Count",
+                    "fillGapWithZero": false,
+                    "unit": "Count"
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "name": "Microsoft.Storage/storageAccounts/tableServices/providers/Microsoft.Insights/diagnosticSettings/read",
+            "display": {
+              "description": "Gets the diagnostic setting for the resource.",
+              "operation": "Read diagnostic setting",
+              "provider": "Microsoft Storage",
+              "resource": "Table service"
+            },
+            "origin": "system"
+          },
+          {
+            "name": "Microsoft.Storage/storageAccounts/tableServices/providers/Microsoft.Insights/diagnosticSettings/write",
+            "display": {
+              "description": "Creates or updates the diagnostic setting for the resource.",
+              "operation": "Write diagnostic setting",
+              "provider": "Microsoft Storage",
+              "resource": "Table service"
+            },
+            "origin": "system"
+          },
+          {
+            "name": "Microsoft.Storage/storageAccounts/queueServices/providers/Microsoft.Insights/metricDefinitions/read",
+            "display": {
+              "description": "Get list of Microsoft Storage Metrics definitions.",
+              "operation": "Get list of Microsoft Storage Metrics definitions",
+              "provider": "Microsoft Storage",
+              "resource": "Queue service"
+            },
+            "origin": "system",
+            "properties": {
+              "serviceSpecification": {
+                "metricSpecifications": [
+                  {
+                    "name": "QueueCapacity",
+                    "aggregationType": "Average",
+                    "category": "Capacity",
+                    "displayDescription": "The amount of storage used by the storage account’s Queue service in bytes.",
+                    "displayName": "Queue Capacity",
+                    "fillGapWithZero": false,
+                    "unit": "Bytes"
+                  },
+                  {
+                    "name": "QueueCount",
+                    "aggregationType": "Average",
+                    "category": "Capacity",
+                    "displayDescription": "The number of queue in the storage account’s Queue service.",
+                    "displayName": "Queue Count",
+                    "fillGapWithZero": false,
+                    "unit": "Count"
+                  },
+                  {
+                    "name": "QueueMessageCount",
+                    "aggregationType": "Average",
+                    "category": "Capacity",
+                    "displayDescription": "The approximate number of queue messages in the storage account’s Queue service.",
+                    "displayName": "Queue Message Count",
+                    "fillGapWithZero": false,
+                    "unit": "Count"
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "name": "Microsoft.Storage/storageAccounts/queueServices/providers/Microsoft.Insights/diagnosticSettings/read",
+            "display": {
+              "description": "Gets the diagnostic setting for the resource.",
+              "operation": "Read diagnostic setting",
+              "provider": "Microsoft Storage",
+              "resource": "Queue service"
+            },
+            "origin": "system"
+          },
+          {
+            "name": "Microsoft.Storage/storageAccounts/queueServices/providers/Microsoft.Insights/diagnosticSettings/write",
+            "display": {
+              "description": "Creates or updates the diagnostic setting for the resource.",
+              "operation": "Write diagnostic setting",
+              "provider": "Microsoft Storage",
+              "resource": "Queue service"
+            },
+            "origin": "system"
+          },
+          {
+            "name": "Microsoft.Storage/storageAccounts/fileServices/providers/Microsoft.Insights/metricDefinitions/read",
+            "display": {
+              "description": "Get list of Microsoft Storage Metrics definitions.",
+              "operation": "Get list of Microsoft Storage Metrics definitions",
+              "provider": "Microsoft Storage",
+              "resource": "File service"
+            },
+            "origin": "system",
+            "properties": {
+              "serviceSpecification": {
+                "metricSpecifications": [
+                  {
+                    "name": "FileCapacity",
+                    "aggregationType": "Average",
+                    "category": "Capacity",
+                    "displayDescription": "The amount of storage used by the storage account’s File service in bytes.",
+                    "displayName": "File Capacity",
+                    "fillGapWithZero": false,
+                    "unit": "Bytes"
+                  },
+                  {
+                    "name": "FileProvisionedSize",
+                    "aggregationType": "Average",
+                    "category": "Capacity",
+                    "displayDescription": "The amount of storage provisioned in the storage account’s File service in bytes.",
+                    "displayName": "File Provisioned Size",
+                    "fillGapWithZero": false,
+                    "unit": "Bytes"
+                  },
+                  {
+                    "name": "FileCount",
+                    "aggregationType": "Average",
+                    "category": "Capacity",
+                    "displayDescription": "The number of file in the storage account’s File service.",
+                    "displayName": "File Count",
+                    "fillGapWithZero": false,
+                    "unit": "Count"
+                  },
+                  {
+                    "name": "FileShareCount",
+                    "aggregationType": "Average",
+                    "category": "Capacity",
+                    "displayDescription": "The number of file shares in the storage account’s File service.",
+                    "displayName": "File Share Count",
+                    "fillGapWithZero": false,
+                    "unit": "Count"
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "name": "Microsoft.Storage/storageAccounts/fileServices/providers/Microsoft.Insights/diagnosticSettings/read",
+            "display": {
+              "description": "Gets the diagnostic setting for the resource.",
+              "operation": "Read diagnostic setting",
+              "provider": "Microsoft Storage",
+              "resource": "File service"
+            },
+            "origin": "system"
+          },
+          {
+            "name": "Microsoft.Storage/storageAccounts/fileServices/providers/Microsoft.Insights/diagnosticSettings/write",
+            "display": {
+              "description": "Creates or updates the diagnostic setting for the resource.",
+              "operation": "Write diagnostic setting",
+              "provider": "Microsoft Storage",
+              "resource": "File service"
+            },
+            "origin": "system"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Operations_List",
+  "title": "OperationsList"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/QueueOperationDelete.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/QueueOperationDelete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "accountName": "sto328",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "queueName": "queue6185",
+    "resourceGroupName": "res3376",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "204": {}
+  },
+  "operationId": "Queue_Delete",
+  "title": "QueueOperationDelete"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/QueueOperationGet.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/QueueOperationGet.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "accountName": "sto328",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "queueName": "queue6185",
+    "resourceGroupName": "res3376",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "queue6185",
+        "type": "Microsoft.Storage/storageAccounts/queueServices/queues",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res3376/providers/Microsoft.Storage/storageAccounts/sto328/queueServices/default/queues/queue6185",
+        "properties": {
+          "metadata": {
+            "sample1": "meta1",
+            "sample2": "meta2"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "Queue_Get",
+  "title": "QueueOperationGet"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/QueueOperationList.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/QueueOperationList.json
@@ -1,0 +1,42 @@
+{
+  "parameters": {
+    "accountName": "sto328",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res9290",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://sto1590endpoint/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res9290/providers/Microsoft.Storage/storageAccounts/sto328/queueServices/default/queues?api-version=2022-09-01&$maxpagesize=2&$skipToken=/sto328/queue6187",
+        "value": [
+          {
+            "name": "queue6185",
+            "type": "Microsoft.Storage/storageAccounts/queueServices/queues",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res3376/providers/Microsoft.Storage/storageAccounts/sto328/queueServices/default/queues/queue6185",
+            "properties": {
+              "metadata": {
+                "sample1": "meta1",
+                "sample2": "meta2"
+              }
+            }
+          },
+          {
+            "name": "queue6186",
+            "type": "Microsoft.Storage/storageAccounts/queueServices/queues",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res3376/providers/Microsoft.Storage/storageAccounts/sto328/queueServices/default/queues/queue6186",
+            "properties": {
+              "metadata": {
+                "sample1": "meta1",
+                "sample2": "meta2"
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Queue_List",
+  "title": "QueueOperationList"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/QueueOperationPatch.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/QueueOperationPatch.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "accountName": "sto328",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "queue": {},
+    "queueName": "queue6185",
+    "resourceGroupName": "res3376",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "queue6185",
+        "type": "Microsoft.Storage/storageAccounts/queueServices/queues",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res3376/providers/Microsoft.Storage/storageAccounts/sto328/queueServices/default/queues/queue6185"
+      }
+    }
+  },
+  "operationId": "Queue_Update",
+  "title": "QueueOperationPatch"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/QueueOperationPut.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/QueueOperationPut.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "accountName": "sto328",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "queue": {},
+    "queueName": "queue6185",
+    "resourceGroupName": "res3376",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "queue6185",
+        "type": "Microsoft.Storage/storageAccounts/queueServices/queues",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res3376/providers/Microsoft.Storage/storageAccounts/sto328/queueServices/default/queues/queue6185"
+      }
+    }
+  },
+  "operationId": "Queue_Create",
+  "title": "QueueOperationPut"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/QueueOperationPutWithMetadata.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/QueueOperationPutWithMetadata.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "accountName": "sto328",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "queue": {
+      "properties": {
+        "metadata": {
+          "sample1": "meta1",
+          "sample2": "meta2"
+        }
+      }
+    },
+    "queueName": "queue6185",
+    "resourceGroupName": "res3376",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "queue6185",
+        "type": "Microsoft.Storage/storageAccounts/queueServices/queues",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res3376/providers/Microsoft.Storage/storageAccounts/sto328/queueServices/default/queues/queue6185",
+        "properties": {
+          "metadata": {
+            "sample1": "meta1",
+            "sample2": "meta2"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "Queue_Create",
+  "title": "QueueOperationPutWithMetadata"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/QueueServicesGet.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/QueueServicesGet.json
@@ -1,0 +1,84 @@
+{
+  "parameters": {
+    "accountName": "sto8607",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "queueServiceName": "default",
+    "resourceGroupName": "res4410",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.Storage/storageAccounts/queueServices",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res4410/providers/Microsoft.Storage/storageAccounts/sto8607/queueServices/default",
+        "properties": {
+          "cors": {
+            "corsRules": [
+              {
+                "allowedHeaders": [
+                  "x-ms-meta-abc",
+                  "x-ms-meta-data*",
+                  "x-ms-meta-target*"
+                ],
+                "allowedMethods": [
+                  "GET",
+                  "HEAD",
+                  "POST",
+                  "OPTIONS",
+                  "MERGE",
+                  "PUT"
+                ],
+                "allowedOrigins": [
+                  "http://www.contoso.com",
+                  "http://www.fabrikam.com"
+                ],
+                "exposedHeaders": [
+                  "x-ms-meta-*"
+                ],
+                "maxAgeInSeconds": 100
+              },
+              {
+                "allowedHeaders": [
+                  "*"
+                ],
+                "allowedMethods": [
+                  "GET"
+                ],
+                "allowedOrigins": [
+                  "*"
+                ],
+                "exposedHeaders": [
+                  "*"
+                ],
+                "maxAgeInSeconds": 2
+              },
+              {
+                "allowedHeaders": [
+                  "x-ms-meta-12345675754564*"
+                ],
+                "allowedMethods": [
+                  "GET",
+                  "PUT"
+                ],
+                "allowedOrigins": [
+                  "http://www.abc23.com",
+                  "https://www.fabrikam.com/*"
+                ],
+                "exposedHeaders": [
+                  "x-ms-meta-abc",
+                  "x-ms-meta-data*",
+                  "x-ms-meta-target*"
+                ],
+                "maxAgeInSeconds": 2000
+              }
+            ]
+          }
+        }
+      }
+    }
+  },
+  "operationId": "QueueServices_GetServiceProperties",
+  "title": "QueueServicesGet"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/QueueServicesList.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/QueueServicesList.json
@@ -1,0 +1,87 @@
+{
+  "parameters": {
+    "accountName": "sto1590",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res9290",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "default",
+            "type": "Microsoft.Storage/storageAccounts/queueServices",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/res4410/providers/Microsoft.Storage/storageAccounts/sto8607/queueServices/default",
+            "properties": {
+              "cors": {
+                "corsRules": [
+                  {
+                    "allowedHeaders": [
+                      "x-ms-meta-abc",
+                      "x-ms-meta-data*",
+                      "x-ms-meta-target*"
+                    ],
+                    "allowedMethods": [
+                      "GET",
+                      "HEAD",
+                      "POST",
+                      "OPTIONS",
+                      "MERGE",
+                      "PUT"
+                    ],
+                    "allowedOrigins": [
+                      "http://www.contoso.com",
+                      "http://www.fabrikam.com"
+                    ],
+                    "exposedHeaders": [
+                      "x-ms-meta-*"
+                    ],
+                    "maxAgeInSeconds": 100
+                  },
+                  {
+                    "allowedHeaders": [
+                      "*"
+                    ],
+                    "allowedMethods": [
+                      "GET"
+                    ],
+                    "allowedOrigins": [
+                      "*"
+                    ],
+                    "exposedHeaders": [
+                      "*"
+                    ],
+                    "maxAgeInSeconds": 2
+                  },
+                  {
+                    "allowedHeaders": [
+                      "x-ms-meta-12345675754564*"
+                    ],
+                    "allowedMethods": [
+                      "GET",
+                      "PUT"
+                    ],
+                    "allowedOrigins": [
+                      "http://www.abc23.com",
+                      "https://www.fabrikam.com/*"
+                    ],
+                    "exposedHeaders": [
+                      "x-ms-meta-abc",
+                      "x-ms-meta-data*",
+                      "x-ms-meta-target*"
+                    ],
+                    "maxAgeInSeconds": 2000
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "QueueServices_List",
+  "title": "QueueServicesList"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/QueueServicesPut.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/QueueServicesPut.json
@@ -1,0 +1,149 @@
+{
+  "parameters": {
+    "accountName": "sto8607",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "parameters": {
+      "properties": {
+        "cors": {
+          "corsRules": [
+            {
+              "allowedHeaders": [
+                "x-ms-meta-abc",
+                "x-ms-meta-data*",
+                "x-ms-meta-target*"
+              ],
+              "allowedMethods": [
+                "GET",
+                "HEAD",
+                "POST",
+                "OPTIONS",
+                "MERGE",
+                "PUT"
+              ],
+              "allowedOrigins": [
+                "http://www.contoso.com",
+                "http://www.fabrikam.com"
+              ],
+              "exposedHeaders": [
+                "x-ms-meta-*"
+              ],
+              "maxAgeInSeconds": 100
+            },
+            {
+              "allowedHeaders": [
+                "*"
+              ],
+              "allowedMethods": [
+                "GET"
+              ],
+              "allowedOrigins": [
+                "*"
+              ],
+              "exposedHeaders": [
+                "*"
+              ],
+              "maxAgeInSeconds": 2
+            },
+            {
+              "allowedHeaders": [
+                "x-ms-meta-12345675754564*"
+              ],
+              "allowedMethods": [
+                "GET",
+                "PUT"
+              ],
+              "allowedOrigins": [
+                "http://www.abc23.com",
+                "https://www.fabrikam.com/*"
+              ],
+              "exposedHeaders": [
+                "x-ms-meta-abc",
+                "x-ms-meta-data*",
+                "x-ms-meta-target*"
+              ],
+              "maxAgeInSeconds": 2000
+            }
+          ]
+        }
+      }
+    },
+    "queueServiceName": "default",
+    "resourceGroupName": "res4410",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.Storage/storageAccounts/queueServices",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res4410/providers/Microsoft.Storage/storageAccounts/sto8607/queueServices/default",
+        "properties": {
+          "cors": {
+            "corsRules": [
+              {
+                "allowedHeaders": [
+                  "x-ms-meta-abc",
+                  "x-ms-meta-data*",
+                  "x-ms-meta-target*"
+                ],
+                "allowedMethods": [
+                  "GET",
+                  "HEAD",
+                  "POST",
+                  "OPTIONS",
+                  "MERGE",
+                  "PUT"
+                ],
+                "allowedOrigins": [
+                  "http://www.contoso.com",
+                  "http://www.fabrikam.com"
+                ],
+                "exposedHeaders": [
+                  "x-ms-meta-*"
+                ],
+                "maxAgeInSeconds": 100
+              },
+              {
+                "allowedHeaders": [
+                  "*"
+                ],
+                "allowedMethods": [
+                  "GET"
+                ],
+                "allowedOrigins": [
+                  "*"
+                ],
+                "exposedHeaders": [
+                  "*"
+                ],
+                "maxAgeInSeconds": 2
+              },
+              {
+                "allowedHeaders": [
+                  "x-ms-meta-12345675754564*"
+                ],
+                "allowedMethods": [
+                  "GET",
+                  "PUT"
+                ],
+                "allowedOrigins": [
+                  "http://www.abc23.com",
+                  "https://www.fabrikam.com/*"
+                ],
+                "exposedHeaders": [
+                  "x-ms-meta-abc",
+                  "x-ms-meta-data*",
+                  "x-ms-meta-target*"
+                ],
+                "maxAgeInSeconds": 2000
+              }
+            ]
+          }
+        }
+      }
+    }
+  },
+  "operationId": "QueueServices_SetServiceProperties",
+  "title": "QueueServicesPut"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/SKUList.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/SKUList.json
@@ -1,0 +1,6456 @@
+{
+  "parameters": {
+    "api-version": "2026-09-01",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "eastus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_ZRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "eastus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "eastus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "eastus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Premium_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "eastus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Premium"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsarchivepreview",
+                "value": "false"
+              },
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "eastus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "eastus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "eastus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "eastus2"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_ZRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "eastus2"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "eastus2"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "eastus2"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Premium_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "eastus2"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Premium"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsarchivepreview",
+                "value": "true"
+              },
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "eastus2"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "eastus2"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "eastus2"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "true"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "eastus2(stage)"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_ZRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "true"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "eastus2(stage)"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "true"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "eastus2(stage)"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "eastus2(stage)"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Premium_LRS",
+            "capabilities": [
+              {
+                "name": "supportsnetworkacls",
+                "value": "true"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "eastus2(stage)"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Premium"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsarchivepreview",
+                "value": "false"
+              },
+              {
+                "name": "supportschangenotification",
+                "value": "true"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "true"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "eastus2(stage)"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "true"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "true"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "eastus2(stage)"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "true"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "eastus2(stage)"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "westus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_ZRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "westus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "westus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "westus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Premium_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "westus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Premium"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsarchivepreview",
+                "value": "false"
+              },
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "westus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "westus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "westus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "westeurope"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_ZRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "westeurope"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "westeurope"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "westeurope"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Premium_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "westeurope"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Premium"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsarchivepreview",
+                "value": "false"
+              },
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "westeurope"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "westeurope"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "westeurope"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "eastasia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_ZRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "eastasia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "eastasia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "eastasia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Premium_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "eastasia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Premium"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsarchivepreview",
+                "value": "false"
+              },
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "eastasia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "eastasia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "eastasia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "southeastasia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_ZRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "southeastasia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "southeastasia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "southeastasia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Premium_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "southeastasia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Premium"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsarchivepreview",
+                "value": "false"
+              },
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "southeastasia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "southeastasia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "southeastasia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "japaneast"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_ZRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "japaneast"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "japaneast"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "japaneast"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Premium_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "japaneast"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Premium"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsarchivepreview",
+                "value": "false"
+              },
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "japaneast"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "japaneast"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "japaneast"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "japanwest"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_ZRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "japanwest"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "japanwest"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "japanwest"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Premium_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "japanwest"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Premium"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsarchivepreview",
+                "value": "false"
+              },
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "japanwest"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "japanwest"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "japanwest"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "northcentralus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_ZRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "northcentralus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "northcentralus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "northcentralus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Premium_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "northcentralus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Premium"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsarchivepreview",
+                "value": "false"
+              },
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "northcentralus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "northcentralus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "northcentralus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "southcentralus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_ZRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "southcentralus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "southcentralus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "southcentralus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Premium_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "southcentralus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Premium"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsarchivepreview",
+                "value": "false"
+              },
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "southcentralus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "southcentralus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "southcentralus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "centralus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_ZRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "centralus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "centralus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "centralus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Premium_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "centralus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Premium"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsarchivepreview",
+                "value": "false"
+              },
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "centralus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "centralus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "centralus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "northeurope"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_ZRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "northeurope"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "northeurope"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "northeurope"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Premium_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "northeurope"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Premium"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsarchivepreview",
+                "value": "false"
+              },
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "northeurope"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "northeurope"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "northeurope"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "brazilsouth"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_ZRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "brazilsouth"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "brazilsouth"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "brazilsouth"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Premium_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "brazilsouth"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Premium"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsarchivepreview",
+                "value": "false"
+              },
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "brazilsouth"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "brazilsouth"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "brazilsouth"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "australiaeast"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_ZRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "australiaeast"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "australiaeast"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "australiaeast"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Premium_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "australiaeast"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Premium"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsarchivepreview",
+                "value": "false"
+              },
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "australiaeast"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "australiaeast"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "australiaeast"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "australiasoutheast"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_ZRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "australiasoutheast"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "australiasoutheast"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "australiasoutheast"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Premium_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "australiasoutheast"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Premium"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsarchivepreview",
+                "value": "false"
+              },
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "australiasoutheast"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "australiasoutheast"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "australiasoutheast"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "southindia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_ZRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "southindia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "southindia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "southindia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Premium_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "southindia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Premium"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsarchivepreview",
+                "value": "false"
+              },
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "southindia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "southindia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "southindia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "centralindia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_ZRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "centralindia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "centralindia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "centralindia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Premium_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "centralindia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Premium"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsarchivepreview",
+                "value": "false"
+              },
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "centralindia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "centralindia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "centralindia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "westindia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_ZRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "westindia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "westindia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "westindia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Premium_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "westindia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Premium"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsarchivepreview",
+                "value": "false"
+              },
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "westindia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "westindia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "westindia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "canadaeast"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_ZRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "canadaeast"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "canadaeast"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "canadaeast"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Premium_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "canadaeast"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Premium"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsarchivepreview",
+                "value": "false"
+              },
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "canadaeast"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "canadaeast"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "canadaeast"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "canadacentral"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_ZRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "canadacentral"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "canadacentral"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "canadacentral"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Premium_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "canadacentral"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Premium"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsarchivepreview",
+                "value": "false"
+              },
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "canadacentral"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "canadacentral"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "canadacentral"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "westus2"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_ZRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "westus2"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "westus2"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "westus2"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Premium_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "westus2"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Premium"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsarchivepreview",
+                "value": "false"
+              },
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "westus2"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "westus2"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "westus2"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "true"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "westcentralus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_ZRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "true"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "westcentralus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "true"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "westcentralus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "westcentralus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Premium_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "true"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "westcentralus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Premium"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsarchivepreview",
+                "value": "false"
+              },
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "true"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "westcentralus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "true"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "westcentralus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "westcentralus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "uksouth"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_ZRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "uksouth"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "uksouth"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "uksouth"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Premium_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "uksouth"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Premium"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsarchivepreview",
+                "value": "false"
+              },
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "uksouth"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "uksouth"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "uksouth"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "ukwest"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_ZRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "ukwest"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "ukwest"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "ukwest"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Premium_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "ukwest"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Premium"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsarchivepreview",
+                "value": "false"
+              },
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "ukwest"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "ukwest"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "ukwest"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "koreacentral"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_ZRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "koreacentral"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "koreacentral"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "koreacentral"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Premium_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "koreacentral"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Premium"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsarchivepreview",
+                "value": "false"
+              },
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "koreacentral"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "koreacentral"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "koreacentral"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "koreasouth"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_ZRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "koreasouth"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "koreasouth"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "koreasouth"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Premium_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "koreasouth"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Premium"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsarchivepreview",
+                "value": "false"
+              },
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "koreasouth"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "koreasouth"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "koreasouth"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "uknorth"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_ZRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "uknorth"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "uknorth"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "uknorth"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Premium_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "uknorth"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Premium"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsarchivepreview",
+                "value": "false"
+              },
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "uknorth"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "uknorth"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "uknorth"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "uksouth2"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_ZRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "uksouth2"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "uksouth2"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "uksouth2"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Premium_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "uksouth2"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Premium"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsarchivepreview",
+                "value": "false"
+              },
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "uksouth2"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "uksouth2"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "uksouth2"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "true"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "eastus2euap"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_ZRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "true"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "eastus2euap"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "true"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "eastus2euap"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "eastus2euap"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Premium_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "true"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "eastus2euap"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Premium"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsarchivepreview",
+                "value": "false"
+              },
+              {
+                "name": "supportschangenotification",
+                "value": "true"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "true"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "eastus2euap"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "true"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "true"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "eastus2euap"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "true"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "eastus2euap"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "true"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "centraluseuap"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_ZRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "true"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "centraluseuap"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "true"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "centraluseuap"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "centraluseuap"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Premium_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "true"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "centraluseuap"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Premium"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsarchivepreview",
+                "value": "false"
+              },
+              {
+                "name": "supportschangenotification",
+                "value": "true"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "true"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "centraluseuap"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "true"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "true"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "centraluseuap"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "true"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "centraluseuap"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Skus_List",
+  "title": "SkuList"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/SKUListWithLocationInfo.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/SKUListWithLocationInfo.json
@@ -1,0 +1,54 @@
+{
+  "parameters": {
+    "api-version": "2026-09-01",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Premium_LRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "true"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "FileStorage",
+            "locationInfo": [
+              {
+                "location": "centraluseuap",
+                "zones": [
+                  "1",
+                  "2",
+                  "3"
+                ]
+              }
+            ],
+            "locations": [
+              "centraluseuap"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Premium"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Skus_List",
+  "title": "SKUListWithLocationInfo"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountAbortHierarchicalNamespaceMigration.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountAbortHierarchicalNamespaceMigration.json
@@ -1,0 +1,18 @@
+{
+  "parameters": {
+    "accountName": "sto2434",
+    "api-version": "2026-09-01",
+    "resourceGroupName": "res4228",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "https://endpoint:port/subscriptions/{subscription-id}/providers/Microsoft.Storage/locations/{location}/asyncoperations/{operationid}?monitor=true&api-version=2022-09-01"
+      }
+    }
+  },
+  "operationId": "StorageAccounts_AbortHierarchicalNamespaceMigration",
+  "title": "StorageAccountAbortHierarchicalNamespaceMigration"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountCheckNameAvailability.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountCheckNameAvailability.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "accountName": {
+      "name": "sto3363",
+      "type": "Microsoft.Storage/storageAccounts"
+    },
+    "api-version": "2026-09-01",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nameAvailable": true
+      }
+    }
+  },
+  "operationId": "StorageAccounts_CheckNameAvailability",
+  "title": "StorageAccountCheckNameAvailability"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountCreate.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountCreate.json
@@ -1,0 +1,191 @@
+{
+  "parameters": {
+    "accountName": "sto4445",
+    "api-version": "2026-09-01",
+    "parameters": {
+      "extendedLocation": {
+        "name": "losangeles001",
+        "type": "EdgeZone"
+      },
+      "kind": "Storage",
+      "location": "eastus",
+      "properties": {
+        "allowBlobPublicAccess": false,
+        "allowSharedKeyAccess": true,
+        "defaultToOAuthAuthentication": false,
+        "encryption": {
+          "keySource": "Microsoft.Storage",
+          "requireInfrastructureEncryption": false,
+          "services": {
+            "blob": {
+              "enabled": true,
+              "keyType": "Account"
+            },
+            "file": {
+              "enabled": true,
+              "keyType": "Account"
+            }
+          }
+        },
+        "isHnsEnabled": true,
+        "isSftpEnabled": true,
+        "keyPolicy": {
+          "keyExpirationPeriodInDays": 20
+        },
+        "minimumTlsVersion": "TLS1_2",
+        "routingPreference": {
+          "publishInternetEndpoints": true,
+          "publishMicrosoftEndpoints": true,
+          "routingChoice": "MicrosoftRouting"
+        },
+        "sasPolicy": {
+          "expirationAction": "Log",
+          "sasExpirationPeriod": "1.15:59:59",
+          "requireUserBoundUserDelegationSas": true,
+          "requireUserBoundUserDelegationSasAction": "Block"
+        },
+        "geoPriorityReplicationStatus": {
+          "isBlobEnabled": true
+        },
+        "allowSharedKeyAccessForServices": {
+          "blob": {
+            "enabled": true
+          },
+          "file": {
+            "enabled": false
+          },
+          "queue": {
+            "enabled": true
+          },
+          "table": {
+            "enabled": false
+          }
+        },
+        "allowCrossTenantDelegationSas": false
+      },
+      "sku": {
+        "name": "Standard_GRS"
+      },
+      "tags": {
+        "key1": "value1",
+        "key2": "value2"
+      }
+    },
+    "resourceGroupName": "res9101",
+    "subscriptionId": "a3f7c2b9-4e1d-4c8a-9d6f-8b2a5e41c7f3"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto4445",
+        "type": "Microsoft.Storage/storageAccounts",
+        "extendedLocation": {
+          "name": "losangeles001",
+          "type": "EdgeZone"
+        },
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.Storage/storageAccounts/sto4445",
+        "kind": "Storage",
+        "location": "eastus",
+        "properties": {
+          "allowBlobPublicAccess": false,
+          "allowSharedKeyAccess": true,
+          "creationTime": "2017-05-24T13:25:33.4863236Z",
+          "encryption": {
+            "keySource": "Microsoft.Storage",
+            "requireInfrastructureEncryption": false,
+            "services": {
+              "blob": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              },
+              "file": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              }
+            }
+          },
+          "isHnsEnabled": true,
+          "isSftpEnabled": true,
+          "keyCreationTime": {
+            "key1": "2021-03-18T04:42:22.4322836Z",
+            "key2": "2021-03-18T04:42:22.4322836Z"
+          },
+          "keyPolicy": {
+            "keyExpirationPeriodInDays": 20
+          },
+          "minimumTlsVersion": "TLS1_2",
+          "primaryEndpoints": {
+            "blob": "https://sto4445.blob.core.windows.net/",
+            "dfs": "https://sto4445.dfs.core.windows.net/",
+            "file": "https://sto4445.file.core.windows.net/",
+            "internetEndpoints": {
+              "blob": "https://sto4445-internetrouting.blob.core.windows.net/",
+              "dfs": "https://sto4445-internetrouting.dfs.core.windows.net/",
+              "file": "https://sto4445-internetrouting.file.core.windows.net/",
+              "web": "https://sto4445-internetrouting.web.core.windows.net/"
+            },
+            "microsoftEndpoints": {
+              "blob": "https://sto4445-microsoftrouting.blob.core.windows.net/",
+              "dfs": "https://sto4445-microsoftrouting.dfs.core.windows.net/",
+              "file": "https://sto4445-microsoftrouting.file.core.windows.net/",
+              "queue": "https://sto4445-microsoftrouting.queue.core.windows.net/",
+              "table": "https://sto4445-microsoftrouting.table.core.windows.net/",
+              "web": "https://sto4445-microsoftrouting.web.core.windows.net/"
+            },
+            "queue": "https://sto4445.queue.core.windows.net/",
+            "table": "https://sto4445.table.core.windows.net/",
+            "web": "https://sto4445.web.core.windows.net/"
+          },
+          "primaryLocation": "eastus2euap",
+          "provisioningState": "Succeeded",
+          "routingPreference": {
+            "publishInternetEndpoints": true,
+            "publishMicrosoftEndpoints": true,
+            "routingChoice": "MicrosoftRouting"
+          },
+          "sasPolicy": {
+            "expirationAction": "Log",
+            "sasExpirationPeriod": "1.15:59:59",
+            "requireUserBoundUserDelegationSas": true,
+            "requireUserBoundUserDelegationSasAction": "Block"
+          },
+          "secondaryLocation": "centraluseuap",
+          "statusOfPrimary": "available",
+          "statusOfSecondary": "available",
+          "supportsHttpsTrafficOnly": true,
+          "geoPriorityReplicationStatus": {
+            "isBlobEnabled": true
+          },
+          "allowSharedKeyAccessForServices": {
+            "blob": {
+              "enabled": true
+            },
+            "file": {
+              "enabled": false
+            },
+            "queue": {
+              "enabled": true
+            },
+            "table": {
+              "enabled": false
+            }
+          },
+          "allowCrossTenantDelegationSas": false
+        },
+        "sku": {
+          "name": "Standard_GRS",
+          "tier": "Standard"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        }
+      }
+    },
+    "202": {}
+  },
+  "operationId": "StorageAccounts_Create",
+  "title": "StorageAccountCreate"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountCreateAllowedCopyScopeToAAD.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountCreateAllowedCopyScopeToAAD.json
@@ -1,0 +1,146 @@
+{
+  "parameters": {
+    "accountName": "sto4445",
+    "api-version": "2026-09-01",
+    "parameters": {
+      "kind": "Storage",
+      "location": "eastus",
+      "properties": {
+        "allowBlobPublicAccess": false,
+        "allowSharedKeyAccess": true,
+        "allowedCopyScope": "AAD",
+        "encryption": {
+          "keySource": "Microsoft.Storage",
+          "requireInfrastructureEncryption": false,
+          "services": {
+            "blob": {
+              "enabled": true,
+              "keyType": "Account"
+            },
+            "file": {
+              "enabled": true,
+              "keyType": "Account"
+            }
+          }
+        },
+        "isHnsEnabled": true,
+        "keyPolicy": {
+          "keyExpirationPeriodInDays": 20
+        },
+        "minimumTlsVersion": "TLS1_2",
+        "routingPreference": {
+          "publishInternetEndpoints": true,
+          "publishMicrosoftEndpoints": true,
+          "routingChoice": "MicrosoftRouting"
+        },
+        "sasPolicy": {
+          "expirationAction": "Log",
+          "sasExpirationPeriod": "1.15:59:59"
+        }
+      },
+      "sku": {
+        "name": "Standard_GRS"
+      },
+      "tags": {
+        "key1": "value1",
+        "key2": "value2"
+      }
+    },
+    "resourceGroupName": "res9101",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto4445",
+        "type": "Microsoft.Storage/storageAccounts",
+        "extendedLocation": {
+          "name": "losangeles001",
+          "type": "EdgeZone"
+        },
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.Storage/storageAccounts/sto4445",
+        "kind": "Storage",
+        "location": "eastus",
+        "properties": {
+          "allowBlobPublicAccess": false,
+          "allowSharedKeyAccess": true,
+          "allowedCopyScope": "AAD",
+          "creationTime": "2017-05-24T13:25:33.4863236Z",
+          "encryption": {
+            "keySource": "Microsoft.Storage",
+            "requireInfrastructureEncryption": false,
+            "services": {
+              "blob": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              },
+              "file": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              }
+            }
+          },
+          "isHnsEnabled": true,
+          "keyCreationTime": {
+            "key1": "2021-03-18T04:42:22.4322836Z",
+            "key2": "2021-03-18T04:42:22.4322836Z"
+          },
+          "keyPolicy": {
+            "keyExpirationPeriodInDays": 20
+          },
+          "minimumTlsVersion": "TLS1_2",
+          "primaryEndpoints": {
+            "blob": "https://sto4445.blob.core.windows.net/",
+            "dfs": "https://sto4445.dfs.core.windows.net/",
+            "file": "https://sto4445.file.core.windows.net/",
+            "internetEndpoints": {
+              "blob": "https://sto4445-internetrouting.blob.core.windows.net/",
+              "dfs": "https://sto4445-internetrouting.dfs.core.windows.net/",
+              "file": "https://sto4445-internetrouting.file.core.windows.net/",
+              "web": "https://sto4445-internetrouting.web.core.windows.net/"
+            },
+            "microsoftEndpoints": {
+              "blob": "https://sto4445-microsoftrouting.blob.core.windows.net/",
+              "dfs": "https://sto4445-microsoftrouting.dfs.core.windows.net/",
+              "file": "https://sto4445-microsoftrouting.file.core.windows.net/",
+              "queue": "https://sto4445-microsoftrouting.queue.core.windows.net/",
+              "table": "https://sto4445-microsoftrouting.table.core.windows.net/",
+              "web": "https://sto4445-microsoftrouting.web.core.windows.net/"
+            },
+            "queue": "https://sto4445.queue.core.windows.net/",
+            "table": "https://sto4445.table.core.windows.net/",
+            "web": "https://sto4445.web.core.windows.net/"
+          },
+          "primaryLocation": "eastus2euap",
+          "provisioningState": "Succeeded",
+          "routingPreference": {
+            "publishInternetEndpoints": true,
+            "publishMicrosoftEndpoints": true,
+            "routingChoice": "MicrosoftRouting"
+          },
+          "sasPolicy": {
+            "expirationAction": "Log",
+            "sasExpirationPeriod": "1.15:59:59"
+          },
+          "secondaryLocation": "centraluseuap",
+          "statusOfPrimary": "available",
+          "statusOfSecondary": "available",
+          "supportsHttpsTrafficOnly": true
+        },
+        "sku": {
+          "name": "Standard_GRS",
+          "tier": "Standard"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        }
+      }
+    },
+    "202": {}
+  },
+  "operationId": "StorageAccounts_Create",
+  "title": "StorageAccountCreateAllowedCopyScopeToAAD"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountCreateAllowedCopyScopeToPrivateLink.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountCreateAllowedCopyScopeToPrivateLink.json
@@ -1,0 +1,146 @@
+{
+  "parameters": {
+    "accountName": "sto4445",
+    "api-version": "2026-09-01",
+    "parameters": {
+      "kind": "Storage",
+      "location": "eastus",
+      "properties": {
+        "allowBlobPublicAccess": false,
+        "allowSharedKeyAccess": true,
+        "allowedCopyScope": "PrivateLink",
+        "encryption": {
+          "keySource": "Microsoft.Storage",
+          "requireInfrastructureEncryption": false,
+          "services": {
+            "blob": {
+              "enabled": true,
+              "keyType": "Account"
+            },
+            "file": {
+              "enabled": true,
+              "keyType": "Account"
+            }
+          }
+        },
+        "isHnsEnabled": true,
+        "keyPolicy": {
+          "keyExpirationPeriodInDays": 20
+        },
+        "minimumTlsVersion": "TLS1_2",
+        "routingPreference": {
+          "publishInternetEndpoints": true,
+          "publishMicrosoftEndpoints": true,
+          "routingChoice": "MicrosoftRouting"
+        },
+        "sasPolicy": {
+          "expirationAction": "Log",
+          "sasExpirationPeriod": "1.15:59:59"
+        }
+      },
+      "sku": {
+        "name": "Standard_GRS"
+      },
+      "tags": {
+        "key1": "value1",
+        "key2": "value2"
+      }
+    },
+    "resourceGroupName": "res9101",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto4445",
+        "type": "Microsoft.Storage/storageAccounts",
+        "extendedLocation": {
+          "name": "losangeles001",
+          "type": "EdgeZone"
+        },
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.Storage/storageAccounts/sto4445",
+        "kind": "Storage",
+        "location": "eastus",
+        "properties": {
+          "allowBlobPublicAccess": false,
+          "allowSharedKeyAccess": true,
+          "allowedCopyScope": "PrivateLink",
+          "creationTime": "2017-05-24T13:25:33.4863236Z",
+          "encryption": {
+            "keySource": "Microsoft.Storage",
+            "requireInfrastructureEncryption": false,
+            "services": {
+              "blob": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              },
+              "file": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              }
+            }
+          },
+          "isHnsEnabled": true,
+          "keyCreationTime": {
+            "key1": "2021-03-18T04:42:22.4322836Z",
+            "key2": "2021-03-18T04:42:22.4322836Z"
+          },
+          "keyPolicy": {
+            "keyExpirationPeriodInDays": 20
+          },
+          "minimumTlsVersion": "TLS1_2",
+          "primaryEndpoints": {
+            "blob": "https://sto4445.blob.core.windows.net/",
+            "dfs": "https://sto4445.dfs.core.windows.net/",
+            "file": "https://sto4445.file.core.windows.net/",
+            "internetEndpoints": {
+              "blob": "https://sto4445-internetrouting.blob.core.windows.net/",
+              "dfs": "https://sto4445-internetrouting.dfs.core.windows.net/",
+              "file": "https://sto4445-internetrouting.file.core.windows.net/",
+              "web": "https://sto4445-internetrouting.web.core.windows.net/"
+            },
+            "microsoftEndpoints": {
+              "blob": "https://sto4445-microsoftrouting.blob.core.windows.net/",
+              "dfs": "https://sto4445-microsoftrouting.dfs.core.windows.net/",
+              "file": "https://sto4445-microsoftrouting.file.core.windows.net/",
+              "queue": "https://sto4445-microsoftrouting.queue.core.windows.net/",
+              "table": "https://sto4445-microsoftrouting.table.core.windows.net/",
+              "web": "https://sto4445-microsoftrouting.web.core.windows.net/"
+            },
+            "queue": "https://sto4445.queue.core.windows.net/",
+            "table": "https://sto4445.table.core.windows.net/",
+            "web": "https://sto4445.web.core.windows.net/"
+          },
+          "primaryLocation": "eastus2euap",
+          "provisioningState": "Succeeded",
+          "routingPreference": {
+            "publishInternetEndpoints": true,
+            "publishMicrosoftEndpoints": true,
+            "routingChoice": "MicrosoftRouting"
+          },
+          "sasPolicy": {
+            "expirationAction": "Log",
+            "sasExpirationPeriod": "1.15:59:59"
+          },
+          "secondaryLocation": "centraluseuap",
+          "statusOfPrimary": "available",
+          "statusOfSecondary": "available",
+          "supportsHttpsTrafficOnly": true
+        },
+        "sku": {
+          "name": "Standard_GRS",
+          "tier": "Standard"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        }
+      }
+    },
+    "202": {}
+  },
+  "operationId": "StorageAccounts_Create",
+  "title": "StorageAccountCreateAllowedCopyScopeToPrivateLink"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountCreateDisallowPublicNetworkAccess.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountCreateDisallowPublicNetworkAccess.json
@@ -1,0 +1,150 @@
+{
+  "parameters": {
+    "accountName": "sto4445",
+    "api-version": "2026-09-01",
+    "parameters": {
+      "extendedLocation": {
+        "name": "losangeles001",
+        "type": "EdgeZone"
+      },
+      "kind": "Storage",
+      "location": "eastus",
+      "properties": {
+        "allowBlobPublicAccess": false,
+        "allowSharedKeyAccess": true,
+        "encryption": {
+          "keySource": "Microsoft.Storage",
+          "requireInfrastructureEncryption": false,
+          "services": {
+            "blob": {
+              "enabled": true,
+              "keyType": "Account"
+            },
+            "file": {
+              "enabled": true,
+              "keyType": "Account"
+            }
+          }
+        },
+        "isHnsEnabled": true,
+        "keyPolicy": {
+          "keyExpirationPeriodInDays": 20
+        },
+        "minimumTlsVersion": "TLS1_2",
+        "publicNetworkAccess": "Disabled",
+        "routingPreference": {
+          "publishInternetEndpoints": true,
+          "publishMicrosoftEndpoints": true,
+          "routingChoice": "MicrosoftRouting"
+        },
+        "sasPolicy": {
+          "expirationAction": "Log",
+          "sasExpirationPeriod": "1.15:59:59"
+        }
+      },
+      "sku": {
+        "name": "Standard_GRS"
+      },
+      "tags": {
+        "key1": "value1",
+        "key2": "value2"
+      }
+    },
+    "resourceGroupName": "res9101",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto4445",
+        "type": "Microsoft.Storage/storageAccounts",
+        "extendedLocation": {
+          "name": "losangeles001",
+          "type": "EdgeZone"
+        },
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.Storage/storageAccounts/sto4445",
+        "kind": "Storage",
+        "location": "eastus",
+        "properties": {
+          "allowBlobPublicAccess": false,
+          "allowSharedKeyAccess": true,
+          "creationTime": "2017-05-24T13:25:33.4863236Z",
+          "encryption": {
+            "keySource": "Microsoft.Storage",
+            "requireInfrastructureEncryption": false,
+            "services": {
+              "blob": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              },
+              "file": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              }
+            }
+          },
+          "isHnsEnabled": true,
+          "keyCreationTime": {
+            "key1": "2021-03-18T04:42:22.4322836Z",
+            "key2": "2021-03-18T04:42:22.4322836Z"
+          },
+          "keyPolicy": {
+            "keyExpirationPeriodInDays": 20
+          },
+          "minimumTlsVersion": "TLS1_2",
+          "primaryEndpoints": {
+            "blob": "https://sto4445.blob.core.windows.net/",
+            "dfs": "https://sto4445.dfs.core.windows.net/",
+            "file": "https://sto4445.file.core.windows.net/",
+            "internetEndpoints": {
+              "blob": "https://sto4445-internetrouting.blob.core.windows.net/",
+              "dfs": "https://sto4445-internetrouting.dfs.core.windows.net/",
+              "file": "https://sto4445-internetrouting.file.core.windows.net/",
+              "web": "https://sto4445-internetrouting.web.core.windows.net/"
+            },
+            "microsoftEndpoints": {
+              "blob": "https://sto4445-microsoftrouting.blob.core.windows.net/",
+              "dfs": "https://sto4445-microsoftrouting.dfs.core.windows.net/",
+              "file": "https://sto4445-microsoftrouting.file.core.windows.net/",
+              "queue": "https://sto4445-microsoftrouting.queue.core.windows.net/",
+              "table": "https://sto4445-microsoftrouting.table.core.windows.net/",
+              "web": "https://sto4445-microsoftrouting.web.core.windows.net/"
+            },
+            "queue": "https://sto4445.queue.core.windows.net/",
+            "table": "https://sto4445.table.core.windows.net/",
+            "web": "https://sto4445.web.core.windows.net/"
+          },
+          "primaryLocation": "eastus2euap",
+          "provisioningState": "Succeeded",
+          "publicNetworkAccess": "Disabled",
+          "routingPreference": {
+            "publishInternetEndpoints": true,
+            "publishMicrosoftEndpoints": true,
+            "routingChoice": "MicrosoftRouting"
+          },
+          "sasPolicy": {
+            "expirationAction": "Log",
+            "sasExpirationPeriod": "1.15:59:59"
+          },
+          "secondaryLocation": "centraluseuap",
+          "statusOfPrimary": "available",
+          "statusOfSecondary": "available",
+          "supportsHttpsTrafficOnly": true
+        },
+        "sku": {
+          "name": "Standard_GRS",
+          "tier": "Standard"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        }
+      }
+    },
+    "202": {}
+  },
+  "operationId": "StorageAccounts_Create",
+  "title": "StorageAccountCreateDisallowPublicNetworkAccess"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountCreateDnsEndpointTypeToAzureDnsZone.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountCreateDnsEndpointTypeToAzureDnsZone.json
@@ -1,0 +1,153 @@
+{
+  "parameters": {
+    "accountName": "sto4445",
+    "api-version": "2026-09-01",
+    "parameters": {
+      "extendedLocation": {
+        "name": "losangeles001",
+        "type": "EdgeZone"
+      },
+      "kind": "Storage",
+      "location": "eastus",
+      "properties": {
+        "allowBlobPublicAccess": false,
+        "allowSharedKeyAccess": true,
+        "defaultToOAuthAuthentication": false,
+        "dnsEndpointType": "AzureDnsZone",
+        "encryption": {
+          "keySource": "Microsoft.Storage",
+          "requireInfrastructureEncryption": false,
+          "services": {
+            "blob": {
+              "enabled": true,
+              "keyType": "Account"
+            },
+            "file": {
+              "enabled": true,
+              "keyType": "Account"
+            }
+          }
+        },
+        "isHnsEnabled": true,
+        "isSftpEnabled": true,
+        "keyPolicy": {
+          "keyExpirationPeriodInDays": 20
+        },
+        "minimumTlsVersion": "TLS1_2",
+        "routingPreference": {
+          "publishInternetEndpoints": true,
+          "publishMicrosoftEndpoints": true,
+          "routingChoice": "MicrosoftRouting"
+        },
+        "sasPolicy": {
+          "expirationAction": "Log",
+          "sasExpirationPeriod": "1.15:59:59"
+        }
+      },
+      "sku": {
+        "name": "Standard_GRS"
+      },
+      "tags": {
+        "key1": "value1",
+        "key2": "value2"
+      }
+    },
+    "resourceGroupName": "res9101",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto4445",
+        "type": "Microsoft.Storage/storageAccounts",
+        "extendedLocation": {
+          "name": "losangeles001",
+          "type": "EdgeZone"
+        },
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.Storage/storageAccounts/sto4445",
+        "kind": "Storage",
+        "location": "eastus",
+        "properties": {
+          "allowBlobPublicAccess": false,
+          "allowSharedKeyAccess": true,
+          "creationTime": "2017-05-24T13:25:33.4863236Z",
+          "dnsEndpointType": "AzureDnsZone",
+          "encryption": {
+            "keySource": "Microsoft.Storage",
+            "requireInfrastructureEncryption": false,
+            "services": {
+              "blob": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              },
+              "file": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              }
+            }
+          },
+          "isHnsEnabled": true,
+          "isSftpEnabled": true,
+          "keyCreationTime": {
+            "key1": "2021-03-18T04:42:22.4322836Z",
+            "key2": "2021-03-18T04:42:22.4322836Z"
+          },
+          "keyPolicy": {
+            "keyExpirationPeriodInDays": 20
+          },
+          "minimumTlsVersion": "TLS1_2",
+          "primaryEndpoints": {
+            "blob": "https://sto4445.z24.blob.storage.azure.net/",
+            "dfs": "https://sto4445.z24.dfs.storage.azure.net/",
+            "file": "https://sto4445.z24.file.storage.azure.net/",
+            "internetEndpoints": {
+              "blob": "https://sto4445-internetrouting.z24.blob.storage.azure.net/",
+              "dfs": "https://sto4445-internetrouting.z24.dfs.storage.azure.net/",
+              "file": "https://sto4445-internetrouting.z24.file.storage.azure.net/",
+              "web": "https://sto4445-internetrouting.z24.web.storage.azure.net/"
+            },
+            "microsoftEndpoints": {
+              "blob": "https://sto4445-microsoftrouting.z24.blob.storage.azure.net/",
+              "dfs": "https://sto4445-microsoftrouting.z24.dfs.storage.azure.net/",
+              "file": "https://sto4445-microsoftrouting.z24.file.storage.azure.net/",
+              "queue": "https://sto4445-microsoftrouting.z24.queue.storage.azure.net/",
+              "table": "https://sto4445-microsoftrouting.z24.table.storage.azure.net/",
+              "web": "https://sto4445-microsoftrouting.z24.web.storage.azure.net/"
+            },
+            "queue": "https://sto4445.z24.queue.storage.azure.net/",
+            "table": "https://sto4445.z24.table.storage.azure.net/",
+            "web": "https://sto4445.z24.web.storage.azure.net/"
+          },
+          "primaryLocation": "eastus2euap",
+          "provisioningState": "Succeeded",
+          "routingPreference": {
+            "publishInternetEndpoints": true,
+            "publishMicrosoftEndpoints": true,
+            "routingChoice": "MicrosoftRouting"
+          },
+          "sasPolicy": {
+            "expirationAction": "Log",
+            "sasExpirationPeriod": "1.15:59:59"
+          },
+          "secondaryLocation": "centraluseuap",
+          "statusOfPrimary": "available",
+          "statusOfSecondary": "available",
+          "supportsHttpsTrafficOnly": true
+        },
+        "sku": {
+          "name": "Standard_GRS",
+          "tier": "Standard"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        }
+      }
+    },
+    "202": {}
+  },
+  "operationId": "StorageAccounts_Create",
+  "title": "StorageAccountCreateDnsEndpointTypeToAzureDnsZone"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountCreateDnsEndpointTypeToStandard.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountCreateDnsEndpointTypeToStandard.json
@@ -1,0 +1,153 @@
+{
+  "parameters": {
+    "accountName": "sto4445",
+    "api-version": "2026-09-01",
+    "parameters": {
+      "extendedLocation": {
+        "name": "losangeles001",
+        "type": "EdgeZone"
+      },
+      "kind": "Storage",
+      "location": "eastus",
+      "properties": {
+        "allowBlobPublicAccess": false,
+        "allowSharedKeyAccess": true,
+        "defaultToOAuthAuthentication": false,
+        "dnsEndpointType": "Standard",
+        "encryption": {
+          "keySource": "Microsoft.Storage",
+          "requireInfrastructureEncryption": false,
+          "services": {
+            "blob": {
+              "enabled": true,
+              "keyType": "Account"
+            },
+            "file": {
+              "enabled": true,
+              "keyType": "Account"
+            }
+          }
+        },
+        "isHnsEnabled": true,
+        "isSftpEnabled": true,
+        "keyPolicy": {
+          "keyExpirationPeriodInDays": 20
+        },
+        "minimumTlsVersion": "TLS1_2",
+        "routingPreference": {
+          "publishInternetEndpoints": true,
+          "publishMicrosoftEndpoints": true,
+          "routingChoice": "MicrosoftRouting"
+        },
+        "sasPolicy": {
+          "expirationAction": "Log",
+          "sasExpirationPeriod": "1.15:59:59"
+        }
+      },
+      "sku": {
+        "name": "Standard_GRS"
+      },
+      "tags": {
+        "key1": "value1",
+        "key2": "value2"
+      }
+    },
+    "resourceGroupName": "res9101",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto4445",
+        "type": "Microsoft.Storage/storageAccounts",
+        "extendedLocation": {
+          "name": "losangeles001",
+          "type": "EdgeZone"
+        },
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.Storage/storageAccounts/sto4445",
+        "kind": "Storage",
+        "location": "eastus",
+        "properties": {
+          "allowBlobPublicAccess": false,
+          "allowSharedKeyAccess": true,
+          "creationTime": "2017-05-24T13:25:33.4863236Z",
+          "dnsEndpointType": "Standard",
+          "encryption": {
+            "keySource": "Microsoft.Storage",
+            "requireInfrastructureEncryption": false,
+            "services": {
+              "blob": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              },
+              "file": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              }
+            }
+          },
+          "isHnsEnabled": true,
+          "isSftpEnabled": true,
+          "keyCreationTime": {
+            "key1": "2021-03-18T04:42:22.4322836Z",
+            "key2": "2021-03-18T04:42:22.4322836Z"
+          },
+          "keyPolicy": {
+            "keyExpirationPeriodInDays": 20
+          },
+          "minimumTlsVersion": "TLS1_2",
+          "primaryEndpoints": {
+            "blob": "https://sto4445.blob.core.windows.net/",
+            "dfs": "https://sto4445.dfs.core.windows.net/",
+            "file": "https://sto4445.file.core.windows.net/",
+            "internetEndpoints": {
+              "blob": "https://sto4445-internetrouting.blob.core.windows.net/",
+              "dfs": "https://sto4445-internetrouting.dfs.core.windows.net/",
+              "file": "https://sto4445-internetrouting.file.core.windows.net/",
+              "web": "https://sto4445-internetrouting.web.core.windows.net/"
+            },
+            "microsoftEndpoints": {
+              "blob": "https://sto4445-microsoftrouting.blob.core.windows.net/",
+              "dfs": "https://sto4445-microsoftrouting.dfs.core.windows.net/",
+              "file": "https://sto4445-microsoftrouting.file.core.windows.net/",
+              "queue": "https://sto4445-microsoftrouting.queue.core.windows.net/",
+              "table": "https://sto4445-microsoftrouting.table.core.windows.net/",
+              "web": "https://sto4445-microsoftrouting.web.core.windows.net/"
+            },
+            "queue": "https://sto4445.queue.core.windows.net/",
+            "table": "https://sto4445.table.core.windows.net/",
+            "web": "https://sto4445.web.core.windows.net/"
+          },
+          "primaryLocation": "eastus2euap",
+          "provisioningState": "Succeeded",
+          "routingPreference": {
+            "publishInternetEndpoints": true,
+            "publishMicrosoftEndpoints": true,
+            "routingChoice": "MicrosoftRouting"
+          },
+          "sasPolicy": {
+            "expirationAction": "Log",
+            "sasExpirationPeriod": "1.15:59:59"
+          },
+          "secondaryLocation": "centraluseuap",
+          "statusOfPrimary": "available",
+          "statusOfSecondary": "available",
+          "supportsHttpsTrafficOnly": true
+        },
+        "sku": {
+          "name": "Standard_GRS",
+          "tier": "Standard"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        }
+      }
+    },
+    "202": {}
+  },
+  "operationId": "StorageAccounts_Create",
+  "title": "StorageAccountCreateDnsEndpointTypeToStandard"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountCreateEnablePublicNetworkAccess.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountCreateEnablePublicNetworkAccess.json
@@ -1,0 +1,150 @@
+{
+  "parameters": {
+    "accountName": "sto4445",
+    "api-version": "2026-09-01",
+    "parameters": {
+      "extendedLocation": {
+        "name": "losangeles001",
+        "type": "EdgeZone"
+      },
+      "kind": "Storage",
+      "location": "eastus",
+      "properties": {
+        "allowBlobPublicAccess": false,
+        "allowSharedKeyAccess": true,
+        "encryption": {
+          "keySource": "Microsoft.Storage",
+          "requireInfrastructureEncryption": false,
+          "services": {
+            "blob": {
+              "enabled": true,
+              "keyType": "Account"
+            },
+            "file": {
+              "enabled": true,
+              "keyType": "Account"
+            }
+          }
+        },
+        "isHnsEnabled": true,
+        "keyPolicy": {
+          "keyExpirationPeriodInDays": 20
+        },
+        "minimumTlsVersion": "TLS1_2",
+        "publicNetworkAccess": "Enabled",
+        "routingPreference": {
+          "publishInternetEndpoints": true,
+          "publishMicrosoftEndpoints": true,
+          "routingChoice": "MicrosoftRouting"
+        },
+        "sasPolicy": {
+          "expirationAction": "Log",
+          "sasExpirationPeriod": "1.15:59:59"
+        }
+      },
+      "sku": {
+        "name": "Standard_GRS"
+      },
+      "tags": {
+        "key1": "value1",
+        "key2": "value2"
+      }
+    },
+    "resourceGroupName": "res9101",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto4445",
+        "type": "Microsoft.Storage/storageAccounts",
+        "extendedLocation": {
+          "name": "losangeles001",
+          "type": "EdgeZone"
+        },
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.Storage/storageAccounts/sto4445",
+        "kind": "Storage",
+        "location": "eastus",
+        "properties": {
+          "allowBlobPublicAccess": false,
+          "allowSharedKeyAccess": true,
+          "creationTime": "2017-05-24T13:25:33.4863236Z",
+          "encryption": {
+            "keySource": "Microsoft.Storage",
+            "requireInfrastructureEncryption": false,
+            "services": {
+              "blob": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              },
+              "file": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              }
+            }
+          },
+          "isHnsEnabled": true,
+          "keyCreationTime": {
+            "key1": "2021-03-18T04:42:22.4322836Z",
+            "key2": "2021-03-18T04:42:22.4322836Z"
+          },
+          "keyPolicy": {
+            "keyExpirationPeriodInDays": 20
+          },
+          "minimumTlsVersion": "TLS1_2",
+          "primaryEndpoints": {
+            "blob": "https://sto4445.blob.core.windows.net/",
+            "dfs": "https://sto4445.dfs.core.windows.net/",
+            "file": "https://sto4445.file.core.windows.net/",
+            "internetEndpoints": {
+              "blob": "https://sto4445-internetrouting.blob.core.windows.net/",
+              "dfs": "https://sto4445-internetrouting.dfs.core.windows.net/",
+              "file": "https://sto4445-internetrouting.file.core.windows.net/",
+              "web": "https://sto4445-internetrouting.web.core.windows.net/"
+            },
+            "microsoftEndpoints": {
+              "blob": "https://sto4445-microsoftrouting.blob.core.windows.net/",
+              "dfs": "https://sto4445-microsoftrouting.dfs.core.windows.net/",
+              "file": "https://sto4445-microsoftrouting.file.core.windows.net/",
+              "queue": "https://sto4445-microsoftrouting.queue.core.windows.net/",
+              "table": "https://sto4445-microsoftrouting.table.core.windows.net/",
+              "web": "https://sto4445-microsoftrouting.web.core.windows.net/"
+            },
+            "queue": "https://sto4445.queue.core.windows.net/",
+            "table": "https://sto4445.table.core.windows.net/",
+            "web": "https://sto4445.web.core.windows.net/"
+          },
+          "primaryLocation": "eastus2euap",
+          "provisioningState": "Succeeded",
+          "publicNetworkAccess": "Enabled",
+          "routingPreference": {
+            "publishInternetEndpoints": true,
+            "publishMicrosoftEndpoints": true,
+            "routingChoice": "MicrosoftRouting"
+          },
+          "sasPolicy": {
+            "expirationAction": "Log",
+            "sasExpirationPeriod": "1.15:59:59"
+          },
+          "secondaryLocation": "centraluseuap",
+          "statusOfPrimary": "available",
+          "statusOfSecondary": "available",
+          "supportsHttpsTrafficOnly": true
+        },
+        "sku": {
+          "name": "Standard_GRS",
+          "tier": "Standard"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        }
+      }
+    },
+    "202": {}
+  },
+  "operationId": "StorageAccounts_Create",
+  "title": "StorageAccountCreateEnablePublicNetworkAccess"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountCreateObjectReplicationPolicyOnDestination.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountCreateObjectReplicationPolicyOnDestination.json
@@ -1,0 +1,75 @@
+{
+  "parameters": {
+    "accountName": "dst112",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "objectReplicationPolicyId": "default",
+    "properties": {
+      "properties": {
+        "destinationAccount": "dst112",
+        "metrics": {
+          "enabled": true
+        },
+        "priorityReplication": {
+          "enabled": true
+        },
+        "rules": [
+          {
+            "destinationContainer": "dcont139",
+            "filters": {
+              "prefixMatch": [
+                "blobA",
+                "blobB"
+              ]
+            },
+            "sourceContainer": "scont139"
+          }
+        ],
+        "sourceAccount": "src1122",
+        "tagsReplication": {
+          "enabled": true
+        }
+      }
+    },
+    "resourceGroupName": "res7687",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "2a20bb73-5717-4635-985a-5d4cf777438f",
+        "type": "Microsoft.Storage/storageAccounts/objectReplicationPolicies",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res7687/providers/Microsoft.Storage/storageAccounts/dst112/objectReplicationPolicies/2a20bb73-5717-4635-985a-5d4cf777438f",
+        "properties": {
+          "destinationAccount": "dst112",
+          "metrics": {
+            "enabled": true
+          },
+          "priorityReplication": {
+            "enabled": true
+          },
+          "policyId": "2a20bb73-5717-4635-985a-5d4cf777438f",
+          "rules": [
+            {
+              "destinationContainer": "destContainer1",
+              "filters": {
+                "prefixMatch": [
+                  "blobA",
+                  "blobB"
+                ]
+              },
+              "ruleId": "d5d18a48-8801-4554-aeaa-74faf65f5ef9",
+              "sourceContainer": "sourceContainer1"
+            }
+          ],
+          "sourceAccount": "src1122",
+          "tagsReplication": {
+            "enabled": true
+          }
+        }
+      }
+    }
+  },
+  "operationId": "ObjectReplicationPolicies_CreateOrUpdate",
+  "title": "StorageAccountCreateObjectReplicationPolicyOnDestination"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountCreateObjectReplicationPolicyOnSource.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountCreateObjectReplicationPolicyOnSource.json
@@ -1,0 +1,79 @@
+{
+  "parameters": {
+    "accountName": "src1122",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "objectReplicationPolicyId": "2a20bb73-5717-4635-985a-5d4cf777438f",
+    "properties": {
+      "properties": {
+        "destinationAccount": "dst112",
+        "metrics": {
+          "enabled": true
+        },
+        "priorityReplication": {
+          "enabled": true
+        },
+        "rules": [
+          {
+            "destinationContainer": "dcont139",
+            "filters": {
+              "minCreationTime": "2020-02-19T16:05:00Z",
+              "prefixMatch": [
+                "blobA",
+                "blobB"
+              ]
+            },
+            "ruleId": "d5d18a48-8801-4554-aeaa-74faf65f5ef9",
+            "sourceContainer": "scont139"
+          }
+        ],
+        "sourceAccount": "src1122",
+        "tagsReplication": {
+          "enabled": true
+        }
+      }
+    },
+    "resourceGroupName": "res7687",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "2a20bb73-5717-4635-985a-5d4cf777438f",
+        "type": "Microsoft.Storage/storageAccounts/objectReplicationPolicies",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res7687/providers/Microsoft.Storage/storageAccounts/src1122/objectReplicationPolicies/2a20bb73-5717-4635-985a-5d4cf777438f",
+        "properties": {
+          "destinationAccount": "dst112",
+          "enabledTime": "2019-06-08T03:01:55.7168089Z",
+          "metrics": {
+            "enabled": true
+          },
+          "priorityReplication": {
+            "enabled": true
+          },
+          "policyId": "2a20bb73-5717-4635-985a-5d4cf777438f",
+          "rules": [
+            {
+              "destinationContainer": "destContainer1",
+              "filters": {
+                "minCreationTime": "2020-02-19T16:05:00Z",
+                "prefixMatch": [
+                  "blobA",
+                  "blobB"
+                ]
+              },
+              "ruleId": "d5d18a48-8801-4554-aeaa-74faf65f5ef9",
+              "sourceContainer": "sourceContainer1"
+            }
+          ],
+          "sourceAccount": "src1122",
+          "tagsReplication": {
+            "enabled": true
+          }
+        }
+      }
+    }
+  },
+  "operationId": "ObjectReplicationPolicies_CreateOrUpdate",
+  "title": "StorageAccountCreateObjectReplicationPolicyOnSource"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountCreatePremiumBlockBlobStorage.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountCreatePremiumBlockBlobStorage.json
@@ -1,0 +1,91 @@
+{
+  "parameters": {
+    "accountName": "sto4445",
+    "api-version": "2026-09-01",
+    "parameters": {
+      "kind": "BlockBlobStorage",
+      "location": "eastus",
+      "properties": {
+        "allowSharedKeyAccess": true,
+        "encryption": {
+          "keySource": "Microsoft.Storage",
+          "requireInfrastructureEncryption": false,
+          "services": {
+            "blob": {
+              "enabled": true,
+              "keyType": "Account"
+            },
+            "file": {
+              "enabled": true,
+              "keyType": "Account"
+            }
+          }
+        },
+        "minimumTlsVersion": "TLS1_2"
+      },
+      "sku": {
+        "name": "Premium_LRS"
+      },
+      "tags": {
+        "key1": "value1",
+        "key2": "value2"
+      }
+    },
+    "resourceGroupName": "res9101",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto4445",
+        "type": "Microsoft.Storage/storageAccounts",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.Storage/storageAccounts/sto4445",
+        "kind": "Storage",
+        "location": "eastus",
+        "properties": {
+          "accessTier": "Premium",
+          "allowBlobPublicAccess": false,
+          "creationTime": "2017-05-24T13:25:33.4863236Z",
+          "encryption": {
+            "keySource": "Microsoft.Storage",
+            "requireInfrastructureEncryption": false,
+            "services": {
+              "blob": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              },
+              "file": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              }
+            }
+          },
+          "minimumTlsVersion": "TLS1_2",
+          "primaryEndpoints": {
+            "blob": "https://sto4445.blob.core.windows.net/",
+            "dfs": "https://sto4445.dfs.core.windows.net/",
+            "web": "https://sto4445.web.core.windows.net/"
+          },
+          "primaryLocation": "eastus2euap",
+          "provisioningState": "Succeeded",
+          "statusOfPrimary": "available",
+          "statusOfSecondary": "available",
+          "supportsHttpsTrafficOnly": true
+        },
+        "sku": {
+          "name": "Premium_LRS",
+          "tier": "Premium"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        }
+      }
+    },
+    "202": {}
+  },
+  "operationId": "StorageAccounts_Create",
+  "title": "StorageAccountCreatePremiumBlockBlobStorage"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountCreateUserAssignedEncryptionIdentityWithCMK.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountCreateUserAssignedEncryptionIdentityWithCMK.json
@@ -1,0 +1,120 @@
+{
+  "parameters": {
+    "accountName": "sto4445",
+    "api-version": "2026-09-01",
+    "parameters": {
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{managed-identity-name}": {}
+        }
+      },
+      "kind": "Storage",
+      "location": "eastus",
+      "properties": {
+        "encryption": {
+          "identity": {
+            "userAssignedIdentity": "/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{managed-identity-name}"
+          },
+          "keySource": "Microsoft.Keyvault",
+          "keyvaultproperties": {
+            "keyname": "wrappingKey",
+            "keyvaulturi": "https://myvault8569.vault.azure.net",
+            "keyversion": ""
+          },
+          "services": {
+            "blob": {
+              "enabled": true,
+              "keyType": "Account"
+            },
+            "file": {
+              "enabled": true,
+              "keyType": "Account"
+            }
+          }
+        }
+      },
+      "sku": {
+        "name": "Standard_LRS"
+      }
+    },
+    "resourceGroupName": "res9101",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto4445",
+        "type": "Microsoft.Storage/storageAccounts",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.Storage/storageAccounts/sto4445",
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{managed-identity-name}": {
+              "clientId": "fbaa6278-1ecc-415c-819f-6e2058d3acb5",
+              "principalId": "8d823284-1060-42a5-9ec4-ed3d831e24d7"
+            }
+          }
+        },
+        "kind": "StorageV2",
+        "location": "eastus",
+        "properties": {
+          "accessTier": "Hot",
+          "creationTime": "2020-12-15T00:43:14.0839093Z",
+          "encryption": {
+            "identity": {
+              "userAssignedIdentity": "/subscriptions/{subscription-id}/resourcegroups/res9101/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{managed-identity-name}"
+            },
+            "keySource": "Microsoft.Keyvault",
+            "keyvaultproperties": {
+              "currentVersionedKeyIdentifier": "https://myvault8569.vault.azure.net/keys/wrappingKey/0682afdd9c104f4285df20107e956cad",
+              "keyname": "wrappingKey",
+              "keyvaulturi": "https://myvault8569.vault.azure.net",
+              "keyversion": "",
+              "lastKeyRotationTimestamp": "2019-12-13T20:36:23.7023290Z"
+            },
+            "services": {
+              "blob": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2020-12-15T00:43:14.1739587Z"
+              },
+              "file": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2020-12-15T00:43:14.1739587Z"
+              }
+            }
+          },
+          "networkAcls": {
+            "bypass": "AzureServices",
+            "defaultAction": "Allow",
+            "ipRules": [],
+            "virtualNetworkRules": []
+          },
+          "primaryEndpoints": {
+            "blob": "https://sto4445.blob.core.windows.net/",
+            "dfs": "https://sto4445.dfs.core.windows.net/",
+            "file": "https://sto4445.file.core.windows.net/",
+            "queue": "https://sto4445.queue.core.windows.net/",
+            "table": "https://sto4445.table.core.windows.net/",
+            "web": "https://sto4445.web.core.windows.net/"
+          },
+          "primaryLocation": "eastus",
+          "privateEndpointConnections": [],
+          "provisioningState": "Succeeded",
+          "statusOfPrimary": "available",
+          "supportsHttpsTrafficOnly": true
+        },
+        "sku": {
+          "name": "Standard_LRS",
+          "tier": "Standard"
+        },
+        "tags": {}
+      }
+    },
+    "202": {}
+  },
+  "operationId": "StorageAccounts_Create",
+  "title": "StorageAccountCreateUserAssignedEncryptionIdentityWithCMK"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountCreateUserAssignedIdentityWithFederatedIdentityClientId.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountCreateUserAssignedIdentityWithFederatedIdentityClientId.json
@@ -1,0 +1,122 @@
+{
+  "parameters": {
+    "accountName": "sto131918",
+    "api-version": "2026-09-01",
+    "parameters": {
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{managed-identity-name}": {}
+        }
+      },
+      "kind": "Storage",
+      "location": "eastus",
+      "properties": {
+        "encryption": {
+          "identity": {
+            "federatedIdentityClientId": "f83c6b1b-4d34-47e4-bb34-9d83df58b540",
+            "userAssignedIdentity": "/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{managed-identity-name}"
+          },
+          "keySource": "Microsoft.Keyvault",
+          "keyvaultproperties": {
+            "keyname": "wrappingKey",
+            "keyvaulturi": "https://myvault8569.vault.azure.net",
+            "keyversion": ""
+          },
+          "services": {
+            "blob": {
+              "enabled": true,
+              "keyType": "Account"
+            },
+            "file": {
+              "enabled": true,
+              "keyType": "Account"
+            }
+          }
+        }
+      },
+      "sku": {
+        "name": "Standard_LRS"
+      }
+    },
+    "resourceGroupName": "res131918",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto4445",
+        "type": "Microsoft.Storage/storageAccounts",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.Storage/storageAccounts/sto4445",
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{managed-identity-name}": {
+              "clientId": "fbaa6278-1ecc-415c-819f-6e2058d3acb5",
+              "principalId": "8d823284-1060-42a5-9ec4-ed3d831e24d7"
+            }
+          }
+        },
+        "kind": "StorageV2",
+        "location": "eastus",
+        "properties": {
+          "accessTier": "Hot",
+          "creationTime": "2020-12-15T00:43:14.0839093Z",
+          "encryption": {
+            "identity": {
+              "federatedIdentityClientId": "f83c6b1b-4d34-47e4-bb34-9d83df58b540",
+              "userAssignedIdentity": "/subscriptions/{subscription-id}/resourcegroups/res9101/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{managed-identity-name}"
+            },
+            "keySource": "Microsoft.Keyvault",
+            "keyvaultproperties": {
+              "currentVersionedKeyIdentifier": "https://myvault8569.vault.azure.net/keys/wrappingKey/0682afdd9c104f4285df20107e956cad",
+              "keyname": "wrappingKey",
+              "keyvaulturi": "https://myvault8569.vault.azure.net",
+              "keyversion": "",
+              "lastKeyRotationTimestamp": "2019-12-13T20:36:23.7023290Z"
+            },
+            "services": {
+              "blob": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2020-12-15T00:43:14.1739587Z"
+              },
+              "file": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2020-12-15T00:43:14.1739587Z"
+              }
+            }
+          },
+          "networkAcls": {
+            "bypass": "AzureServices",
+            "defaultAction": "Allow",
+            "ipRules": [],
+            "virtualNetworkRules": []
+          },
+          "primaryEndpoints": {
+            "blob": "https://sto4445.blob.core.windows.net/",
+            "dfs": "https://sto4445.dfs.core.windows.net/",
+            "file": "https://sto4445.file.core.windows.net/",
+            "queue": "https://sto4445.queue.core.windows.net/",
+            "table": "https://sto4445.table.core.windows.net/",
+            "web": "https://sto4445.web.core.windows.net/"
+          },
+          "primaryLocation": "eastus",
+          "privateEndpointConnections": [],
+          "provisioningState": "Succeeded",
+          "statusOfPrimary": "available",
+          "supportsHttpsTrafficOnly": true
+        },
+        "sku": {
+          "name": "Standard_LRS",
+          "tier": "Standard"
+        },
+        "tags": {}
+      }
+    },
+    "202": {}
+  },
+  "operationId": "StorageAccounts_Create",
+  "title": "StorageAccountCreateUserAssignedIdentityWithFederatedIdentityClientId."
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountCreateWithDataCollaborationPolicy.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountCreateWithDataCollaborationPolicy.json
@@ -1,0 +1,58 @@
+{
+  "parameters": {
+    "accountName": "sto4445",
+    "api-version": "2026-09-01",
+    "parameters": {
+      "kind": "Storage",
+      "location": "eastus",
+      "properties": {
+        "dataCollaborationPolicyProperties": {
+          "allowStorageConnectors": true,
+          "allowStorageDataShares": true,
+          "allowCrossTenantDataSharing": false
+        }
+      },
+      "sku": {
+        "name": "Standard_GRS"
+      }
+    },
+    "resourceGroupName": "res9101",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto4445",
+        "type": "Microsoft.Storage/storageAccounts",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.Storage/storageAccounts/sto4445",
+        "kind": "Storage",
+        "location": "eastus",
+        "properties": {
+          "creationTime": "2017-05-24T13:25:33.4863236Z",
+          "primaryEndpoints": {
+            "blob": "https://sto4445.blob.core.windows.net/",
+            "dfs": "https://sto4445.dfs.core.windows.net/",
+            "file": "https://sto4445.file.core.windows.net/",
+            "queue": "https://sto4445.queue.core.windows.net/",
+            "table": "https://sto4445.table.core.windows.net/",
+            "web": "https://sto4445.web.core.windows.net/"
+          },
+          "primaryLocation": "eastus2euap",
+          "provisioningState": "Succeeded",
+          "dataCollaborationPolicyProperties": {
+            "allowStorageConnectors": true,
+            "allowStorageDataShares": true,
+            "allowCrossTenantDataSharing": false
+          }
+        },
+        "sku": {
+          "name": "Standard_GRS",
+          "tier": "Standard"
+        }
+      }
+    },
+    "202": {}
+  },
+  "operationId": "StorageAccounts_Create",
+  "title": "StorageAccountCreateWithDataCollaborationPolicy"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountCreateWithImmutabilityPolicy.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountCreateWithImmutabilityPolicy.json
@@ -1,0 +1,72 @@
+{
+  "parameters": {
+    "accountName": "sto4445",
+    "api-version": "2026-09-01",
+    "parameters": {
+      "extendedLocation": {
+        "name": "losangeles001",
+        "type": "EdgeZone"
+      },
+      "kind": "Storage",
+      "location": "eastus",
+      "properties": {
+        "immutableStorageWithVersioning": {
+          "enabled": true,
+          "immutabilityPolicy": {
+            "allowProtectedAppendWrites": true,
+            "immutabilityPeriodSinceCreationInDays": 15,
+            "state": "Unlocked"
+          }
+        }
+      },
+      "sku": {
+        "name": "Standard_GRS"
+      }
+    },
+    "resourceGroupName": "res9101",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto4445",
+        "type": "Microsoft.Storage/storageAccounts",
+        "extendedLocation": {
+          "name": "losangeles001",
+          "type": "EdgeZone"
+        },
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.Storage/storageAccounts/sto4445",
+        "kind": "Storage",
+        "location": "eastus",
+        "properties": {
+          "creationTime": "2017-05-24T13:25:33.4863236Z",
+          "immutableStorageWithVersioning": {
+            "enabled": true,
+            "immutabilityPolicy": {
+              "allowProtectedAppendWrites": true,
+              "immutabilityPeriodSinceCreationInDays": 15,
+              "state": "Unlocked"
+            }
+          },
+          "primaryEndpoints": {
+            "blob": "https://sto4445.blob.core.windows.net/",
+            "dfs": "https://sto4445.dfs.core.windows.net/",
+            "file": "https://sto4445.file.core.windows.net/",
+            "queue": "https://sto4445.queue.core.windows.net/",
+            "table": "https://sto4445.table.core.windows.net/",
+            "web": "https://sto4445.web.core.windows.net/"
+          },
+          "primaryLocation": "eastus2euap",
+          "provisioningState": "Succeeded"
+        },
+        "sku": {
+          "name": "Standard_GRS",
+          "tier": "Standard"
+        }
+      }
+    },
+    "202": {}
+  },
+  "operationId": "StorageAccounts_Create",
+  "title": "StorageAccountCreateWithImmutabilityPolicy"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountCreateWithSmartAccessTier.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountCreateWithSmartAccessTier.json
@@ -1,0 +1,158 @@
+{
+  "parameters": {
+    "accountName": "sto4445",
+    "api-version": "2026-09-01",
+    "parameters": {
+      "extendedLocation": {
+        "name": "losangeles001",
+        "type": "EdgeZone"
+      },
+      "kind": "Storage",
+      "location": "eastus",
+      "properties": {
+        "accessTier": "Smart",
+        "allowBlobPublicAccess": false,
+        "allowSharedKeyAccess": true,
+        "defaultToOAuthAuthentication": false,
+        "encryption": {
+          "keySource": "Microsoft.Storage",
+          "requireInfrastructureEncryption": false,
+          "services": {
+            "blob": {
+              "enabled": true,
+              "keyType": "Account"
+            },
+            "file": {
+              "enabled": true,
+              "keyType": "Account"
+            }
+          }
+        },
+        "isHnsEnabled": true,
+        "isSftpEnabled": true,
+        "keyPolicy": {
+          "keyExpirationPeriodInDays": 20
+        },
+        "minimumTlsVersion": "TLS1_2",
+        "routingPreference": {
+          "publishInternetEndpoints": true,
+          "publishMicrosoftEndpoints": true,
+          "routingChoice": "MicrosoftRouting"
+        },
+        "sasPolicy": {
+          "expirationAction": "Log",
+          "sasExpirationPeriod": "1.15:59:59"
+        },
+        "geoPriorityReplicationStatus": {
+          "isBlobEnabled": true
+        }
+      },
+      "sku": {
+        "name": "Standard_GRS"
+      },
+      "tags": {
+        "key1": "value1",
+        "key2": "value2"
+      }
+    },
+    "resourceGroupName": "res9101",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto4445",
+        "type": "Microsoft.Storage/storageAccounts",
+        "extendedLocation": {
+          "name": "losangeles001",
+          "type": "EdgeZone"
+        },
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.Storage/storageAccounts/sto4445",
+        "kind": "Storage",
+        "location": "eastus",
+        "properties": {
+          "allowBlobPublicAccess": false,
+          "allowSharedKeyAccess": true,
+          "creationTime": "2017-05-24T13:25:33.4863236Z",
+          "encryption": {
+            "keySource": "Microsoft.Storage",
+            "requireInfrastructureEncryption": false,
+            "services": {
+              "blob": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              },
+              "file": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              }
+            }
+          },
+          "isHnsEnabled": true,
+          "isSftpEnabled": true,
+          "keyCreationTime": {
+            "key1": "2021-03-18T04:42:22.4322836Z",
+            "key2": "2021-03-18T04:42:22.4322836Z"
+          },
+          "keyPolicy": {
+            "keyExpirationPeriodInDays": 20
+          },
+          "minimumTlsVersion": "TLS1_2",
+          "primaryEndpoints": {
+            "blob": "https://sto4445.blob.core.windows.net/",
+            "dfs": "https://sto4445.dfs.core.windows.net/",
+            "file": "https://sto4445.file.core.windows.net/",
+            "internetEndpoints": {
+              "blob": "https://sto4445-internetrouting.blob.core.windows.net/",
+              "dfs": "https://sto4445-internetrouting.dfs.core.windows.net/",
+              "file": "https://sto4445-internetrouting.file.core.windows.net/",
+              "web": "https://sto4445-internetrouting.web.core.windows.net/"
+            },
+            "microsoftEndpoints": {
+              "blob": "https://sto4445-microsoftrouting.blob.core.windows.net/",
+              "dfs": "https://sto4445-microsoftrouting.dfs.core.windows.net/",
+              "file": "https://sto4445-microsoftrouting.file.core.windows.net/",
+              "queue": "https://sto4445-microsoftrouting.queue.core.windows.net/",
+              "table": "https://sto4445-microsoftrouting.table.core.windows.net/",
+              "web": "https://sto4445-microsoftrouting.web.core.windows.net/"
+            },
+            "queue": "https://sto4445.queue.core.windows.net/",
+            "table": "https://sto4445.table.core.windows.net/",
+            "web": "https://sto4445.web.core.windows.net/"
+          },
+          "primaryLocation": "eastus2euap",
+          "provisioningState": "Succeeded",
+          "routingPreference": {
+            "publishInternetEndpoints": true,
+            "publishMicrosoftEndpoints": true,
+            "routingChoice": "MicrosoftRouting"
+          },
+          "sasPolicy": {
+            "expirationAction": "Log",
+            "sasExpirationPeriod": "1.15:59:59"
+          },
+          "secondaryLocation": "centraluseuap",
+          "statusOfPrimary": "available",
+          "statusOfSecondary": "available",
+          "supportsHttpsTrafficOnly": true,
+          "geoPriorityReplicationStatus": {
+            "isBlobEnabled": true
+          }
+        },
+        "sku": {
+          "name": "Standard_GRS",
+          "tier": "Standard"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        }
+      }
+    },
+    "202": {}
+  },
+  "operationId": "StorageAccounts_Create",
+  "title": "StorageAccountCreateWithSmartAccessTier"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountCreate_placement.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountCreate_placement.json
@@ -1,0 +1,160 @@
+{
+  "parameters": {
+    "accountName": "sto4445",
+    "api-version": "2026-09-01",
+    "parameters": {
+      "extendedLocation": {
+        "name": "losangeles001",
+        "type": "EdgeZone"
+      },
+      "kind": "Storage",
+      "location": "eastus",
+      "placement": {
+        "zonePlacementPolicy": "Any"
+      },
+      "properties": {
+        "allowBlobPublicAccess": false,
+        "allowSharedKeyAccess": true,
+        "defaultToOAuthAuthentication": false,
+        "encryption": {
+          "keySource": "Microsoft.Storage",
+          "requireInfrastructureEncryption": false,
+          "services": {
+            "blob": {
+              "enabled": true,
+              "keyType": "Account"
+            },
+            "file": {
+              "enabled": true,
+              "keyType": "Account"
+            }
+          }
+        },
+        "isHnsEnabled": true,
+        "isSftpEnabled": true,
+        "keyPolicy": {
+          "keyExpirationPeriodInDays": 20
+        },
+        "minimumTlsVersion": "TLS1_2",
+        "routingPreference": {
+          "publishInternetEndpoints": true,
+          "publishMicrosoftEndpoints": true,
+          "routingChoice": "MicrosoftRouting"
+        },
+        "sasPolicy": {
+          "expirationAction": "Log",
+          "sasExpirationPeriod": "1.15:59:59"
+        }
+      },
+      "sku": {
+        "name": "Standard_GRS"
+      },
+      "tags": {
+        "key1": "value1",
+        "key2": "value2"
+      }
+    },
+    "resourceGroupName": "res9101",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto4445",
+        "type": "Microsoft.Storage/storageAccounts",
+        "extendedLocation": {
+          "name": "losangeles001",
+          "type": "EdgeZone"
+        },
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.Storage/storageAccounts/sto4445",
+        "kind": "Storage",
+        "location": "eastus",
+        "placement": {
+          "zonePlacementPolicy": "Any"
+        },
+        "properties": {
+          "allowBlobPublicAccess": false,
+          "allowSharedKeyAccess": true,
+          "creationTime": "2017-05-24T13:25:33.4863236Z",
+          "encryption": {
+            "keySource": "Microsoft.Storage",
+            "requireInfrastructureEncryption": false,
+            "services": {
+              "blob": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              },
+              "file": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              }
+            }
+          },
+          "isHnsEnabled": true,
+          "isSftpEnabled": true,
+          "keyCreationTime": {
+            "key1": "2021-03-18T04:42:22.4322836Z",
+            "key2": "2021-03-18T04:42:22.4322836Z"
+          },
+          "keyPolicy": {
+            "keyExpirationPeriodInDays": 20
+          },
+          "minimumTlsVersion": "TLS1_2",
+          "primaryEndpoints": {
+            "blob": "https://sto4445.blob.core.windows.net/",
+            "dfs": "https://sto4445.dfs.core.windows.net/",
+            "file": "https://sto4445.file.core.windows.net/",
+            "internetEndpoints": {
+              "blob": "https://sto4445-internetrouting.blob.core.windows.net/",
+              "dfs": "https://sto4445-internetrouting.dfs.core.windows.net/",
+              "file": "https://sto4445-internetrouting.file.core.windows.net/",
+              "web": "https://sto4445-internetrouting.web.core.windows.net/"
+            },
+            "microsoftEndpoints": {
+              "blob": "https://sto4445-microsoftrouting.blob.core.windows.net/",
+              "dfs": "https://sto4445-microsoftrouting.dfs.core.windows.net/",
+              "file": "https://sto4445-microsoftrouting.file.core.windows.net/",
+              "queue": "https://sto4445-microsoftrouting.queue.core.windows.net/",
+              "table": "https://sto4445-microsoftrouting.table.core.windows.net/",
+              "web": "https://sto4445-microsoftrouting.web.core.windows.net/"
+            },
+            "queue": "https://sto4445.queue.core.windows.net/",
+            "table": "https://sto4445.table.core.windows.net/",
+            "web": "https://sto4445.web.core.windows.net/"
+          },
+          "primaryLocation": "eastus2euap",
+          "provisioningState": "Succeeded",
+          "routingPreference": {
+            "publishInternetEndpoints": true,
+            "publishMicrosoftEndpoints": true,
+            "routingChoice": "MicrosoftRouting"
+          },
+          "sasPolicy": {
+            "expirationAction": "Log",
+            "sasExpirationPeriod": "1.15:59:59"
+          },
+          "secondaryLocation": "centraluseuap",
+          "statusOfPrimary": "available",
+          "statusOfSecondary": "available",
+          "supportsHttpsTrafficOnly": true
+        },
+        "sku": {
+          "name": "Standard_GRS",
+          "tier": "Standard"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        },
+        "zones": [
+          "1"
+        ]
+      }
+    },
+    "202": {}
+  },
+  "operationId": "StorageAccounts_Create",
+  "title": "StorageAccountCreate_placement"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountCreate_zones.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountCreate_zones.json
@@ -1,0 +1,157 @@
+{
+  "parameters": {
+    "accountName": "sto4445",
+    "api-version": "2026-09-01",
+    "parameters": {
+      "extendedLocation": {
+        "name": "losangeles001",
+        "type": "EdgeZone"
+      },
+      "kind": "Storage",
+      "location": "eastus",
+      "properties": {
+        "allowBlobPublicAccess": false,
+        "allowSharedKeyAccess": true,
+        "defaultToOAuthAuthentication": false,
+        "encryption": {
+          "keySource": "Microsoft.Storage",
+          "requireInfrastructureEncryption": false,
+          "services": {
+            "blob": {
+              "enabled": true,
+              "keyType": "Account"
+            },
+            "file": {
+              "enabled": true,
+              "keyType": "Account"
+            }
+          }
+        },
+        "isHnsEnabled": true,
+        "isSftpEnabled": true,
+        "keyPolicy": {
+          "keyExpirationPeriodInDays": 20
+        },
+        "minimumTlsVersion": "TLS1_2",
+        "routingPreference": {
+          "publishInternetEndpoints": true,
+          "publishMicrosoftEndpoints": true,
+          "routingChoice": "MicrosoftRouting"
+        },
+        "sasPolicy": {
+          "expirationAction": "Log",
+          "sasExpirationPeriod": "1.15:59:59"
+        }
+      },
+      "sku": {
+        "name": "Standard_GRS"
+      },
+      "tags": {
+        "key1": "value1",
+        "key2": "value2"
+      },
+      "zones": [
+        "1"
+      ]
+    },
+    "resourceGroupName": "res9101",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto4445",
+        "type": "Microsoft.Storage/storageAccounts",
+        "extendedLocation": {
+          "name": "losangeles001",
+          "type": "EdgeZone"
+        },
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.Storage/storageAccounts/sto4445",
+        "kind": "Storage",
+        "location": "eastus",
+        "properties": {
+          "allowBlobPublicAccess": false,
+          "allowSharedKeyAccess": true,
+          "creationTime": "2017-05-24T13:25:33.4863236Z",
+          "encryption": {
+            "keySource": "Microsoft.Storage",
+            "requireInfrastructureEncryption": false,
+            "services": {
+              "blob": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              },
+              "file": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              }
+            }
+          },
+          "isHnsEnabled": true,
+          "isSftpEnabled": true,
+          "keyCreationTime": {
+            "key1": "2021-03-18T04:42:22.4322836Z",
+            "key2": "2021-03-18T04:42:22.4322836Z"
+          },
+          "keyPolicy": {
+            "keyExpirationPeriodInDays": 20
+          },
+          "minimumTlsVersion": "TLS1_2",
+          "primaryEndpoints": {
+            "blob": "https://sto4445.blob.core.windows.net/",
+            "dfs": "https://sto4445.dfs.core.windows.net/",
+            "file": "https://sto4445.file.core.windows.net/",
+            "internetEndpoints": {
+              "blob": "https://sto4445-internetrouting.blob.core.windows.net/",
+              "dfs": "https://sto4445-internetrouting.dfs.core.windows.net/",
+              "file": "https://sto4445-internetrouting.file.core.windows.net/",
+              "web": "https://sto4445-internetrouting.web.core.windows.net/"
+            },
+            "microsoftEndpoints": {
+              "blob": "https://sto4445-microsoftrouting.blob.core.windows.net/",
+              "dfs": "https://sto4445-microsoftrouting.dfs.core.windows.net/",
+              "file": "https://sto4445-microsoftrouting.file.core.windows.net/",
+              "queue": "https://sto4445-microsoftrouting.queue.core.windows.net/",
+              "table": "https://sto4445-microsoftrouting.table.core.windows.net/",
+              "web": "https://sto4445-microsoftrouting.web.core.windows.net/"
+            },
+            "queue": "https://sto4445.queue.core.windows.net/",
+            "table": "https://sto4445.table.core.windows.net/",
+            "web": "https://sto4445.web.core.windows.net/"
+          },
+          "primaryLocation": "eastus2euap",
+          "provisioningState": "Succeeded",
+          "routingPreference": {
+            "publishInternetEndpoints": true,
+            "publishMicrosoftEndpoints": true,
+            "routingChoice": "MicrosoftRouting"
+          },
+          "sasPolicy": {
+            "expirationAction": "Log",
+            "sasExpirationPeriod": "1.15:59:59"
+          },
+          "secondaryLocation": "centraluseuap",
+          "statusOfPrimary": "available",
+          "statusOfSecondary": "available",
+          "supportsHttpsTrafficOnly": true
+        },
+        "sku": {
+          "name": "Standard_GRS",
+          "tier": "Standard"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        },
+        "zones": [
+          "1"
+        ]
+      }
+    },
+    "202": {}
+  },
+  "operationId": "StorageAccounts_Create",
+  "title": "StorageAccountCreate_zones"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountDelete.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountDelete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "accountName": "sto2434",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res4228",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "StorageAccounts_Delete",
+  "title": "StorageAccountDelete"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountDeleteBlobInventoryPolicy.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountDeleteBlobInventoryPolicy.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "accountName": "sto2527",
+    "api-version": "2026-09-01",
+    "blobInventoryPolicyName": "default",
+    "monitor": "true",
+    "resourceGroupName": "res6977",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "BlobInventoryPolicies_Delete",
+  "title": "StorageAccountDeleteBlobInventoryPolicy"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountDeleteManagementPolicy.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountDeleteManagementPolicy.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "accountName": "sto2527",
+    "api-version": "2026-09-01",
+    "managementPolicyName": "default",
+    "monitor": "true",
+    "resourceGroupName": "res6977",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "ManagementPolicies_Delete",
+  "title": "StorageAccountDeleteManagementPolicies"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountDeleteObjectReplicationPolicy.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountDeleteObjectReplicationPolicy.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "accountName": "sto2527",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "objectReplicationPolicyId": "{objectReplicationPolicy-Id}",
+    "resourceGroupName": "res6977",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "ObjectReplicationPolicies_Delete",
+  "title": "StorageAccountDeleteObjectReplicationPolicies"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountDeletePrivateEndpointConnection.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountDeletePrivateEndpointConnection.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "accountName": "sto2527",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "privateEndpointConnectionName": "{privateEndpointConnectionName}",
+    "resourceGroupName": "res6977",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "PrivateEndpointConnections_Delete",
+  "title": "StorageAccountDeletePrivateEndpointConnection"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountEnableAD.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountEnableAD.json
@@ -1,0 +1,77 @@
+{
+  "parameters": {
+    "accountName": "sto8596",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "parameters": {
+      "properties": {
+        "azureFilesIdentityBasedAuthentication": {
+          "activeDirectoryProperties": {
+            "accountType": "User",
+            "azureStorageSid": "S-1-5-21-2400535526-2334094090-2402026252-0012",
+            "domainGuid": "aebfc118-9fa9-4732-a21f-d98e41a77ae1",
+            "domainName": "adtest.com",
+            "domainSid": "S-1-5-21-2400535526-2334094090-2402026252",
+            "forestName": "adtest.com",
+            "netBiosDomainName": "adtest.com",
+            "samAccountName": "sam12498"
+          },
+          "directoryServiceOptions": "AD"
+        }
+      }
+    },
+    "resourceGroupName": "res9407",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto8596",
+        "type": "Microsoft.Storage/storageAccounts",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9407/providers/Microsoft.Storage/storageAccounts/sto8596",
+        "kind": "Storage",
+        "location": "eastus2(stage)",
+        "properties": {
+          "azureFilesIdentityBasedAuthentication": {
+            "activeDirectoryProperties": {
+              "accountType": "User",
+              "azureStorageSid": "S-1-5-21-2400535526-2334094090-2402026252-0012",
+              "domainGuid": "aebfc118-9fa9-4732-a21f-d98e41a77ae1",
+              "domainName": "adtest.com",
+              "domainSid": "S-1-5-21-2400535526-2334094090-2402026252",
+              "forestName": "adtest.com",
+              "netBiosDomainName": "adtest.com",
+              "samAccountName": "sam12498"
+            },
+            "directoryServiceOptions": "AD"
+          },
+          "creationTime": "2017-06-01T02:42:41.7633306Z",
+          "primaryEndpoints": {
+            "blob": "https://sto8596.blob.core.windows.net/",
+            "dfs": "https://sto8596.dfs.core.windows.net/",
+            "file": "https://sto8596.file.core.windows.net/",
+            "queue": "https://sto8596.queue.core.windows.net/",
+            "table": "https://sto8596.table.core.windows.net/",
+            "web": "https://sto8596.web.core.windows.net/"
+          },
+          "primaryLocation": "eastus2(stage)",
+          "provisioningState": "Succeeded",
+          "secondaryLocation": "northcentralus(stage)",
+          "statusOfPrimary": "available",
+          "statusOfSecondary": "available",
+          "supportsHttpsTrafficOnly": false
+        },
+        "sku": {
+          "name": "Standard_GRS",
+          "tier": "Standard"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "StorageAccounts_Update",
+  "title": "StorageAccountEnableAD"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountEnableCMK.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountEnableCMK.json
@@ -1,0 +1,96 @@
+{
+  "parameters": {
+    "accountName": "sto8596",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "parameters": {
+      "properties": {
+        "encryption": {
+          "keySource": "Microsoft.Keyvault",
+          "keyvaultproperties": {
+            "keyname": "wrappingKey",
+            "keyvaulturi": "https://myvault8569.vault.azure.net",
+            "keyversion": ""
+          },
+          "services": {
+            "blob": {
+              "enabled": true,
+              "keyType": "Account"
+            },
+            "file": {
+              "enabled": true,
+              "keyType": "Account"
+            }
+          }
+        }
+      }
+    },
+    "resourceGroupName": "res9407",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto8596",
+        "type": "Microsoft.Storage/storageAccounts",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9407/providers/Microsoft.Storage/storageAccounts/sto8596",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "911871cc-ffd1-4fc4-ac11-7a316433ea66",
+          "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+        },
+        "kind": "Storage",
+        "location": "eastus2(stage)",
+        "properties": {
+          "creationTime": "2017-06-01T02:42:41.7633306Z",
+          "encryption": {
+            "keySource": "Microsoft.Keyvault",
+            "keyvaultproperties": {
+              "currentVersionedKeyIdentifier": "https://myvault8569.vault.azure.net/keys/wrappingKey/0682afdd9c104f4285df20107e956cad",
+              "keyname": "wrappingKey",
+              "keyvaulturi": "https://myvault8569.vault.azure.net",
+              "keyversion": "",
+              "lastKeyRotationTimestamp": "2019-12-13T20:36:23.7023290Z"
+            },
+            "services": {
+              "blob": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              },
+              "file": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              }
+            }
+          },
+          "primaryEndpoints": {
+            "blob": "https://sto8596.blob.core.windows.net/",
+            "dfs": "https://sto8596.dfs.core.windows.net/",
+            "file": "https://sto8596.file.core.windows.net/",
+            "queue": "https://sto8596.queue.core.windows.net/",
+            "table": "https://sto8596.table.core.windows.net/",
+            "web": "https://sto8596.web.core.windows.net/"
+          },
+          "primaryLocation": "eastus2(stage)",
+          "provisioningState": "Succeeded",
+          "secondaryLocation": "northcentralus(stage)",
+          "statusOfPrimary": "available",
+          "statusOfSecondary": "available",
+          "supportsHttpsTrafficOnly": false
+        },
+        "sku": {
+          "name": "Standard_GRS",
+          "tier": "Standard"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "StorageAccounts_Update",
+  "title": "StorageAccountEnableCMK"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountEnableSmbOAuth.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountEnableSmbOAuth.json
@@ -1,0 +1,63 @@
+{
+  "parameters": {
+    "accountName": "sto8596",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "parameters": {
+      "properties": {
+        "azureFilesIdentityBasedAuthentication": {
+          "directoryServiceOptions": "None",
+          "smbOAuthSettings": {
+            "isSmbOAuthEnabled": true
+          }
+        }
+      }
+    },
+    "resourceGroupName": "res9407",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto8596",
+        "type": "Microsoft.Storage/storageAccounts",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9407/providers/Microsoft.Storage/storageAccounts/sto8596",
+        "kind": "Storage",
+        "location": "eastus2(stage)",
+        "properties": {
+          "azureFilesIdentityBasedAuthentication": {
+            "directoryServiceOptions": "None",
+            "smbOAuthSettings": {
+              "isSmbOAuthEnabled": true
+            }
+          },
+          "creationTime": "2017-06-01T02:42:41.7633306Z",
+          "primaryEndpoints": {
+            "blob": "https://sto8596.blob.core.windows.net/",
+            "dfs": "https://sto8596.dfs.core.windows.net/",
+            "file": "https://sto8596.file.core.windows.net/",
+            "queue": "https://sto8596.queue.core.windows.net/",
+            "table": "https://sto8596.table.core.windows.net/",
+            "web": "https://sto8596.web.core.windows.net/"
+          },
+          "primaryLocation": "eastus2(stage)",
+          "provisioningState": "Succeeded",
+          "secondaryLocation": "northcentralus(stage)",
+          "statusOfPrimary": "available",
+          "statusOfSecondary": "available",
+          "supportsHttpsTrafficOnly": false
+        },
+        "sku": {
+          "name": "Standard_GRS",
+          "tier": "Standard"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "StorageAccounts_Update",
+  "title": "StorageAccountEnableSmbOAuth"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountEncryptionScopeList.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountEncryptionScopeList.json
@@ -1,0 +1,45 @@
+{
+  "parameters": {
+    "accountName": "accountname",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "resource-group-name",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": null,
+        "value": [
+          {
+            "name": "scope-1",
+            "type": "Microsoft.Storage/storageAccounts/encryptionScopes",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/resource-group-name/providers/Microsoft.Storage/storageAccounts/accountname/encryptionScopes/scope-1",
+            "properties": {
+              "creationTime": "2018-10-16T02:42:41.7633306Z",
+              "lastModifiedTime": "2018-10-16T02:42:41.7633306Z",
+              "source": "Microsoft.Storage",
+              "state": "Enabled"
+            }
+          },
+          {
+            "name": "scope-2",
+            "type": "Microsoft.Storage/storageAccounts/encryptionScopes",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/resource-group-name/providers/Microsoft.Storage/storageAccounts/accountname/encryptionScopes/scope-2",
+            "properties": {
+              "creationTime": "2018-10-16T04:32:14.3355306Z",
+              "keyVaultProperties": {
+                "keyUri": "https://testvault.vault.core.windows.net/keys/key1/863425f1358359c"
+              },
+              "lastModifiedTime": "2018-10-17T06:23:14.4513306Z",
+              "source": "Microsoft.KeyVault",
+              "state": "Enabled"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "EncryptionScopes_List",
+  "title": "StorageAccountEncryptionScopeList"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountFailover.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountFailover.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "accountName": "sto2434",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res4228",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "https://endpoint:port/subscriptions/{subscription-id}/providers/Microsoft.Storage/locations/{location}/asyncoperations/{operationid}?monitor=true&api-version=2022-09-01"
+      }
+    }
+  },
+  "operationId": "StorageAccounts_Failover",
+  "title": "StorageAccountFailover"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountFailoverPlanned.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountFailoverPlanned.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "accountName": "sto2434",
+    "api-version": "2026-09-01",
+    "failoverType": "Planned",
+    "monitor": "true",
+    "resourceGroupName": "res4228",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "https://endpoint:port/subscriptions/{subscription-id}/providers/Microsoft.Storage/locations/{location}/asyncoperations/{operationid}?monitor=true&api-version=2022-09-01"
+      }
+    }
+  },
+  "operationId": "StorageAccounts_Failover",
+  "title": "StorageAccountFailoverPlanned"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountGetAsyncSkuConversionStatus.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountGetAsyncSkuConversionStatus.json
@@ -1,0 +1,36 @@
+{
+  "parameters": {
+    "accountName": "sto8596",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res9407",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto8596",
+        "type": "Microsoft.Storage/storageAccounts",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9407/providers/Microsoft.Storage/storageAccounts/sto8596",
+        "kind": "StorageV2",
+        "location": "eastus",
+        "properties": {
+          "allowBlobPublicAccess": false,
+          "minimumTlsVersion": "TLS1_2",
+          "storageAccountSkuConversionStatus": {
+            "endTime": "2021-09-02T02:53:39.0932539Z",
+            "skuConversionStatus": "InProgress",
+            "startTime": "2022-09-01T02:53:39.0932539Z",
+            "targetSkuName": "Standard_GRS"
+          }
+        },
+        "sku": {
+          "name": "Standard_GRS",
+          "tier": "Standard"
+        }
+      }
+    }
+  },
+  "operationId": "StorageAccounts_GetProperties",
+  "title": "StorageAccountGetAsyncSkuConversionStatus"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountGetBlobInventoryPolicy.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountGetBlobInventoryPolicy.json
@@ -1,0 +1,67 @@
+{
+  "parameters": {
+    "accountName": "sto9699",
+    "api-version": "2026-09-01",
+    "blobInventoryPolicyName": "default",
+    "monitor": "true",
+    "resourceGroupName": "res7687",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "DefaultInventoryPolicy",
+        "type": "Microsoft.Storage/storageAccounts/inventoryPolicies",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res7687/providers/Microsoft.Storage/storageAccounts/sto9699/inventoryPolicies/default",
+        "properties": {
+          "lastModifiedTime": "2020-10-05T02:53:39.0932539Z",
+          "policy": {
+            "type": "Inventory",
+            "enabled": true,
+            "rules": [
+              {
+                "name": "inventoryPolicyRule1",
+                "definition": {
+                  "format": "Csv",
+                  "filters": {
+                    "blobTypes": [
+                      "blockBlob",
+                      "appendBlob",
+                      "pageBlob"
+                    ],
+                    "includeBlobVersions": true,
+                    "includeSnapshots": true,
+                    "prefixMatch": [
+                      "inventoryprefix1",
+                      "inventoryprefix2"
+                    ]
+                  },
+                  "objectType": "Blob",
+                  "schedule": "Daily",
+                  "schemaFields": [
+                    "Name",
+                    "Creation-Time",
+                    "Last-Modified",
+                    "Content-Length",
+                    "Content-MD5",
+                    "BlobType",
+                    "AccessTier",
+                    "AccessTierChangeTime",
+                    "Snapshot",
+                    "VersionId",
+                    "IsCurrentVersion",
+                    "Metadata"
+                  ]
+                },
+                "destination": "container1",
+                "enabled": true
+              }
+            ]
+          }
+        }
+      }
+    }
+  },
+  "operationId": "BlobInventoryPolicies_Get",
+  "title": "StorageAccountGetBlobInventoryPolicy"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountGetEncryptionScope.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountGetEncryptionScope.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "accountName": "accountname",
+    "api-version": "2026-09-01",
+    "encryptionScopeName": "{encryption-scope-name}",
+    "monitor": "true",
+    "resourceGroupName": "resource-group-name",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "{encyrption-scope-name}",
+        "type": "Microsoft.Storage/storageAccounts/encryptionScopes",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/resource-group-name/providers/Microsoft.Storage/storageAccounts/accountname/encryptionScopes/{encryption-scope-name}",
+        "properties": {
+          "creationTime": "2018-10-16T02:42:41.7633306Z",
+          "lastModifiedTime": "2018-10-16T02:42:41.7633306Z",
+          "source": "Microsoft.Storage",
+          "state": "Enabled"
+        }
+      }
+    }
+  },
+  "operationId": "EncryptionScopes_Get",
+  "title": "StorageAccountGetEncryptionScope"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountGetManagementPolicy.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountGetManagementPolicy.json
@@ -1,0 +1,61 @@
+{
+  "parameters": {
+    "accountName": "sto2527",
+    "api-version": "2026-09-01",
+    "managementPolicyName": "default",
+    "monitor": "true",
+    "resourceGroupName": "res6977",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "DefaultManagementPolicy",
+        "type": "Microsoft.Storage/storageAccounts/managementPolicies",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res7231/providers/Microsoft.Storage/storageAccounts/sto288/managementPolicies/default",
+        "properties": {
+          "lastModifiedTime": "2018-06-08T03:01:55.7168089Z",
+          "policy": {
+            "rules": [
+              {
+                "name": "olcmtest",
+                "type": "Lifecycle",
+                "definition": {
+                  "actions": {
+                    "baseBlob": {
+                      "delete": {
+                        "daysAfterModificationGreaterThan": 1000
+                      },
+                      "tierToArchive": {
+                        "daysAfterModificationGreaterThan": 90
+                      },
+                      "tierToCool": {
+                        "daysAfterModificationGreaterThan": 30
+                      }
+                    },
+                    "snapshot": {
+                      "delete": {
+                        "daysAfterCreationGreaterThan": 30
+                      }
+                    }
+                  },
+                  "filters": {
+                    "blobTypes": [
+                      "blockBlob"
+                    ],
+                    "prefixMatch": [
+                      "olcmtestcontainer"
+                    ]
+                  }
+                },
+                "enabled": true
+              }
+            ]
+          }
+        }
+      }
+    }
+  },
+  "operationId": "ManagementPolicies_Get",
+  "title": "StorageAccountGetManagementPolicies"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountGetMigrationFailed.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountGetMigrationFailed.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "accountName": "accountname",
+    "api-version": "2026-09-01",
+    "migrationName": "default",
+    "monitor": "true",
+    "resourceGroupName": "resource-group-name",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.Storage/storageAccounts/accountMigrations",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/resource-group-name/providers/Microsoft.Storage/storageAccounts/accountname/accountMigrations/default",
+        "properties": {
+          "migrationFailedDetailedReason": "ZRS is not supported for accounts with archive data.",
+          "migrationFailedReason": "ZrsNotSupportedForAccountWithArchiveData",
+          "migrationStatus": "Failed",
+          "targetSkuName": "Standard_ZRS"
+        }
+      }
+    }
+  },
+  "operationId": "StorageAccounts_GetCustomerInitiatedMigration",
+  "title": "StorageAccountGetMigrationFailed"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountGetMigrationInProgress.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountGetMigrationInProgress.json
@@ -1,0 +1,25 @@
+{
+  "parameters": {
+    "accountName": "accountname",
+    "api-version": "2026-09-01",
+    "migrationName": "default",
+    "monitor": "true",
+    "resourceGroupName": "resource-group-name",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.Storage/storageAccounts/accountMigrations",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/resource-group-name/providers/Microsoft.Storage/storageAccounts/accountname/accountMigrations/default",
+        "properties": {
+          "migrationStatus": "InProgress",
+          "targetSkuName": "Standard_ZRS"
+        }
+      }
+    }
+  },
+  "operationId": "StorageAccounts_GetCustomerInitiatedMigration",
+  "title": "StorageAccountGetMigrationInProgress"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountGetObjectReplicationPolicy.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountGetObjectReplicationPolicy.json
@@ -1,0 +1,58 @@
+{
+  "parameters": {
+    "accountName": "sto2527",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "objectReplicationPolicyId": "{objectReplicationPolicy-Id}",
+    "resourceGroupName": "res6977",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "{objectReplicationPolicy-Id}",
+        "type": "Microsoft.Storage/storageAccounts/objectReplicationPolicies",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res6977/providers/Microsoft.Storage/storageAccounts/sto2527/objectReplicationPolicies/{objectReplicationPolicy-Id}",
+        "properties": {
+          "destinationAccount": "destAccount1",
+          "enabledTime": "2019-06-08T03:01:55.7168089Z",
+          "metrics": {
+            "enabled": true
+          },
+          "priorityReplication": {
+            "enabled": true
+          },
+          "policyId": "{objectReplicationPolicy-Id}",
+          "rules": [
+            {
+              "destinationContainer": "destContainer1",
+              "filters": {
+                "prefixMatch": [
+                  "blobA",
+                  "blobB"
+                ]
+              },
+              "sourceContainer": "sourceContainer1"
+            },
+            {
+              "destinationContainer": "destContainer1",
+              "filters": {
+                "prefixMatch": [
+                  "blobC",
+                  "blobD"
+                ]
+              },
+              "sourceContainer": "sourceContainer1"
+            }
+          ],
+          "sourceAccount": "sto2527",
+          "tagsReplication": {
+            "enabled": true
+          }
+        }
+      }
+    }
+  },
+  "operationId": "ObjectReplicationPolicies_Get",
+  "title": "StorageAccountGetObjectReplicationPolicies"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountGetPrivateEndpointConnection.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountGetPrivateEndpointConnection.json
@@ -1,0 +1,32 @@
+{
+  "parameters": {
+    "accountName": "sto2527",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "privateEndpointConnectionName": "{privateEndpointConnectionName}",
+    "resourceGroupName": "res6977",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "{privateEndpointConnectionName}",
+        "type": "Microsoft.Storage/storageAccounts/privateEndpointConnections",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res7231/providers/Microsoft.Storage/storageAccounts/sto288/privateEndpointConnections/{privateEndpointConnectionName}",
+        "properties": {
+          "privateEndpoint": {
+            "id": "/subscriptions/{subscription-id}/resourceGroups/res7231/providers/Microsoft.Network/privateEndpoints/petest01"
+          },
+          "privateLinkServiceConnectionState": {
+            "description": "Auto-Approved",
+            "actionRequired": "None",
+            "status": "Approved"
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "PrivateEndpointConnections_Get",
+  "title": "StorageAccountGetPrivateEndpointConnection"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountGetProperties.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountGetProperties.json
@@ -1,0 +1,115 @@
+{
+  "parameters": {
+    "accountName": "sto8596",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res9407",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto8596",
+        "type": "Microsoft.Storage/storageAccounts",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9407/providers/Microsoft.Storage/storageAccounts/sto8596",
+        "kind": "Storage",
+        "location": "eastus2(stage)",
+        "properties": {
+          "accountMigrationInProgress": false,
+          "creationTime": "2017-06-01T02:42:41.7633306Z",
+          "encryption": {
+            "keySource": "Microsoft.Storage",
+            "services": {
+              "blob": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              },
+              "file": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              }
+            }
+          },
+          "geoReplicationStats": {
+            "canFailover": true,
+            "lastSyncTime": "2018-10-30T00:25:34Z",
+            "status": "Live"
+          },
+          "isHnsEnabled": true,
+          "isSkuConversionBlocked": false,
+          "keyCreationTime": {
+            "key1": "2021-03-18T04:42:22.4322836Z",
+            "key2": "2021-03-18T04:42:22.4322836Z"
+          },
+          "networkAcls": {
+            "bypass": "AzureServices",
+            "defaultAction": "Allow",
+            "ipRules": [],
+            "resourceAccessRules": [
+              {
+                "resourceId": "/subscriptions/a7e99807-abbf-4642-bdec-2c809a96a8bc/resourceGroups/res9407/providers/Microsoft.Synapse/workspaces/testworkspace",
+                "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+              }
+            ],
+            "virtualNetworkRules": []
+          },
+          "primaryEndpoints": {
+            "blob": "https://sto8596.blob.core.windows.net/",
+            "dfs": "https://sto8596.dfs.core.windows.net/",
+            "file": "https://sto8596.file.core.windows.net/",
+            "internetEndpoints": {
+              "blob": "https://sto8596-internetrouting.blob.core.windows.net/",
+              "dfs": "https://sto8596-internetrouting.dfs.core.windows.net/",
+              "file": "https://sto8596-internetrouting.file.core.windows.net/",
+              "web": "https://sto8596-internetrouting.web.core.windows.net/"
+            },
+            "microsoftEndpoints": {
+              "blob": "https://sto8596-microsoftrouting.blob.core.windows.net/",
+              "dfs": "https://sto8596-microsoftrouting.dfs.core.windows.net/",
+              "file": "https://sto8596-microsoftrouting.file.core.windows.net/",
+              "queue": "https://sto8596-microsoftrouting.queue.core.windows.net/",
+              "table": "https://sto8596-microsoftrouting.table.core.windows.net/",
+              "web": "https://sto8596-microsoftrouting.web.core.windows.net/"
+            },
+            "queue": "https://sto8596.queue.core.windows.net/",
+            "table": "https://sto8596.table.core.windows.net/",
+            "web": "https://sto8596.web.core.windows.net/"
+          },
+          "primaryLocation": "eastus2(stage)",
+          "provisioningState": "Succeeded",
+          "routingPreference": {
+            "publishInternetEndpoints": true,
+            "publishMicrosoftEndpoints": true,
+            "routingChoice": "MicrosoftRouting"
+          },
+          "secondaryLocation": "northcentralus(stage)",
+          "statusOfPrimary": "available",
+          "statusOfSecondary": "available",
+          "supportsHttpsTrafficOnly": false,
+          "geoPriorityReplicationStatus": {
+            "isBlobEnabled": true
+          },
+          "sasPolicy": {
+            "expirationAction": "Log",
+            "sasExpirationPeriod": "1.15:59:59",
+            "requireUserBoundUserDelegationSas": true,
+            "requireUserBoundUserDelegationSasAction": "Block"
+          },
+          "allowCrossTenantDelegationSas": false
+        },
+        "sku": {
+          "name": "Standard_GRS",
+          "tier": "Standard"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "StorageAccounts_GetProperties",
+  "title": "StorageAccountGetProperties"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountGetPropertiesCMKEnabled.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountGetPropertiesCMKEnabled.json
@@ -1,0 +1,106 @@
+{
+  "parameters": {
+    "accountName": "sto8596",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res9407",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto8596",
+        "type": "Microsoft.Storage/storageAccounts",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9407/providers/Microsoft.Storage/storageAccounts/sto8596",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "911871cc-ffd1-4fc4-ac11-7a316433ea66",
+          "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+        },
+        "kind": "Storage",
+        "location": "eastus2(stage)",
+        "properties": {
+          "creationTime": "2017-06-01T02:42:41.7633306Z",
+          "encryption": {
+            "keySource": "Microsoft.Keyvault",
+            "keyvaultproperties": {
+              "currentVersionedKeyIdentifier": "https://myvault8569.vault.azure.net/keys/wrappingKey/0682afdd9c104f4285df20107e956cad",
+              "keyname": "wrappingKey",
+              "keyvaulturi": "https://myvault8569.vault.azure.net",
+              "keyversion": "",
+              "lastKeyRotationTimestamp": "2019-12-13T20:36:23.7023290Z"
+            },
+            "services": {
+              "blob": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              },
+              "file": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              }
+            }
+          },
+          "geoReplicationStats": {
+            "canFailover": true,
+            "lastSyncTime": "2018-10-30T00:25:34Z",
+            "status": "Live"
+          },
+          "isHnsEnabled": true,
+          "networkAcls": {
+            "bypass": "AzureServices",
+            "defaultAction": "Allow",
+            "ipRules": [],
+            "resourceAccessRules": [],
+            "virtualNetworkRules": []
+          },
+          "primaryEndpoints": {
+            "blob": "https://sto8596.blob.core.windows.net/",
+            "dfs": "https://sto8596.dfs.core.windows.net/",
+            "file": "https://sto8596.file.core.windows.net/",
+            "internetEndpoints": {
+              "blob": "https://sto8596-internetrouting.blob.core.windows.net/",
+              "dfs": "https://sto8596-internetrouting.dfs.core.windows.net/",
+              "file": "https://sto8596-internetrouting.file.core.windows.net/",
+              "web": "https://sto8596-internetrouting.web.core.windows.net/"
+            },
+            "microsoftEndpoints": {
+              "blob": "https://sto8596-microsoftrouting.blob.core.windows.net/",
+              "dfs": "https://sto8596-microsoftrouting.dfs.core.windows.net/",
+              "file": "https://sto8596-microsoftrouting.file.core.windows.net/",
+              "queue": "https://sto8596-microsoftrouting.queue.core.windows.net/",
+              "table": "https://sto8596-microsoftrouting.table.core.windows.net/",
+              "web": "https://sto8596-microsoftrouting.web.core.windows.net/"
+            },
+            "queue": "https://sto8596.queue.core.windows.net/",
+            "table": "https://sto8596.table.core.windows.net/",
+            "web": "https://sto8596.web.core.windows.net/"
+          },
+          "primaryLocation": "eastus2(stage)",
+          "provisioningState": "Succeeded",
+          "routingPreference": {
+            "publishInternetEndpoints": true,
+            "publishMicrosoftEndpoints": true,
+            "routingChoice": "MicrosoftRouting"
+          },
+          "secondaryLocation": "northcentralus(stage)",
+          "statusOfPrimary": "available",
+          "statusOfSecondary": "available",
+          "supportsHttpsTrafficOnly": false
+        },
+        "sku": {
+          "name": "Standard_GRS",
+          "tier": "Standard"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "StorageAccounts_GetProperties",
+  "title": "StorageAccountGetPropertiesCMKEnabled"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountGetPropertiesCMKVersionExpirationTime.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountGetPropertiesCMKVersionExpirationTime.json
@@ -1,0 +1,107 @@
+{
+  "parameters": {
+    "accountName": "sto8596",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res9407",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto8596",
+        "type": "Microsoft.Storage/storageAccounts",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9407/providers/Microsoft.Storage/storageAccounts/sto8596",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "911871cc-ffd1-4fc4-ac11-7a316433ea66",
+          "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+        },
+        "kind": "Storage",
+        "location": "eastus2(stage)",
+        "properties": {
+          "creationTime": "2017-06-01T02:42:41.7633306Z",
+          "encryption": {
+            "keySource": "Microsoft.Keyvault",
+            "keyvaultproperties": {
+              "currentVersionedKeyExpirationTimestamp": "2019-12-13T20:36:23.7023290Z",
+              "currentVersionedKeyIdentifier": "https://myvault8569.vault.azure.net/keys/wrappingKey/0682afdd9c104f4285df20107e956cad",
+              "keyname": "wrappingKey",
+              "keyvaulturi": "https://myvault8569.vault.azure.net",
+              "keyversion": "",
+              "lastKeyRotationTimestamp": "2019-12-13T20:36:23.7023290Z"
+            },
+            "services": {
+              "blob": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              },
+              "file": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              }
+            }
+          },
+          "geoReplicationStats": {
+            "canFailover": true,
+            "lastSyncTime": "2018-10-30T00:25:34Z",
+            "status": "Live"
+          },
+          "isHnsEnabled": true,
+          "networkAcls": {
+            "bypass": "AzureServices",
+            "defaultAction": "Allow",
+            "ipRules": [],
+            "resourceAccessRules": [],
+            "virtualNetworkRules": []
+          },
+          "primaryEndpoints": {
+            "blob": "https://sto8596.blob.core.windows.net/",
+            "dfs": "https://sto8596.dfs.core.windows.net/",
+            "file": "https://sto8596.file.core.windows.net/",
+            "internetEndpoints": {
+              "blob": "https://sto8596-internetrouting.blob.core.windows.net/",
+              "dfs": "https://sto8596-internetrouting.dfs.core.windows.net/",
+              "file": "https://sto8596-internetrouting.file.core.windows.net/",
+              "web": "https://sto8596-internetrouting.web.core.windows.net/"
+            },
+            "microsoftEndpoints": {
+              "blob": "https://sto8596-microsoftrouting.blob.core.windows.net/",
+              "dfs": "https://sto8596-microsoftrouting.dfs.core.windows.net/",
+              "file": "https://sto8596-microsoftrouting.file.core.windows.net/",
+              "queue": "https://sto8596-microsoftrouting.queue.core.windows.net/",
+              "table": "https://sto8596-microsoftrouting.table.core.windows.net/",
+              "web": "https://sto8596-microsoftrouting.web.core.windows.net/"
+            },
+            "queue": "https://sto8596.queue.core.windows.net/",
+            "table": "https://sto8596.table.core.windows.net/",
+            "web": "https://sto8596.web.core.windows.net/"
+          },
+          "primaryLocation": "eastus2(stage)",
+          "provisioningState": "Succeeded",
+          "routingPreference": {
+            "publishInternetEndpoints": true,
+            "publishMicrosoftEndpoints": true,
+            "routingChoice": "MicrosoftRouting"
+          },
+          "secondaryLocation": "northcentralus(stage)",
+          "statusOfPrimary": "available",
+          "statusOfSecondary": "available",
+          "supportsHttpsTrafficOnly": false
+        },
+        "sku": {
+          "name": "Standard_GRS",
+          "tier": "Standard"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "StorageAccounts_GetProperties",
+  "title": "StorageAccountGetPropertiesCMKVersionExpirationTime"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountGetPropertiesGeoReplicationStatscanFailoverFalse.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountGetPropertiesGeoReplicationStatscanFailoverFalse.json
@@ -1,0 +1,109 @@
+{
+  "parameters": {
+    "$expand": "geoReplicationStats",
+    "accountName": "sto8596",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res9407",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto8596",
+        "type": "Microsoft.Storage/storageAccounts",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9407/providers/Microsoft.Storage/storageAccounts/sto8596",
+        "kind": "Storage",
+        "location": "eastus2(stage)",
+        "properties": {
+          "accountMigrationInProgress": false,
+          "creationTime": "2017-06-01T02:42:41.7633306Z",
+          "encryption": {
+            "keySource": "Microsoft.Storage",
+            "services": {
+              "blob": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              },
+              "file": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              }
+            }
+          },
+          "geoReplicationStats": {
+            "canFailover": false,
+            "canPlannedFailover": false,
+            "lastSyncTime": "2018-10-30T00:25:34Z",
+            "postFailoverRedundancy": "Standard_LRS",
+            "postPlannedFailoverRedundancy": "Standard_GRS",
+            "status": "Live"
+          },
+          "isHnsEnabled": true,
+          "isSkuConversionBlocked": false,
+          "keyCreationTime": {
+            "key1": "2021-03-18T04:42:22.4322836Z",
+            "key2": "2021-03-18T04:42:22.4322836Z"
+          },
+          "networkAcls": {
+            "bypass": "AzureServices",
+            "defaultAction": "Allow",
+            "ipRules": [],
+            "resourceAccessRules": [
+              {
+                "resourceId": "/subscriptions/a7e99807-abbf-4642-bdec-2c809a96a8bc/resourceGroups/res9407/providers/Microsoft.Synapse/workspaces/testworkspace",
+                "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+              }
+            ],
+            "virtualNetworkRules": []
+          },
+          "primaryEndpoints": {
+            "blob": "https://sto8596.blob.core.windows.net/",
+            "dfs": "https://sto8596.dfs.core.windows.net/",
+            "file": "https://sto8596.file.core.windows.net/",
+            "internetEndpoints": {
+              "blob": "https://sto8596-internetrouting.blob.core.windows.net/",
+              "dfs": "https://sto8596-internetrouting.dfs.core.windows.net/",
+              "file": "https://sto8596-internetrouting.file.core.windows.net/",
+              "web": "https://sto8596-internetrouting.web.core.windows.net/"
+            },
+            "microsoftEndpoints": {
+              "blob": "https://sto8596-microsoftrouting.blob.core.windows.net/",
+              "dfs": "https://sto8596-microsoftrouting.dfs.core.windows.net/",
+              "file": "https://sto8596-microsoftrouting.file.core.windows.net/",
+              "queue": "https://sto8596-microsoftrouting.queue.core.windows.net/",
+              "table": "https://sto8596-microsoftrouting.table.core.windows.net/",
+              "web": "https://sto8596-microsoftrouting.web.core.windows.net/"
+            },
+            "queue": "https://sto8596.queue.core.windows.net/",
+            "table": "https://sto8596.table.core.windows.net/",
+            "web": "https://sto8596.web.core.windows.net/"
+          },
+          "primaryLocation": "eastus2(stage)",
+          "provisioningState": "Succeeded",
+          "routingPreference": {
+            "publishInternetEndpoints": true,
+            "publishMicrosoftEndpoints": true,
+            "routingChoice": "MicrosoftRouting"
+          },
+          "secondaryLocation": "northcentralus(stage)",
+          "statusOfPrimary": "available",
+          "statusOfSecondary": "available",
+          "supportsHttpsTrafficOnly": false
+        },
+        "sku": {
+          "name": "Standard_GRS",
+          "tier": "Standard"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "StorageAccounts_GetProperties",
+  "title": "StorageAccountGetPropertiesGeoReplicationStatscanFailoverFalse"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountGetPropertiesGeoReplicationStatscanFailoverTrue.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountGetPropertiesGeoReplicationStatscanFailoverTrue.json
@@ -1,0 +1,109 @@
+{
+  "parameters": {
+    "$expand": "geoReplicationStats",
+    "accountName": "sto8596",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res9407",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto8596",
+        "type": "Microsoft.Storage/storageAccounts",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9407/providers/Microsoft.Storage/storageAccounts/sto8596",
+        "kind": "Storage",
+        "location": "eastus2(stage)",
+        "properties": {
+          "accountMigrationInProgress": false,
+          "creationTime": "2017-06-01T02:42:41.7633306Z",
+          "encryption": {
+            "keySource": "Microsoft.Storage",
+            "services": {
+              "blob": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              },
+              "file": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              }
+            }
+          },
+          "geoReplicationStats": {
+            "canFailover": true,
+            "canPlannedFailover": true,
+            "lastSyncTime": "2018-10-30T00:25:34Z",
+            "postFailoverRedundancy": "Standard_LRS",
+            "postPlannedFailoverRedundancy": "Standard_GRS",
+            "status": "Live"
+          },
+          "isHnsEnabled": true,
+          "isSkuConversionBlocked": false,
+          "keyCreationTime": {
+            "key1": "2021-03-18T04:42:22.4322836Z",
+            "key2": "2021-03-18T04:42:22.4322836Z"
+          },
+          "networkAcls": {
+            "bypass": "AzureServices",
+            "defaultAction": "Allow",
+            "ipRules": [],
+            "resourceAccessRules": [
+              {
+                "resourceId": "/subscriptions/a7e99807-abbf-4642-bdec-2c809a96a8bc/resourceGroups/res9407/providers/Microsoft.Synapse/workspaces/testworkspace",
+                "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+              }
+            ],
+            "virtualNetworkRules": []
+          },
+          "primaryEndpoints": {
+            "blob": "https://sto8596.blob.core.windows.net/",
+            "dfs": "https://sto8596.dfs.core.windows.net/",
+            "file": "https://sto8596.file.core.windows.net/",
+            "internetEndpoints": {
+              "blob": "https://sto8596-internetrouting.blob.core.windows.net/",
+              "dfs": "https://sto8596-internetrouting.dfs.core.windows.net/",
+              "file": "https://sto8596-internetrouting.file.core.windows.net/",
+              "web": "https://sto8596-internetrouting.web.core.windows.net/"
+            },
+            "microsoftEndpoints": {
+              "blob": "https://sto8596-microsoftrouting.blob.core.windows.net/",
+              "dfs": "https://sto8596-microsoftrouting.dfs.core.windows.net/",
+              "file": "https://sto8596-microsoftrouting.file.core.windows.net/",
+              "queue": "https://sto8596-microsoftrouting.queue.core.windows.net/",
+              "table": "https://sto8596-microsoftrouting.table.core.windows.net/",
+              "web": "https://sto8596-microsoftrouting.web.core.windows.net/"
+            },
+            "queue": "https://sto8596.queue.core.windows.net/",
+            "table": "https://sto8596.table.core.windows.net/",
+            "web": "https://sto8596.web.core.windows.net/"
+          },
+          "primaryLocation": "eastus2(stage)",
+          "provisioningState": "Succeeded",
+          "routingPreference": {
+            "publishInternetEndpoints": true,
+            "publishMicrosoftEndpoints": true,
+            "routingChoice": "MicrosoftRouting"
+          },
+          "secondaryLocation": "northcentralus(stage)",
+          "statusOfPrimary": "available",
+          "statusOfSecondary": "available",
+          "supportsHttpsTrafficOnly": false
+        },
+        "sku": {
+          "name": "Standard_GRS",
+          "tier": "Standard"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "StorageAccounts_GetProperties",
+  "title": "StorageAccountGetPropertiesGeoReplicationStatscanFailoverTrue"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountHierarchicalNamespaceMigration.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountHierarchicalNamespaceMigration.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "accountName": "sto2434",
+    "api-version": "2026-09-01",
+    "requestType": "HnsOnValidationRequest",
+    "resourceGroupName": "res4228",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "https://endpoint:port/subscriptions/{subscription-id}/providers/Microsoft.Storage/locations/{location}/asyncoperations/{operationid}?monitor=true&api-version=2022-09-01"
+      }
+    }
+  },
+  "operationId": "StorageAccounts_HierarchicalNamespaceMigration",
+  "title": "StorageAccountHierarchicalNamespaceMigration"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountLeverageIPv6Ability.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountLeverageIPv6Ability.json
@@ -1,0 +1,87 @@
+{
+  "parameters": {
+    "accountName": "sto8596",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "parameters": {
+      "properties": {
+        "dualStackEndpointPreference": {
+          "publishIpv6Endpoint": true
+        },
+        "networkAcls": {
+          "defaultAction": "Deny",
+          "ipv6Rules": [
+            {
+              "action": "Allow",
+              "value": "2001:0db8:85a3::/64"
+            }
+          ]
+        }
+      }
+    },
+    "resourceGroupName": "res9407",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto8596",
+        "type": "Microsoft.Storage/storageAccounts",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res9407/providers/Microsoft.Storage/storageAccounts/sto8596",
+        "kind": "Storage",
+        "location": "eastus2(stage)",
+        "properties": {
+          "creationTime": "2017-06-01T02:42:41.7633306Z",
+          "dualStackEndpointPreference": {
+            "publishIpv6Endpoint": true
+          },
+          "keyCreationTime": {
+            "key1": "2021-03-18T04:42:22.4322836Z",
+            "key2": "2021-03-18T04:42:22.4322836Z"
+          },
+          "networkAcls": {
+            "bypass": "AzureServices",
+            "defaultAction": "Deny",
+            "ipRules": [],
+            "ipv6Rules": [
+              {
+                "action": "Allow",
+                "value": "2001:0db8:85a3::/64"
+              }
+            ],
+            "virtualNetworkRules": []
+          },
+          "primaryEndpoints": {
+            "blob": "https://sto8596.blob.core.windows.net/",
+            "dfs": "https://sto8596.dfs.core.windows.net/",
+            "file": "https://sto8596.file.core.windows.net/",
+            "ipv6Endpoints": {
+              "blob": "https://sto8596-ipv6.blob.core.windows.net/",
+              "dfs": "https://sto8596-ipv6.dfs.core.windows.net/",
+              "file": "https://sto8596-ipv6.file.core.windows.net/",
+              "queue": "https://sto8596-ipv6.queue.core.windows.net/",
+              "table": "https://sto8596-ipv6.table.core.windows.net/",
+              "web": "https://sto8596-ipv6.web.core.windows.net/"
+            },
+            "queue": "https://sto8596.queue.core.windows.net/",
+            "table": "https://sto8596.table.core.windows.net/",
+            "web": "https://sto8596.web.core.windows.net/"
+          },
+          "primaryLocation": "eastus2(stage)",
+          "provisioningState": "Succeeded",
+          "statusOfPrimary": "available"
+        },
+        "sku": {
+          "name": "Standard_LRS",
+          "tier": "Standard"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "StorageAccounts_Update",
+  "title": "StorageAccountUpdateEnableIpv6Features"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountList.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountList.json
@@ -1,0 +1,315 @@
+{
+  "parameters": {
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "sto1125",
+            "type": "Microsoft.Storage/storageAccounts",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/res2627/providers/Microsoft.Storage/storageAccounts/sto1125",
+            "kind": "Storage",
+            "location": "eastus",
+            "properties": {
+              "creationTime": "2017-05-24T13:28:53.4540398Z",
+              "encryption": {
+                "keySource": "Microsoft.Storage",
+                "services": {
+                  "blob": {
+                    "enabled": true,
+                    "keyType": "Account",
+                    "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+                  },
+                  "file": {
+                    "enabled": true,
+                    "keyType": "Account",
+                    "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+                  }
+                }
+              },
+              "isHnsEnabled": true,
+              "primaryEndpoints": {
+                "blob": "https://sto1125.blob.core.windows.net/",
+                "dfs": "https://sto1125.dfs.core.windows.net/",
+                "file": "https://sto1125.file.core.windows.net/",
+                "internetEndpoints": {
+                  "blob": "https://sto1125-internetrouting.blob.core.windows.net/",
+                  "dfs": "https://sto1125-internetrouting.dfs.core.windows.net/",
+                  "file": "https://sto1125-internetrouting.file.core.windows.net/",
+                  "web": "https://sto1125-internetrouting.web.core.windows.net/"
+                },
+                "microsoftEndpoints": {
+                  "blob": "https://sto1125-microsoftrouting.blob.core.windows.net/",
+                  "dfs": "https://sto1125-microsoftrouting.dfs.core.windows.net/",
+                  "file": "https://sto1125-microsoftrouting.file.core.windows.net/",
+                  "queue": "https://sto1125-microsoftrouting.queue.core.windows.net/",
+                  "table": "https://sto1125-microsoftrouting.table.core.windows.net/",
+                  "web": "https://sto1125-microsoftrouting.web.core.windows.net/"
+                },
+                "queue": "https://sto1125.queue.core.windows.net/",
+                "table": "https://sto1125.table.core.windows.net/",
+                "web": "https://sto1125.web.core.windows.net/"
+              },
+              "primaryLocation": "eastus",
+              "provisioningState": "Succeeded",
+              "routingPreference": {
+                "publishInternetEndpoints": true,
+                "publishMicrosoftEndpoints": true,
+                "routingChoice": "MicrosoftRouting"
+              },
+              "secondaryLocation": "centraluseuap",
+              "statusOfPrimary": "available",
+              "statusOfSecondary": "available",
+              "supportsHttpsTrafficOnly": false
+            },
+            "sku": {
+              "name": "Standard_GRS",
+              "tier": "Standard"
+            },
+            "tags": {
+              "key1": "value1",
+              "key2": "value2"
+            }
+          },
+          {
+            "name": "sto3699",
+            "type": "Microsoft.Storage/storageAccounts",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/testcmk3/providers/Microsoft.Storage/storageAccounts/sto3699",
+            "identity": {
+              "type": "SystemAssigned",
+              "principalId": "356d057d-cba5-44dd-8a30-b2e547bc416b",
+              "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+            },
+            "kind": "Storage",
+            "location": "eastus",
+            "properties": {
+              "creationTime": "2017-05-24T10:06:30.6093014Z",
+              "primaryEndpoints": {
+                "blob": "https://sto3699.blob.core.windows.net/",
+                "file": "https://sto3699.file.core.windows.net/",
+                "queue": "https://sto3699.queue.core.windows.net/",
+                "table": "https://sto3699.table.core.windows.net/"
+              },
+              "primaryLocation": "eastus",
+              "provisioningState": "Succeeded",
+              "secondaryLocation": "centraluseuap",
+              "statusOfPrimary": "available",
+              "statusOfSecondary": "available",
+              "supportsHttpsTrafficOnly": false
+            },
+            "sku": {
+              "name": "Standard_GRS",
+              "tier": "Standard"
+            },
+            "tags": {
+              "key1": "value1",
+              "key2": "value2"
+            }
+          },
+          {
+            "name": "sto8596",
+            "type": "Microsoft.Storage/storageAccounts",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/res9407/providers/Microsoft.Storage/storageAccounts/sto8596",
+            "identity": {
+              "type": "SystemAssigned",
+              "principalId": "911871cc-ffd1-4fc4-ac11-7a316433ea66",
+              "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+            },
+            "kind": "Storage",
+            "location": "eastus2(stage)",
+            "properties": {
+              "creationTime": "2017-06-01T02:42:41.7633306Z",
+              "encryption": {
+                "keySource": "Microsoft.Keyvault",
+                "keyvaultproperties": {
+                  "currentVersionedKeyIdentifier": "https://myvault8569.vault.azure.net/keys/wrappingKey/0682afdd9c104f4285df20107e956cad",
+                  "keyname": "wrappingKey",
+                  "keyvaulturi": "https://myvault8569.vault.azure.net",
+                  "keyversion": "",
+                  "lastKeyRotationTimestamp": "2019-12-13T20:36:23.7023290Z"
+                },
+                "services": {
+                  "blob": {
+                    "enabled": true,
+                    "keyType": "Account",
+                    "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+                  },
+                  "file": {
+                    "enabled": true,
+                    "keyType": "Account",
+                    "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+                  }
+                }
+              },
+              "geoReplicationStats": {
+                "canFailover": true,
+                "lastSyncTime": "2018-10-30T00:25:34Z",
+                "status": "Live"
+              },
+              "isHnsEnabled": true,
+              "networkAcls": {
+                "bypass": "AzureServices",
+                "defaultAction": "Allow",
+                "ipRules": [],
+                "resourceAccessRules": [
+                  {
+                    "resourceId": "/subscriptions/a7e99807-abbf-4642-bdec-2c809a96a8bc/resourceGroups/res9407/providers/Microsoft.Synapse/workspaces/testworkspace",
+                    "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+                  }
+                ],
+                "virtualNetworkRules": []
+              },
+              "primaryEndpoints": {
+                "blob": "https://sto8596.blob.core.windows.net/",
+                "dfs": "https://sto8596.dfs.core.windows.net/",
+                "file": "https://sto8596.file.core.windows.net/",
+                "internetEndpoints": {
+                  "blob": "https://sto8596-internetrouting.blob.core.windows.net/",
+                  "dfs": "https://sto8596-internetrouting.dfs.core.windows.net/",
+                  "file": "https://sto8596-internetrouting.file.core.windows.net/",
+                  "web": "https://sto8596-internetrouting.web.core.windows.net/"
+                },
+                "microsoftEndpoints": {
+                  "blob": "https://sto8596-microsoftrouting.blob.core.windows.net/",
+                  "dfs": "https://sto8596-microsoftrouting.dfs.core.windows.net/",
+                  "file": "https://sto8596-microsoftrouting.file.core.windows.net/",
+                  "queue": "https://sto8596-microsoftrouting.queue.core.windows.net/",
+                  "table": "https://sto8596-microsoftrouting.table.core.windows.net/",
+                  "web": "https://sto8596-microsoftrouting.web.core.windows.net/"
+                },
+                "queue": "https://sto8596.queue.core.windows.net/",
+                "table": "https://sto8596.table.core.windows.net/",
+                "web": "https://sto8596.web.core.windows.net/"
+              },
+              "primaryLocation": "eastus2(stage)",
+              "provisioningState": "Succeeded",
+              "routingPreference": {
+                "publishInternetEndpoints": true,
+                "publishMicrosoftEndpoints": true,
+                "routingChoice": "MicrosoftRouting"
+              },
+              "secondaryLocation": "northcentralus(stage)",
+              "statusOfPrimary": "available",
+              "statusOfSecondary": "available",
+              "supportsHttpsTrafficOnly": false
+            },
+            "sku": {
+              "name": "Standard_GRS",
+              "tier": "Standard"
+            },
+            "tags": {
+              "key1": "value1",
+              "key2": "value2"
+            }
+          },
+          {
+            "name": "sto6637",
+            "type": "Microsoft.Storage/storageAccounts",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/testcmk3/providers/Microsoft.Storage/storageAccounts/sto6637",
+            "identity": {
+              "type": "SystemAssigned",
+              "principalId": "911871cc-ffd1-4fc4-ac11-7a316433ea66",
+              "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+            },
+            "kind": "Storage",
+            "location": "eastus",
+            "properties": {
+              "creationTime": "2017-05-24T10:09:39.5625175Z",
+              "primaryEndpoints": {
+                "blob": "https://sto6637.blob.core.windows.net/",
+                "file": "https://sto6637.file.core.windows.net/",
+                "queue": "https://sto6637.queue.core.windows.net/",
+                "table": "https://sto6637.table.core.windows.net/"
+              },
+              "primaryLocation": "eastus",
+              "provisioningState": "Succeeded",
+              "secondaryLocation": "centraluseuap",
+              "statusOfPrimary": "available",
+              "statusOfSecondary": "available",
+              "supportsHttpsTrafficOnly": false
+            },
+            "sku": {
+              "name": "Standard_GRS",
+              "tier": "Standard"
+            },
+            "tags": {
+              "key1": "value1",
+              "key2": "value2"
+            }
+          },
+          {
+            "name": "sto834",
+            "type": "Microsoft.Storage/storageAccounts",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/res8186/providers/Microsoft.Storage/storageAccounts/sto834",
+            "kind": "Storage",
+            "location": "eastus",
+            "properties": {
+              "creationTime": "2017-05-24T13:28:20.8686541Z",
+              "primaryEndpoints": {
+                "blob": "https://sto834.blob.core.windows.net/",
+                "file": "https://sto834.file.core.windows.net/",
+                "queue": "https://sto834.queue.core.windows.net/",
+                "table": "https://sto834.table.core.windows.net/"
+              },
+              "primaryLocation": "eastus",
+              "provisioningState": "Succeeded",
+              "secondaryLocation": "centraluseuap",
+              "statusOfPrimary": "available",
+              "statusOfSecondary": "available",
+              "supportsHttpsTrafficOnly": false
+            },
+            "sku": {
+              "name": "Standard_GRS",
+              "tier": "Standard"
+            },
+            "tags": {
+              "key1": "value1",
+              "key2": "value2"
+            }
+          },
+          {
+            "name": "sto9174",
+            "type": "Microsoft.Storage/storageAccounts",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/testcmk3/providers/Microsoft.Storage/storageAccounts/sto9174",
+            "identity": {
+              "type": "SystemAssigned",
+              "principalId": "933e3ddf-1802-4a51-9469-18a33b576f88",
+              "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+            },
+            "kind": "Storage",
+            "location": "eastus",
+            "properties": {
+              "creationTime": "2017-05-24T09:46:19.6556989Z",
+              "primaryEndpoints": {
+                "blob": "https://sto9174.blob.core.windows.net/",
+                "file": "https://sto9174.file.core.windows.net/",
+                "queue": "https://sto9174.queue.core.windows.net/",
+                "table": "https://sto9174.table.core.windows.net/"
+              },
+              "primaryLocation": "eastus",
+              "provisioningState": "Succeeded",
+              "secondaryLocation": "centraluseuap",
+              "statusOfPrimary": "available",
+              "statusOfSecondary": "available",
+              "supportsHttpsTrafficOnly": false
+            },
+            "sku": {
+              "name": "Standard_GRS",
+              "tier": "Standard"
+            },
+            "tags": {
+              "key1": "value1",
+              "key2": "value2"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "StorageAccounts_List",
+  "title": "StorageAccountList"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountListAccountSAS.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountListAccountSAS.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "accountName": "sto8588",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "parameters": {
+      "keyToSign": "key1",
+      "signedExpiry": "2017-05-24T11:42:03.1567373Z",
+      "signedPermission": "r",
+      "signedProtocol": "https,http",
+      "signedResourceTypes": "s",
+      "signedServices": "b",
+      "signedStart": "2017-05-24T10:42:03.1567373Z"
+    },
+    "resourceGroupName": "res7985",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "accountSasToken": "sv=2015-04-05&ss=b&srt=s&sp=r&st=2017-05-24T10%3A42%3A03Z&se=2017-05-24T11%3A42%3A03Z&spr=https,http&sig=Z0I%2BEpM%2BPPlTC8ApfUf%2BcffO2aahMgZim3U0iArqsS0%3D"
+      }
+    }
+  },
+  "operationId": "StorageAccounts_ListAccountSAS",
+  "title": "StorageAccountListAccountSAS"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountListBlobInventoryPolicy.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountListBlobInventoryPolicy.json
@@ -1,0 +1,70 @@
+{
+  "parameters": {
+    "accountName": "sto9699",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res7687",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "DefaultInventoryPolicy",
+            "type": "Microsoft.Storage/storageAccounts/inventoryPolicies",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/res7687/providers/Microsoft.Storage/storageAccounts/sto9699/inventoryPolicies/default",
+            "properties": {
+              "lastModifiedTime": "2020-10-05T02:53:39.0932539Z",
+              "policy": {
+                "type": "Inventory",
+                "enabled": true,
+                "rules": [
+                  {
+                    "name": "inventoryPolicyRule1",
+                    "definition": {
+                      "format": "Csv",
+                      "filters": {
+                        "blobTypes": [
+                          "blockBlob",
+                          "appendBlob",
+                          "pageBlob"
+                        ],
+                        "includeBlobVersions": true,
+                        "includeSnapshots": true,
+                        "prefixMatch": [
+                          "inventoryprefix1",
+                          "inventoryprefix2"
+                        ]
+                      },
+                      "objectType": "Blob",
+                      "schedule": "Daily",
+                      "schemaFields": [
+                        "Name",
+                        "Creation-Time",
+                        "Last-Modified",
+                        "Content-Length",
+                        "Content-MD5",
+                        "BlobType",
+                        "AccessTier",
+                        "AccessTierChangeTime",
+                        "Snapshot",
+                        "VersionId",
+                        "IsCurrentVersion",
+                        "Metadata"
+                      ]
+                    },
+                    "destination": "container1",
+                    "enabled": true
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "BlobInventoryPolicies_List",
+  "title": "StorageAccountGetBlobInventoryPolicy"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountListByResourceGroup.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountListByResourceGroup.json
@@ -1,0 +1,80 @@
+{
+  "parameters": {
+    "api-version": "2026-09-01",
+    "resourceGroupName": "res6117",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "sto4036",
+            "type": "Microsoft.Storage/storageAccounts",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/res6117/providers/Microsoft.Storage/storageAccounts/sto4036",
+            "kind": "Storage",
+            "location": "eastus",
+            "properties": {
+              "creationTime": "2017-05-24T13:24:47.818801Z",
+              "isHnsEnabled": true,
+              "primaryEndpoints": {
+                "blob": "https://sto4036.blob.core.windows.net/",
+                "dfs": "https://sto4036.dfs.core.windows.net/",
+                "file": "https://sto4036.file.core.windows.net/",
+                "queue": "https://sto4036.queue.core.windows.net/",
+                "table": "https://sto4036.table.core.windows.net/",
+                "web": "https://sto4036.web.core.windows.net/"
+              },
+              "primaryLocation": "eastus",
+              "provisioningState": "Succeeded",
+              "secondaryLocation": "centraluseuap",
+              "statusOfPrimary": "available",
+              "statusOfSecondary": "available",
+              "supportsHttpsTrafficOnly": false
+            },
+            "sku": {
+              "name": "Standard_GRS",
+              "tier": "Standard"
+            },
+            "tags": {
+              "key1": "value1",
+              "key2": "value2"
+            }
+          },
+          {
+            "name": "sto4452",
+            "type": "Microsoft.Storage/storageAccounts",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/res6117/providers/Microsoft.Storage/storageAccounts/sto4452",
+            "kind": "Storage",
+            "location": "eastus",
+            "properties": {
+              "creationTime": "2017-05-24T13:24:15.7068366Z",
+              "primaryEndpoints": {
+                "blob": "https://sto4452.blob.core.windows.net/",
+                "file": "https://sto4452.file.core.windows.net/",
+                "queue": "https://sto4452.queue.core.windows.net/",
+                "table": "https://sto4452.table.core.windows.net/"
+              },
+              "primaryLocation": "eastus",
+              "provisioningState": "Succeeded",
+              "secondaryLocation": "centraluseuap",
+              "statusOfPrimary": "available",
+              "statusOfSecondary": "available",
+              "supportsHttpsTrafficOnly": false
+            },
+            "sku": {
+              "name": "Standard_GRS",
+              "tier": "Standard"
+            },
+            "tags": {
+              "key1": "value1",
+              "key2": "value2"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "StorageAccounts_ListByResourceGroup",
+  "title": "StorageAccountListByResourceGroup"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountListKeys.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountListKeys.json
@@ -1,0 +1,29 @@
+{
+  "parameters": {
+    "accountName": "sto2220",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res418",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "keys": [
+          {
+            "keyName": "key1",
+            "permissions": "Full",
+            "value": "<value>"
+          },
+          {
+            "keyName": "key2",
+            "permissions": "Full",
+            "value": "<value>"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "StorageAccounts_ListKeys",
+  "title": "StorageAccountListKeys"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountListLocationUsage.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountListLocationUsage.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "api-version": "2026-09-01",
+    "location": "eastus2(stage)",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": {
+              "localizedValue": "Storage Accounts",
+              "value": "StorageAccounts"
+            },
+            "currentValue": 55,
+            "limit": 250,
+            "unit": "Count"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Usages_ListByLocation",
+  "title": "UsageList"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountListObjectReplicationPolicies.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountListObjectReplicationPolicies.json
@@ -1,0 +1,46 @@
+{
+  "parameters": {
+    "accountName": "sto2527",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res6977",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "c6c23999-fd4e-433a-bcf9-1db69d27cd8a",
+            "type": "Microsoft.Storage/storageAccounts/objectReplicationPolicies",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/res6977/providers/Microsoft.Storage/storageAccounts/sto2527/objectReplicationPolicies/c6c23999-fd4e-433a-bcf9-1db69d27cd8a",
+            "properties": {
+              "destinationAccount": "destAccount1",
+              "sourceAccount": "sto2527"
+            }
+          },
+          {
+            "name": "141d23dc-8958-4b48-b6e6-5a40bf1af116",
+            "type": "Microsoft.Storage/storageAccounts/objectReplicationPolicies",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/res9290/providers/Microsoft.Storage/storageAccounts/sto1590/objectReplicationPolicies/141d23dc-8958-4b48-b6e6-5a40bf1af116",
+            "properties": {
+              "destinationAccount": "destAccount2",
+              "metrics": {
+                "enabled": true
+              },
+              "priorityReplication": {
+                "enabled": true
+              },
+              "sourceAccount": "sto2527",
+              "tagsReplication": {
+                "enabled": true
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ObjectReplicationPolicies_List",
+  "title": "StorageAccountListObjectReplicationPolicies"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountListPrivateEndpointConnections.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountListPrivateEndpointConnections.json
@@ -1,0 +1,51 @@
+{
+  "parameters": {
+    "accountName": "sto2527",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res6977",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "{privateEndpointConnectionName}",
+            "type": "Microsoft.Storage/storageAccounts/privateEndpointConnections",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/res7231/providers/Microsoft.Storage/storageAccounts/sto288/privateEndpointConnections/{privateEndpointConnectionName}",
+            "properties": {
+              "privateEndpoint": {
+                "id": "/subscriptions/{subscription-id}/resourceGroups/res7231/providers/Microsoft.Network/privateEndpoints/petest01"
+              },
+              "privateLinkServiceConnectionState": {
+                "description": "Auto-Approved",
+                "actionRequired": "None",
+                "status": "Approved"
+              },
+              "provisioningState": "Succeeded"
+            }
+          },
+          {
+            "name": "{privateEndpointConnectionName}",
+            "type": "Microsoft.Storage/storageAccounts/privateEndpointConnections",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/res7231/providers/Microsoft.Storage/storageAccounts/sto288/privateEndpointConnections/{privateEndpointConnectionName}",
+            "properties": {
+              "privateEndpoint": {
+                "id": "/subscriptions/{subscription-id}/resourceGroups/res7231/providers/Microsoft.Network/privateEndpoints/petest02"
+              },
+              "privateLinkServiceConnectionState": {
+                "description": "Auto-Approved",
+                "actionRequired": "None",
+                "status": "Approved"
+              },
+              "provisioningState": "Succeeded"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "PrivateEndpointConnections_List",
+  "title": "StorageAccountListPrivateEndpointConnections"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountListPrivateLinkResources.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountListPrivateLinkResources.json
@@ -1,0 +1,103 @@
+{
+  "parameters": {
+    "accountName": "sto2527",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res6977",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "blob",
+            "type": "Microsoft.Storage/storageAccounts/privateLinkResources",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/res6977/providers/Microsoft.Storage/storageAccounts/sto2527/privateLinkResources/blob",
+            "properties": {
+              "groupId": "blob",
+              "requiredMembers": [
+                "blob"
+              ],
+              "requiredZoneNames": [
+                "privatelink.blob.core.windows.net"
+              ]
+            }
+          },
+          {
+            "name": "blob_secondary",
+            "type": "Microsoft.Storage/storageAccounts/privateLinkResources",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/res6977/providers/Microsoft.Storage/storageAccounts/sto2527/privateLinkResources/blob_secondary",
+            "properties": {
+              "groupId": "blob_secondary",
+              "requiredMembers": [
+                "blob_secondary"
+              ],
+              "requiredZoneNames": [
+                "privatelink.blob.core.windows.net"
+              ]
+            }
+          },
+          {
+            "name": "table",
+            "type": "Microsoft.Storage/storageAccounts/privateLinkResources",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/res6977/providers/Microsoft.Storage/storageAccounts/sto2527/privateLinkResources/table",
+            "properties": {
+              "groupId": "table",
+              "requiredMembers": [
+                "table"
+              ],
+              "requiredZoneNames": [
+                "privatelink.table.core.windows.net"
+              ]
+            }
+          },
+          {
+            "name": "table_secondary",
+            "type": "Microsoft.Storage/storageAccounts/privateLinkResources",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/res6977/providers/Microsoft.Storage/storageAccounts/sto2527/privateLinkResources/table_secondary",
+            "properties": {
+              "groupId": "table_secondary",
+              "requiredMembers": [
+                "table_secondary"
+              ],
+              "requiredZoneNames": [
+                "privatelink.table.core.windows.net"
+              ]
+            }
+          },
+          {
+            "name": "dfs",
+            "type": "Microsoft.Storage/storageAccounts/privateLinkResources",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/res6977/providers/Microsoft.Storage/storageAccounts/sto2527/privateLinkResources/dfs",
+            "properties": {
+              "groupId": "dfs",
+              "requiredMembers": [
+                "dfs"
+              ],
+              "requiredZoneNames": [
+                "privatelink.dfs.core.windows.net"
+              ]
+            }
+          },
+          {
+            "name": "dfs_secondary",
+            "type": "Microsoft.Storage/storageAccounts/privateLinkResources",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/res6977/providers/Microsoft.Storage/storageAccounts/sto2527/privateLinkResources/dfs_secondary",
+            "properties": {
+              "groupId": "dfs_secondary",
+              "requiredMembers": [
+                "dfs_secondary"
+              ],
+              "requiredZoneNames": [
+                "privatelink.dfs.core.windows.net"
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "PrivateLinkResources_ListByStorageAccount",
+  "title": "StorageAccountListPrivateLinkResources"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountListServiceSAS.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountListServiceSAS.json
@@ -1,0 +1,24 @@
+{
+  "parameters": {
+    "accountName": "sto1299",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "parameters": {
+      "canonicalizedResource": "/blob/sto1299/music",
+      "signedExpiry": "2017-05-24T11:32:48.8457197Z",
+      "signedPermission": "l",
+      "signedResource": "c"
+    },
+    "resourceGroupName": "res7439",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "serviceSasToken": "sv=2015-04-05&sr=c&se=2017-05-24T11%3A32%3A48Z&sp=l&sig=PoF8yBUGixsjzwroLmw7vG3VbGz4KB2woZC2D4C2oio%3D"
+      }
+    }
+  },
+  "operationId": "StorageAccounts_ListServiceSAS",
+  "title": "StorageAccountListServiceSAS"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountPatchEncryptionScope.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountPatchEncryptionScope.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "accountName": "accountname",
+    "api-version": "2026-09-01",
+    "encryptionScope": {
+      "properties": {
+        "keyVaultProperties": {
+          "keyUri": "https://testvault.vault.core.windows.net/keys/key1/863425f1358359c"
+        },
+        "source": "Microsoft.KeyVault"
+      }
+    },
+    "encryptionScopeName": "{encryption-scope-name}",
+    "monitor": "true",
+    "resourceGroupName": "resource-group-name",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "{encryption-scope-name}",
+        "type": "Microsoft.Storage/storageAccounts/encryptionScopes",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/resource-group-name/providers/Microsoft.Storage/storageAccounts/accountname/encryptionScopes/{encryption-scope-name}",
+        "properties": {
+          "creationTime": "2018-10-16T02:42:41.7633306Z",
+          "keyVaultProperties": {
+            "currentVersionedKeyIdentifier": "https://testvault.vault.core.windows.net/keys/key1/863425f1358359c",
+            "keyUri": "https://testvault.vault.core.windows.net/keys/key1/863425f1358359c",
+            "lastKeyRotationTimestamp": "2019-12-13T20:36:23.7023290Z"
+          },
+          "lastModifiedTime": "2018-10-17T06:23:14.4513306Z",
+          "source": "Microsoft.KeyVault",
+          "state": "Enabled"
+        }
+      }
+    }
+  },
+  "operationId": "EncryptionScopes_Patch",
+  "title": "StorageAccountPatchEncryptionScope"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountPostMigration.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountPostMigration.json
@@ -1,0 +1,24 @@
+{
+  "parameters": {
+    "accountName": "accountname",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "parameters": {
+      "properties": {
+        "targetSkuName": "Standard_ZRS"
+      }
+    },
+    "resourceGroupName": "resource-group-name",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.Storage/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2022-09-01"
+      }
+    }
+  },
+  "operationId": "StorageAccounts_CustomerInitiatedMigration",
+  "title": "StorageAccountPostMigration"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountPutEncryptionScope.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountPutEncryptionScope.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "accountName": "accountname",
+    "api-version": "2026-09-01",
+    "encryptionScope": {},
+    "encryptionScopeName": "{encryption-scope-name}",
+    "monitor": "true",
+    "resourceGroupName": "resource-group-name",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "{encryption-scope-name}",
+        "type": "Microsoft.Storage/storageAccounts/encryptionScopes",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/resource-group-name/providers/Microsoft.Storage/storageAccounts/accountname/encryptionScopes/{encryption-scope-name}",
+        "properties": {
+          "creationTime": "2018-10-16T02:42:41.7633306Z",
+          "lastModifiedTime": "2018-10-16T02:42:41.7633306Z",
+          "source": "Microsoft.Storage",
+          "state": "Enabled"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "{encryption-scope-name}",
+        "type": "Microsoft.Storage/storageAccounts/encryptionScopes",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/resource-group-name/providers/Microsoft.Storage/storageAccounts/accountname/encryptionScopes/{encryption-scope-name}",
+        "properties": {
+          "creationTime": "2018-10-16T02:42:41.7633306Z",
+          "lastModifiedTime": "2018-10-16T02:42:41.7633306Z",
+          "source": "Microsoft.Storage",
+          "state": "Enabled"
+        }
+      }
+    }
+  },
+  "operationId": "EncryptionScopes_Put",
+  "title": "StorageAccountPutEncryptionScope"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountPutEncryptionScopeWithInfrastructureEncryption.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountPutEncryptionScopeWithInfrastructureEncryption.json
@@ -1,0 +1,47 @@
+{
+  "parameters": {
+    "accountName": "accountname",
+    "api-version": "2026-09-01",
+    "encryptionScope": {
+      "properties": {
+        "requireInfrastructureEncryption": true
+      }
+    },
+    "encryptionScopeName": "{encryption-scope-name}",
+    "monitor": "true",
+    "resourceGroupName": "resource-group-name",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "{encryption-scope-name}",
+        "type": "Microsoft.Storage/storageAccounts/encryptionScopes",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/resource-group-name/providers/Microsoft.Storage/storageAccounts/accountname/encryptionScopes/{encryption-scope-name}",
+        "properties": {
+          "creationTime": "2018-10-16T02:42:41.7633306Z",
+          "lastModifiedTime": "2018-10-16T02:42:41.7633306Z",
+          "requireInfrastructureEncryption": true,
+          "source": "Microsoft.Storage",
+          "state": "Enabled"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "{encryption-scope-name}",
+        "type": "Microsoft.Storage/storageAccounts/encryptionScopes",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/resource-group-name/providers/Microsoft.Storage/storageAccounts/accountname/encryptionScopes/{encryption-scope-name}",
+        "properties": {
+          "creationTime": "2018-10-16T02:42:41.7633306Z",
+          "lastModifiedTime": "2018-10-16T02:42:41.7633306Z",
+          "requireInfrastructureEncryption": true,
+          "source": "Microsoft.Storage",
+          "state": "Enabled"
+        }
+      }
+    }
+  },
+  "operationId": "EncryptionScopes_Put",
+  "title": "StorageAccountPutEncryptionScopeWithInfrastructureEncryption"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountPutPrivateEndpointConnection.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountPutPrivateEndpointConnection.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "accountName": "sto9699",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "privateEndpointConnectionName": "{privateEndpointConnectionName}",
+    "properties": {
+      "properties": {
+        "privateLinkServiceConnectionState": {
+          "description": "Auto-Approved",
+          "status": "Approved"
+        }
+      }
+    },
+    "resourceGroupName": "res7687",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "{privateEndpointConnectionName}",
+        "type": "Microsoft.Storage/storageAccounts/privateEndpointConnections",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res7231/providers/Microsoft.Storage/storageAccounts/sto288/privateEndpointConnections/{privateEndpointConnectionName}",
+        "properties": {
+          "privateEndpoint": {
+            "id": "/subscriptions/{subscription-id}/resourceGroups/res7231/providers/Microsoft.Network/privateEndpoints/petest01"
+          },
+          "privateLinkServiceConnectionState": {
+            "description": "Auto-Approved",
+            "actionRequired": "None",
+            "status": "Approved"
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "PrivateEndpointConnections_Put",
+  "title": "StorageAccountPutPrivateEndpointConnection"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountRegenerateKerbKey.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountRegenerateKerbKey.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "accountName": "sto3539",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "regenerateKey": {
+      "keyName": "kerb1"
+    },
+    "resourceGroupName": "res4167",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "keys": [
+          {
+            "keyName": "key1",
+            "permissions": "Full",
+            "value": "<value>"
+          },
+          {
+            "keyName": "key2",
+            "permissions": "Full",
+            "value": "<value>"
+          },
+          {
+            "keyName": "kerb1",
+            "permissions": "Full",
+            "value": "<value>"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "StorageAccounts_RegenerateKey",
+  "title": "StorageAccountRegenerateKerbKey"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountRegenerateKey.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountRegenerateKey.json
@@ -1,0 +1,32 @@
+{
+  "parameters": {
+    "accountName": "sto3539",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "regenerateKey": {
+      "keyName": "key2"
+    },
+    "resourceGroupName": "res4167",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "keys": [
+          {
+            "keyName": "key1",
+            "permissions": "Full",
+            "value": "<value>"
+          },
+          {
+            "keyName": "key2",
+            "permissions": "Full",
+            "value": "<value>"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "StorageAccounts_RegenerateKey",
+  "title": "StorageAccountRegenerateKey"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountRevokeUserDelegationKeys.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountRevokeUserDelegationKeys.json
@@ -1,0 +1,13 @@
+{
+  "parameters": {
+    "accountName": "sto3539",
+    "api-version": "2026-09-01",
+    "resourceGroupName": "res4167",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {}
+  },
+  "operationId": "StorageAccounts_RevokeUserDelegationKeys",
+  "title": "StorageAccountRevokeUserDelegationKeys"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountSetBlobInventoryPolicy.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountSetBlobInventoryPolicy.json
@@ -1,0 +1,162 @@
+{
+  "parameters": {
+    "accountName": "sto9699",
+    "api-version": "2026-09-01",
+    "blobInventoryPolicyName": "default",
+    "monitor": "true",
+    "properties": {
+      "properties": {
+        "policy": {
+          "type": "Inventory",
+          "enabled": true,
+          "rules": [
+            {
+              "name": "inventoryPolicyRule1",
+              "definition": {
+                "format": "Csv",
+                "filters": {
+                  "blobTypes": [
+                    "blockBlob",
+                    "appendBlob",
+                    "pageBlob"
+                  ],
+                  "creationTime": {
+                    "lastNDays": 1000
+                  },
+                  "includeBlobVersions": true,
+                  "includeSnapshots": true,
+                  "prefixMatch": [
+                    "inventoryprefix1",
+                    "inventoryprefix2"
+                  ]
+                },
+                "objectType": "Blob",
+                "schedule": "Daily",
+                "schemaFields": [
+                  "Name",
+                  "Creation-Time",
+                  "Last-Modified",
+                  "Content-Length",
+                  "Content-MD5",
+                  "BlobType",
+                  "AccessTier",
+                  "AccessTierChangeTime",
+                  "Snapshot",
+                  "VersionId",
+                  "IsCurrentVersion",
+                  "Metadata"
+                ]
+              },
+              "destination": "container1",
+              "enabled": true
+            },
+            {
+              "name": "inventoryPolicyRule2",
+              "definition": {
+                "format": "Parquet",
+                "objectType": "Container",
+                "schedule": "Weekly",
+                "schemaFields": [
+                  "Name",
+                  "Last-Modified",
+                  "Metadata",
+                  "LeaseStatus",
+                  "LeaseState",
+                  "LeaseDuration",
+                  "PublicAccess",
+                  "HasImmutabilityPolicy",
+                  "HasLegalHold"
+                ]
+              },
+              "destination": "container2",
+              "enabled": true
+            }
+          ]
+        }
+      }
+    },
+    "resourceGroupName": "res7687",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "DefaultInventoryPolicy",
+        "type": "Microsoft.Storage/storageAccounts/inventoryPolicies",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res7687/providers/Microsoft.Storage/storageAccounts/sto9699/inventoryPolicies/default",
+        "properties": {
+          "lastModifiedTime": "2020-10-05T02:53:39.0932539Z",
+          "policy": {
+            "type": "Inventory",
+            "enabled": true,
+            "rules": [
+              {
+                "name": "inventoryPolicyRule1",
+                "definition": {
+                  "format": "Csv",
+                  "filters": {
+                    "blobTypes": [
+                      "blockBlob",
+                      "appendBlob",
+                      "pageBlob"
+                    ],
+                    "creationTime": {
+                      "lastNDays": 1000
+                    },
+                    "includeBlobVersions": true,
+                    "includeSnapshots": true,
+                    "prefixMatch": [
+                      "inventoryprefix1",
+                      "inventoryprefix2"
+                    ]
+                  },
+                  "objectType": "Blob",
+                  "schedule": "Daily",
+                  "schemaFields": [
+                    "Name",
+                    "Creation-Time",
+                    "Last-Modified",
+                    "Content-Length",
+                    "Content-MD5",
+                    "BlobType",
+                    "AccessTier",
+                    "AccessTierChangeTime",
+                    "Snapshot",
+                    "VersionId",
+                    "IsCurrentVersion",
+                    "Metadata"
+                  ]
+                },
+                "destination": "container1",
+                "enabled": true
+              },
+              {
+                "name": "inventoryPolicyRule2",
+                "definition": {
+                  "format": "Parquet",
+                  "objectType": "Container",
+                  "schedule": "Weekly",
+                  "schemaFields": [
+                    "Name",
+                    "Last-Modified",
+                    "Metadata",
+                    "LeaseStatus",
+                    "LeaseState",
+                    "LeaseDuration",
+                    "PublicAccess",
+                    "HasImmutabilityPolicy",
+                    "HasLegalHold"
+                  ]
+                },
+                "destination": "container2",
+                "enabled": true
+              }
+            ]
+          }
+        }
+      }
+    }
+  },
+  "operationId": "BlobInventoryPolicies_CreateOrUpdate",
+  "title": "StorageAccountSetBlobInventoryPolicy"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountSetBlobInventoryPolicyIncludeDeleteAndNewSchemaForHnsAccount.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountSetBlobInventoryPolicyIncludeDeleteAndNewSchemaForHnsAccount.json
@@ -1,0 +1,199 @@
+{
+  "parameters": {
+    "accountName": "sto9699",
+    "api-version": "2026-09-01",
+    "blobInventoryPolicyName": "default",
+    "monitor": "true",
+    "properties": {
+      "properties": {
+        "policy": {
+          "type": "Inventory",
+          "enabled": true,
+          "rules": [
+            {
+              "name": "inventoryPolicyRule1",
+              "definition": {
+                "format": "Csv",
+                "filters": {
+                  "blobTypes": [
+                    "blockBlob",
+                    "appendBlob",
+                    "pageBlob"
+                  ],
+                  "excludePrefix": [
+                    "excludeprefix1",
+                    "excludeprefix2"
+                  ],
+                  "includeBlobVersions": true,
+                  "includeDeleted": true,
+                  "includeSnapshots": true,
+                  "prefixMatch": [
+                    "inventoryprefix1",
+                    "inventoryprefix2"
+                  ]
+                },
+                "objectType": "Blob",
+                "schedule": "Daily",
+                "schemaFields": [
+                  "Name",
+                  "Creation-Time",
+                  "Last-Modified",
+                  "Content-Length",
+                  "Content-MD5",
+                  "BlobType",
+                  "AccessTier",
+                  "AccessTierChangeTime",
+                  "Snapshot",
+                  "VersionId",
+                  "IsCurrentVersion",
+                  "ContentType",
+                  "ContentEncoding",
+                  "ContentLanguage",
+                  "ContentCRC64",
+                  "CacheControl",
+                  "Metadata",
+                  "DeletionId",
+                  "Deleted",
+                  "DeletedTime",
+                  "RemainingRetentionDays"
+                ]
+              },
+              "destination": "container1",
+              "enabled": true
+            },
+            {
+              "name": "inventoryPolicyRule2",
+              "definition": {
+                "format": "Parquet",
+                "objectType": "Container",
+                "schedule": "Weekly",
+                "schemaFields": [
+                  "Name",
+                  "Last-Modified",
+                  "Metadata",
+                  "LeaseStatus",
+                  "LeaseState",
+                  "LeaseDuration",
+                  "PublicAccess",
+                  "HasImmutabilityPolicy",
+                  "HasLegalHold",
+                  "Etag",
+                  "DefaultEncryptionScope",
+                  "DenyEncryptionScopeOverride",
+                  "ImmutableStorageWithVersioningEnabled",
+                  "Deleted",
+                  "Version",
+                  "DeletedTime",
+                  "RemainingRetentionDays"
+                ]
+              },
+              "destination": "container2",
+              "enabled": true
+            }
+          ]
+        }
+      }
+    },
+    "resourceGroupName": "res7687",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "DefaultInventoryPolicy",
+        "type": "Microsoft.Storage/storageAccounts/inventoryPolicies",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res7687/providers/Microsoft.Storage/storageAccounts/sto9699/inventoryPolicies/default",
+        "properties": {
+          "policy": {
+            "type": "Inventory",
+            "enabled": true,
+            "rules": [
+              {
+                "name": "inventoryPolicyRule1",
+                "definition": {
+                  "format": "Csv",
+                  "filters": {
+                    "blobTypes": [
+                      "blockBlob",
+                      "appendBlob",
+                      "pageBlob"
+                    ],
+                    "excludePrefix": [
+                      "excludeprefix1",
+                      "excludeprefix2"
+                    ],
+                    "includeBlobVersions": true,
+                    "includeDeleted": true,
+                    "includeSnapshots": true,
+                    "prefixMatch": [
+                      "inventoryprefix1",
+                      "inventoryprefix2"
+                    ]
+                  },
+                  "objectType": "Blob",
+                  "schedule": "Daily",
+                  "schemaFields": [
+                    "Name",
+                    "Creation-Time",
+                    "Last-Modified",
+                    "Content-Length",
+                    "Content-MD5",
+                    "BlobType",
+                    "AccessTier",
+                    "AccessTierChangeTime",
+                    "Snapshot",
+                    "VersionId",
+                    "IsCurrentVersion",
+                    "ContentType",
+                    "ContentEncoding",
+                    "ContentLanguage",
+                    "ContentCRC64",
+                    "CacheControl",
+                    "Metadata",
+                    "DeletionId",
+                    "Deleted",
+                    "DeletedTime",
+                    "RemainingRetentionDays"
+                  ]
+                },
+                "destination": "container1",
+                "enabled": true
+              },
+              {
+                "name": "inventoryPolicyRule2",
+                "definition": {
+                  "format": "Parquet",
+                  "objectType": "Container",
+                  "schedule": "Weekly",
+                  "schemaFields": [
+                    "Name",
+                    "Last-Modified",
+                    "Metadata",
+                    "LeaseStatus",
+                    "LeaseState",
+                    "LeaseDuration",
+                    "PublicAccess",
+                    "HasImmutabilityPolicy",
+                    "HasLegalHold",
+                    "Etag",
+                    "DefaultEncryptionScope",
+                    "DenyEncryptionScopeOverride",
+                    "ImmutableStorageWithVersioningEnabled",
+                    "Deleted",
+                    "Version",
+                    "DeletedTime",
+                    "RemainingRetentionDays"
+                  ]
+                },
+                "destination": "container2",
+                "enabled": true
+              }
+            ]
+          }
+        }
+      }
+    }
+  },
+  "operationId": "BlobInventoryPolicies_CreateOrUpdate",
+  "title": "StorageAccountSetBlobInventoryPolicyIncludeDeleteAndNewSchemaForHnsAccount"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountSetBlobInventoryPolicyIncludeDeleteAndNewSchemaForNonHnsAccount.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountSetBlobInventoryPolicyIncludeDeleteAndNewSchemaForNonHnsAccount.json
@@ -1,0 +1,197 @@
+{
+  "parameters": {
+    "accountName": "sto9699",
+    "api-version": "2026-09-01",
+    "blobInventoryPolicyName": "default",
+    "monitor": "true",
+    "properties": {
+      "properties": {
+        "policy": {
+          "type": "Inventory",
+          "enabled": true,
+          "rules": [
+            {
+              "name": "inventoryPolicyRule1",
+              "definition": {
+                "format": "Csv",
+                "filters": {
+                  "blobTypes": [
+                    "blockBlob",
+                    "appendBlob",
+                    "pageBlob"
+                  ],
+                  "excludePrefix": [
+                    "excludeprefix1",
+                    "excludeprefix2"
+                  ],
+                  "includeBlobVersions": true,
+                  "includeDeleted": true,
+                  "includeSnapshots": true,
+                  "prefixMatch": [
+                    "inventoryprefix1",
+                    "inventoryprefix2"
+                  ]
+                },
+                "objectType": "Blob",
+                "schedule": "Daily",
+                "schemaFields": [
+                  "Name",
+                  "Creation-Time",
+                  "Last-Modified",
+                  "Content-Length",
+                  "Content-MD5",
+                  "BlobType",
+                  "AccessTier",
+                  "AccessTierChangeTime",
+                  "Snapshot",
+                  "VersionId",
+                  "IsCurrentVersion",
+                  "Tags",
+                  "ContentType",
+                  "ContentEncoding",
+                  "ContentLanguage",
+                  "ContentCRC64",
+                  "CacheControl",
+                  "Metadata",
+                  "Deleted",
+                  "RemainingRetentionDays"
+                ]
+              },
+              "destination": "container1",
+              "enabled": true
+            },
+            {
+              "name": "inventoryPolicyRule2",
+              "definition": {
+                "format": "Parquet",
+                "objectType": "Container",
+                "schedule": "Weekly",
+                "schemaFields": [
+                  "Name",
+                  "Last-Modified",
+                  "Metadata",
+                  "LeaseStatus",
+                  "LeaseState",
+                  "LeaseDuration",
+                  "PublicAccess",
+                  "HasImmutabilityPolicy",
+                  "HasLegalHold",
+                  "Etag",
+                  "DefaultEncryptionScope",
+                  "DenyEncryptionScopeOverride",
+                  "ImmutableStorageWithVersioningEnabled",
+                  "Deleted",
+                  "Version",
+                  "DeletedTime",
+                  "RemainingRetentionDays"
+                ]
+              },
+              "destination": "container2",
+              "enabled": true
+            }
+          ]
+        }
+      }
+    },
+    "resourceGroupName": "res7687",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "DefaultInventoryPolicy",
+        "type": "Microsoft.Storage/storageAccounts/inventoryPolicies",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res7687/providers/Microsoft.Storage/storageAccounts/sto9699/inventoryPolicies/default",
+        "properties": {
+          "policy": {
+            "type": "Inventory",
+            "enabled": true,
+            "rules": [
+              {
+                "name": "inventoryPolicyRule1",
+                "definition": {
+                  "format": "Csv",
+                  "filters": {
+                    "blobTypes": [
+                      "blockBlob",
+                      "appendBlob",
+                      "pageBlob"
+                    ],
+                    "excludePrefix": [
+                      "excludeprefix1",
+                      "excludeprefix2"
+                    ],
+                    "includeBlobVersions": true,
+                    "includeDeleted": true,
+                    "includeSnapshots": true,
+                    "prefixMatch": [
+                      "inventoryprefix1",
+                      "inventoryprefix2"
+                    ]
+                  },
+                  "objectType": "Blob",
+                  "schedule": "Daily",
+                  "schemaFields": [
+                    "Name",
+                    "Creation-Time",
+                    "Last-Modified",
+                    "Content-Length",
+                    "Content-MD5",
+                    "BlobType",
+                    "AccessTier",
+                    "AccessTierChangeTime",
+                    "Snapshot",
+                    "VersionId",
+                    "IsCurrentVersion",
+                    "Tags",
+                    "ContentType",
+                    "ContentEncoding",
+                    "ContentLanguage",
+                    "ContentCRC64",
+                    "CacheControl",
+                    "Metadata",
+                    "Deleted",
+                    "RemainingRetentionDays"
+                  ]
+                },
+                "destination": "container1",
+                "enabled": true
+              },
+              {
+                "name": "inventoryPolicyRule2",
+                "definition": {
+                  "format": "Parquet",
+                  "objectType": "Container",
+                  "schedule": "Weekly",
+                  "schemaFields": [
+                    "Name",
+                    "Last-Modified",
+                    "Metadata",
+                    "LeaseStatus",
+                    "LeaseState",
+                    "LeaseDuration",
+                    "PublicAccess",
+                    "HasImmutabilityPolicy",
+                    "HasLegalHold",
+                    "Etag",
+                    "DefaultEncryptionScope",
+                    "DenyEncryptionScopeOverride",
+                    "ImmutableStorageWithVersioningEnabled",
+                    "Deleted",
+                    "Version",
+                    "DeletedTime",
+                    "RemainingRetentionDays"
+                  ]
+                },
+                "destination": "container2",
+                "enabled": true
+              }
+            ]
+          }
+        }
+      }
+    }
+  },
+  "operationId": "BlobInventoryPolicies_CreateOrUpdate",
+  "title": "StorageAccountSetBlobInventoryPolicyIncludeDeleteAndNewSchemaForNonHnsAccount"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountSetManagementPolicy.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountSetManagementPolicy.json
@@ -1,0 +1,182 @@
+{
+  "parameters": {
+    "accountName": "sto9699",
+    "api-version": "2026-09-01",
+    "managementPolicyName": "default",
+    "monitor": "true",
+    "properties": {
+      "properties": {
+        "policy": {
+          "rules": [
+            {
+              "name": "olcmtest1",
+              "type": "Lifecycle",
+              "definition": {
+                "actions": {
+                  "baseBlob": {
+                    "delete": {
+                      "daysAfterModificationGreaterThan": 1000
+                    },
+                    "tierToArchive": {
+                      "daysAfterModificationGreaterThan": 90
+                    },
+                    "tierToCool": {
+                      "daysAfterModificationGreaterThan": 30
+                    }
+                  },
+                  "snapshot": {
+                    "delete": {
+                      "daysAfterCreationGreaterThan": 30
+                    }
+                  }
+                },
+                "filters": {
+                  "blobTypes": [
+                    "blockBlob"
+                  ],
+                  "prefixMatch": [
+                    "olcmtestcontainer1"
+                  ]
+                }
+              },
+              "enabled": true
+            },
+            {
+              "name": "olcmtest2",
+              "type": "Lifecycle",
+              "definition": {
+                "actions": {
+                  "baseBlob": {
+                    "delete": {
+                      "daysAfterModificationGreaterThan": 1000
+                    },
+                    "tierToArchive": {
+                      "daysAfterModificationGreaterThan": 90
+                    },
+                    "tierToCool": {
+                      "daysAfterModificationGreaterThan": 30
+                    }
+                  }
+                },
+                "filters": {
+                  "blobIndexMatch": [
+                    {
+                      "name": "tag1",
+                      "op": "==",
+                      "value": "val1"
+                    },
+                    {
+                      "name": "tag2",
+                      "op": "==",
+                      "value": "val2"
+                    }
+                  ],
+                  "blobTypes": [
+                    "blockBlob"
+                  ],
+                  "prefixMatch": [
+                    "olcmtestcontainer2"
+                  ]
+                }
+              },
+              "enabled": true
+            }
+          ]
+        }
+      }
+    },
+    "resourceGroupName": "res7687",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "DefaultManagementPolicy",
+        "type": "Microsoft.Storage/storageAccounts/managementPolicies",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res7231/providers/Microsoft.Storage/storageAccounts/sto288/managementPolicies/default",
+        "properties": {
+          "lastModifiedTime": "2018-06-08T02:53:39.0932539Z",
+          "policy": {
+            "rules": [
+              {
+                "name": "olcmtest1",
+                "type": "Lifecycle",
+                "definition": {
+                  "actions": {
+                    "baseBlob": {
+                      "delete": {
+                        "daysAfterModificationGreaterThan": 1000
+                      },
+                      "tierToArchive": {
+                        "daysAfterModificationGreaterThan": 90
+                      },
+                      "tierToCool": {
+                        "daysAfterModificationGreaterThan": 30
+                      }
+                    },
+                    "snapshot": {
+                      "delete": {
+                        "daysAfterCreationGreaterThan": 30
+                      }
+                    }
+                  },
+                  "filters": {
+                    "blobTypes": [
+                      "blockBlob"
+                    ],
+                    "prefixMatch": [
+                      "olcmtestcontainer1"
+                    ]
+                  }
+                },
+                "enabled": true
+              },
+              {
+                "name": "olcmtest2",
+                "type": "Lifecycle",
+                "definition": {
+                  "actions": {
+                    "baseBlob": {
+                      "delete": {
+                        "daysAfterModificationGreaterThan": 1000
+                      },
+                      "tierToArchive": {
+                        "daysAfterModificationGreaterThan": 90
+                      },
+                      "tierToCool": {
+                        "daysAfterModificationGreaterThan": 30
+                      }
+                    }
+                  },
+                  "filters": {
+                    "blobIndexMatch": [
+                      {
+                        "name": "tag1",
+                        "op": "==",
+                        "value": "val1"
+                      },
+                      {
+                        "name": "tag2",
+                        "op": "==",
+                        "value": "val2"
+                      }
+                    ],
+                    "blobTypes": [
+                      "blockBlob"
+                    ],
+                    "prefixMatch": [
+                      "olcmtestcontainer2"
+                    ]
+                  }
+                },
+                "enabled": true
+              }
+            ]
+          }
+        }
+      }
+    }
+  },
+  "operationId": "ManagementPolicies_CreateOrUpdate",
+  "title": "StorageAccountSetManagementPolicies"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountSetManagementPolicyColdTierActions.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountSetManagementPolicyColdTierActions.json
@@ -1,0 +1,130 @@
+{
+  "parameters": {
+    "accountName": "sto9699",
+    "api-version": "2026-09-01",
+    "managementPolicyName": "default",
+    "monitor": "true",
+    "properties": {
+      "properties": {
+        "policy": {
+          "rules": [
+            {
+              "name": "olcmtest1",
+              "type": "Lifecycle",
+              "definition": {
+                "actions": {
+                  "baseBlob": {
+                    "delete": {
+                      "daysAfterModificationGreaterThan": 1000
+                    },
+                    "tierToArchive": {
+                      "daysAfterModificationGreaterThan": 90
+                    },
+                    "tierToCold": {
+                      "daysAfterModificationGreaterThan": 30
+                    },
+                    "tierToCool": {
+                      "daysAfterModificationGreaterThan": 30
+                    }
+                  },
+                  "snapshot": {
+                    "delete": {
+                      "daysAfterCreationGreaterThan": 30
+                    },
+                    "tierToCold": {
+                      "daysAfterCreationGreaterThan": 30
+                    }
+                  },
+                  "version": {
+                    "delete": {
+                      "daysAfterCreationGreaterThan": 30
+                    },
+                    "tierToCold": {
+                      "daysAfterCreationGreaterThan": 30
+                    }
+                  }
+                },
+                "filters": {
+                  "blobTypes": [
+                    "blockBlob"
+                  ],
+                  "prefixMatch": [
+                    "olcmtestcontainer1"
+                  ]
+                }
+              },
+              "enabled": true
+            }
+          ]
+        }
+      }
+    },
+    "resourceGroupName": "res7687",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "DefaultManagementPolicy",
+        "type": "Microsoft.Storage/storageAccounts/managementPolicies",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res7231/providers/Microsoft.Storage/storageAccounts/sto288/managementPolicies/default",
+        "properties": {
+          "lastModifiedTime": "2021-06-08T02:53:39.0932539Z",
+          "policy": {
+            "rules": [
+              {
+                "name": "olcmtest1",
+                "type": "Lifecycle",
+                "definition": {
+                  "actions": {
+                    "baseBlob": {
+                      "delete": {
+                        "daysAfterModificationGreaterThan": 1000
+                      },
+                      "tierToArchive": {
+                        "daysAfterModificationGreaterThan": 90
+                      },
+                      "tierToCold": {
+                        "daysAfterModificationGreaterThan": 30
+                      },
+                      "tierToCool": {
+                        "daysAfterModificationGreaterThan": 30
+                      }
+                    },
+                    "snapshot": {
+                      "delete": {
+                        "daysAfterCreationGreaterThan": 30
+                      },
+                      "tierToCold": {
+                        "daysAfterCreationGreaterThan": 30
+                      }
+                    },
+                    "version": {
+                      "delete": {
+                        "daysAfterCreationGreaterThan": 30
+                      },
+                      "tierToCold": {
+                        "daysAfterCreationGreaterThan": 30
+                      }
+                    }
+                  },
+                  "filters": {
+                    "blobTypes": [
+                      "blockBlob"
+                    ],
+                    "prefixMatch": [
+                      "olcmtestcontainer1"
+                    ]
+                  }
+                },
+                "enabled": true
+              }
+            ]
+          }
+        }
+      }
+    }
+  },
+  "operationId": "ManagementPolicies_CreateOrUpdate",
+  "title": "StorageAccountSetManagementPolicyColdTierActions"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountSetManagementPolicyForBlockAndAppendBlobs.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountSetManagementPolicyForBlockAndAppendBlobs.json
@@ -1,0 +1,102 @@
+{
+  "parameters": {
+    "accountName": "sto9699",
+    "api-version": "2026-09-01",
+    "managementPolicyName": "default",
+    "monitor": "true",
+    "properties": {
+      "properties": {
+        "policy": {
+          "rules": [
+            {
+              "name": "olcmtest1",
+              "type": "Lifecycle",
+              "definition": {
+                "actions": {
+                  "baseBlob": {
+                    "delete": {
+                      "daysAfterModificationGreaterThan": 90
+                    }
+                  },
+                  "snapshot": {
+                    "delete": {
+                      "daysAfterCreationGreaterThan": 90
+                    }
+                  },
+                  "version": {
+                    "delete": {
+                      "daysAfterCreationGreaterThan": 90
+                    }
+                  }
+                },
+                "filters": {
+                  "blobTypes": [
+                    "blockBlob",
+                    "appendBlob"
+                  ],
+                  "prefixMatch": [
+                    "olcmtestcontainer1"
+                  ]
+                }
+              },
+              "enabled": true
+            }
+          ]
+        }
+      }
+    },
+    "resourceGroupName": "res7687",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "DefaultManagementPolicy",
+        "type": "Microsoft.Storage/storageAccounts/managementPolicies",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res7231/providers/Microsoft.Storage/storageAccounts/sto288/managementPolicies/default",
+        "properties": {
+          "lastModifiedTime": "2018-06-08T02:53:39.0932539Z",
+          "policy": {
+            "rules": [
+              {
+                "name": "olcmtest1",
+                "type": "Lifecycle",
+                "definition": {
+                  "actions": {
+                    "baseBlob": {
+                      "delete": {
+                        "daysAfterModificationGreaterThan": 90
+                      }
+                    },
+                    "snapshot": {
+                      "delete": {
+                        "daysAfterCreationGreaterThan": 90
+                      }
+                    },
+                    "version": {
+                      "delete": {
+                        "daysAfterCreationGreaterThan": 90
+                      }
+                    }
+                  },
+                  "filters": {
+                    "blobTypes": [
+                      "blockBlob",
+                      "appendBlob"
+                    ],
+                    "prefixMatch": [
+                      "olcmtestcontainer1"
+                    ]
+                  }
+                },
+                "enabled": true
+              }
+            ]
+          }
+        }
+      }
+    }
+  },
+  "operationId": "ManagementPolicies_CreateOrUpdate",
+  "title": "StorageAccountSetManagementPolicyForBlockAndAppendBlobs"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountSetManagementPolicyHotTierActions.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountSetManagementPolicyHotTierActions.json
@@ -1,0 +1,100 @@
+{
+  "parameters": {
+    "accountName": "sto9699",
+    "api-version": "2026-09-01",
+    "managementPolicyName": "default",
+    "monitor": "true",
+    "properties": {
+      "properties": {
+        "policy": {
+          "rules": [
+            {
+              "name": "olcmtest1",
+              "type": "Lifecycle",
+              "definition": {
+                "actions": {
+                  "baseBlob": {
+                    "tierToHot": {
+                      "daysAfterModificationGreaterThan": 30
+                    }
+                  },
+                  "snapshot": {
+                    "tierToHot": {
+                      "daysAfterCreationGreaterThan": 30
+                    }
+                  },
+                  "version": {
+                    "tierToHot": {
+                      "daysAfterCreationGreaterThan": 30
+                    }
+                  }
+                },
+                "filters": {
+                  "blobTypes": [
+                    "blockBlob"
+                  ],
+                  "prefixMatch": [
+                    "olcmtestcontainer1"
+                  ]
+                }
+              },
+              "enabled": true
+            }
+          ]
+        }
+      }
+    },
+    "resourceGroupName": "res7687",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "DefaultManagementPolicy",
+        "type": "Microsoft.Storage/storageAccounts/managementPolicies",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res7231/providers/Microsoft.Storage/storageAccounts/sto288/managementPolicies/default",
+        "properties": {
+          "lastModifiedTime": "2021-06-08T02:53:39.0932539Z",
+          "policy": {
+            "rules": [
+              {
+                "name": "olcmtest1",
+                "type": "Lifecycle",
+                "definition": {
+                  "actions": {
+                    "baseBlob": {
+                      "tierToHot": {
+                        "daysAfterModificationGreaterThan": 30
+                      }
+                    },
+                    "snapshot": {
+                      "tierToHot": {
+                        "daysAfterCreationGreaterThan": 30
+                      }
+                    },
+                    "version": {
+                      "tierToHot": {
+                        "daysAfterCreationGreaterThan": 30
+                      }
+                    }
+                  },
+                  "filters": {
+                    "blobTypes": [
+                      "blockBlob"
+                    ],
+                    "prefixMatch": [
+                      "olcmtestcontainer1"
+                    ]
+                  }
+                },
+                "enabled": true
+              }
+            ]
+          }
+        }
+      }
+    }
+  },
+  "operationId": "ManagementPolicies_CreateOrUpdate",
+  "title": "StorageAccountSetManagementPolicyHotTierActions"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountSetManagementPolicyWithSnapshotAndVersion.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountSetManagementPolicyWithSnapshotAndVersion.json
@@ -1,0 +1,136 @@
+{
+  "parameters": {
+    "accountName": "sto9699",
+    "api-version": "2026-09-01",
+    "managementPolicyName": "default",
+    "monitor": "true",
+    "properties": {
+      "properties": {
+        "policy": {
+          "rules": [
+            {
+              "name": "olcmtest1",
+              "type": "Lifecycle",
+              "definition": {
+                "actions": {
+                  "baseBlob": {
+                    "delete": {
+                      "daysAfterModificationGreaterThan": 1000
+                    },
+                    "tierToArchive": {
+                      "daysAfterModificationGreaterThan": 90
+                    },
+                    "tierToCool": {
+                      "daysAfterModificationGreaterThan": 30
+                    }
+                  },
+                  "snapshot": {
+                    "delete": {
+                      "daysAfterCreationGreaterThan": 1000
+                    },
+                    "tierToArchive": {
+                      "daysAfterCreationGreaterThan": 90
+                    },
+                    "tierToCool": {
+                      "daysAfterCreationGreaterThan": 30
+                    }
+                  },
+                  "version": {
+                    "delete": {
+                      "daysAfterCreationGreaterThan": 1000
+                    },
+                    "tierToArchive": {
+                      "daysAfterCreationGreaterThan": 90
+                    },
+                    "tierToCool": {
+                      "daysAfterCreationGreaterThan": 30
+                    }
+                  }
+                },
+                "filters": {
+                  "blobTypes": [
+                    "blockBlob"
+                  ],
+                  "prefixMatch": [
+                    "olcmtestcontainer1"
+                  ]
+                }
+              },
+              "enabled": true
+            }
+          ]
+        }
+      }
+    },
+    "resourceGroupName": "res7687",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "DefaultManagementPolicy",
+        "type": "Microsoft.Storage/storageAccounts/managementPolicies",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res7231/providers/Microsoft.Storage/storageAccounts/sto288/managementPolicies/default",
+        "properties": {
+          "lastModifiedTime": "2018-06-08T02:53:39.0932539Z",
+          "policy": {
+            "rules": [
+              {
+                "name": "olcmtest1",
+                "type": "Lifecycle",
+                "definition": {
+                  "actions": {
+                    "baseBlob": {
+                      "delete": {
+                        "daysAfterModificationGreaterThan": 1000
+                      },
+                      "tierToArchive": {
+                        "daysAfterModificationGreaterThan": 90
+                      },
+                      "tierToCool": {
+                        "daysAfterModificationGreaterThan": 30
+                      }
+                    },
+                    "snapshot": {
+                      "delete": {
+                        "daysAfterCreationGreaterThan": 1000
+                      },
+                      "tierToArchive": {
+                        "daysAfterCreationGreaterThan": 90
+                      },
+                      "tierToCool": {
+                        "daysAfterCreationGreaterThan": 30
+                      }
+                    },
+                    "version": {
+                      "delete": {
+                        "daysAfterCreationGreaterThan": 1000
+                      },
+                      "tierToArchive": {
+                        "daysAfterCreationGreaterThan": 90
+                      },
+                      "tierToCool": {
+                        "daysAfterCreationGreaterThan": 30
+                      }
+                    }
+                  },
+                  "filters": {
+                    "blobTypes": [
+                      "blockBlob"
+                    ],
+                    "prefixMatch": [
+                      "olcmtestcontainer1"
+                    ]
+                  }
+                },
+                "enabled": true
+              }
+            ]
+          }
+        }
+      }
+    }
+  },
+  "operationId": "ManagementPolicies_CreateOrUpdate",
+  "title": "StorageAccountSetManagementPolicyWithSnapshotAndVersion"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountSetManagementPolicy_BaseBlobDaysAfterCreationActions.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountSetManagementPolicy_BaseBlobDaysAfterCreationActions.json
@@ -1,0 +1,92 @@
+{
+  "parameters": {
+    "accountName": "sto9699",
+    "api-version": "2026-09-01",
+    "managementPolicyName": "default",
+    "monitor": "true",
+    "properties": {
+      "properties": {
+        "policy": {
+          "rules": [
+            {
+              "name": "olcmtest1",
+              "type": "Lifecycle",
+              "definition": {
+                "actions": {
+                  "baseBlob": {
+                    "delete": {
+                      "daysAfterCreationGreaterThan": 1000
+                    },
+                    "tierToArchive": {
+                      "daysAfterCreationGreaterThan": 90
+                    },
+                    "tierToCool": {
+                      "daysAfterCreationGreaterThan": 30
+                    }
+                  }
+                },
+                "filters": {
+                  "blobTypes": [
+                    "blockBlob"
+                  ],
+                  "prefixMatch": [
+                    "olcmtestcontainer1"
+                  ]
+                }
+              },
+              "enabled": true
+            }
+          ]
+        }
+      }
+    },
+    "resourceGroupName": "res7687",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "DefaultManagementPolicy",
+        "type": "Microsoft.Storage/storageAccounts/managementPolicies",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res7231/providers/Microsoft.Storage/storageAccounts/sto288/managementPolicies/default",
+        "properties": {
+          "lastModifiedTime": "2021-06-08T02:53:39.0932539Z",
+          "policy": {
+            "rules": [
+              {
+                "name": "olcmtest1",
+                "type": "Lifecycle",
+                "definition": {
+                  "actions": {
+                    "baseBlob": {
+                      "delete": {
+                        "daysAfterCreationGreaterThan": 1000
+                      },
+                      "tierToArchive": {
+                        "daysAfterCreationGreaterThan": 90
+                      },
+                      "tierToCool": {
+                        "daysAfterCreationGreaterThan": 30
+                      }
+                    }
+                  },
+                  "filters": {
+                    "blobTypes": [
+                      "blockBlob"
+                    ],
+                    "prefixMatch": [
+                      "olcmtestcontainer1"
+                    ]
+                  }
+                },
+                "enabled": true
+              }
+            ]
+          }
+        }
+      }
+    }
+  },
+  "operationId": "ManagementPolicies_CreateOrUpdate",
+  "title": "StorageAccountSetManagementPolicy_BaseBlobDaysAfterCreationActions"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountSetManagementPolicy_LastAccessTimeBasedBlobActions.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountSetManagementPolicy_LastAccessTimeBasedBlobActions.json
@@ -1,0 +1,104 @@
+{
+  "parameters": {
+    "accountName": "sto9699",
+    "api-version": "2026-09-01",
+    "managementPolicyName": "default",
+    "monitor": "true",
+    "properties": {
+      "properties": {
+        "policy": {
+          "rules": [
+            {
+              "name": "olcmtest",
+              "type": "Lifecycle",
+              "definition": {
+                "actions": {
+                  "baseBlob": {
+                    "delete": {
+                      "daysAfterLastAccessTimeGreaterThan": 1000
+                    },
+                    "enableAutoTierToHotFromCool": true,
+                    "tierToArchive": {
+                      "daysAfterLastAccessTimeGreaterThan": 90
+                    },
+                    "tierToCool": {
+                      "daysAfterLastAccessTimeGreaterThan": 30
+                    }
+                  },
+                  "snapshot": {
+                    "delete": {
+                      "daysAfterCreationGreaterThan": 30
+                    }
+                  }
+                },
+                "filters": {
+                  "blobTypes": [
+                    "blockBlob"
+                  ],
+                  "prefixMatch": [
+                    "olcmtestcontainer"
+                  ]
+                }
+              },
+              "enabled": true
+            }
+          ]
+        }
+      }
+    },
+    "resourceGroupName": "res7687",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "DefaultManagementPolicy",
+        "type": "Microsoft.Storage/storageAccounts/managementPolicies",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res7231/providers/Microsoft.Storage/storageAccounts/sto288/managementPolicies/default",
+        "properties": {
+          "lastModifiedTime": "2018-06-08T02:53:39.0932539Z",
+          "policy": {
+            "rules": [
+              {
+                "name": "olcmtest",
+                "type": "Lifecycle",
+                "definition": {
+                  "actions": {
+                    "baseBlob": {
+                      "delete": {
+                        "daysAfterLastAccessTimeGreaterThan": 1000
+                      },
+                      "enableAutoTierToHotFromCool": true,
+                      "tierToArchive": {
+                        "daysAfterLastAccessTimeGreaterThan": 90
+                      },
+                      "tierToCool": {
+                        "daysAfterLastAccessTimeGreaterThan": 30
+                      }
+                    },
+                    "snapshot": {
+                      "delete": {
+                        "daysAfterCreationGreaterThan": 30
+                      }
+                    }
+                  },
+                  "filters": {
+                    "blobTypes": [
+                      "blockBlob"
+                    ],
+                    "prefixMatch": [
+                      "olcmtestcontainer"
+                    ]
+                  }
+                },
+                "enabled": true
+              }
+            ]
+          }
+        }
+      }
+    }
+  },
+  "operationId": "ManagementPolicies_CreateOrUpdate",
+  "title": "StorageAccountSetManagementPolicy_LastAccessTimeBasedBlobActions"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountSetManagementPolicy_LastTierChangeTimeActions.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountSetManagementPolicy_LastTierChangeTimeActions.json
@@ -1,0 +1,118 @@
+{
+  "parameters": {
+    "accountName": "sto9699",
+    "api-version": "2026-09-01",
+    "managementPolicyName": "default",
+    "monitor": "true",
+    "properties": {
+      "properties": {
+        "policy": {
+          "rules": [
+            {
+              "name": "olcmtest",
+              "type": "Lifecycle",
+              "definition": {
+                "actions": {
+                  "baseBlob": {
+                    "delete": {
+                      "daysAfterModificationGreaterThan": 1000
+                    },
+                    "tierToArchive": {
+                      "daysAfterLastTierChangeGreaterThan": 120,
+                      "daysAfterModificationGreaterThan": 90
+                    },
+                    "tierToCool": {
+                      "daysAfterModificationGreaterThan": 30
+                    }
+                  },
+                  "snapshot": {
+                    "tierToArchive": {
+                      "daysAfterCreationGreaterThan": 30,
+                      "daysAfterLastTierChangeGreaterThan": 90
+                    }
+                  },
+                  "version": {
+                    "tierToArchive": {
+                      "daysAfterCreationGreaterThan": 30,
+                      "daysAfterLastTierChangeGreaterThan": 90
+                    }
+                  }
+                },
+                "filters": {
+                  "blobTypes": [
+                    "blockBlob"
+                  ],
+                  "prefixMatch": [
+                    "olcmtestcontainer"
+                  ]
+                }
+              },
+              "enabled": true
+            }
+          ]
+        }
+      }
+    },
+    "resourceGroupName": "res7687",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "DefaultManagementPolicy",
+        "type": "Microsoft.Storage/storageAccounts/managementPolicies",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res7231/providers/Microsoft.Storage/storageAccounts/sto288/managementPolicies/default",
+        "properties": {
+          "lastModifiedTime": "2018-06-08T02:53:39.0932539Z",
+          "policy": {
+            "rules": [
+              {
+                "name": "olcmtest",
+                "type": "Lifecycle",
+                "definition": {
+                  "actions": {
+                    "baseBlob": {
+                      "delete": {
+                        "daysAfterModificationGreaterThan": 1000
+                      },
+                      "tierToArchive": {
+                        "daysAfterLastTierChangeGreaterThan": 120,
+                        "daysAfterModificationGreaterThan": 90
+                      },
+                      "tierToCool": {
+                        "daysAfterModificationGreaterThan": 30
+                      }
+                    },
+                    "snapshot": {
+                      "tierToArchive": {
+                        "daysAfterCreationGreaterThan": 30,
+                        "daysAfterLastTierChangeGreaterThan": 90
+                      }
+                    },
+                    "version": {
+                      "tierToArchive": {
+                        "daysAfterCreationGreaterThan": 30,
+                        "daysAfterLastTierChangeGreaterThan": 90
+                      }
+                    }
+                  },
+                  "filters": {
+                    "blobTypes": [
+                      "blockBlob"
+                    ],
+                    "prefixMatch": [
+                      "olcmtestcontainer"
+                    ]
+                  }
+                },
+                "enabled": true
+              }
+            ]
+          }
+        }
+      }
+    }
+  },
+  "operationId": "ManagementPolicies_CreateOrUpdate",
+  "title": "StorageAccountSetManagementPolicy_LastTierChangeTimeActions"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountUpdate.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountUpdate.json
@@ -1,0 +1,196 @@
+{
+  "parameters": {
+    "accountName": "sto8596",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "parameters": {
+      "properties": {
+        "allowBlobPublicAccess": false,
+        "allowSharedKeyAccess": true,
+        "defaultToOAuthAuthentication": false,
+        "enableExtendedGroups": true,
+        "encryption": {
+          "keySource": "Microsoft.Storage",
+          "services": {
+            "blob": {
+              "enabled": true,
+              "keyType": "Account"
+            },
+            "file": {
+              "enabled": true,
+              "keyType": "Account"
+            }
+          }
+        },
+        "isLocalUserEnabled": true,
+        "isSftpEnabled": true,
+        "keyPolicy": {
+          "keyExpirationPeriodInDays": 20
+        },
+        "minimumTlsVersion": "TLS1_2",
+        "networkAcls": {
+          "defaultAction": "Allow",
+          "resourceAccessRules": [
+            {
+              "resourceId": "/subscriptions/a7e99807-abbf-4642-bdec-2c809a96a8bc/resourceGroups/res9407/providers/Microsoft.Synapse/workspaces/testworkspace",
+              "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+            }
+          ]
+        },
+        "routingPreference": {
+          "publishInternetEndpoints": true,
+          "publishMicrosoftEndpoints": true,
+          "routingChoice": "MicrosoftRouting"
+        },
+        "sasPolicy": {
+          "expirationAction": "Log",
+          "sasExpirationPeriod": "1.15:59:59",
+          "requireUserBoundUserDelegationSas": true,
+          "requireUserBoundUserDelegationSasAction": "Block"
+        },
+        "geoPriorityReplicationStatus": {
+          "isBlobEnabled": true
+        },
+        "allowSharedKeyAccessForServices": {
+          "blob": {
+            "enabled": true
+          },
+          "file": {
+            "enabled": false
+          },
+          "queue": {
+            "enabled": true
+          },
+          "table": {
+            "enabled": false
+          }
+        },
+        "allowCrossTenantDelegationSas": false
+      }
+    },
+    "resourceGroupName": "res9407",
+    "subscriptionId": "a3f7c2b9-4e1d-4c8a-9d6f-8b2a5e41c7f3"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto8596",
+        "type": "Microsoft.Storage/storageAccounts",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9407/providers/Microsoft.Storage/storageAccounts/sto8596",
+        "kind": "Storage",
+        "location": "eastus2(stage)",
+        "properties": {
+          "allowBlobPublicAccess": false,
+          "allowSharedKeyAccess": true,
+          "creationTime": "2017-06-01T02:42:41.7633306Z",
+          "enableExtendedGroups": true,
+          "encryption": {
+            "keySource": "Microsoft.Storage",
+            "services": {
+              "blob": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              },
+              "file": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              }
+            }
+          },
+          "isHnsEnabled": true,
+          "isLocalUserEnabled": true,
+          "isSftpEnabled": true,
+          "keyCreationTime": {
+            "key1": "2021-03-18T04:42:22.4322836Z",
+            "key2": "2021-03-18T04:42:22.4322836Z"
+          },
+          "keyPolicy": {
+            "keyExpirationPeriodInDays": 20
+          },
+          "minimumTlsVersion": "TLS1_2",
+          "networkAcls": {
+            "bypass": "AzureServices",
+            "defaultAction": "Allow",
+            "ipRules": [],
+            "resourceAccessRules": [
+              {
+                "resourceId": "/subscriptions/a7e99807-abbf-4642-bdec-2c809a96a8bc/resourceGroups/res9407/providers/Microsoft.Synapse/workspaces/testworkspace",
+                "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+              }
+            ],
+            "virtualNetworkRules": []
+          },
+          "primaryEndpoints": {
+            "blob": "https://sto8596.blob.core.windows.net/",
+            "dfs": "https://sto8596.dfs.core.windows.net/",
+            "file": "https://sto8596.file.core.windows.net/",
+            "internetEndpoints": {
+              "blob": "https://sto8596-internetrouting.blob.core.windows.net/",
+              "dfs": "https://sto8596-internetrouting.dfs.core.windows.net/",
+              "file": "https://sto8596-internetrouting.file.core.windows.net/",
+              "web": "https://sto8596-internetrouting.web.core.windows.net/"
+            },
+            "microsoftEndpoints": {
+              "blob": "https://sto8596-microsoftrouting.blob.core.windows.net/",
+              "dfs": "https://sto8596-microsoftrouting.dfs.core.windows.net/",
+              "file": "https://sto8596-microsoftrouting.file.core.windows.net/",
+              "queue": "https://sto8596-microsoftrouting.queue.core.windows.net/",
+              "table": "https://sto8596-microsoftrouting.table.core.windows.net/",
+              "web": "https://sto8596-microsoftrouting.web.core.windows.net/"
+            },
+            "queue": "https://sto8596.queue.core.windows.net/",
+            "table": "https://sto8596.table.core.windows.net/",
+            "web": "https://sto8596.web.core.windows.net/"
+          },
+          "primaryLocation": "eastus2(stage)",
+          "provisioningState": "Succeeded",
+          "routingPreference": {
+            "publishInternetEndpoints": true,
+            "publishMicrosoftEndpoints": true,
+            "routingChoice": "MicrosoftRouting"
+          },
+          "sasPolicy": {
+            "expirationAction": "Log",
+            "sasExpirationPeriod": "1.15:59:59",
+            "requireUserBoundUserDelegationSas": true,
+            "requireUserBoundUserDelegationSasAction": "Block"
+          },
+          "secondaryLocation": "northcentralus(stage)",
+          "statusOfPrimary": "available",
+          "statusOfSecondary": "available",
+          "supportsHttpsTrafficOnly": false,
+          "geoPriorityReplicationStatus": {
+            "isBlobEnabled": true
+          },
+          "allowSharedKeyAccessForServices": {
+            "blob": {
+              "enabled": true
+            },
+            "file": {
+              "enabled": false
+            },
+            "queue": {
+              "enabled": true
+            },
+            "table": {
+              "enabled": false
+            }
+          },
+          "allowCrossTenantDelegationSas": false
+        },
+        "sku": {
+          "name": "Standard_GRS",
+          "tier": "Standard"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "StorageAccounts_Update",
+  "title": "StorageAccountUpdate"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountUpdateAccessTierToSmart.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountUpdateAccessTierToSmart.json
@@ -1,0 +1,163 @@
+{
+  "parameters": {
+    "accountName": "sto8596",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "parameters": {
+      "properties": {
+        "accessTier": "Smart",
+        "allowBlobPublicAccess": false,
+        "allowSharedKeyAccess": true,
+        "defaultToOAuthAuthentication": false,
+        "enableExtendedGroups": true,
+        "encryption": {
+          "keySource": "Microsoft.Storage",
+          "services": {
+            "blob": {
+              "enabled": true,
+              "keyType": "Account"
+            },
+            "file": {
+              "enabled": true,
+              "keyType": "Account"
+            }
+          }
+        },
+        "isLocalUserEnabled": true,
+        "isSftpEnabled": true,
+        "keyPolicy": {
+          "keyExpirationPeriodInDays": 20
+        },
+        "minimumTlsVersion": "TLS1_2",
+        "networkAcls": {
+          "defaultAction": "Allow",
+          "resourceAccessRules": [
+            {
+              "resourceId": "/subscriptions/a7e99807-abbf-4642-bdec-2c809a96a8bc/resourceGroups/res9407/providers/Microsoft.Synapse/workspaces/testworkspace",
+              "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+            }
+          ]
+        },
+        "routingPreference": {
+          "publishInternetEndpoints": true,
+          "publishMicrosoftEndpoints": true,
+          "routingChoice": "MicrosoftRouting"
+        },
+        "sasPolicy": {
+          "expirationAction": "Log",
+          "sasExpirationPeriod": "1.15:59:59"
+        },
+        "geoPriorityReplicationStatus": {
+          "isBlobEnabled": true
+        }
+      }
+    },
+    "resourceGroupName": "res9407",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto8596",
+        "type": "Microsoft.Storage/storageAccounts",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9407/providers/Microsoft.Storage/storageAccounts/sto8596",
+        "kind": "Storage",
+        "location": "eastus2(stage)",
+        "properties": {
+          "allowBlobPublicAccess": false,
+          "allowSharedKeyAccess": true,
+          "creationTime": "2017-06-01T02:42:41.7633306Z",
+          "enableExtendedGroups": true,
+          "encryption": {
+            "keySource": "Microsoft.Storage",
+            "services": {
+              "blob": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              },
+              "file": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              }
+            }
+          },
+          "isHnsEnabled": true,
+          "isLocalUserEnabled": true,
+          "isSftpEnabled": true,
+          "keyCreationTime": {
+            "key1": "2021-03-18T04:42:22.4322836Z",
+            "key2": "2021-03-18T04:42:22.4322836Z"
+          },
+          "keyPolicy": {
+            "keyExpirationPeriodInDays": 20
+          },
+          "minimumTlsVersion": "TLS1_2",
+          "networkAcls": {
+            "bypass": "AzureServices",
+            "defaultAction": "Allow",
+            "ipRules": [],
+            "resourceAccessRules": [
+              {
+                "resourceId": "/subscriptions/a7e99807-abbf-4642-bdec-2c809a96a8bc/resourceGroups/res9407/providers/Microsoft.Synapse/workspaces/testworkspace",
+                "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+              }
+            ],
+            "virtualNetworkRules": []
+          },
+          "primaryEndpoints": {
+            "blob": "https://sto8596.blob.core.windows.net/",
+            "dfs": "https://sto8596.dfs.core.windows.net/",
+            "file": "https://sto8596.file.core.windows.net/",
+            "internetEndpoints": {
+              "blob": "https://sto8596-internetrouting.blob.core.windows.net/",
+              "dfs": "https://sto8596-internetrouting.dfs.core.windows.net/",
+              "file": "https://sto8596-internetrouting.file.core.windows.net/",
+              "web": "https://sto8596-internetrouting.web.core.windows.net/"
+            },
+            "microsoftEndpoints": {
+              "blob": "https://sto8596-microsoftrouting.blob.core.windows.net/",
+              "dfs": "https://sto8596-microsoftrouting.dfs.core.windows.net/",
+              "file": "https://sto8596-microsoftrouting.file.core.windows.net/",
+              "queue": "https://sto8596-microsoftrouting.queue.core.windows.net/",
+              "table": "https://sto8596-microsoftrouting.table.core.windows.net/",
+              "web": "https://sto8596-microsoftrouting.web.core.windows.net/"
+            },
+            "queue": "https://sto8596.queue.core.windows.net/",
+            "table": "https://sto8596.table.core.windows.net/",
+            "web": "https://sto8596.web.core.windows.net/"
+          },
+          "primaryLocation": "eastus2(stage)",
+          "provisioningState": "Succeeded",
+          "routingPreference": {
+            "publishInternetEndpoints": true,
+            "publishMicrosoftEndpoints": true,
+            "routingChoice": "MicrosoftRouting"
+          },
+          "sasPolicy": {
+            "expirationAction": "Log",
+            "sasExpirationPeriod": "1.15:59:59"
+          },
+          "secondaryLocation": "northcentralus(stage)",
+          "statusOfPrimary": "available",
+          "statusOfSecondary": "available",
+          "supportsHttpsTrafficOnly": false,
+          "geoPriorityReplicationStatus": {
+            "isBlobEnabled": true
+          }
+        },
+        "sku": {
+          "name": "Standard_GRS",
+          "tier": "Standard"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "StorageAccounts_Update",
+  "title": "StorageAccountUpdateAccessTierToSmart"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountUpdateAllowedCopyScopeToAAD.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountUpdateAllowedCopyScopeToAAD.json
@@ -1,0 +1,151 @@
+{
+  "parameters": {
+    "accountName": "sto8596",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "parameters": {
+      "properties": {
+        "allowBlobPublicAccess": false,
+        "allowSharedKeyAccess": true,
+        "allowedCopyScope": "AAD",
+        "encryption": {
+          "keySource": "Microsoft.Storage",
+          "services": {
+            "blob": {
+              "enabled": true,
+              "keyType": "Account"
+            },
+            "file": {
+              "enabled": true,
+              "keyType": "Account"
+            }
+          }
+        },
+        "keyPolicy": {
+          "keyExpirationPeriodInDays": 20
+        },
+        "minimumTlsVersion": "TLS1_2",
+        "networkAcls": {
+          "defaultAction": "Allow",
+          "resourceAccessRules": [
+            {
+              "resourceId": "/subscriptions/a7e99807-abbf-4642-bdec-2c809a96a8bc/resourceGroups/res9407/providers/Microsoft.Synapse/workspaces/testworkspace",
+              "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+            }
+          ]
+        },
+        "routingPreference": {
+          "publishInternetEndpoints": true,
+          "publishMicrosoftEndpoints": true,
+          "routingChoice": "MicrosoftRouting"
+        },
+        "sasPolicy": {
+          "expirationAction": "Log",
+          "sasExpirationPeriod": "1.15:59:59"
+        }
+      }
+    },
+    "resourceGroupName": "res9407",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto8596",
+        "type": "Microsoft.Storage/storageAccounts",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9407/providers/Microsoft.Storage/storageAccounts/sto8596",
+        "kind": "Storage",
+        "location": "eastus2(stage)",
+        "properties": {
+          "allowBlobPublicAccess": false,
+          "allowSharedKeyAccess": true,
+          "allowedCopyScope": "AAD",
+          "creationTime": "2017-06-01T02:42:41.7633306Z",
+          "encryption": {
+            "keySource": "Microsoft.Storage",
+            "services": {
+              "blob": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              },
+              "file": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              }
+            }
+          },
+          "isHnsEnabled": true,
+          "keyCreationTime": {
+            "key1": "2021-03-18T04:42:22.4322836Z",
+            "key2": "2021-03-18T04:42:22.4322836Z"
+          },
+          "keyPolicy": {
+            "keyExpirationPeriodInDays": 20
+          },
+          "minimumTlsVersion": "TLS1_2",
+          "networkAcls": {
+            "bypass": "AzureServices",
+            "defaultAction": "Allow",
+            "ipRules": [],
+            "resourceAccessRules": [
+              {
+                "resourceId": "/subscriptions/a7e99807-abbf-4642-bdec-2c809a96a8bc/resourceGroups/res9407/providers/Microsoft.Synapse/workspaces/testworkspace",
+                "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+              }
+            ],
+            "virtualNetworkRules": []
+          },
+          "primaryEndpoints": {
+            "blob": "https://sto8596.blob.core.windows.net/",
+            "dfs": "https://sto8596.dfs.core.windows.net/",
+            "file": "https://sto8596.file.core.windows.net/",
+            "internetEndpoints": {
+              "blob": "https://sto8596-internetrouting.blob.core.windows.net/",
+              "dfs": "https://sto8596-internetrouting.dfs.core.windows.net/",
+              "file": "https://sto8596-internetrouting.file.core.windows.net/",
+              "web": "https://sto8596-internetrouting.web.core.windows.net/"
+            },
+            "microsoftEndpoints": {
+              "blob": "https://sto8596-microsoftrouting.blob.core.windows.net/",
+              "dfs": "https://sto8596-microsoftrouting.dfs.core.windows.net/",
+              "file": "https://sto8596-microsoftrouting.file.core.windows.net/",
+              "queue": "https://sto8596-microsoftrouting.queue.core.windows.net/",
+              "table": "https://sto8596-microsoftrouting.table.core.windows.net/",
+              "web": "https://sto8596-microsoftrouting.web.core.windows.net/"
+            },
+            "queue": "https://sto8596.queue.core.windows.net/",
+            "table": "https://sto8596.table.core.windows.net/",
+            "web": "https://sto8596.web.core.windows.net/"
+          },
+          "primaryLocation": "eastus2(stage)",
+          "provisioningState": "Succeeded",
+          "routingPreference": {
+            "publishInternetEndpoints": true,
+            "publishMicrosoftEndpoints": true,
+            "routingChoice": "MicrosoftRouting"
+          },
+          "sasPolicy": {
+            "expirationAction": "Log",
+            "sasExpirationPeriod": "1.15:59:59"
+          },
+          "secondaryLocation": "northcentralus(stage)",
+          "statusOfPrimary": "available",
+          "statusOfSecondary": "available",
+          "supportsHttpsTrafficOnly": false
+        },
+        "sku": {
+          "name": "Standard_GRS",
+          "tier": "Standard"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "StorageAccounts_Update",
+  "title": "StorageAccountUpdateAllowedCopyScopeToAAD"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountUpdateDisablePublicNetworkAccess.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountUpdateDisablePublicNetworkAccess.json
@@ -1,0 +1,151 @@
+{
+  "parameters": {
+    "accountName": "sto8596",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "parameters": {
+      "properties": {
+        "allowBlobPublicAccess": false,
+        "allowSharedKeyAccess": true,
+        "encryption": {
+          "keySource": "Microsoft.Storage",
+          "services": {
+            "blob": {
+              "enabled": true,
+              "keyType": "Account"
+            },
+            "file": {
+              "enabled": true,
+              "keyType": "Account"
+            }
+          }
+        },
+        "keyPolicy": {
+          "keyExpirationPeriodInDays": 20
+        },
+        "minimumTlsVersion": "TLS1_2",
+        "networkAcls": {
+          "defaultAction": "Allow",
+          "resourceAccessRules": [
+            {
+              "resourceId": "/subscriptions/a7e99807-abbf-4642-bdec-2c809a96a8bc/resourceGroups/res9407/providers/Microsoft.Synapse/workspaces/testworkspace",
+              "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+            }
+          ]
+        },
+        "publicNetworkAccess": "Disabled",
+        "routingPreference": {
+          "publishInternetEndpoints": true,
+          "publishMicrosoftEndpoints": true,
+          "routingChoice": "MicrosoftRouting"
+        },
+        "sasPolicy": {
+          "expirationAction": "Log",
+          "sasExpirationPeriod": "1.15:59:59"
+        }
+      }
+    },
+    "resourceGroupName": "res9407",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto8596",
+        "type": "Microsoft.Storage/storageAccounts",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9407/providers/Microsoft.Storage/storageAccounts/sto8596",
+        "kind": "Storage",
+        "location": "eastus2(stage)",
+        "properties": {
+          "allowBlobPublicAccess": false,
+          "allowSharedKeyAccess": true,
+          "creationTime": "2017-06-01T02:42:41.7633306Z",
+          "encryption": {
+            "keySource": "Microsoft.Storage",
+            "services": {
+              "blob": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              },
+              "file": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              }
+            }
+          },
+          "isHnsEnabled": true,
+          "keyCreationTime": {
+            "key1": "2021-03-18T04:42:22.4322836Z",
+            "key2": "2021-03-18T04:42:22.4322836Z"
+          },
+          "keyPolicy": {
+            "keyExpirationPeriodInDays": 20
+          },
+          "minimumTlsVersion": "TLS1_2",
+          "networkAcls": {
+            "bypass": "AzureServices",
+            "defaultAction": "Allow",
+            "ipRules": [],
+            "resourceAccessRules": [
+              {
+                "resourceId": "/subscriptions/a7e99807-abbf-4642-bdec-2c809a96a8bc/resourceGroups/res9407/providers/Microsoft.Synapse/workspaces/testworkspace",
+                "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+              }
+            ],
+            "virtualNetworkRules": []
+          },
+          "primaryEndpoints": {
+            "blob": "https://sto8596.blob.core.windows.net/",
+            "dfs": "https://sto8596.dfs.core.windows.net/",
+            "file": "https://sto8596.file.core.windows.net/",
+            "internetEndpoints": {
+              "blob": "https://sto8596-internetrouting.blob.core.windows.net/",
+              "dfs": "https://sto8596-internetrouting.dfs.core.windows.net/",
+              "file": "https://sto8596-internetrouting.file.core.windows.net/",
+              "web": "https://sto8596-internetrouting.web.core.windows.net/"
+            },
+            "microsoftEndpoints": {
+              "blob": "https://sto8596-microsoftrouting.blob.core.windows.net/",
+              "dfs": "https://sto8596-microsoftrouting.dfs.core.windows.net/",
+              "file": "https://sto8596-microsoftrouting.file.core.windows.net/",
+              "queue": "https://sto8596-microsoftrouting.queue.core.windows.net/",
+              "table": "https://sto8596-microsoftrouting.table.core.windows.net/",
+              "web": "https://sto8596-microsoftrouting.web.core.windows.net/"
+            },
+            "queue": "https://sto8596.queue.core.windows.net/",
+            "table": "https://sto8596.table.core.windows.net/",
+            "web": "https://sto8596.web.core.windows.net/"
+          },
+          "primaryLocation": "eastus2(stage)",
+          "provisioningState": "Succeeded",
+          "publicNetworkAccess": "Disabled",
+          "routingPreference": {
+            "publishInternetEndpoints": true,
+            "publishMicrosoftEndpoints": true,
+            "routingChoice": "MicrosoftRouting"
+          },
+          "sasPolicy": {
+            "expirationAction": "Log",
+            "sasExpirationPeriod": "1.15:59:59"
+          },
+          "secondaryLocation": "northcentralus(stage)",
+          "statusOfPrimary": "available",
+          "statusOfSecondary": "available",
+          "supportsHttpsTrafficOnly": false
+        },
+        "sku": {
+          "name": "Standard_GRS",
+          "tier": "Standard"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "StorageAccounts_Update",
+  "title": "StorageAccountUpdateDisablePublicNetworkAccess"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountUpdateObjectReplicationPolicyOnDestination.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountUpdateObjectReplicationPolicyOnDestination.json
@@ -1,0 +1,85 @@
+{
+  "parameters": {
+    "accountName": "dst112",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "objectReplicationPolicyId": "2a20bb73-5717-4635-985a-5d4cf777438f",
+    "properties": {
+      "properties": {
+        "destinationAccount": "dst112",
+        "metrics": {
+          "enabled": true
+        },
+        "priorityReplication": {
+          "enabled": true
+        },
+        "rules": [
+          {
+            "destinationContainer": "dcont139",
+            "filters": {
+              "prefixMatch": [
+                "blobA",
+                "blobB"
+              ]
+            },
+            "ruleId": "d5d18a48-8801-4554-aeaa-74faf65f5ef9",
+            "sourceContainer": "scont139"
+          },
+          {
+            "destinationContainer": "dcont179",
+            "sourceContainer": "scont179"
+          }
+        ],
+        "sourceAccount": "src1122",
+        "tagsReplication": {
+          "enabled": true
+        }
+      }
+    },
+    "resourceGroupName": "res7687",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "2a20bb73-5717-4635-985a-5d4cf777438f",
+        "type": "Microsoft.Storage/storageAccounts/objectReplicationPolicies",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res7687/providers/Microsoft.Storage/storageAccounts/dst112/objectReplicationPolicies/2a20bb73-5717-4635-985a-5d4cf777438f",
+        "properties": {
+          "destinationAccount": "dst112",
+          "metrics": {
+            "enabled": true
+          },
+          "priorityReplication": {
+            "enabled": true
+          },
+          "policyId": "2a20bb73-5717-4635-985a-5d4cf777438f",
+          "rules": [
+            {
+              "destinationContainer": "destContainer1",
+              "filters": {
+                "prefixMatch": [
+                  "blobA",
+                  "blobB"
+                ]
+              },
+              "ruleId": "d5d18a48-8801-4554-aeaa-74faf65f5ef9",
+              "sourceContainer": "sourceContainer1"
+            },
+            {
+              "destinationContainer": "dcont179",
+              "ruleId": "cfbb4bc2-8b60-429f-b05a-d1e0942b33b2",
+              "sourceContainer": "scont179"
+            }
+          ],
+          "sourceAccount": "src1122",
+          "tagsReplication": {
+            "enabled": true
+          }
+        }
+      }
+    }
+  },
+  "operationId": "ObjectReplicationPolicies_CreateOrUpdate",
+  "title": "StorageAccountUpdateObjectReplicationPolicyOnDestination"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountUpdateObjectReplicationPolicyOnSource.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountUpdateObjectReplicationPolicyOnSource.json
@@ -1,0 +1,87 @@
+{
+  "parameters": {
+    "accountName": "src1122",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "objectReplicationPolicyId": "2a20bb73-5717-4635-985a-5d4cf777438f",
+    "properties": {
+      "properties": {
+        "destinationAccount": "dst112",
+        "metrics": {
+          "enabled": true
+        },
+        "priorityReplication": {
+          "enabled": true
+        },
+        "rules": [
+          {
+            "destinationContainer": "dcont139",
+            "filters": {
+              "prefixMatch": [
+                "blobA",
+                "blobB"
+              ]
+            },
+            "ruleId": "d5d18a48-8801-4554-aeaa-74faf65f5ef9",
+            "sourceContainer": "scont139"
+          },
+          {
+            "destinationContainer": "dcont179",
+            "ruleId": "cfbb4bc2-8b60-429f-b05a-d1e0942b33b2",
+            "sourceContainer": "scont179"
+          }
+        ],
+        "sourceAccount": "src1122",
+        "tagsReplication": {
+          "enabled": true
+        }
+      }
+    },
+    "resourceGroupName": "res7687",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "2a20bb73-5717-4635-985a-5d4cf777438f",
+        "type": "Microsoft.Storage/storageAccounts/objectReplicationPolicies",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res7687/providers/Microsoft.Storage/storageAccounts/src1122/objectReplicationPolicies/2a20bb73-5717-4635-985a-5d4cf777438f",
+        "properties": {
+          "destinationAccount": "dst112",
+          "enabledTime": "2019-06-08T03:01:55.7168089Z",
+          "metrics": {
+            "enabled": true
+          },
+          "priorityReplication": {
+            "enabled": true
+          },
+          "policyId": "2a20bb73-5717-4635-985a-5d4cf777438f",
+          "rules": [
+            {
+              "destinationContainer": "destContainer1",
+              "filters": {
+                "prefixMatch": [
+                  "blobA",
+                  "blobB"
+                ]
+              },
+              "ruleId": "d5d18a48-8801-4554-aeaa-74faf65f5ef9",
+              "sourceContainer": "sourceContainer1"
+            },
+            {
+              "destinationContainer": "dcont179",
+              "ruleId": "cfbb4bc2-8b60-429f-b05a-d1e0942b33b2",
+              "sourceContainer": "scont179"
+            }
+          ],
+          "sourceAccount": "src1122",
+          "tagsReplication": {
+            "enabled": true
+          }
+        }
+      }
+    }
+  },
+  "operationId": "ObjectReplicationPolicies_CreateOrUpdate",
+  "title": "StorageAccountUpdateObjectReplicationPolicyOnSource"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountUpdateUserAssignedEncryptionIdentityWithCMK.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountUpdateUserAssignedEncryptionIdentityWithCMK.json
@@ -1,0 +1,118 @@
+{
+  "parameters": {
+    "accountName": "sto4445",
+    "api-version": "2026-09-01",
+    "parameters": {
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{managed-identity-name}": {}
+        }
+      },
+      "kind": "Storage",
+      "properties": {
+        "encryption": {
+          "identity": {
+            "userAssignedIdentity": "/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{managed-identity-name}"
+          },
+          "keySource": "Microsoft.Keyvault",
+          "keyvaultproperties": {
+            "keyname": "wrappingKey",
+            "keyvaulturi": "https://myvault8569.vault.azure.net",
+            "keyversion": ""
+          },
+          "services": {
+            "blob": {
+              "enabled": true,
+              "keyType": "Account"
+            },
+            "file": {
+              "enabled": true,
+              "keyType": "Account"
+            }
+          }
+        }
+      },
+      "sku": {
+        "name": "Standard_LRS"
+      }
+    },
+    "resourceGroupName": "res9101",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto4445",
+        "type": "Microsoft.Storage/storageAccounts",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.Storage/storageAccounts/sto4445",
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{managed-identity-name}": {
+              "clientId": "fbaa6278-1ecc-415c-819f-6e2058d3acb5",
+              "principalId": "8d823284-1060-42a5-9ec4-ed3d831e24d7"
+            }
+          }
+        },
+        "kind": "StorageV2",
+        "location": "eastus",
+        "properties": {
+          "accessTier": "Hot",
+          "creationTime": "2020-12-15T00:43:14.0839093Z",
+          "encryption": {
+            "identity": {
+              "userAssignedIdentity": "/subscriptions/{subscription-id}/resourcegroups/res9101/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{managed-identity-name}"
+            },
+            "keySource": "Microsoft.Keyvault",
+            "keyvaultproperties": {
+              "currentVersionedKeyIdentifier": "https://myvault8569.vault.azure.net/keys/wrappingKey/0682afdd9c104f4285df20107e956cad",
+              "keyname": "wrappingKey",
+              "keyvaulturi": "https://myvault8569.vault.azure.net",
+              "keyversion": "",
+              "lastKeyRotationTimestamp": "2019-12-13T20:36:23.7023290Z"
+            },
+            "services": {
+              "blob": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2020-12-15T00:43:14.1739587Z"
+              },
+              "file": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2020-12-15T00:43:14.1739587Z"
+              }
+            }
+          },
+          "networkAcls": {
+            "bypass": "AzureServices",
+            "defaultAction": "Allow",
+            "ipRules": [],
+            "virtualNetworkRules": []
+          },
+          "primaryEndpoints": {
+            "blob": "https://sto4445.blob.core.windows.net/",
+            "dfs": "https://sto4445.dfs.core.windows.net/",
+            "file": "https://sto4445.file.core.windows.net/",
+            "queue": "https://sto4445.queue.core.windows.net/",
+            "table": "https://sto4445.table.core.windows.net/",
+            "web": "https://sto4445.web.core.windows.net/"
+          },
+          "primaryLocation": "eastus",
+          "privateEndpointConnections": [],
+          "provisioningState": "Succeeded",
+          "statusOfPrimary": "available",
+          "supportsHttpsTrafficOnly": true
+        },
+        "sku": {
+          "name": "Standard_LRS",
+          "tier": "Standard"
+        },
+        "tags": {}
+      }
+    }
+  },
+  "operationId": "StorageAccounts_Update",
+  "title": "StorageAccountUpdateUserAssignedEncryptionIdentityWithCMK"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountUpdateUserAssignedIdentityWithFederatedIdentityClientId.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountUpdateUserAssignedIdentityWithFederatedIdentityClientId.json
@@ -1,0 +1,120 @@
+{
+  "parameters": {
+    "accountName": "sto131918",
+    "api-version": "2026-09-01",
+    "parameters": {
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{managed-identity-name}": {}
+        }
+      },
+      "kind": "Storage",
+      "properties": {
+        "encryption": {
+          "identity": {
+            "federatedIdentityClientId": "3109d1c4-a5de-4d84-8832-feabb916a4b6",
+            "userAssignedIdentity": "/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{managed-identity-name}"
+          },
+          "keySource": "Microsoft.Keyvault",
+          "keyvaultproperties": {
+            "keyname": "wrappingKey",
+            "keyvaulturi": "https://myvault8569.vault.azure.net",
+            "keyversion": ""
+          },
+          "services": {
+            "blob": {
+              "enabled": true,
+              "keyType": "Account"
+            },
+            "file": {
+              "enabled": true,
+              "keyType": "Account"
+            }
+          }
+        }
+      },
+      "sku": {
+        "name": "Standard_LRS"
+      }
+    },
+    "resourceGroupName": "res131918",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto4445",
+        "type": "Microsoft.Storage/storageAccounts",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.Storage/storageAccounts/sto4445",
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{managed-identity-name}": {
+              "clientId": "fbaa6278-1ecc-415c-819f-6e2058d3acb5",
+              "principalId": "8d823284-1060-42a5-9ec4-ed3d831e24d7"
+            }
+          }
+        },
+        "kind": "StorageV2",
+        "location": "eastus",
+        "properties": {
+          "accessTier": "Hot",
+          "creationTime": "2020-12-15T00:43:14.0839093Z",
+          "encryption": {
+            "identity": {
+              "federatedIdentityClientId": "3109d1c4-a5de-4d84-8832-feabb916a4b6",
+              "userAssignedIdentity": "/subscriptions/{subscription-id}/resourcegroups/res9101/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{managed-identity-name}"
+            },
+            "keySource": "Microsoft.Keyvault",
+            "keyvaultproperties": {
+              "currentVersionedKeyIdentifier": "https://myvault8569.vault.azure.net/keys/wrappingKey/0682afdd9c104f4285df20107e956cad",
+              "keyname": "wrappingKey",
+              "keyvaulturi": "https://myvault8569.vault.azure.net",
+              "keyversion": "",
+              "lastKeyRotationTimestamp": "2019-12-13T20:36:23.7023290Z"
+            },
+            "services": {
+              "blob": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2020-12-15T00:43:14.1739587Z"
+              },
+              "file": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2020-12-15T00:43:14.1739587Z"
+              }
+            }
+          },
+          "networkAcls": {
+            "bypass": "AzureServices",
+            "defaultAction": "Allow",
+            "ipRules": [],
+            "virtualNetworkRules": []
+          },
+          "primaryEndpoints": {
+            "blob": "https://sto4445.blob.core.windows.net/",
+            "dfs": "https://sto4445.dfs.core.windows.net/",
+            "file": "https://sto4445.file.core.windows.net/",
+            "queue": "https://sto4445.queue.core.windows.net/",
+            "table": "https://sto4445.table.core.windows.net/",
+            "web": "https://sto4445.web.core.windows.net/"
+          },
+          "primaryLocation": "eastus",
+          "privateEndpointConnections": [],
+          "provisioningState": "Succeeded",
+          "statusOfPrimary": "available",
+          "supportsHttpsTrafficOnly": true
+        },
+        "sku": {
+          "name": "Standard_LRS",
+          "tier": "Standard"
+        },
+        "tags": {}
+      }
+    }
+  },
+  "operationId": "StorageAccounts_Update",
+  "title": "StorageAccountUpdateUserAssignedIdentityWithFederatedIdentityClientId"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountUpdateWithDataCollaborationPolicy.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountUpdateWithDataCollaborationPolicy.json
@@ -1,0 +1,46 @@
+{
+  "parameters": {
+    "accountName": "sto8596",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "parameters": {
+      "properties": {
+        "dataCollaborationPolicyProperties": {
+          "allowStorageConnectors": true,
+          "allowStorageDataShares": true,
+          "allowCrossTenantDataSharing": false
+        }
+      }
+    },
+    "resourceGroupName": "res9407",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto8596",
+        "type": "Microsoft.Storage/storageAccounts",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9407/providers/Microsoft.Storage/storageAccounts/sto8596",
+        "kind": "Storage",
+        "location": "eastus2(stage)",
+        "properties": {
+          "dataCollaborationPolicyProperties": {
+            "allowStorageConnectors": true,
+            "allowStorageDataShares": true,
+            "allowCrossTenantDataSharing": false
+          }
+        },
+        "sku": {
+          "name": "Standard_GRS",
+          "tier": "Standard"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "StorageAccounts_Update",
+  "title": "StorageAccountUpdateWithDataCollaborationPolicy"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountUpdateWithImmutabilityPolicy.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountUpdateWithImmutabilityPolicy.json
@@ -1,0 +1,52 @@
+{
+  "parameters": {
+    "accountName": "sto8596",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "parameters": {
+      "properties": {
+        "immutableStorageWithVersioning": {
+          "enabled": true,
+          "immutabilityPolicy": {
+            "allowProtectedAppendWrites": true,
+            "immutabilityPeriodSinceCreationInDays": 15,
+            "state": "Locked"
+          }
+        }
+      }
+    },
+    "resourceGroupName": "res9407",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto8596",
+        "type": "Microsoft.Storage/storageAccounts",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9407/providers/Microsoft.Storage/storageAccounts/sto8596",
+        "kind": "Storage",
+        "location": "eastus2(stage)",
+        "properties": {
+          "immutableStorageWithVersioning": {
+            "enabled": true,
+            "immutabilityPolicy": {
+              "allowProtectedAppendWrites": true,
+              "immutabilityPeriodSinceCreationInDays": 15,
+              "state": "Locked"
+            }
+          }
+        },
+        "sku": {
+          "name": "Standard_GRS",
+          "tier": "Standard"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "StorageAccounts_Update",
+  "title": "StorageAccountUpdateWithImmutabilityPolicy"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountUpdate_placement.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountUpdate_placement.json
@@ -1,0 +1,165 @@
+{
+  "parameters": {
+    "accountName": "sto8596",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "parameters": {
+      "placement": {
+        "zonePlacementPolicy": "Any"
+      },
+      "properties": {
+        "allowBlobPublicAccess": false,
+        "allowSharedKeyAccess": true,
+        "defaultToOAuthAuthentication": false,
+        "enableExtendedGroups": true,
+        "encryption": {
+          "keySource": "Microsoft.Storage",
+          "services": {
+            "blob": {
+              "enabled": true,
+              "keyType": "Account"
+            },
+            "file": {
+              "enabled": true,
+              "keyType": "Account"
+            }
+          }
+        },
+        "isLocalUserEnabled": true,
+        "isSftpEnabled": true,
+        "keyPolicy": {
+          "keyExpirationPeriodInDays": 20
+        },
+        "minimumTlsVersion": "TLS1_2",
+        "networkAcls": {
+          "defaultAction": "Allow",
+          "resourceAccessRules": [
+            {
+              "resourceId": "/subscriptions/a7e99807-abbf-4642-bdec-2c809a96a8bc/resourceGroups/res9407/providers/Microsoft.Synapse/workspaces/testworkspace",
+              "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+            }
+          ]
+        },
+        "routingPreference": {
+          "publishInternetEndpoints": true,
+          "publishMicrosoftEndpoints": true,
+          "routingChoice": "MicrosoftRouting"
+        },
+        "sasPolicy": {
+          "expirationAction": "Log",
+          "sasExpirationPeriod": "1.15:59:59"
+        }
+      }
+    },
+    "resourceGroupName": "res9407",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto8596",
+        "type": "Microsoft.Storage/storageAccounts",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9407/providers/Microsoft.Storage/storageAccounts/sto8596",
+        "kind": "Storage",
+        "location": "eastus2(stage)",
+        "placement": {
+          "zonePlacementPolicy": "Any"
+        },
+        "properties": {
+          "allowBlobPublicAccess": false,
+          "allowSharedKeyAccess": true,
+          "creationTime": "2017-06-01T02:42:41.7633306Z",
+          "enableExtendedGroups": true,
+          "encryption": {
+            "keySource": "Microsoft.Storage",
+            "services": {
+              "blob": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              },
+              "file": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              }
+            }
+          },
+          "isHnsEnabled": true,
+          "isLocalUserEnabled": true,
+          "isSftpEnabled": true,
+          "keyCreationTime": {
+            "key1": "2021-03-18T04:42:22.4322836Z",
+            "key2": "2021-03-18T04:42:22.4322836Z"
+          },
+          "keyPolicy": {
+            "keyExpirationPeriodInDays": 20
+          },
+          "minimumTlsVersion": "TLS1_2",
+          "networkAcls": {
+            "bypass": "AzureServices",
+            "defaultAction": "Allow",
+            "ipRules": [],
+            "resourceAccessRules": [
+              {
+                "resourceId": "/subscriptions/a7e99807-abbf-4642-bdec-2c809a96a8bc/resourceGroups/res9407/providers/Microsoft.Synapse/workspaces/testworkspace",
+                "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+              }
+            ],
+            "virtualNetworkRules": []
+          },
+          "primaryEndpoints": {
+            "blob": "https://sto8596.blob.core.windows.net/",
+            "dfs": "https://sto8596.dfs.core.windows.net/",
+            "file": "https://sto8596.file.core.windows.net/",
+            "internetEndpoints": {
+              "blob": "https://sto8596-internetrouting.blob.core.windows.net/",
+              "dfs": "https://sto8596-internetrouting.dfs.core.windows.net/",
+              "file": "https://sto8596-internetrouting.file.core.windows.net/",
+              "web": "https://sto8596-internetrouting.web.core.windows.net/"
+            },
+            "microsoftEndpoints": {
+              "blob": "https://sto8596-microsoftrouting.blob.core.windows.net/",
+              "dfs": "https://sto8596-microsoftrouting.dfs.core.windows.net/",
+              "file": "https://sto8596-microsoftrouting.file.core.windows.net/",
+              "queue": "https://sto8596-microsoftrouting.queue.core.windows.net/",
+              "table": "https://sto8596-microsoftrouting.table.core.windows.net/",
+              "web": "https://sto8596-microsoftrouting.web.core.windows.net/"
+            },
+            "queue": "https://sto8596.queue.core.windows.net/",
+            "table": "https://sto8596.table.core.windows.net/",
+            "web": "https://sto8596.web.core.windows.net/"
+          },
+          "primaryLocation": "eastus2(stage)",
+          "provisioningState": "Succeeded",
+          "routingPreference": {
+            "publishInternetEndpoints": true,
+            "publishMicrosoftEndpoints": true,
+            "routingChoice": "MicrosoftRouting"
+          },
+          "sasPolicy": {
+            "expirationAction": "Log",
+            "sasExpirationPeriod": "1.15:59:59"
+          },
+          "secondaryLocation": "northcentralus(stage)",
+          "statusOfPrimary": "available",
+          "statusOfSecondary": "available",
+          "supportsHttpsTrafficOnly": false
+        },
+        "sku": {
+          "name": "Standard_GRS",
+          "tier": "Standard"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        },
+        "zones": [
+          "1"
+        ]
+      }
+    }
+  },
+  "operationId": "StorageAccounts_Update",
+  "title": "StorageAccountUpdate_placement"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountUpdate_zones.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageAccountUpdate_zones.json
@@ -1,0 +1,162 @@
+{
+  "parameters": {
+    "accountName": "sto8596",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "parameters": {
+      "properties": {
+        "allowBlobPublicAccess": false,
+        "allowSharedKeyAccess": true,
+        "defaultToOAuthAuthentication": false,
+        "enableExtendedGroups": true,
+        "encryption": {
+          "keySource": "Microsoft.Storage",
+          "services": {
+            "blob": {
+              "enabled": true,
+              "keyType": "Account"
+            },
+            "file": {
+              "enabled": true,
+              "keyType": "Account"
+            }
+          }
+        },
+        "isLocalUserEnabled": true,
+        "isSftpEnabled": true,
+        "keyPolicy": {
+          "keyExpirationPeriodInDays": 20
+        },
+        "minimumTlsVersion": "TLS1_2",
+        "networkAcls": {
+          "defaultAction": "Allow",
+          "resourceAccessRules": [
+            {
+              "resourceId": "/subscriptions/a7e99807-abbf-4642-bdec-2c809a96a8bc/resourceGroups/res9407/providers/Microsoft.Synapse/workspaces/testworkspace",
+              "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+            }
+          ]
+        },
+        "routingPreference": {
+          "publishInternetEndpoints": true,
+          "publishMicrosoftEndpoints": true,
+          "routingChoice": "MicrosoftRouting"
+        },
+        "sasPolicy": {
+          "expirationAction": "Log",
+          "sasExpirationPeriod": "1.15:59:59"
+        }
+      },
+      "zones": [
+        "1"
+      ]
+    },
+    "resourceGroupName": "res9407",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto8596",
+        "type": "Microsoft.Storage/storageAccounts",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9407/providers/Microsoft.Storage/storageAccounts/sto8596",
+        "kind": "Storage",
+        "location": "eastus2(stage)",
+        "properties": {
+          "allowBlobPublicAccess": false,
+          "allowSharedKeyAccess": true,
+          "creationTime": "2017-06-01T02:42:41.7633306Z",
+          "enableExtendedGroups": true,
+          "encryption": {
+            "keySource": "Microsoft.Storage",
+            "services": {
+              "blob": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              },
+              "file": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              }
+            }
+          },
+          "isHnsEnabled": true,
+          "isLocalUserEnabled": true,
+          "isSftpEnabled": true,
+          "keyCreationTime": {
+            "key1": "2021-03-18T04:42:22.4322836Z",
+            "key2": "2021-03-18T04:42:22.4322836Z"
+          },
+          "keyPolicy": {
+            "keyExpirationPeriodInDays": 20
+          },
+          "minimumTlsVersion": "TLS1_2",
+          "networkAcls": {
+            "bypass": "AzureServices",
+            "defaultAction": "Allow",
+            "ipRules": [],
+            "resourceAccessRules": [
+              {
+                "resourceId": "/subscriptions/a7e99807-abbf-4642-bdec-2c809a96a8bc/resourceGroups/res9407/providers/Microsoft.Synapse/workspaces/testworkspace",
+                "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+              }
+            ],
+            "virtualNetworkRules": []
+          },
+          "primaryEndpoints": {
+            "blob": "https://sto8596.blob.core.windows.net/",
+            "dfs": "https://sto8596.dfs.core.windows.net/",
+            "file": "https://sto8596.file.core.windows.net/",
+            "internetEndpoints": {
+              "blob": "https://sto8596-internetrouting.blob.core.windows.net/",
+              "dfs": "https://sto8596-internetrouting.dfs.core.windows.net/",
+              "file": "https://sto8596-internetrouting.file.core.windows.net/",
+              "web": "https://sto8596-internetrouting.web.core.windows.net/"
+            },
+            "microsoftEndpoints": {
+              "blob": "https://sto8596-microsoftrouting.blob.core.windows.net/",
+              "dfs": "https://sto8596-microsoftrouting.dfs.core.windows.net/",
+              "file": "https://sto8596-microsoftrouting.file.core.windows.net/",
+              "queue": "https://sto8596-microsoftrouting.queue.core.windows.net/",
+              "table": "https://sto8596-microsoftrouting.table.core.windows.net/",
+              "web": "https://sto8596-microsoftrouting.web.core.windows.net/"
+            },
+            "queue": "https://sto8596.queue.core.windows.net/",
+            "table": "https://sto8596.table.core.windows.net/",
+            "web": "https://sto8596.web.core.windows.net/"
+          },
+          "primaryLocation": "eastus2(stage)",
+          "provisioningState": "Succeeded",
+          "routingPreference": {
+            "publishInternetEndpoints": true,
+            "publishMicrosoftEndpoints": true,
+            "routingChoice": "MicrosoftRouting"
+          },
+          "sasPolicy": {
+            "expirationAction": "Log",
+            "sasExpirationPeriod": "1.15:59:59"
+          },
+          "secondaryLocation": "northcentralus(stage)",
+          "statusOfPrimary": "available",
+          "statusOfSecondary": "available",
+          "supportsHttpsTrafficOnly": false
+        },
+        "sku": {
+          "name": "Standard_GRS",
+          "tier": "Standard"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        },
+        "zones": [
+          "1"
+        ]
+      }
+    }
+  },
+  "operationId": "StorageAccounts_Update",
+  "title": "StorageAccountUpdate_zones"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageConnectorCRUD/StorageConnectors_Create.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageConnectorCRUD/StorageConnectors_Create.json
@@ -1,0 +1,86 @@
+{
+  "operationId": "Connectors_Create",
+  "title": "CreateConnector",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "testrg",
+    "api-version": "2026-09-01",
+    "connectorName": "testconnector",
+    "accountName": "teststorageaccount",
+    "resource": {
+      "location": "eastus",
+      "properties": {
+        "state": "Active",
+        "description": "Example connector",
+        "dataSourceType": "Azure_DataShare",
+        "source": {
+          "type": "DataShare",
+          "connection": {
+            "type": "DataShare",
+            "dataShareUri": "azds://eastus:datashare1:12345678-1234-1234-1234-123456789123"
+          },
+          "authProperties": {
+            "type": "ManagedIdentity",
+            "identityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testIdentity"
+          }
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/storageAccounts/teststorageaccount/connectors/testconnector",
+        "name": "testconnector",
+        "type": "Microsoft.Storage/storageAccounts/connectors",
+        "location": "eastus",
+        "properties": {
+          "uniqueId": "12345678-1234-1234-1234-12345678912",
+          "state": "Active",
+          "creationTime": "2023-04-01T00:00:00Z",
+          "description": "Example connector",
+          "dataSourceType": "Azure_DataShare",
+          "source": {
+            "type": "DataShare",
+            "connection": {
+              "type": "DataShare",
+              "dataShareUri": "azds://eastus:datashare1:12345678-1234-1234-1234-123456789123"
+            },
+            "authProperties": {
+              "type": "ManagedIdentity",
+              "identityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testIdentity"
+            }
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/storageAccounts/teststorageaccount/connectors/testconnector",
+        "name": "testconnector",
+        "type": "Microsoft.Storage/storageAccounts/connectors",
+        "location": "eastus",
+        "properties": {
+          "uniqueId": "12345678-1234-1234-1234-12345678912",
+          "state": "Active",
+          "creationTime": "2023-04-01T00:00:00Z",
+          "description": "Example connector",
+          "dataSourceType": "Azure_DataShare",
+          "source": {
+            "type": "DataShare",
+            "connection": {
+              "type": "DataShare",
+              "dataShareUri": "azds://eastus:datashare1:12345678-1234-1234-1234-123456789123"
+            },
+            "authProperties": {
+              "type": "ManagedIdentity",
+              "identityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testIdentity"
+            }
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  }
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageConnectorCRUD/StorageConnectors_Delete.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageConnectorCRUD/StorageConnectors_Delete.json
@@ -1,0 +1,22 @@
+{
+  "operationId": "Connectors_Delete",
+  "title": "DeleteConnector",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "testrg",
+    "accountName": "teststorageaccount",
+    "connectorName": "testconnector",
+    "api-version": "2026-09-01"
+  },
+  "responses": {
+    "204": {},
+    "202": {
+      "status": "Accepted",
+      "message": "The resource operation has been received and is being processed.",
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/xxxx/resourceGroups/rg-name/providers/Microsoft.Storage/operations/operation-98765",
+        "Retry-After": 30
+      }
+    }
+  }
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageConnectorCRUD/StorageConnectors_Get.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageConnectorCRUD/StorageConnectors_Get.json
@@ -1,0 +1,40 @@
+{
+  "operationId": "Connectors_Get",
+  "title": "GetConnector",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "testrg",
+    "accountName": "teststorageaccount",
+    "api-version": "2026-09-01",
+    "connectorName": "testconnector"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/storageAccounts/teststorageaccount/connectors/testconnector",
+        "name": "testconnector",
+        "type": "Microsoft.Storage/storageAccounts/connectors",
+        "location": "eastus",
+        "properties": {
+          "uniqueId": "12345678-1234-1234-1234-12345678912",
+          "state": "Active",
+          "creationTime": "2023-04-01T00:00:00Z",
+          "description": "Example connector",
+          "dataSourceType": "Azure_DataShare",
+          "source": {
+            "type": "DataShare",
+            "connection": {
+              "type": "DataShare",
+              "dataShareUri": "azds://eastus:datashare1:12345678-1234-1234-1234-123456789123"
+            },
+            "authProperties": {
+              "type": "ManagedIdentity",
+              "identityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testIdentity"
+            }
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  }
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageConnectorCRUD/StorageConnectors_ListByStorageAccount.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageConnectorCRUD/StorageConnectors_ListByStorageAccount.json
@@ -1,0 +1,68 @@
+{
+  "operationId": "Connectors_ListByStorageAccount",
+  "title": "ListConnectorsByStorageAccount",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "testrg",
+    "accountName": "teststorageaccount",
+    "api-version": "2026-09-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/storageAccounts/teststorageaccount/connectors/testconnector",
+            "name": "testconnector1",
+            "type": "Microsoft.Storage/storageAccounts/connectors",
+            "location": "eastus",
+            "properties": {
+              "uniqueId": "12345678-1234-1234-1234-12345678912",
+              "state": "Active",
+              "creationTime": "2023-04-01T00:00:00Z",
+              "description": "Example connector",
+              "dataSourceType": "Azure_DataShare",
+              "source": {
+                "type": "DataShare",
+                "connection": {
+                  "type": "DataShare",
+                  "dataShareUri": "azds://eastus:datashare1:12345678-1234-1234-1234-123456789123"
+                },
+                "authProperties": {
+                  "type": "ManagedIdentity",
+                  "identityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testIdentity"
+                }
+              },
+              "provisioningState": "Succeeded"
+            }
+          },
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/storageAccounts/teststorageaccount/connectors/Jill",
+            "name": "testconnector2",
+            "type": "Microsoft.Storage/storageAccounts/connectors",
+            "location": "westus",
+            "properties": {
+              "uniqueId": "12345678-1234-1234-1234-12345678912",
+              "state": "Active",
+              "creationTime": "2023-04-01T00:00:00Z",
+              "description": "Example connector",
+              "dataSourceType": "Azure_DataShare",
+              "source": {
+                "type": "DataShare",
+                "connection": {
+                  "type": "DataShare",
+                  "dataShareUri": "azds://eastus:datashare1:12345678-1234-1234-1234-123456789123"
+                },
+                "authProperties": {
+                  "type": "ManagedIdentity",
+                  "identityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testIdentity"
+                }
+              },
+              "provisioningState": "Succeeded"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageConnectorCRUD/StorageConnectors_TestExistingConnection.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageConnectorCRUD/StorageConnectors_TestExistingConnection.json
@@ -1,0 +1,30 @@
+{
+  "operationId": "Connectors_TestExistingConnection",
+  "title": "ExistingConnectionTest",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "testrg",
+    "accountName": "teststorageaccount",
+    "api-version": "2026-09-01",
+    "connectorName": "testconnector",
+    "body": {
+      "uniqueId": "12345678-1234-1234-1234-12345678912"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "storageConnectorMethodName": "TestExistingConnection",
+        "storageConnectorRequestId": "request-id-123"
+      }
+    },
+    "202": {
+      "status": "Accepted",
+      "message": "The resource operation has been received and is being processed.",
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/xxxx/resourceGroups/rg-name/providers/Microsoft.Storage/operations/operation-98765",
+        "Retry-After": 30
+      }
+    }
+  }
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageConnectorCRUD/StorageConnectors_Update.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageConnectorCRUD/StorageConnectors_Update.json
@@ -1,0 +1,59 @@
+{
+  "operationId": "Connectors_Update",
+  "title": "UpdateConnector",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "testrg",
+    "accountName": "teststorageaccount",
+    "api-version": "2026-09-01",
+    "connectorName": "testconnector",
+    "properties": {
+      "properties": {
+        "source": {
+          "type": "DataShare",
+          "authProperties": {
+            "type": "ManagedIdentity",
+            "identityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/newTestIdentity"
+          }
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/storageAccounts/teststorageaccount/connectors/testconnector",
+        "name": "testconnector",
+        "type": "Microsoft.Storage/storageAccounts/connectors",
+        "location": "eastus",
+        "properties": {
+          "uniqueId": "12345678-1234-1234-1234-12345678912",
+          "state": "Active",
+          "creationTime": "2023-04-01T00:00:00Z",
+          "description": "Example connector",
+          "dataSourceType": "Azure_DataShare",
+          "source": {
+            "type": "DataShare",
+            "connection": {
+              "type": "DataShare",
+              "dataShareUri": "azds://eastus:datashare1:12345678-1234-1234-1234-123456789123"
+            },
+            "authProperties": {
+              "type": "ManagedIdentity",
+              "identityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/newTestIdentity"
+            }
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    },
+    "202": {
+      "status": "Accepted",
+      "message": "The resource operation has been received and is being processed.",
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/xxxx/resourceGroups/rg-name/providers/Microsoft.Storage/operations/operation-98765",
+        "Retry-After": 30
+      }
+    }
+  }
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageContextCacheCRUD/ContextCaches_CreateOrUpdate.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageContextCacheCRUD/ContextCaches_CreateOrUpdate.json
@@ -1,0 +1,82 @@
+{
+  "operationId": "ContextCaches_CreateOrUpdate",
+  "title": "Create a Context Cache",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "testrg",
+    "api-version": "2026-09-01",
+    "contextCacheName": "testaccount",
+    "resource": {
+      "location": "eastus",
+      "tags": {
+        "environment": "test"
+      },
+      "properties": {
+        "accountKind": "Regional",
+        "description": "Test Azure Context Cache account"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/contextCaches/testaccount",
+        "name": "testaccount",
+        "type": "Microsoft.Storage/contextCaches",
+        "location": "eastus",
+        "tags": {
+          "environment": "test"
+        },
+        "properties": {
+          "accountKind": "Regional",
+          "description": "Test Azure Context Cache account",
+          "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdBy": "user@example.com",
+          "createdByType": "User",
+          "createdAt": "2026-01-01T00:00:00Z",
+          "lastModifiedBy": "user@example.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-01-01T00:00:00Z"
+        }
+      }
+    },
+    "201": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/eastus/operationStatuses/00000000-0000-0000-0000-000000000000?api-version=2026-06-01",
+        "Retry-After": "10"
+      },
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/contextCaches/testaccount",
+        "name": "testaccount",
+        "type": "Microsoft.Storage/contextCaches",
+        "location": "eastus",
+        "tags": {
+          "environment": "test"
+        },
+        "properties": {
+          "accountKind": "Regional",
+          "description": "Test Azure Context Cache account",
+          "provisioningState": "Creating"
+        },
+        "systemData": {
+          "createdBy": "user@example.com",
+          "createdByType": "User",
+          "createdAt": "2026-01-01T00:00:00Z",
+          "lastModifiedBy": "user@example.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-01-01T00:00:00Z"
+        }
+      }
+    },
+    "default": {
+      "body": {
+        "error": {
+          "code": "InvalidOperation",
+          "message": "Invalid request body or parameters"
+        }
+      }
+    }
+  }
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageContextCacheCRUD/ContextCaches_CreateOrUpdate_SystemIdentity.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageContextCacheCRUD/ContextCaches_CreateOrUpdate_SystemIdentity.json
@@ -1,0 +1,119 @@
+{
+  "operationId": "ContextCaches_CreateOrUpdate",
+  "title": "Create a Azure Context Cache Account with System Assigned Identity",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "testrg",
+    "api-version": "2026-09-01",
+    "contextCacheName": "testaccount",
+    "resource": {
+      "location": "eastus",
+      "tags": {
+        "environment": "test"
+      },
+      "identity": {
+        "type": "SystemAssigned"
+      },
+      "properties": {
+        "accountKind": "Regional",
+        "description": "Test Azure Context Cache account",
+        "encryption": {
+          "customerManagedKeyEncryption": {
+            "keyEncryptionKeyIdentity": {
+              "identityType": "systemAssignedIdentity"
+            },
+            "keyEncryptionKeyUrl": "https://mykeyvault.vault.azure.net/keys/myEncryptionKey"
+          }
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/contextCaches/testaccount",
+        "name": "testaccount",
+        "type": "Microsoft.Storage/contextCaches",
+        "location": "eastus",
+        "tags": {
+          "environment": "test"
+        },
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-0000-0000-0000-000000000000",
+          "tenantId": "00000000-0000-0000-0000-000000000000"
+        },
+        "properties": {
+          "accountKind": "Regional",
+          "description": "Test Azure Context Cache account",
+          "encryption": {
+            "customerManagedKeyEncryption": {
+              "keyEncryptionKeyIdentity": {
+                "identityType": "systemAssignedIdentity"
+              },
+              "keyEncryptionKeyUrl": "https://mykeyvault.vault.azure.net/keys/myEncryptionKey"
+            }
+          },
+          "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdBy": "user@example.com",
+          "createdByType": "User",
+          "createdAt": "2026-01-01T00:00:00Z",
+          "lastModifiedBy": "user@example.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-01-01T00:00:00Z"
+        }
+      }
+    },
+    "201": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/eastus/operationStatuses/00000000-0000-0000-0000-000000000000?api-version=2026-06-01",
+        "Retry-After": "10"
+      },
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/contextCaches/testaccount",
+        "name": "testaccount",
+        "type": "Microsoft.Storage/contextCaches",
+        "location": "eastus",
+        "tags": {
+          "environment": "test"
+        },
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-0000-0000-0000-000000000000",
+          "tenantId": "00000000-0000-0000-0000-000000000000"
+        },
+        "properties": {
+          "accountKind": "Regional",
+          "description": "Test Azure Context Cache account",
+          "encryption": {
+            "customerManagedKeyEncryption": {
+              "keyEncryptionKeyIdentity": {
+                "identityType": "systemAssignedIdentity"
+              },
+              "keyEncryptionKeyUrl": "https://mykeyvault.vault.azure.net/keys/myEncryptionKey"
+            }
+          },
+          "provisioningState": "Creating"
+        },
+        "systemData": {
+          "createdBy": "user@example.com",
+          "createdByType": "User",
+          "createdAt": "2026-01-01T00:00:00Z",
+          "lastModifiedBy": "user@example.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-01-01T00:00:00Z"
+        }
+      }
+    },
+    "default": {
+      "body": {
+        "error": {
+          "code": "InvalidOperation",
+          "message": "Invalid request body or parameters"
+        }
+      }
+    }
+  }
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageContextCacheCRUD/ContextCaches_Delete.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageContextCacheCRUD/ContextCaches_Delete.json
@@ -1,0 +1,27 @@
+{
+  "operationId": "ContextCaches_Delete",
+  "title": "Delete a Context Cache",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "testrg",
+    "api-version": "2026-09-01",
+    "contextCacheName": "testaccount"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/eastus/operationStatuses/00000000-0000-0000-0000-000000000001?api-version=2026-06-01",
+        "Retry-After": "10"
+      }
+    },
+    "204": {},
+    "default": {
+      "body": {
+        "error": {
+          "code": "ResourceNotFound",
+          "message": "Resource testaccount not found"
+        }
+      }
+    }
+  }
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageContextCacheCRUD/ContextCaches_Get.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageContextCacheCRUD/ContextCaches_Get.json
@@ -1,0 +1,44 @@
+{
+  "operationId": "ContextCaches_Get",
+  "title": "Get a Context Cache",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "testrg",
+    "api-version": "2026-09-01",
+    "contextCacheName": "testaccount"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/contextCaches/testaccount",
+        "name": "testaccount",
+        "type": "Microsoft.Storage/contextCaches",
+        "location": "eastus",
+        "tags": {
+          "environment": "test"
+        },
+        "properties": {
+          "accountKind": "Regional",
+          "description": "Test Azure Context Cache account",
+          "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdBy": "user@example.com",
+          "createdByType": "User",
+          "createdAt": "2026-01-01T00:00:00Z",
+          "lastModifiedBy": "user@example.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-01-01T00:00:00Z"
+        }
+      }
+    },
+    "default": {
+      "body": {
+        "error": {
+          "code": "ResourceNotFound",
+          "message": "Resource testaccount not found"
+        }
+      }
+    }
+  }
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageContextCacheCRUD/ContextCaches_ListByResourceGroup.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageContextCacheCRUD/ContextCaches_ListByResourceGroup.json
@@ -1,0 +1,47 @@
+{
+  "operationId": "ContextCaches_ListByResourceGroup",
+  "title": "List Context Caches by Resource Group",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "testrg",
+    "api-version": "2026-09-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/contextCaches/testaccount",
+            "name": "testaccount",
+            "type": "Microsoft.Storage/contextCaches",
+            "location": "eastus",
+            "tags": {
+              "environment": "test"
+            },
+            "properties": {
+              "accountKind": "Regional",
+              "description": "Test Azure Context Cache account",
+              "provisioningState": "Succeeded"
+            },
+            "systemData": {
+              "createdBy": "user@example.com",
+              "createdByType": "User",
+              "createdAt": "2026-01-01T00:00:00Z",
+              "lastModifiedBy": "user@example.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2026-01-01T00:00:00Z"
+            }
+          }
+        ]
+      }
+    },
+    "default": {
+      "body": {
+        "error": {
+          "code": "InternalServerError",
+          "message": "An unexpected error occurred"
+        }
+      }
+    }
+  }
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageContextCacheCRUD/ContextCaches_ListBySubscription.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageContextCacheCRUD/ContextCaches_ListBySubscription.json
@@ -1,0 +1,46 @@
+{
+  "operationId": "ContextCaches_ListBySubscription",
+  "title": "List Context Caches by Subscription",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2026-09-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/contextCaches/testaccount",
+            "name": "testaccount",
+            "type": "Microsoft.Storage/contextCaches",
+            "location": "eastus",
+            "tags": {
+              "environment": "test"
+            },
+            "properties": {
+              "accountKind": "Regional",
+              "description": "Test Azure Context Cache account",
+              "provisioningState": "Succeeded"
+            },
+            "systemData": {
+              "createdBy": "user@example.com",
+              "createdByType": "User",
+              "createdAt": "2026-01-01T00:00:00Z",
+              "lastModifiedBy": "user@example.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2026-01-01T00:00:00Z"
+            }
+          }
+        ]
+      }
+    },
+    "default": {
+      "body": {
+        "error": {
+          "code": "InternalServerError",
+          "message": "An unexpected error occurred"
+        }
+      }
+    }
+  }
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageContextCacheCRUD/ContextCaches_Update.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageContextCacheCRUD/ContextCaches_Update.json
@@ -1,0 +1,76 @@
+{
+  "operationId": "ContextCaches_Update",
+  "title": "Update a Context Cache tags",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "testrg",
+    "api-version": "2026-09-01",
+    "contextCacheName": "testaccount",
+    "properties": {
+      "tags": {
+        "environment": "production",
+        "team": "context-cache"
+      },
+      "identity": {
+        "type": "SystemAssigned"
+      },
+      "properties": {
+        "description": "Updated Prompt Service account description"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/contextCaches/testaccount",
+        "name": "testaccount",
+        "type": "Microsoft.Storage/contextCaches",
+        "location": "eastus",
+        "tags": {
+          "environment": "production",
+          "team": "context-cache"
+        },
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-0000-0000-0000-000000000000",
+          "tenantId": "00000000-0000-0000-0000-000000000000"
+        },
+        "properties": {
+          "accountKind": "Regional",
+          "description": "Updated Prompt Service account description",
+          "encryption": {
+            "customerManagedKeyEncryption": {
+              "keyEncryptionKeyIdentity": {
+                "identityType": "systemAssignedIdentity"
+              },
+              "keyEncryptionKeyUrl": "https://mykeyvault.vault.azure.net/keys/myEncryptionKey"
+            }
+          },
+          "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdBy": "user@example.com",
+          "createdByType": "User",
+          "createdAt": "2026-01-01T00:00:00Z",
+          "lastModifiedBy": "user@example.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-01-01T00:00:00Z"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/contextCaches/testaccount?api-version=2026-06-01",
+        "Retry-After": "10"
+      }
+    },
+    "default": {
+      "body": {
+        "error": {
+          "code": "InvalidOperation",
+          "message": "Invalid request body or parameters"
+        }
+      }
+    }
+  }
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageContextCacheCRUD/ContextCaches_Update_CustomerManagedKey.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageContextCacheCRUD/ContextCaches_Update_CustomerManagedKey.json
@@ -1,0 +1,84 @@
+{
+  "operationId": "ContextCaches_Update",
+  "title": "Update a Azure Context Cache Account's Customer Managed Key Encryption Settings",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "testrg",
+    "api-version": "2026-09-01",
+    "contextCacheName": "testaccount",
+    "properties": {
+      "tags": {
+        "environment": "production",
+        "team": "context-cache"
+      },
+      "identity": {
+        "type": "SystemAssigned"
+      },
+      "properties": {
+        "description": "Updated Prompt Service account description",
+        "encryption": {
+          "customerManagedKeyEncryption": {
+            "keyEncryptionKeyIdentity": {
+              "identityType": "systemAssignedIdentity"
+            },
+            "keyEncryptionKeyUrl": "https://mykeyvault.vault.azure.net/keys/newEncryptionKey"
+          }
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/contextCaches/testaccount",
+        "name": "testaccount",
+        "type": "Microsoft.Storage/contextCaches",
+        "location": "eastus",
+        "tags": {
+          "environment": "production",
+          "team": "context-cache"
+        },
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-0000-0000-0000-000000000000",
+          "tenantId": "00000000-0000-0000-0000-000000000000"
+        },
+        "properties": {
+          "accountKind": "Regional",
+          "description": "Updated Prompt Service account description",
+          "encryption": {
+            "customerManagedKeyEncryption": {
+              "keyEncryptionKeyIdentity": {
+                "identityType": "systemAssignedIdentity"
+              },
+              "keyEncryptionKeyUrl": "https://mykeyvault.vault.azure.net/keys/newEncryptionKey"
+            }
+          },
+          "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdBy": "user@example.com",
+          "createdByType": "User",
+          "createdAt": "2026-01-01T00:00:00Z",
+          "lastModifiedBy": "user@example.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-01-01T00:00:00Z"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/contextCaches/testaccount?api-version=2026-06-01",
+        "Retry-After": "10"
+      }
+    },
+    "default": {
+      "body": {
+        "error": {
+          "code": "InvalidOperation",
+          "message": "Invalid request body or parameters"
+        }
+      }
+    }
+  }
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageContextCacheContainerCRUD/ContextCacheContainers_CreateOrUpdate.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageContextCacheContainerCRUD/ContextCacheContainers_CreateOrUpdate.json
@@ -1,0 +1,69 @@
+{
+  "operationId": "ContextCacheContainers_CreateOrUpdate",
+  "title": "Create a Context Cache Container",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "testrg",
+    "api-version": "2026-09-01",
+    "contextCacheName": "testaccount",
+    "contextCacheContainerName": "gpt4-prompts",
+    "resource": {
+      "properties": {
+        "description": "Container for GPT-4 prompt caching",
+        "modelName": "gpt-4",
+        "provider": "OpenAI",
+        "timeToLive": 7
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/contextCaches/testaccount/contextCacheContainers/gpt4-prompts",
+        "name": "gpt4-prompts",
+        "type": "Microsoft.Storage/contextCaches/contextCacheContainers",
+        "properties": {
+          "description": "Container for GPT-4 prompt caching",
+          "modelName": "gpt-4",
+          "provider": "OpenAI",
+          "timeToLive": 7,
+          "provisioningState": "Succeeded"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/contextCaches/testaccount/contextCacheContainers/gpt4-prompts",
+        "name": "gpt4-prompts",
+        "type": "Microsoft.Storage/contextCaches/contextCacheContainers",
+        "properties": {
+          "description": "Container for GPT-4 prompt caching",
+          "modelName": "gpt-4",
+          "provider": "OpenAI",
+          "timeToLive": 7,
+          "provisioningState": "Creating"
+        },
+        "systemData": {
+          "createdBy": "user@example.com",
+          "createdByType": "User",
+          "createdAt": "2026-01-01T00:00:00Z",
+          "lastModifiedBy": "user@example.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-01-01T00:00:00Z"
+        }
+      },
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/eastus/operations/00000000-0000-0000-0000-000000000001?api-version=2026-06-01",
+        "Retry-After": 10
+      }
+    },
+    "default": {
+      "body": {
+        "error": {
+          "code": "InvalidContainerName",
+          "message": "Container name must be 3-63 characters, lowercase alphanumeric and hyphens"
+        }
+      }
+    }
+  }
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageContextCacheContainerCRUD/ContextCacheContainers_Delete.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageContextCacheContainerCRUD/ContextCacheContainers_Delete.json
@@ -1,0 +1,28 @@
+{
+  "operationId": "ContextCacheContainers_Delete",
+  "title": "Delete a Context Cache Container",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "testrg",
+    "api-version": "2026-09-01",
+    "contextCacheName": "testaccount",
+    "contextCacheContainerName": "gpt4-prompts"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/eastus/operationStatuses/00000000-0000-0000-0000-000000000002?api-version=2026-06-01",
+        "Retry-After": "10"
+      }
+    },
+    "204": {},
+    "default": {
+      "body": {
+        "error": {
+          "code": "ResourceNotFound",
+          "message": "Container gpt4-prompts not found"
+        }
+      }
+    }
+  }
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageContextCacheContainerCRUD/ContextCacheContainers_Get.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageContextCacheContainerCRUD/ContextCacheContainers_Get.json
@@ -1,0 +1,42 @@
+{
+  "operationId": "ContextCacheContainers_Get",
+  "title": "Get a Context Cache Container",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "testrg",
+    "api-version": "2026-09-01",
+    "contextCacheName": "testaccount",
+    "contextCacheContainerName": "gpt4-prompts"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/contextCaches/testaccount/contextCacheContainers/gpt4-prompts",
+        "name": "gpt4-prompts",
+        "type": "Microsoft.Storage/contextCaches/contextCacheContainers",
+        "properties": {
+          "description": "Container for GPT-4 prompt caching",
+          "modelName": "gpt-4",
+          "provider": "OpenAI",
+          "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdBy": "user@example.com",
+          "createdByType": "User",
+          "createdAt": "2026-01-01T00:00:00Z",
+          "lastModifiedBy": "user@example.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-01-01T00:00:00Z"
+        }
+      }
+    },
+    "default": {
+      "body": {
+        "error": {
+          "code": "ResourceNotFound",
+          "message": "Container gpt4-prompts not found"
+        }
+      }
+    }
+  }
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageContextCacheContainerCRUD/ContextCacheContainers_ListByContextCache.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageContextCacheContainerCRUD/ContextCacheContainers_ListByContextCache.json
@@ -1,0 +1,48 @@
+{
+  "operationId": "ContextCacheContainers_ListByContextCache",
+  "title": "List Context Cache Containers in a Context Cache",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "testrg",
+    "api-version": "2026-09-01",
+    "contextCacheName": "testaccount"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/contextCaches/testaccount/contextCacheContainers/gpt4-prompts",
+            "name": "gpt4-prompts",
+            "type": "Microsoft.Storage/contextCaches/contextCacheContainers",
+            "properties": {
+              "description": "Container for GPT-4 prompt caching",
+              "modelName": "gpt-4",
+              "provider": "OpenAI",
+              "provisioningState": "Succeeded"
+            }
+          },
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/contextCaches/testaccount/contextCacheContainers/claude3-prompts",
+            "name": "claude3-prompts",
+            "type": "Microsoft.Storage/contextCaches/contextCacheContainers",
+            "properties": {
+              "description": "Container for Claude-3 prompt caching",
+              "modelName": "claude-3",
+              "provider": "Anthropic",
+              "provisioningState": "Succeeded"
+            }
+          }
+        ]
+      }
+    },
+    "default": {
+      "body": {
+        "error": {
+          "code": "ResourceNotFound",
+          "message": "Account testaccount not found"
+        }
+      }
+    }
+  }
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageContextCacheContainerCRUD/ContextCacheContainers_Update.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageContextCacheContainerCRUD/ContextCacheContainers_Update.json
@@ -1,0 +1,47 @@
+{
+  "operationId": "ContextCacheContainers_Update",
+  "title": "Update a Context Cache Container",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "testrg",
+    "api-version": "2026-09-01",
+    "contextCacheName": "testaccount",
+    "contextCacheContainerName": "gpt4-prompts",
+    "properties": {
+      "properties": {
+        "description": "Updated container for GPT-4 prompt caching",
+        "timeToLive": 14
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/contextCaches/testaccount/contextCacheContainers/gpt4-prompts",
+        "name": "gpt4-prompts",
+        "type": "Microsoft.Storage/contextCaches/contextCacheContainers",
+        "properties": {
+          "description": "Updated container for GPT-4 prompt caching",
+          "modelName": "gpt-4",
+          "provider": "OpenAI",
+          "timeToLive": 14,
+          "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdBy": "user@example.com",
+          "createdByType": "User",
+          "createdAt": "2026-01-01T00:00:00Z",
+          "lastModifiedBy": "user@example.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-01-01T00:00:00Z"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/contextCaches/testaccount/contextCacheContainers/gpt4-prompts?api-version=2026-06-01",
+        "Retry-After": "10"
+      }
+    }
+  }
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageDataShareCRUD/StorageDataShares_Create.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageDataShareCRUD/StorageDataShares_Create.json
@@ -1,0 +1,86 @@
+{
+  "operationId": "DataShares_Create",
+  "title": "CreateDataShare",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "testrg",
+    "api-version": "2026-09-01",
+    "dataShareName": "testdatashare",
+    "accountName": "teststorageaccount",
+    "resource": {
+      "location": "eastus",
+      "properties": {
+        "description": "Dummy data share",
+        "accessPolicies": [
+          {
+            "principalId": "00000000-0000-0000-0000-000000000000",
+            "tenantId": "00000000-0000-0000-0000-000000000000",
+            "permission": "Read"
+          }
+        ],
+        "assets": [
+          {
+            "assetPath": "/container/folder/foo",
+            "displayName": "virtualFoo"
+          }
+        ]
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/storageAccounts/teststorageaccount/dataShares/testdatashare",
+        "name": "testdatashare",
+        "type": "Microsoft.Storage/storageAccounts/dataShares",
+        "location": "eastus",
+        "properties": {
+          "dataShareIdentifier": "00000000-0000-0000-0000-000000000000",
+          "description": "Dummy data share",
+          "dataShareUri": "azds://eastus:testdatashare:00000000-0000-0000-0000-000000000000",
+          "accessPolicies": [
+            {
+              "principalId": "00000000-0000-0000-0000-000000000000",
+              "tenantId": "00000000-0000-0000-0000-000000000000",
+              "permission": "Read"
+            }
+          ],
+          "assets": [
+            {
+              "assetPath": "/container/folder/foo",
+              "displayName": "virtualFoo"
+            }
+          ],
+          "provisioningState": "Succeeded"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/storageAccounts/teststorageaccount/dataShares/testdatashare",
+        "name": "testdatashare",
+        "type": "Microsoft.Storage/storageAccounts/dataShares",
+        "location": "eastus",
+        "properties": {
+          "dataShareIdentifier": "00000000-0000-0000-0000-000000000000",
+          "description": "Dummy data share",
+          "dataShareUri": "azds://eastus:testdatashare:00000000-0000-0000-0000-000000000000",
+          "accessPolicies": [
+            {
+              "principalId": "00000000-0000-0000-0000-000000000000",
+              "tenantId": "00000000-0000-0000-0000-000000000000",
+              "permission": "Read"
+            }
+          ],
+          "assets": [
+            {
+              "assetPath": "/container/folder/foo",
+              "displayName": "virtualFoo"
+            }
+          ],
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  }
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageDataShareCRUD/StorageDataShares_Delete.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageDataShareCRUD/StorageDataShares_Delete.json
@@ -1,0 +1,22 @@
+{
+  "operationId": "DataShares_Delete",
+  "title": "DeleteDataShare",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "testrg",
+    "accountName": "teststorageaccount",
+    "dataShareName": "testdatashare",
+    "api-version": "2026-09-01"
+  },
+  "responses": {
+    "204": {},
+    "202": {
+      "status": "Accepted",
+      "message": "The resource operation has been received and is being processed.",
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/xxxx/resourceGroups/rg-name/providers/Microsoft.Storage/operations/operation-98765",
+        "Retry-After": 30
+      }
+    }
+  }
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageDataShareCRUD/StorageDataShares_Get.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageDataShareCRUD/StorageDataShares_Get.json
@@ -1,0 +1,40 @@
+{
+  "operationId": "DataShares_Get",
+  "title": "GetDataShare",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "testrg",
+    "accountName": "teststorageaccount",
+    "api-version": "2026-09-01",
+    "dataShareName": "testdatashare"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/storageAccounts/teststorageaccounts/datashares/testdatashare",
+        "name": "testdatashare",
+        "type": "Microsoft.Storage/storageAccounts/dataShares",
+        "location": "eastus",
+        "properties": {
+          "dataShareIdentifier": "00000000-0000-0000-0000-000000000000",
+          "description": "Dummy data share",
+          "dataShareUri": "azds://eastus:testdatashare:00000000-0000-0000-0000-000000000000",
+          "accessPolicies": [
+            {
+              "principalId": "00000000-0000-0000-0000-000000000000",
+              "tenantId": "00000000-0000-0000-0000-000000000000",
+              "permission": "Read"
+            }
+          ],
+          "assets": [
+            {
+              "assetPath": "/container/folder/foo",
+              "displayName": "virtualFoo"
+            }
+          ],
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  }
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageDataShareCRUD/StorageDataShares_ListByStorageAccount.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageDataShareCRUD/StorageDataShares_ListByStorageAccount.json
@@ -1,0 +1,68 @@
+{
+  "operationId": "DataShares_ListByStorageAccount",
+  "title": "ListDataSharesByStorageAccount",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "testrg",
+    "accountName": "teststorageaccount",
+    "api-version": "2026-09-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/storageAccounts/teststorageaccount/dataShares/testdatashare1",
+            "name": "testdatashare1",
+            "type": "Microsoft.Storage/storageAccounts/dataShares",
+            "location": "eastus",
+            "properties": {
+              "dataShareIdentifier": "00000000-0000-0000-0000-000000000000",
+              "description": "Dummy data share",
+              "dataShareUri": "azds://eastus:testdatashare1:00000000-0000-0000-0000-000000000000",
+              "accessPolicies": [
+                {
+                  "principalId": "00000000-0000-0000-0000-000000000000",
+                  "tenantId": "00000000-0000-0000-0000-000000000000",
+                  "permission": "Read"
+                }
+              ],
+              "assets": [
+                {
+                  "assetPath": "/container/folder/foo",
+                  "displayName": "virtualFoo"
+                }
+              ],
+              "provisioningState": "Succeeded"
+            }
+          },
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/storageAccounts/teststorageaccount/dataShares/testdatashare2",
+            "name": "testdatashare2",
+            "type": "Microsoft.Storage/storageAccounts/dataShares",
+            "location": "westus",
+            "properties": {
+              "dataShareIdentifier": "00000000-0000-0000-0000-000000000000",
+              "description": "Dummy data share",
+              "dataShareUri": "azds://eastus:testdatashare2:00000000-0000-0000-0000-000000000000",
+              "accessPolicies": [
+                {
+                  "principalId": "00000000-0000-0000-0000-000000000000",
+                  "tenantId": "00000000-0000-0000-0000-000000000000",
+                  "permission": "Read"
+                }
+              ],
+              "assets": [
+                {
+                  "assetPath": "/container/folder/foo",
+                  "displayName": "virtualFoo"
+                }
+              ],
+              "provisioningState": "Succeeded"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/StorageDataShareCRUD/StorageDataShares_Update.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/StorageDataShareCRUD/StorageDataShares_Update.json
@@ -1,0 +1,66 @@
+{
+  "operationId": "DataShares_Update",
+  "title": "UpdateDataShare",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "testrg",
+    "accountName": "teststorageaccount",
+    "api-version": "2026-09-01",
+    "dataShareName": "testdatashare",
+    "properties": {
+      "properties": {
+        "description": "New dummy data share",
+        "accessPolicies": [
+          {
+            "principalId": "00000000-0000-0000-0000-123456781234",
+            "tenantId": "00000000-0000-0000-0000-987654321987",
+            "permission": "Read"
+          }
+        ],
+        "assets": [
+          {
+            "assetPath": "/container/folder1/bar",
+            "displayName": "virtualBar"
+          }
+        ]
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/storageAccounts/teststorageaccount/dataShares/testdatashare",
+        "name": "testdatashare",
+        "type": "Microsoft.Storage/storageAccounts/dataShares",
+        "location": "eastus",
+        "properties": {
+          "dataShareIdentifier": "00000000-0000-0000-0000-000000000000",
+          "description": "New dummy data share",
+          "dataShareUri": "azds://eastus:testdatashare:00000000-0000-0000-0000-000000000000",
+          "accessPolicies": [
+            {
+              "principalId": "00000000-0000-0000-0000-123456781234",
+              "tenantId": "00000000-0000-0000-0000-987654321987",
+              "permission": "Read"
+            }
+          ],
+          "assets": [
+            {
+              "assetPath": "/container/folder1/bar",
+              "displayName": "virtualBar"
+            }
+          ],
+          "provisioningState": "Succeeded"
+        }
+      }
+    },
+    "202": {
+      "status": "Accepted",
+      "message": "The resource operation has been received and is being processed.",
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/xxxx/resourceGroups/rg-name/providers/Microsoft.Storage/operations/operation-98765",
+        "Retry-After": 30
+      }
+    }
+  }
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/TableOperationDelete.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/TableOperationDelete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "accountName": "sto328",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res3376",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "tableName": "table6185"
+  },
+  "responses": {
+    "204": {}
+  },
+  "operationId": "Table_Delete",
+  "title": "TableOperationDelete"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/TableOperationGet.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/TableOperationGet.json
@@ -1,0 +1,24 @@
+{
+  "parameters": {
+    "accountName": "sto328",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res3376",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "tableName": "table6185"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "table6185",
+        "type": "Microsoft.Storage/storageAccounts/tableServices/tables",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res3376/providers/Microsoft.Storage/storageAccounts/sto328/tableServices/default/tables/table6185",
+        "properties": {
+          "tableName": "table6185"
+        }
+      }
+    }
+  },
+  "operationId": "Table_Get",
+  "title": "TableOperationGet"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/TableOperationList.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/TableOperationList.json
@@ -1,0 +1,36 @@
+{
+  "parameters": {
+    "accountName": "sto328",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res9290",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://sto1590endpoint/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res9290/providers/Microsoft.Storage/storageAccounts/sto328/tableServices/default/tables?api-version=2022-09-01&NextTableName=1!40!bXl0YWJsZXNoYzU0OAEwMWQ2MTI5ZTJmYjVmODFh",
+        "value": [
+          {
+            "name": "table6185",
+            "type": "Microsoft.Storage/storageAccounts/tableServices/tables",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res3376/providers/Microsoft.Storage/storageAccounts/sto328/tableServices/default/tables/table6185",
+            "properties": {
+              "tableName": "table6185"
+            }
+          },
+          {
+            "name": "table6186",
+            "type": "Microsoft.Storage/storageAccounts/tableServices/tables",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res3376/providers/Microsoft.Storage/storageAccounts/sto328/tableServices/default/tables/table6186",
+            "properties": {
+              "tableName": "table6186"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Table_List",
+  "title": "TableOperationList"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/TableOperationPatch.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/TableOperationPatch.json
@@ -1,0 +1,24 @@
+{
+  "parameters": {
+    "accountName": "sto328",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res3376",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "tableName": "table6185"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "table6185",
+        "type": "Microsoft.Storage/storageAccounts/tableServices/tables",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res3376/providers/Microsoft.Storage/storageAccounts/sto328/tableServices/default/tables/table6185",
+        "properties": {
+          "tableName": "table6185"
+        }
+      }
+    }
+  },
+  "operationId": "Table_Update",
+  "title": "TableOperationPatch"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/TableOperationPut.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/TableOperationPut.json
@@ -1,0 +1,24 @@
+{
+  "parameters": {
+    "accountName": "sto328",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res3376",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "tableName": "table6185"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "table6185",
+        "type": "Microsoft.Storage/storageAccounts/tableServices/tables",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res3376/providers/Microsoft.Storage/storageAccounts/sto328/tableServices/default/tables/table6185",
+        "properties": {
+          "tableName": "table6185"
+        }
+      }
+    }
+  },
+  "operationId": "Table_Create",
+  "title": "TableOperationPut"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/TableOperationPutOrPatchAcls.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/TableOperationPutOrPatchAcls.json
@@ -1,0 +1,64 @@
+{
+  "parameters": {
+    "accountName": "sto328",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "parameters": {
+      "properties": {
+        "signedIdentifiers": [
+          {
+            "accessPolicy": {
+              "expiryTime": "2022-03-20T08:49:37.0000000Z",
+              "permission": "raud",
+              "startTime": "2022-03-17T08:49:37.0000000Z"
+            },
+            "id": "MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI"
+          },
+          {
+            "accessPolicy": {
+              "expiryTime": "2022-03-20T08:49:37.0000000Z",
+              "permission": "rad",
+              "startTime": "2022-03-17T08:49:37.0000000Z"
+            },
+            "id": "PTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODklMTI"
+          }
+        ]
+      }
+    },
+    "resourceGroupName": "res3376",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "tableName": "table6185"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "table6185",
+        "type": "Microsoft.Storage/storageAccounts/tableServices/tables",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res3376/providers/Microsoft.Storage/storageAccounts/sto328/tableServices/default/tables/table6185",
+        "properties": {
+          "signedIdentifiers": [
+            {
+              "accessPolicy": {
+                "expiryTime": "2022-03-20T08:49:37.0000000Z",
+                "permission": "raud",
+                "startTime": "2022-03-17T08:49:37.0000000Z"
+              },
+              "id": "MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI"
+            },
+            {
+              "accessPolicy": {
+                "expiryTime": "2022-03-20T08:49:37.0000000Z",
+                "permission": "rad",
+                "startTime": "2022-03-17T08:49:37.0000000Z"
+              },
+              "id": "PTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODklMTI"
+            }
+          ],
+          "tableName": "table6185"
+        }
+      }
+    }
+  },
+  "operationId": "Table_Update",
+  "title": "TableOperationPutOrPatchAcls"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/TableOperationPutOrPatchAclsTableCreate.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/TableOperationPutOrPatchAclsTableCreate.json
@@ -1,0 +1,64 @@
+{
+  "parameters": {
+    "accountName": "sto328",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "parameters": {
+      "properties": {
+        "signedIdentifiers": [
+          {
+            "accessPolicy": {
+              "expiryTime": "2022-03-20T08:49:37.0000000Z",
+              "permission": "raud",
+              "startTime": "2022-03-17T08:49:37.0000000Z"
+            },
+            "id": "MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI"
+          },
+          {
+            "accessPolicy": {
+              "expiryTime": "2022-03-20T08:49:37.0000000Z",
+              "permission": "rad",
+              "startTime": "2022-03-17T08:49:37.0000000Z"
+            },
+            "id": "PTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODklMTI"
+          }
+        ]
+      }
+    },
+    "resourceGroupName": "res3376",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "tableName": "table6185"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "table6185",
+        "type": "Microsoft.Storage/storageAccounts/tableServices/tables",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res3376/providers/Microsoft.Storage/storageAccounts/sto328/tableServices/default/tables/table6185",
+        "properties": {
+          "signedIdentifiers": [
+            {
+              "accessPolicy": {
+                "expiryTime": "2022-03-20T08:49:37.0000000Z",
+                "permission": "raud",
+                "startTime": "2022-03-17T08:49:37.0000000Z"
+              },
+              "id": "MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI"
+            },
+            {
+              "accessPolicy": {
+                "expiryTime": "2022-03-20T08:49:37.0000000Z",
+                "permission": "rad",
+                "startTime": "2022-03-17T08:49:37.0000000Z"
+              },
+              "id": "PTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODklMTI"
+            }
+          ],
+          "tableName": "table6185"
+        }
+      }
+    }
+  },
+  "operationId": "Table_Create",
+  "title": "TableOperationPutOrPatchAcls"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/TableServicesGet.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/TableServicesGet.json
@@ -1,0 +1,84 @@
+{
+  "parameters": {
+    "accountName": "sto8607",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res4410",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "tableServiceName": "default"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.Storage/storageAccounts/tableServices",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res4410/providers/Microsoft.Storage/storageAccounts/sto8607/tableServices/default",
+        "properties": {
+          "cors": {
+            "corsRules": [
+              {
+                "allowedHeaders": [
+                  "x-ms-meta-abc",
+                  "x-ms-meta-data*",
+                  "x-ms-meta-target*"
+                ],
+                "allowedMethods": [
+                  "GET",
+                  "HEAD",
+                  "POST",
+                  "OPTIONS",
+                  "MERGE",
+                  "PUT"
+                ],
+                "allowedOrigins": [
+                  "http://www.contoso.com",
+                  "http://www.fabrikam.com"
+                ],
+                "exposedHeaders": [
+                  "x-ms-meta-*"
+                ],
+                "maxAgeInSeconds": 100
+              },
+              {
+                "allowedHeaders": [
+                  "*"
+                ],
+                "allowedMethods": [
+                  "GET"
+                ],
+                "allowedOrigins": [
+                  "*"
+                ],
+                "exposedHeaders": [
+                  "*"
+                ],
+                "maxAgeInSeconds": 2
+              },
+              {
+                "allowedHeaders": [
+                  "x-ms-meta-12345675754564*"
+                ],
+                "allowedMethods": [
+                  "GET",
+                  "PUT"
+                ],
+                "allowedOrigins": [
+                  "http://www.abc23.com",
+                  "https://www.fabrikam.com/*"
+                ],
+                "exposedHeaders": [
+                  "x-ms-meta-abc",
+                  "x-ms-meta-data*",
+                  "x-ms-meta-target*"
+                ],
+                "maxAgeInSeconds": 2000
+              }
+            ]
+          }
+        }
+      }
+    }
+  },
+  "operationId": "TableServices_GetServiceProperties",
+  "title": "TableServicesGet"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/TableServicesList.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/TableServicesList.json
@@ -1,0 +1,87 @@
+{
+  "parameters": {
+    "accountName": "sto1590",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res9290",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "default",
+            "type": "Microsoft.Storage/storageAccounts/tableServices",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/res4410/providers/Microsoft.Storage/storageAccounts/sto8607/tableServices/default",
+            "properties": {
+              "cors": {
+                "corsRules": [
+                  {
+                    "allowedHeaders": [
+                      "x-ms-meta-abc",
+                      "x-ms-meta-data*",
+                      "x-ms-meta-target*"
+                    ],
+                    "allowedMethods": [
+                      "GET",
+                      "HEAD",
+                      "POST",
+                      "OPTIONS",
+                      "MERGE",
+                      "PUT"
+                    ],
+                    "allowedOrigins": [
+                      "http://www.contoso.com",
+                      "http://www.fabrikam.com"
+                    ],
+                    "exposedHeaders": [
+                      "x-ms-meta-*"
+                    ],
+                    "maxAgeInSeconds": 100
+                  },
+                  {
+                    "allowedHeaders": [
+                      "*"
+                    ],
+                    "allowedMethods": [
+                      "GET"
+                    ],
+                    "allowedOrigins": [
+                      "*"
+                    ],
+                    "exposedHeaders": [
+                      "*"
+                    ],
+                    "maxAgeInSeconds": 2
+                  },
+                  {
+                    "allowedHeaders": [
+                      "x-ms-meta-12345675754564*"
+                    ],
+                    "allowedMethods": [
+                      "GET",
+                      "PUT"
+                    ],
+                    "allowedOrigins": [
+                      "http://www.abc23.com",
+                      "https://www.fabrikam.com/*"
+                    ],
+                    "exposedHeaders": [
+                      "x-ms-meta-abc",
+                      "x-ms-meta-data*",
+                      "x-ms-meta-target*"
+                    ],
+                    "maxAgeInSeconds": 2000
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "TableServices_List",
+  "title": "TableServicesList"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/TableServicesPut.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/TableServicesPut.json
@@ -1,0 +1,149 @@
+{
+  "parameters": {
+    "accountName": "sto8607",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "parameters": {
+      "properties": {
+        "cors": {
+          "corsRules": [
+            {
+              "allowedHeaders": [
+                "x-ms-meta-abc",
+                "x-ms-meta-data*",
+                "x-ms-meta-target*"
+              ],
+              "allowedMethods": [
+                "GET",
+                "HEAD",
+                "POST",
+                "OPTIONS",
+                "MERGE",
+                "PUT"
+              ],
+              "allowedOrigins": [
+                "http://www.contoso.com",
+                "http://www.fabrikam.com"
+              ],
+              "exposedHeaders": [
+                "x-ms-meta-*"
+              ],
+              "maxAgeInSeconds": 100
+            },
+            {
+              "allowedHeaders": [
+                "*"
+              ],
+              "allowedMethods": [
+                "GET"
+              ],
+              "allowedOrigins": [
+                "*"
+              ],
+              "exposedHeaders": [
+                "*"
+              ],
+              "maxAgeInSeconds": 2
+            },
+            {
+              "allowedHeaders": [
+                "x-ms-meta-12345675754564*"
+              ],
+              "allowedMethods": [
+                "GET",
+                "PUT"
+              ],
+              "allowedOrigins": [
+                "http://www.abc23.com",
+                "https://www.fabrikam.com/*"
+              ],
+              "exposedHeaders": [
+                "x-ms-meta-abc",
+                "x-ms-meta-data*",
+                "x-ms-meta-target*"
+              ],
+              "maxAgeInSeconds": 2000
+            }
+          ]
+        }
+      }
+    },
+    "resourceGroupName": "res4410",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "tableServiceName": "default"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.Storage/storageAccounts/tableServices",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res4410/providers/Microsoft.Storage/storageAccounts/sto8607/tableServices/default",
+        "properties": {
+          "cors": {
+            "corsRules": [
+              {
+                "allowedHeaders": [
+                  "x-ms-meta-abc",
+                  "x-ms-meta-data*",
+                  "x-ms-meta-target*"
+                ],
+                "allowedMethods": [
+                  "GET",
+                  "HEAD",
+                  "POST",
+                  "OPTIONS",
+                  "MERGE",
+                  "PUT"
+                ],
+                "allowedOrigins": [
+                  "http://www.contoso.com",
+                  "http://www.fabrikam.com"
+                ],
+                "exposedHeaders": [
+                  "x-ms-meta-*"
+                ],
+                "maxAgeInSeconds": 100
+              },
+              {
+                "allowedHeaders": [
+                  "*"
+                ],
+                "allowedMethods": [
+                  "GET"
+                ],
+                "allowedOrigins": [
+                  "*"
+                ],
+                "exposedHeaders": [
+                  "*"
+                ],
+                "maxAgeInSeconds": 2
+              },
+              {
+                "allowedHeaders": [
+                  "x-ms-meta-12345675754564*"
+                ],
+                "allowedMethods": [
+                  "GET",
+                  "PUT"
+                ],
+                "allowedOrigins": [
+                  "http://www.abc23.com",
+                  "https://www.fabrikam.com/*"
+                ],
+                "exposedHeaders": [
+                  "x-ms-meta-abc",
+                  "x-ms-meta-data*",
+                  "x-ms-meta-target*"
+                ],
+                "maxAgeInSeconds": 2000
+              }
+            ]
+          }
+        }
+      }
+    }
+  },
+  "operationId": "TableServices_SetServiceProperties",
+  "title": "TableServicesPut"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/storageTaskAssignmentsCrud/DeleteStorageTaskAssignment.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/storageTaskAssignmentsCrud/DeleteStorageTaskAssignment.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "accountName": "sto4445",
+    "api-version": "2026-09-01",
+    "resourceGroupName": "res4228",
+    "storageTaskAssignmentName": "myassignment1",
+    "subscriptionId": "1f31ba14-ce16-4281-b9b4-3e78da6e1616"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.Storage/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-06-01"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "StorageTaskAssignments_Delete",
+  "title": "DeleteStorageTaskAssignment"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/storageTaskAssignmentsCrud/GetStorageTaskAssignment.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/storageTaskAssignmentsCrud/GetStorageTaskAssignment.json
@@ -1,0 +1,44 @@
+{
+  "parameters": {
+    "accountName": "sto4445",
+    "api-version": "2026-09-01",
+    "resourceGroupName": "res4228",
+    "storageTaskAssignmentName": "myassignment1",
+    "subscriptionId": "1f31ba14-ce16-4281-b9b4-3e78da6e1616"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myassignment1",
+        "type": "Microsoft.Storage/storageAccounts/storageTaskAssignments",
+        "id": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourceGroups/res4228/providers/Microsoft.Storage/storageAccounts/sto4445/storageTaskAssignments/myassignment1",
+        "properties": {
+          "description": "My Storage task assignment",
+          "enabled": true,
+          "executionContext": {
+            "target": {
+              "excludePrefix": [],
+              "prefix": [
+                "prefix1",
+                "prefix2"
+              ]
+            },
+            "trigger": {
+              "type": "RunOnce",
+              "parameters": {
+                "startOn": "2022-11-15T21:52:47.8145095Z"
+              }
+            }
+          },
+          "provisioningState": "Succeeded",
+          "report": {
+            "prefix": "container1"
+          },
+          "taskId": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourceGroups/res4228/providers/Microsoft.StorageActions/storageTasks/mytask1"
+        }
+      }
+    }
+  },
+  "operationId": "StorageTaskAssignments_Get",
+  "title": "GetStorageTaskAssignment"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/storageTaskAssignmentsCrud/PatchStorageTaskAssignment.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/storageTaskAssignmentsCrud/PatchStorageTaskAssignment.json
@@ -1,0 +1,73 @@
+{
+  "parameters": {
+    "accountName": "sto4445",
+    "api-version": "2026-09-01",
+    "parameters": {
+      "properties": {
+        "description": "My Storage task assignment",
+        "enabled": true,
+        "executionContext": {
+          "target": {
+            "excludePrefix": [],
+            "prefix": [
+              "prefix1",
+              "prefix2"
+            ]
+          },
+          "trigger": {
+            "type": "RunOnce",
+            "parameters": {
+              "startOn": "2022-11-15T21:52:47.8145095Z"
+            }
+          }
+        },
+        "report": {
+          "prefix": "container1"
+        }
+      }
+    },
+    "resourceGroupName": "res4228",
+    "storageTaskAssignmentName": "myassignment1",
+    "subscriptionId": "1f31ba14-ce16-4281-b9b4-3e78da6e1616"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myassignment1",
+        "type": "Microsoft.Storage/storageAccounts/storageTaskAssignments",
+        "id": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourceGroups/res4228/providers/Microsoft.Storage/storageAccounts/sto4445/storageTaskAssignments/myassignment1",
+        "properties": {
+          "description": "My Storage task assignment",
+          "enabled": true,
+          "executionContext": {
+            "target": {
+              "excludePrefix": [],
+              "prefix": [
+                "prefix1",
+                "prefix2"
+              ]
+            },
+            "trigger": {
+              "type": "RunOnce",
+              "parameters": {
+                "startOn": "2022-11-15T21:52:47.8145095Z"
+              }
+            }
+          },
+          "provisioningState": "Succeeded",
+          "report": {
+            "prefix": "container1"
+          },
+          "taskId": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourceGroups/res4228/providers/Microsoft.StorageActions/storageTasks/mytask1"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.Storage/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-06-01"
+      }
+    }
+  },
+  "operationId": "StorageTaskAssignments_Update",
+  "title": "PatchStorageTaskAssignment"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/storageTaskAssignmentsCrud/PutStorageTaskAssignment.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/storageTaskAssignmentsCrud/PutStorageTaskAssignment.json
@@ -1,0 +1,105 @@
+{
+  "parameters": {
+    "accountName": "sto4445",
+    "api-version": "2026-09-01",
+    "parameters": {
+      "properties": {
+        "description": "My Storage task assignment",
+        "enabled": true,
+        "executionContext": {
+          "target": {
+            "excludePrefix": [],
+            "prefix": [
+              "prefix1",
+              "prefix2"
+            ]
+          },
+          "trigger": {
+            "type": "RunOnce",
+            "parameters": {
+              "startOn": "2022-11-15T21:52:47.8145095Z"
+            }
+          }
+        },
+        "report": {
+          "prefix": "container1"
+        },
+        "taskId": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourceGroups/res4228/providers/Microsoft.StorageActions/storageTasks/mytask1"
+      }
+    },
+    "resourceGroupName": "res4228",
+    "storageTaskAssignmentName": "myassignment1",
+    "subscriptionId": "1f31ba14-ce16-4281-b9b4-3e78da6e1616"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myassignment1",
+        "type": "Microsoft.Storage/storageAccounts/storageTaskAssignments",
+        "id": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourceGroups/res4228/providers/Microsoft.Storage/storageAccounts/sto4445/storageTaskAssignments/myassignment1",
+        "properties": {
+          "description": "My Storage task assignment",
+          "enabled": true,
+          "executionContext": {
+            "target": {
+              "excludePrefix": [],
+              "prefix": [
+                "prefix1",
+                "prefix2"
+              ]
+            },
+            "trigger": {
+              "type": "RunOnce",
+              "parameters": {
+                "startOn": "2022-11-15T21:52:47.8145095Z"
+              }
+            }
+          },
+          "provisioningState": "Succeeded",
+          "report": {
+            "prefix": "container1"
+          },
+          "taskId": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourceGroups/res4228/providers/Microsoft.StorageActions/storageTasks/mytask1"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "myassignment1",
+        "type": "Microsoft.Storage/storageAccounts/storageTaskAssignments",
+        "id": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourceGroups/res4228/providers/Microsoft.Storage/storageAccounts/sto4445/storageTaskAssignments/myassignment1",
+        "properties": {
+          "description": "My Storage task assignment",
+          "enabled": true,
+          "executionContext": {
+            "target": {
+              "excludePrefix": [],
+              "prefix": [
+                "prefix1",
+                "prefix2"
+              ]
+            },
+            "trigger": {
+              "type": "RunOnce",
+              "parameters": {
+                "startOn": "2022-11-15T21:52:47.8145095Z"
+              }
+            }
+          },
+          "provisioningState": "Succeeded",
+          "report": {
+            "prefix": "container1"
+          },
+          "taskId": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourceGroups/res4228/providers/Microsoft.StorageActions/storageTasks/mytask1"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.Storage/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-06-01"
+      }
+    }
+  },
+  "operationId": "StorageTaskAssignments_Create",
+  "title": "PutStorageTaskAssignment"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/storageTaskAssignmentsCrud/PutStorageTaskAssignmentMockRun.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/storageTaskAssignmentsCrud/PutStorageTaskAssignmentMockRun.json
@@ -1,0 +1,96 @@
+{
+  "parameters": {
+    "subscriptionId": "1f31ba14-ce16-4281-b9b4-3e78da6e1616",
+    "resourceGroupName": "res4228",
+    "accountName": "sto4445",
+    "storageTaskAssignmentName": "myassignment1",
+    "api-version": "2026-09-01",
+    "parameters": {
+      "properties": {
+        "taskId": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourceGroups/res4228/providers/Microsoft.StorageActions/storageTasks/myStorageTask",
+        "enabled": true,
+        "description": "My Storage task assignment for testing",
+        "executionContext": {
+          "trigger": {
+            "type": "MockRun",
+            "parameters": {
+              "startOn": "2023-01-01T00:00:00.1234567Z"
+            }
+          },
+          "target": {
+            "prefix": [],
+            "excludePrefix": []
+          }
+        },
+        "report": {
+          "prefix": "reports"
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourceGroups/res4228/providers/Microsoft.Storage/storageAccounts/sto4445/storageTaskAssignments/myassignment1",
+        "name": "myassignment1",
+        "type": "Microsoft.Storage/storageAccounts/storageTaskAssignments",
+        "properties": {
+          "taskId": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourceGroups/res4228/providers/Microsoft.StorageActions/storageTasks/myStorageTask",
+          "enabled": true,
+          "description": "My Storage task assignment for testing",
+          "provisioningState": "ValidateSubscriptionQuotaBegin",
+          "executionContext": {
+            "trigger": {
+              "type": "MockRun",
+              "parameters": {
+                "startOn": "2023-01-01T00:00:00.1234567Z"
+              }
+            },
+            "target": {
+              "prefix": [],
+              "excludePrefix": []
+            }
+          },
+          "report": {
+            "prefix": "reports"
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourceGroups/res4228/providers/Microsoft.Storage/storageAccounts/sto4445/storageTaskAssignments/myassignment1",
+        "name": "myassignment1",
+        "type": "Microsoft.Storage/storageAccounts/storageTaskAssignments",
+        "properties": {
+          "taskId": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourceGroups/res4228/providers/Microsoft.StorageActions/storageTasks/myStorageTask",
+          "enabled": true,
+          "description": "My Storage task assignment for testing",
+          "provisioningState": "ValidateSubscriptionQuotaBegin",
+          "executionContext": {
+            "trigger": {
+              "type": "MockRun",
+              "parameters": {
+                "startOn": "2023-01-01T00:00:00.1234567Z"
+              }
+            },
+            "target": {
+              "prefix": [],
+              "excludePrefix": []
+            }
+          },
+          "report": {
+            "prefix": "reports"
+          }
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/{subscription-id}/resourceGroups/res4228/providers/Microsoft.Storage/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-06-01"
+      }
+    }
+  },
+  "operationId": "StorageTaskAssignments_Create",
+  "title": "PutStorageTaskAssignmentMockRun"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/storageTaskAssignmentsCrud/PutStorageTaskAssignmentRequiredProperties.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/storageTaskAssignmentsCrud/PutStorageTaskAssignmentRequiredProperties.json
@@ -1,0 +1,84 @@
+{
+  "parameters": {
+    "accountName": "sto4445",
+    "api-version": "2026-09-01",
+    "parameters": {
+      "properties": {
+        "description": "My Storage task assignment",
+        "enabled": true,
+        "executionContext": {
+          "trigger": {
+            "type": "RunOnce",
+            "parameters": {
+              "startOn": "2022-11-15T21:52:47.8145095Z"
+            }
+          }
+        },
+        "report": {
+          "prefix": "container1"
+        },
+        "taskId": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourceGroups/res4228/providers/Microsoft.StorageActions/storageTasks/mytask1"
+      }
+    },
+    "resourceGroupName": "res4228",
+    "storageTaskAssignmentName": "myassignment1",
+    "subscriptionId": "1f31ba14-ce16-4281-b9b4-3e78da6e1616"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myassignment1",
+        "type": "Microsoft.Storage/storageAccounts/storageTaskAssignments",
+        "id": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourceGroups/res4228/providers/Microsoft.Storage/storageAccounts/sto4445/storageTaskAssignments/myassignment1",
+        "properties": {
+          "description": "My Storage task assignment",
+          "enabled": true,
+          "executionContext": {
+            "trigger": {
+              "type": "RunOnce",
+              "parameters": {
+                "startOn": "2022-11-15T21:52:47.8145095Z"
+              }
+            }
+          },
+          "provisioningState": "Succeeded",
+          "report": {
+            "prefix": "container1"
+          },
+          "taskId": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourceGroups/res4228/providers/Microsoft.StorageActions/storageTasks/mytask1"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "myassignment1",
+        "type": "Microsoft.Storage/storageAccounts/storageTaskAssignments",
+        "id": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourceGroups/res4228/providers/Microsoft.Storage/storageAccounts/sto4445/storageTaskAssignments/myassignment1",
+        "properties": {
+          "description": "My Storage task assignment",
+          "enabled": true,
+          "executionContext": {
+            "trigger": {
+              "type": "RunOnce",
+              "parameters": {
+                "startOn": "2022-11-15T21:52:47.8145095Z"
+              }
+            }
+          },
+          "provisioningState": "Succeeded",
+          "report": {
+            "prefix": "container1"
+          },
+          "taskId": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourceGroups/res4228/providers/Microsoft.StorageActions/storageTasks/mytask1"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.Storage/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-06-01"
+      }
+    }
+  },
+  "operationId": "StorageTaskAssignments_Create",
+  "title": "PutStorageTaskAssignmentRequiredProperties"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/storageTaskAssignmentsCrud/StopStorageTaskAssignment.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/storageTaskAssignmentsCrud/StopStorageTaskAssignment.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "accountName": "sto4445",
+    "api-version": "2026-09-01",
+    "resourceGroupName": "res4228",
+    "storageTaskAssignmentName": "myassignment1",
+    "subscriptionId": "1f31ba14-ce16-4281-b9b4-3e78da6e1616"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourceGroups/res4228/providers/Microsoft.Storage/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-06-01"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "StorageTaskAssignments_StopAssignment",
+  "title": "StopStorageTaskAssignment"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/storageTaskAssignmentsList/ListStorageTaskAssignmentInstancesReportSummary.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/storageTaskAssignmentsList/ListStorageTaskAssignmentInstancesReportSummary.json
@@ -1,0 +1,61 @@
+{
+  "parameters": {
+    "accountName": "sto4445",
+    "api-version": "2026-09-01",
+    "resourceGroupName": "res4228",
+    "storageTaskAssignmentName": "myassignment1",
+    "subscriptionId": "1f31ba14-ce16-4281-b9b4-3e78da6e1616"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "instance1",
+            "type": "Microsoft.Storage/storageAccounts/reports",
+            "id": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourceGroups/res4228/providers/Microsoft.Storage/storageAccounts/sto4445/storageTaskAssignments/instance1",
+            "properties": {
+              "finishTime": "2023-06-23T00:40:10.2931264Z",
+              "objectFailedCount": "0",
+              "objectsOperatedOnCount": "150",
+              "objectsSucceededCount": "150",
+              "objectsTargetedCount": "150",
+              "runResult": "Succeeded",
+              "runStatusEnum": "Finished",
+              "runStatusError": "0",
+              "startTime": "2023-06-23T00:30:43.226744Z",
+              "storageAccountId": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourcegroups/res4228/providers/Microsoft.Storage/storageAccounts/sto4445",
+              "summaryReportPath": "https://acc123.blob.core.windows.net/result-container/{folderpath}/SummaryReport.json",
+              "taskAssignmentId": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourcegroups/res4228/providers/Microsoft.Storage/storageAccounts/sto4445/storageTaskAssignments/myassignment1",
+              "taskId": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourcegroups/res4228/providers/Microsoft.StorageActions/storageTasks/mytask1",
+              "taskVersion": "1"
+            }
+          },
+          {
+            "name": "instance2",
+            "type": "Microsoft.Storage/storageAccounts/reports",
+            "id": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourceGroups/res4228/providers/Microsoft.Storage/storageAccounts/sto4445/storageTaskAssignments/instance2",
+            "properties": {
+              "finishTime": "2023-06-23T00:40:10.2931264Z",
+              "objectFailedCount": "0",
+              "objectsOperatedOnCount": "150",
+              "objectsSucceededCount": "150",
+              "objectsTargetedCount": "150",
+              "runResult": "Succeeded",
+              "runStatusEnum": "Finished",
+              "runStatusError": "0",
+              "startTime": "2023-06-23T00:30:43.226744Z",
+              "storageAccountId": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourcegroups/res4228/providers/Microsoft.Storage/storageAccounts/sto4445",
+              "summaryReportPath": "https://acc123.blob.core.windows.net/result-container/{folderpath}/SummaryReport.json",
+              "taskAssignmentId": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourcegroups/res4228/providers/Microsoft.Storage/storageAccounts/sto4445/storageTaskAssignments/myassignment1",
+              "taskId": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourcegroups/res4228/providers/Microsoft.StorageActions/storageTasks/mytask1",
+              "taskVersion": "1"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "StorageTaskAssignmentInstancesReport_List",
+  "title": "ListStorageTaskAssignmentInstancesReportSummary"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/storageTaskAssignmentsList/ListStorageTaskAssignmentsForAccount.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/storageTaskAssignmentsList/ListStorageTaskAssignmentsForAccount.json
@@ -1,0 +1,76 @@
+{
+  "parameters": {
+    "accountName": "sto4445",
+    "api-version": "2026-09-01",
+    "resourceGroupName": "res4228",
+    "subscriptionId": "1f31ba14-ce16-4281-b9b4-3e78da6e1616"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "myassignment1",
+            "type": "Microsoft.Storage/storageAccounts/storageTaskAssignments",
+            "id": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourceGroups/res4228/providers/Microsoft.Storage/storageAccounts/sto4445/storageTaskAssignments/myassignment1",
+            "properties": {
+              "description": "My Storage task assignment #1",
+              "enabled": true,
+              "executionContext": {
+                "target": {
+                  "excludePrefix": [],
+                  "prefix": [
+                    "prefix1",
+                    "prefix2"
+                  ]
+                },
+                "trigger": {
+                  "type": "RunOnce",
+                  "parameters": {
+                    "startOn": "2022-11-15T21:52:47.8145095Z"
+                  }
+                }
+              },
+              "provisioningState": "Succeeded",
+              "report": {
+                "prefix": "container1"
+              },
+              "taskId": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourceGroups/res4228/providers/Microsoft.StorageActions/storageTasks/mytask1"
+            }
+          },
+          {
+            "name": "myassignment2",
+            "type": "Microsoft.Storage/storageAccounts/storageTaskAssignments",
+            "id": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourceGroups/res4228/providers/Microsoft.Storage/storageAccounts/sto4445/storageTaskAssignments/myassignment2",
+            "properties": {
+              "description": "My Storage task assignment #2",
+              "enabled": true,
+              "executionContext": {
+                "target": {
+                  "excludePrefix": [],
+                  "prefix": [
+                    "prefix3",
+                    "prefix4"
+                  ]
+                },
+                "trigger": {
+                  "type": "RunOnce",
+                  "parameters": {
+                    "startOn": "2022-11-15T21:52:47.8145095Z"
+                  }
+                }
+              },
+              "provisioningState": "Succeeded",
+              "report": {
+                "prefix": "container2"
+              },
+              "taskId": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourceGroups/res4228/providers/Microsoft.StorageActions/storageTasks/mytask2"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "StorageTaskAssignments_List",
+  "title": "ListStorageTaskAssignmentsForAccount"
+}

--- a/specification/storage/Storage.Management/examples/2026-09-01/storageTaskAssignmentsList/ListStorageTaskAssignmentsInstancesReportSummary.json
+++ b/specification/storage/Storage.Management/examples/2026-09-01/storageTaskAssignmentsList/ListStorageTaskAssignmentsInstancesReportSummary.json
@@ -1,0 +1,60 @@
+{
+  "parameters": {
+    "accountName": "sto4445",
+    "api-version": "2026-09-01",
+    "resourceGroupName": "res4228",
+    "subscriptionId": "1f31ba14-ce16-4281-b9b4-3e78da6e1616"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "instance1",
+            "type": "Microsoft.Storage/storageAccounts/reports",
+            "id": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourceGroups/res4228/providers/Microsoft.Storage/storageAccounts/sto4445/storageTaskAssignments/instance1",
+            "properties": {
+              "finishTime": "2023-06-23T00:40:10.2931264Z",
+              "objectFailedCount": "0",
+              "objectsOperatedOnCount": "150",
+              "objectsSucceededCount": "150",
+              "objectsTargetedCount": "150",
+              "runResult": "Succeeded",
+              "runStatusEnum": "Finished",
+              "runStatusError": "0",
+              "startTime": "2023-06-23T00:30:43.226744Z",
+              "storageAccountId": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourcegroups/res4228/providers/Microsoft.Storage/storageAccounts/sto4445",
+              "summaryReportPath": "https://acc123.blob.core.windows.net/result-container/{folderpath}/SummaryReport.json",
+              "taskAssignmentId": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourcegroups/res4228/providers/Microsoft.Storage/storageAccounts/sto4445/storageTaskAssignments/myassignment1",
+              "taskId": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourcegroups/res4228/providers/Microsoft.StorageActions/storageTasks/mytask1",
+              "taskVersion": "1"
+            }
+          },
+          {
+            "name": "instance2",
+            "type": "Microsoft.Storage/storageAccounts/reports",
+            "id": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourceGroups/res4228/providers/Microsoft.Storage/storageAccounts/sto4445/storageTaskAssignments/instance2",
+            "properties": {
+              "finishTime": "2023-06-23T00:40:10.2931264Z",
+              "objectFailedCount": "0",
+              "objectsOperatedOnCount": "150",
+              "objectsSucceededCount": "150",
+              "objectsTargetedCount": "150",
+              "runResult": "Succeeded",
+              "runStatusEnum": "Finished",
+              "runStatusError": "0",
+              "startTime": "2023-06-23T00:30:43.226744Z",
+              "storageAccountId": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourcegroups/res4228/providers/Microsoft.Storage/storageAccounts/sto4445",
+              "summaryReportPath": "https://acc123.blob.core.windows.net/result-container/{folderpath}/SummaryReport.json",
+              "taskAssignmentId": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourcegroups/res4228/providers/Microsoft.Storage/storageAccounts/sto4445/storageTaskAssignments/myassignment2",
+              "taskId": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourcegroups/res4228/providers/Microsoft.StorageActions/storageTasks/mytask1",
+              "taskVersion": "1"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "StorageTaskAssignmentsInstancesReport_List",
+  "title": "ListStorageTaskAssignmentsInstancesReportSummary"
+}

--- a/specification/storage/Storage.Management/main.tsp
+++ b/specification/storage/Storage.Management/main.tsp
@@ -80,6 +80,11 @@ enum Versions {
    * The 2026-06-01 API version.
    */
   v2026_06_01: "2026-06-01",
+
+  /**
+   * The 2026-09-01 API version.
+   */
+  v2026_09_01: "2026-09-01",
 }
 
 interface Operations

--- a/specification/storage/Storage.Management/service.yaml
+++ b/specification/storage/Storage.Management/service.yaml
@@ -205,3 +205,7 @@ versions:
     source: typespec
     swagger-files:
       - ../resource-manager/Microsoft.Storage/stable/2026-06-01/openapi.json
+  - version: 2026-09-01
+    source: typespec
+    swagger-files:
+      - ../resource-manager/Microsoft.Storage/stable/2026-09-01/openapi.json

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/AdvancedPlatformMetricsCRUD/AdvancedPlatformMetricsRules_CreateOrUpdate_AllContainers.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/AdvancedPlatformMetricsCRUD/AdvancedPlatformMetricsRules_CreateOrUpdate_AllContainers.json
@@ -1,0 +1,59 @@
+{
+  "operationId": "AdvancedPlatformMetrics_CreateOrUpdate",
+  "title": "AdvancedPlatformMetricsRules_CreateOrUpdate_AllContainers - Create advanced platform metrics rule with all containers filter",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "res6977",
+    "accountName": "sto2527",
+    "advancedPlatformMetricsRuleType": "ContainerLevelCapacityMetrics",
+    "api-version": "2026-09-01",
+    "resource": {
+      "properties": {
+        "enabled": true,
+        "ruleConfig": {
+          "filterType": "AllContainersFilter"
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res6977/providers/Microsoft.Storage/storageAccounts/sto2527/advancedPlatformMetrics/ContainerLevelCapacityMetrics",
+        "name": "DefaultAdvancedPlatformMetricsRule",
+        "type": "Microsoft.Storage/storageAccounts/advancedPlatformMetrics",
+        "properties": {
+          "ruleType": "ContainerLevelCapacityMetrics",
+          "enabled": true,
+          "lastModifiedTime": "2025-01-01T11:00:00.0000000Z",
+          "metricsEmitted": [
+            "ContainerUsedSize",
+            "ContainerBlobCount"
+          ],
+          "ruleConfig": {
+            "filterType": "AllContainersFilter"
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res6977/providers/Microsoft.Storage/storageAccounts/sto2527/advancedPlatformMetrics/ContainerLevelCapacityMetrics",
+        "name": "DefaultAdvancedPlatformMetricsRule",
+        "type": "Microsoft.Storage/storageAccounts/advancedPlatformMetrics",
+        "properties": {
+          "ruleType": "ContainerLevelCapacityMetrics",
+          "enabled": true,
+          "lastModifiedTime": "2025-01-01T11:00:00.0000000Z",
+          "metricsEmitted": [
+            "ContainerUsedSize",
+            "ContainerBlobCount"
+          ],
+          "ruleConfig": {
+            "filterType": "AllContainersFilter"
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/AdvancedPlatformMetricsCRUD/AdvancedPlatformMetricsRules_CreateOrUpdate_ContainerList.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/AdvancedPlatformMetricsCRUD/AdvancedPlatformMetricsRules_CreateOrUpdate_ContainerList.json
@@ -1,0 +1,74 @@
+{
+  "operationId": "AdvancedPlatformMetrics_CreateOrUpdate",
+  "title": "AdvancedPlatformMetricsRules_CreateOrUpdate_ContainerList - Create advanced platform metrics rule with container list filter",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "res6977",
+    "accountName": "sto2527",
+    "advancedPlatformMetricsRuleType": "ContainerLevelCapacityMetrics",
+    "api-version": "2026-09-01",
+    "resource": {
+      "properties": {
+        "enabled": true,
+        "ruleConfig": {
+          "filterType": "ContainerListFilter",
+          "filterValues": [
+            "container1",
+            "container2",
+            "container3"
+          ]
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res6977/providers/Microsoft.Storage/storageAccounts/sto2527/advancedPlatformMetrics/ContainerLevelCapacityMetrics",
+        "name": "DefaultAdvancedPlatformMetricsRule",
+        "type": "Microsoft.Storage/storageAccounts/advancedPlatformMetrics",
+        "properties": {
+          "ruleType": "ContainerLevelCapacityMetrics",
+          "enabled": true,
+          "lastModifiedTime": "2025-01-01T11:00:00.0000000Z",
+          "metricsEmitted": [
+            "ContainerUsedSize",
+            "ContainerBlobCount"
+          ],
+          "ruleConfig": {
+            "filterType": "ContainerListFilter",
+            "filterValues": [
+              "container1",
+              "container2",
+              "container3"
+            ]
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res6977/providers/Microsoft.Storage/storageAccounts/sto2527/advancedPlatformMetrics/ContainerLevelCapacityMetrics",
+        "name": "DefaultAdvancedPlatformMetricsRule",
+        "type": "Microsoft.Storage/storageAccounts/advancedPlatformMetrics",
+        "properties": {
+          "ruleType": "ContainerLevelCapacityMetrics",
+          "enabled": true,
+          "lastModifiedTime": "2025-01-01T11:00:00.0000000Z",
+          "metricsEmitted": [
+            "ContainerUsedSize",
+            "ContainerBlobCount"
+          ],
+          "ruleConfig": {
+            "filterType": "ContainerListFilter",
+            "filterValues": [
+              "container1",
+              "container2",
+              "container3"
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/AdvancedPlatformMetricsCRUD/AdvancedPlatformMetricsRules_CreateOrUpdate_ContainerPrefix.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/AdvancedPlatformMetricsCRUD/AdvancedPlatformMetricsRules_CreateOrUpdate_ContainerPrefix.json
@@ -1,0 +1,71 @@
+{
+  "operationId": "AdvancedPlatformMetrics_CreateOrUpdate",
+  "title": "AdvancedPlatformMetricsRules_CreateOrUpdate_ContainerPrefix - Create advanced platform metrics rule with container prefix filter",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "res6977",
+    "accountName": "sto2527",
+    "advancedPlatformMetricsRuleType": "ContainerLevelCapacityMetrics",
+    "api-version": "2026-09-01",
+    "resource": {
+      "properties": {
+        "enabled": true,
+        "ruleConfig": {
+          "filterType": "ContainerPrefixFilter",
+          "filterValues": [
+            "logs",
+            "data"
+          ]
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res6977/providers/Microsoft.Storage/storageAccounts/sto2527/advancedPlatformMetrics/ContainerLevelCapacityMetrics",
+        "name": "DefaultAdvancedPlatformMetricsRule",
+        "type": "Microsoft.Storage/storageAccounts/advancedPlatformMetrics",
+        "properties": {
+          "ruleType": "ContainerLevelCapacityMetrics",
+          "enabled": true,
+          "lastModifiedTime": "2025-01-01T11:00:00.0000000Z",
+          "metricsEmitted": [
+            "ContainerUsedSize",
+            "ContainerBlobCount"
+          ],
+          "ruleConfig": {
+            "filterType": "ContainerPrefixFilter",
+            "filterValues": [
+              "logs",
+              "data"
+            ]
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res6977/providers/Microsoft.Storage/storageAccounts/sto2527/advancedPlatformMetrics/ContainerLevelCapacityMetrics",
+        "name": "DefaultAdvancedPlatformMetricsRule",
+        "type": "Microsoft.Storage/storageAccounts/advancedPlatformMetrics",
+        "properties": {
+          "ruleType": "ContainerLevelCapacityMetrics",
+          "enabled": true,
+          "lastModifiedTime": "2025-01-01T11:00:00.0000000Z",
+          "metricsEmitted": [
+            "ContainerUsedSize",
+            "ContainerBlobCount"
+          ],
+          "ruleConfig": {
+            "filterType": "ContainerPrefixFilter",
+            "filterValues": [
+              "logs",
+              "data"
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/AdvancedPlatformMetricsCRUD/AdvancedPlatformMetricsRules_Delete.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/AdvancedPlatformMetricsCRUD/AdvancedPlatformMetricsRules_Delete.json
@@ -1,0 +1,15 @@
+{
+  "operationId": "AdvancedPlatformMetrics_Delete",
+  "title": "AdvancedPlatformMetricsRules_Delete - Delete advanced platform metrics rule",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "res6977",
+    "accountName": "sto2527",
+    "advancedPlatformMetricsRuleType": "ContainerLevelCapacityMetrics",
+    "api-version": "2026-09-01"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  }
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/AdvancedPlatformMetricsCRUD/AdvancedPlatformMetricsRules_Get.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/AdvancedPlatformMetricsCRUD/AdvancedPlatformMetricsRules_Get.json
@@ -1,0 +1,32 @@
+{
+  "operationId": "AdvancedPlatformMetrics_Get",
+  "title": "AdvancedPlatformMetricsRules_Get - Get advanced platform metrics rule",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "res6977",
+    "accountName": "sto2527",
+    "advancedPlatformMetricsRuleType": "ContainerLevelCapacityMetrics",
+    "api-version": "2026-09-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res6977/providers/Microsoft.Storage/storageAccounts/sto2527/advancedPlatformMetrics/ContainerLevelCapacityMetrics",
+        "name": "DefaultAdvancedPlatformMetricsRule",
+        "type": "Microsoft.Storage/storageAccounts/advancedPlatformMetrics",
+        "properties": {
+          "ruleType": "ContainerLevelCapacityMetrics",
+          "enabled": true,
+          "lastModifiedTime": "2025-01-01T11:00:00.0000000Z",
+          "metricsEmitted": [
+            "ContainerUsedSize",
+            "ContainerBlobCount"
+          ],
+          "ruleConfig": {
+            "filterType": "AllContainersFilter"
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/AdvancedPlatformMetricsCRUD/AdvancedPlatformMetricsRules_List.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/AdvancedPlatformMetricsCRUD/AdvancedPlatformMetricsRules_List.json
@@ -1,0 +1,35 @@
+{
+  "operationId": "AdvancedPlatformMetrics_List",
+  "title": "AdvancedPlatformMetricsRules_List - List advanced platform metrics rules",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "res6977",
+    "accountName": "sto2527",
+    "api-version": "2026-09-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res6977/providers/Microsoft.Storage/storageAccounts/sto2527/advancedPlatformMetrics/ContainerLevelCapacityMetrics",
+            "name": "DefaultAdvancedPlatformMetricsRule",
+            "type": "Microsoft.Storage/storageAccounts/advancedPlatformMetrics",
+            "properties": {
+              "ruleType": "ContainerLevelCapacityMetrics",
+              "enabled": true,
+              "lastModifiedTime": "2025-01-01T11:00:00.0000000Z",
+              "metricsEmitted": [
+                "ContainerUsedSize",
+                "ContainerBlobCount"
+              ],
+              "ruleConfig": {
+                "filterType": "AllContainersFilter"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/BlobContainersClearLegalHold.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/BlobContainersClearLegalHold.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "LegalHold": {
+      "tags": [
+        "tag1",
+        "tag2",
+        "tag3"
+      ]
+    },
+    "accountName": "sto7280",
+    "api-version": "2026-09-01",
+    "containerName": "container8723",
+    "monitor": "true",
+    "resourceGroupName": "res4303",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "hasLegalHold": false,
+        "tags": []
+      }
+    }
+  },
+  "operationId": "BlobContainers_ClearLegalHold",
+  "title": "ClearLegalHoldContainers"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/BlobContainersDelete.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/BlobContainersDelete.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "accountName": "sto4506",
+    "api-version": "2026-09-01",
+    "containerName": "container9689",
+    "monitor": "true",
+    "resourceGroupName": "res4079",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "BlobContainers_Delete",
+  "title": "DeleteContainers"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/BlobContainersDeleteImmutabilityPolicy.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/BlobContainersDeleteImmutabilityPolicy.json
@@ -1,0 +1,28 @@
+{
+  "parameters": {
+    "If-Match": "8d59f81a7fa7be0",
+    "accountName": "sto9621",
+    "api-version": "2026-09-01",
+    "containerName": "container4910",
+    "immutabilityPolicyName": "default",
+    "monitor": "true",
+    "resourceGroupName": "res1581",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.Storage/storageAccounts/blobServices/containers/immutabilityPolicies",
+        "etag": "\"8d59f81a87b40c0\"",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res1581/providers/Microsoft.Storage/storageAccounts/sto9621/blobServices/default/containers/container4910/immutabilityPolicies/default",
+        "properties": {
+          "immutabilityPeriodSinceCreationInDays": 0,
+          "state": "Unlocked"
+        }
+      }
+    }
+  },
+  "operationId": "BlobContainers_DeleteImmutabilityPolicy",
+  "title": "DeleteImmutabilityPolicy"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/BlobContainersExtendImmutabilityPolicy.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/BlobContainersExtendImmutabilityPolicy.json
@@ -1,0 +1,32 @@
+{
+  "parameters": {
+    "If-Match": "8d59f830d0c3bf9",
+    "accountName": "sto232",
+    "api-version": "2026-09-01",
+    "containerName": "container5023",
+    "monitor": "true",
+    "parameters": {
+      "properties": {
+        "immutabilityPeriodSinceCreationInDays": 100
+      }
+    },
+    "resourceGroupName": "res6238",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.Storage/storageAccounts/blobServices/containers/immutabilityPolicies",
+        "etag": "\"8d57a8b2ff50332\"",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res6238/providers/Microsoft.Storage/storageAccounts/sto232/blobServices/default/containers/container5023/immutabilityPolicies/default",
+        "properties": {
+          "immutabilityPeriodSinceCreationInDays": 100,
+          "state": "Locked"
+        }
+      }
+    }
+  },
+  "operationId": "BlobContainers_ExtendImmutabilityPolicy",
+  "title": "ExtendImmutabilityPolicy"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/BlobContainersGet.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/BlobContainersGet.json
@@ -1,0 +1,83 @@
+{
+  "parameters": {
+    "accountName": "sto6217",
+    "api-version": "2026-09-01",
+    "containerName": "container1634",
+    "monitor": "true",
+    "resourceGroupName": "res9871",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "container1634",
+        "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
+        "etag": "\"0x8D592D74CC20EBA\"",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9871/providers/Microsoft.Storage/storageAccounts/sto6217/blobServices/default/containers/container1634",
+        "properties": {
+          "hasImmutabilityPolicy": true,
+          "hasLegalHold": true,
+          "immutabilityPolicy": {
+            "etag": "\"8d592d74cb3011a\"",
+            "properties": {
+              "immutabilityPeriodSinceCreationInDays": 100,
+              "state": "Locked"
+            },
+            "updateHistory": [
+              {
+                "immutabilityPeriodSinceCreationInDays": 3,
+                "objectIdentifier": "ce7cd28a-fc25-4bf1-8fb9-e1b9833ffd4b",
+                "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
+                "timestamp": "2018-03-26T05:06:11.431403Z",
+                "update": "put"
+              },
+              {
+                "immutabilityPeriodSinceCreationInDays": 3,
+                "objectIdentifier": "ce7cd28a-fc25-4bf1-8fb9-e1b9833ffd4b",
+                "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
+                "timestamp": "2018-03-26T05:06:13.0907641Z",
+                "update": "lock"
+              },
+              {
+                "immutabilityPeriodSinceCreationInDays": 100,
+                "objectIdentifier": "ce7cd28a-fc25-4bf1-8fb9-e1b9833ffd4b",
+                "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
+                "timestamp": "2018-03-26T05:06:14.7097716Z",
+                "update": "extend"
+              }
+            ]
+          },
+          "lastModifiedTime": "2018-03-26T05:06:14Z",
+          "leaseState": "Available",
+          "leaseStatus": "Unlocked",
+          "legalHold": {
+            "hasLegalHold": true,
+            "tags": [
+              {
+                "objectIdentifier": "ce7cd28a-fc25-4bf1-8fb9-e1b9833ffd4b",
+                "tag": "tag1",
+                "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
+                "timestamp": "2018-03-26T05:06:09.6964643Z"
+              },
+              {
+                "objectIdentifier": "ce7cd28a-fc25-4bf1-8fb9-e1b9833ffd4b",
+                "tag": "tag2",
+                "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
+                "timestamp": "2018-03-26T05:06:09.6964643Z"
+              },
+              {
+                "objectIdentifier": "ce7cd28a-fc25-4bf1-8fb9-e1b9833ffd4b",
+                "tag": "tag3",
+                "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
+                "timestamp": "2018-03-26T05:06:09.6964643Z"
+              }
+            ]
+          },
+          "publicAccess": "None"
+        }
+      }
+    }
+  },
+  "operationId": "BlobContainers_Get",
+  "title": "GetContainers"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/BlobContainersGetImmutabilityPolicy.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/BlobContainersGetImmutabilityPolicy.json
@@ -1,0 +1,28 @@
+{
+  "parameters": {
+    "accountName": "sto9177",
+    "api-version": "2026-09-01",
+    "containerName": "container3489",
+    "immutabilityPolicyName": "default",
+    "monitor": "true",
+    "resourceGroupName": "res5221",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.Storage/storageAccounts/blobServices/containers/immutabilityPolicies",
+        "etag": "\"8d59f828e64b75c\"",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res5221/providers/Microsoft.Storage/storageAccounts/sto9177/blobServices/default/containers/container3489/immutabilityPolicies/default",
+        "properties": {
+          "allowProtectedAppendWrites": true,
+          "immutabilityPeriodSinceCreationInDays": 5,
+          "state": "Unlocked"
+        }
+      }
+    }
+  },
+  "operationId": "BlobContainers_GetImmutabilityPolicy",
+  "title": "GetImmutabilityPolicy"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/BlobContainersGetWithAllowProtectedAppendWritesAll.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/BlobContainersGetWithAllowProtectedAppendWritesAll.json
@@ -1,0 +1,91 @@
+{
+  "parameters": {
+    "accountName": "sto6217",
+    "api-version": "2026-09-01",
+    "containerName": "container1634",
+    "monitor": "true",
+    "resourceGroupName": "res9871",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "container1634",
+        "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
+        "etag": "\"0x8D592D74CC20EBA\"",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9871/providers/Microsoft.Storage/storageAccounts/sto6217/blobServices/default/containers/container1634",
+        "properties": {
+          "hasImmutabilityPolicy": true,
+          "hasLegalHold": true,
+          "immutabilityPolicy": {
+            "etag": "\"8d592d74cb3011a\"",
+            "properties": {
+              "allowProtectedAppendWritesAll": true,
+              "immutabilityPeriodSinceCreationInDays": 100,
+              "state": "Locked"
+            },
+            "updateHistory": [
+              {
+                "allowProtectedAppendWritesAll": true,
+                "immutabilityPeriodSinceCreationInDays": 3,
+                "objectIdentifier": "ce7cd28a-fc25-4bf1-8fb9-e1b9833ffd4b",
+                "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
+                "timestamp": "2018-03-26T05:06:11.431403Z",
+                "update": "put"
+              },
+              {
+                "allowProtectedAppendWritesAll": true,
+                "immutabilityPeriodSinceCreationInDays": 3,
+                "objectIdentifier": "ce7cd28a-fc25-4bf1-8fb9-e1b9833ffd4b",
+                "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
+                "timestamp": "2018-03-26T05:06:13.0907641Z",
+                "update": "lock"
+              },
+              {
+                "allowProtectedAppendWritesAll": true,
+                "immutabilityPeriodSinceCreationInDays": 100,
+                "objectIdentifier": "ce7cd28a-fc25-4bf1-8fb9-e1b9833ffd4b",
+                "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
+                "timestamp": "2018-03-26T05:06:14.7097716Z",
+                "update": "extend"
+              }
+            ]
+          },
+          "lastModifiedTime": "2018-03-26T05:06:14Z",
+          "leaseState": "Available",
+          "leaseStatus": "Unlocked",
+          "legalHold": {
+            "hasLegalHold": true,
+            "protectedAppendWritesHistory": {
+              "allowProtectedAppendWritesAll": true,
+              "timestamp": "2022-09-01T01:58:44.5044483Z"
+            },
+            "tags": [
+              {
+                "objectIdentifier": "ce7cd28a-fc25-4bf1-8fb9-e1b9833ffd4b",
+                "tag": "tag1",
+                "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
+                "timestamp": "2018-03-26T05:06:09.6964643Z"
+              },
+              {
+                "objectIdentifier": "ce7cd28a-fc25-4bf1-8fb9-e1b9833ffd4b",
+                "tag": "tag2",
+                "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
+                "timestamp": "2018-03-26T05:06:09.6964643Z"
+              },
+              {
+                "objectIdentifier": "ce7cd28a-fc25-4bf1-8fb9-e1b9833ffd4b",
+                "tag": "tag3",
+                "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
+                "timestamp": "2018-03-26T05:06:09.6964643Z"
+              }
+            ]
+          },
+          "publicAccess": "None"
+        }
+      }
+    }
+  },
+  "operationId": "BlobContainers_Get",
+  "title": "GetBlobContainersGetWithAllowProtectedAppendWritesAll"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/BlobContainersLease_Acquire.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/BlobContainersLease_Acquire.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "accountName": "sto328",
+    "api-version": "2026-09-01",
+    "containerName": "container6185",
+    "monitor": "true",
+    "parameters": {
+      "action": "Acquire",
+      "breakPeriod": null,
+      "leaseDuration": -1,
+      "leaseId": null,
+      "proposedLeaseId": null
+    },
+    "resourceGroupName": "res3376",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "leaseId": "8698f513-fa75-44a1-b8eb-30ba336af27d"
+      }
+    }
+  },
+  "operationId": "BlobContainers_Lease",
+  "title": "Acquire a lease on a container"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/BlobContainersLease_Break.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/BlobContainersLease_Break.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "accountName": "sto328",
+    "api-version": "2026-09-01",
+    "containerName": "container6185",
+    "monitor": "true",
+    "parameters": {
+      "action": "Break",
+      "breakPeriod": null,
+      "leaseDuration": null,
+      "leaseId": "8698f513-fa75-44a1-b8eb-30ba336af27d",
+      "proposedLeaseId": null
+    },
+    "resourceGroupName": "res3376",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "leaseTimeSeconds": "0"
+      }
+    }
+  },
+  "operationId": "BlobContainers_Lease",
+  "title": "Break a lease on a container"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/BlobContainersList.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/BlobContainersList.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "accountName": "sto1590",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res9290",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://sto1590endpoint/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res9290/providers/Microsoft.Storage/storageAccounts/sto1590/blobServices/default/containers?api-version=2022-09-01&$maxpagesize=2&$skipToken=/sto1590/container5103",
+        "value": [
+          {
+            "name": "container1644",
+            "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
+            "etag": "\"0x8D589847D51C7DE\"",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res9290/providers/Microsoft.Storage/storageAccounts/sto1590/blobServices/default/containers/container1644",
+            "properties": {
+              "hasImmutabilityPolicy": false,
+              "hasLegalHold": false,
+              "lastModifiedTime": "2018-03-14T08:20:47Z",
+              "leaseState": "Available",
+              "leaseStatus": "Unlocked",
+              "publicAccess": "Container"
+            }
+          },
+          {
+            "name": "container4052",
+            "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
+            "etag": "\"0x8D589847DAB5AF9\"",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res9290/providers/Microsoft.Storage/storageAccounts/sto1590/blobServices/default/containers/container4052",
+            "properties": {
+              "hasImmutabilityPolicy": false,
+              "hasLegalHold": false,
+              "lastModifiedTime": "2018-03-14T08:20:47Z",
+              "leaseState": "Available",
+              "leaseStatus": "Unlocked",
+              "publicAccess": "None"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "BlobContainers_List",
+  "title": "ListContainers"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/BlobContainersLockImmutabilityPolicy.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/BlobContainersLockImmutabilityPolicy.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "If-Match": "8d59f825b721dd3",
+    "accountName": "sto5009",
+    "api-version": "2026-09-01",
+    "containerName": "container1631",
+    "monitor": "true",
+    "resourceGroupName": "res2702",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.Storage/storageAccounts/blobServices/containers/immutabilityPolicies",
+        "etag": "\"8d57a8a5edb084a\"",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res2702/providers/Microsoft.Storage/storageAccounts/sto5009/blobServices/default/containers/container1631/immutabilityPolicies/default",
+        "properties": {
+          "immutabilityPeriodSinceCreationInDays": 3,
+          "state": "Locked"
+        }
+      }
+    }
+  },
+  "operationId": "BlobContainers_LockImmutabilityPolicy",
+  "title": "LockImmutabilityPolicy"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/BlobContainersPatch.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/BlobContainersPatch.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "accountName": "sto328",
+    "api-version": "2026-09-01",
+    "blobContainer": {
+      "properties": {
+        "metadata": {
+          "metadata": "true"
+        },
+        "publicAccess": "Container"
+      }
+    },
+    "containerName": "container6185",
+    "monitor": "true",
+    "resourceGroupName": "res3376",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "container6185",
+        "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res3376/providers/Microsoft.Storage/storageAccounts/sto328/blobServices/default/containers/container6185",
+        "properties": {
+          "hasImmutabilityPolicy": false,
+          "hasLegalHold": false,
+          "metadata": {
+            "metadata": "true"
+          },
+          "publicAccess": "Container"
+        }
+      }
+    }
+  },
+  "operationId": "BlobContainers_Update",
+  "title": "UpdateContainers"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/BlobContainersPut.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/BlobContainersPut.json
@@ -1,0 +1,29 @@
+{
+  "parameters": {
+    "accountName": "sto328",
+    "api-version": "2026-09-01",
+    "blobContainer": {},
+    "containerName": "container6185",
+    "monitor": "true",
+    "resourceGroupName": "res3376",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "container6185",
+        "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res3376/providers/Microsoft.Storage/storageAccounts/sto328/blobServices/default/containers/container6185"
+      }
+    },
+    "201": {
+      "body": {
+        "name": "container6185",
+        "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res3376/providers/Microsoft.Storage/storageAccounts/sto328/blobServices/default/containers/container6185"
+      }
+    }
+  },
+  "operationId": "BlobContainers_Create",
+  "title": "PutContainers"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/BlobContainersPutDefaultEncryptionScope.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/BlobContainersPutDefaultEncryptionScope.json
@@ -1,0 +1,42 @@
+{
+  "parameters": {
+    "accountName": "sto328",
+    "api-version": "2026-09-01",
+    "blobContainer": {
+      "properties": {
+        "defaultEncryptionScope": "encryptionscope185",
+        "denyEncryptionScopeOverride": true
+      }
+    },
+    "containerName": "container6185",
+    "monitor": "true",
+    "resourceGroupName": "res3376",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "container6185",
+        "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res3376/providers/Microsoft.Storage/storageAccounts/sto328/blobServices/default/containers/container6185",
+        "properties": {
+          "defaultEncryptionScope": "encryptionscope185",
+          "denyEncryptionScopeOverride": true
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "container6185",
+        "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res3376/providers/Microsoft.Storage/storageAccounts/sto328/blobServices/default/containers/container6185",
+        "properties": {
+          "defaultEncryptionScope": "encryptionscope185",
+          "denyEncryptionScopeOverride": true
+        }
+      }
+    }
+  },
+  "operationId": "BlobContainers_Create",
+  "title": "PutContainerWithDefaultEncryptionScope"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/BlobContainersPutImmutabilityPolicy.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/BlobContainersPutImmutabilityPolicy.json
@@ -1,0 +1,34 @@
+{
+  "parameters": {
+    "accountName": "sto7069",
+    "api-version": "2026-09-01",
+    "containerName": "container6397",
+    "immutabilityPolicyName": "default",
+    "monitor": "true",
+    "parameters": {
+      "properties": {
+        "allowProtectedAppendWrites": true,
+        "immutabilityPeriodSinceCreationInDays": 3
+      }
+    },
+    "resourceGroupName": "res1782",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.Storage/storageAccounts/blobServices/containers/immutabilityPolicies",
+        "etag": "\"8d59f830cb130e5\"",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res1782/providers/Microsoft.Storage/storageAccounts/sto7069/blobServices/default/containers/container6397/immutabilityPolicies/default",
+        "properties": {
+          "allowProtectedAppendWrites": true,
+          "immutabilityPeriodSinceCreationInDays": 3,
+          "state": "Unlocked"
+        }
+      }
+    }
+  },
+  "operationId": "BlobContainers_CreateOrUpdateImmutabilityPolicy",
+  "title": "CreateOrUpdateImmutabilityPolicy"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/BlobContainersPutImmutabilityPolicyAllowProtectedAppendWritesAll.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/BlobContainersPutImmutabilityPolicyAllowProtectedAppendWritesAll.json
@@ -1,0 +1,34 @@
+{
+  "parameters": {
+    "accountName": "sto7069",
+    "api-version": "2026-09-01",
+    "containerName": "container6397",
+    "immutabilityPolicyName": "default",
+    "monitor": "true",
+    "parameters": {
+      "properties": {
+        "allowProtectedAppendWritesAll": true,
+        "immutabilityPeriodSinceCreationInDays": 3
+      }
+    },
+    "resourceGroupName": "res1782",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.Storage/storageAccounts/blobServices/containers/immutabilityPolicies",
+        "etag": "\"8d59f830cb130e5\"",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res1782/providers/Microsoft.Storage/storageAccounts/sto7069/blobServices/default/containers/container6397/immutabilityPolicies/default",
+        "properties": {
+          "allowProtectedAppendWritesAll": true,
+          "immutabilityPeriodSinceCreationInDays": 3,
+          "state": "Unlocked"
+        }
+      }
+    }
+  },
+  "operationId": "BlobContainers_CreateOrUpdateImmutabilityPolicy",
+  "title": "CreateOrUpdateImmutabilityPolicyWithAllowProtectedAppendWritesAll"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/BlobContainersPutObjectLevelWorm.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/BlobContainersPutObjectLevelWorm.json
@@ -1,0 +1,45 @@
+{
+  "parameters": {
+    "accountName": "sto328",
+    "api-version": "2026-09-01",
+    "blobContainer": {
+      "properties": {
+        "immutableStorageWithVersioning": {
+          "enabled": true
+        }
+      }
+    },
+    "containerName": "container6185",
+    "monitor": "true",
+    "resourceGroupName": "res3376",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "container6185",
+        "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res3376/providers/Microsoft.Storage/storageAccounts/sto328/blobServices/default/containers/container6185",
+        "properties": {
+          "immutableStorageWithVersioning": {
+            "enabled": true
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "container6185",
+        "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res3376/providers/Microsoft.Storage/storageAccounts/sto328/blobServices/default/containers/container6185",
+        "properties": {
+          "immutableStorageWithVersioning": {
+            "enabled": true
+          }
+        }
+      }
+    }
+  },
+  "operationId": "BlobContainers_Create",
+  "title": "PutContainerWithObjectLevelWorm"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/BlobContainersSetLegalHold.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/BlobContainersSetLegalHold.json
@@ -1,0 +1,31 @@
+{
+  "parameters": {
+    "LegalHold": {
+      "tags": [
+        "tag1",
+        "tag2",
+        "tag3"
+      ]
+    },
+    "accountName": "sto7280",
+    "api-version": "2026-09-01",
+    "containerName": "container8723",
+    "monitor": "true",
+    "resourceGroupName": "res4303",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "hasLegalHold": true,
+        "tags": [
+          "tag1",
+          "tag2",
+          "tag3"
+        ]
+      }
+    }
+  },
+  "operationId": "BlobContainers_SetLegalHold",
+  "title": "SetLegalHoldContainers"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/BlobContainersSetLegalHoldAllowProtectedAppendWritesAll.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/BlobContainersSetLegalHoldAllowProtectedAppendWritesAll.json
@@ -1,0 +1,33 @@
+{
+  "parameters": {
+    "LegalHold": {
+      "allowProtectedAppendWritesAll": true,
+      "tags": [
+        "tag1",
+        "tag2",
+        "tag3"
+      ]
+    },
+    "accountName": "sto7280",
+    "api-version": "2026-09-01",
+    "containerName": "container8723",
+    "monitor": "true",
+    "resourceGroupName": "res4303",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "allowProtectedAppendWritesAll": true,
+        "hasLegalHold": true,
+        "tags": [
+          "tag1",
+          "tag2",
+          "tag3"
+        ]
+      }
+    }
+  },
+  "operationId": "BlobContainers_SetLegalHold",
+  "title": "SetLegalHoldContainersWithAllowProtectedAppendWritesAll"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/BlobRangesRestore.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/BlobRangesRestore.json
@@ -1,0 +1,66 @@
+{
+  "parameters": {
+    "accountName": "sto4445",
+    "api-version": "2026-09-01",
+    "parameters": {
+      "blobRanges": [
+        {
+          "endRange": "container/blobpath2",
+          "startRange": "container/blobpath1"
+        },
+        {
+          "endRange": "",
+          "startRange": "container2/blobpath3"
+        }
+      ],
+      "timeToRestore": "2019-04-20T15:30:00.0000000Z"
+    },
+    "resourceGroupName": "res9101",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "parameters": {
+          "blobRanges": [
+            {
+              "endRange": "container/blobpath2",
+              "startRange": "container/blobpath1"
+            },
+            {
+              "endRange": "",
+              "startRange": "container2/blobpath3"
+            }
+          ],
+          "timeToRestore": "2019-04-20T15:30:00.0000000Z"
+        },
+        "restoreId": "{restore_id}",
+        "status": "Succeeded"
+      }
+    },
+    "202": {
+      "body": {
+        "parameters": {
+          "blobRanges": [
+            {
+              "endRange": "container/blobpath2",
+              "startRange": "container/blobpath1"
+            },
+            {
+              "endRange": "",
+              "startRange": "container2/blobpath3"
+            }
+          ],
+          "timeToRestore": "2019-04-20T15:30:00.0000000Z"
+        },
+        "restoreId": "{restore_id}",
+        "status": "InProgress"
+      },
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.Storage/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2022-09-01"
+      }
+    }
+  },
+  "operationId": "StorageAccounts_RestoreBlobRanges",
+  "title": "BlobRangesRestore"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/BlobServicesGet.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/BlobServicesGet.json
@@ -1,0 +1,103 @@
+{
+  "parameters": {
+    "BlobServicesName": "default",
+    "accountName": "sto8607",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res4410",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.Storage/storageAccounts/blobServices",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res4410/providers/Microsoft.Storage/storageAccounts/sto8607/blobServices/default",
+        "properties": {
+          "changeFeed": {
+            "enabled": true,
+            "retentionInDays": 7
+          },
+          "cors": {
+            "corsRules": [
+              {
+                "allowedHeaders": [
+                  "x-ms-meta-abc",
+                  "x-ms-meta-data*",
+                  "x-ms-meta-target*"
+                ],
+                "allowedMethods": [
+                  "GET",
+                  "HEAD",
+                  "POST",
+                  "OPTIONS",
+                  "MERGE",
+                  "PUT"
+                ],
+                "allowedOrigins": [
+                  "http://www.contoso.com",
+                  "http://www.fabrikam.com"
+                ],
+                "exposedHeaders": [
+                  "x-ms-meta-*"
+                ],
+                "maxAgeInSeconds": 100
+              },
+              {
+                "allowedHeaders": [
+                  "*"
+                ],
+                "allowedMethods": [
+                  "GET"
+                ],
+                "allowedOrigins": [
+                  "*"
+                ],
+                "exposedHeaders": [
+                  "*"
+                ],
+                "maxAgeInSeconds": 2
+              },
+              {
+                "allowedHeaders": [
+                  "x-ms-meta-12345675754564*"
+                ],
+                "allowedMethods": [
+                  "GET",
+                  "PUT"
+                ],
+                "allowedOrigins": [
+                  "http://www.abc23.com",
+                  "https://www.fabrikam.com/*"
+                ],
+                "exposedHeaders": [
+                  "x-ms-meta-abc",
+                  "x-ms-meta-data*",
+                  "x -ms-meta-target*"
+                ],
+                "maxAgeInSeconds": 2000
+              }
+            ]
+          },
+          "defaultServiceVersion": "2017-07-29",
+          "deleteRetentionPolicy": {
+            "days": 300,
+            "enabled": true
+          },
+          "isVersioningEnabled": true,
+          "staticWebsite": {
+            "enabled": true,
+            "indexDocument": "home.html",
+            "errorDocument404Path": "site/errors/not-found.html"
+          }
+        },
+        "sku": {
+          "name": "Standard_GRS",
+          "tier": "Standard"
+        }
+      }
+    }
+  },
+  "operationId": "BlobServices_GetServiceProperties",
+  "title": "GetBlobServices"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/BlobServicesList.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/BlobServicesList.json
@@ -1,0 +1,106 @@
+{
+  "parameters": {
+    "accountName": "sto8607",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res4410",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "default",
+            "type": "Microsoft.Storage/storageAccounts/blobServices",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/res4410/providers/Microsoft.Storage/storageAccounts/sto8607/blobServices/default",
+            "properties": {
+              "changeFeed": {
+                "enabled": true,
+                "retentionInDays": 7
+              },
+              "cors": {
+                "corsRules": [
+                  {
+                    "allowedHeaders": [
+                      "x-ms-meta-abc",
+                      "x-ms-meta-data*",
+                      "x-ms-meta-target*"
+                    ],
+                    "allowedMethods": [
+                      "GET",
+                      "HEAD",
+                      "POST",
+                      "OPTIONS",
+                      "MERGE",
+                      "PUT"
+                    ],
+                    "allowedOrigins": [
+                      "http://www.contoso.com",
+                      "http://www.fabrikam.com"
+                    ],
+                    "exposedHeaders": [
+                      "x-ms-meta-*"
+                    ],
+                    "maxAgeInSeconds": 100
+                  },
+                  {
+                    "allowedHeaders": [
+                      "*"
+                    ],
+                    "allowedMethods": [
+                      "GET"
+                    ],
+                    "allowedOrigins": [
+                      "*"
+                    ],
+                    "exposedHeaders": [
+                      "*"
+                    ],
+                    "maxAgeInSeconds": 2
+                  },
+                  {
+                    "allowedHeaders": [
+                      "x-ms-meta-12345675754564*"
+                    ],
+                    "allowedMethods": [
+                      "GET",
+                      "PUT"
+                    ],
+                    "allowedOrigins": [
+                      "http://www.abc23.com",
+                      "https://www.fabrikam.com/*"
+                    ],
+                    "exposedHeaders": [
+                      "x-ms-meta-abc",
+                      "x-ms-meta-data*",
+                      "x -ms-meta-target*"
+                    ],
+                    "maxAgeInSeconds": 2000
+                  }
+                ]
+              },
+              "defaultServiceVersion": "2017-07-29",
+              "deleteRetentionPolicy": {
+                "days": 300,
+                "enabled": true
+              },
+              "isVersioningEnabled": true,
+              "staticWebsite": {
+                "enabled": true,
+                "indexDocument": "home.html",
+                "errorDocument404Path": "site/errors/not-found.html"
+              }
+            },
+            "sku": {
+              "name": "Standard_GRS",
+              "tier": "Standard"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "BlobServices_List",
+  "title": "ListBlobServices"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/BlobServicesPut.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/BlobServicesPut.json
@@ -1,0 +1,183 @@
+{
+  "parameters": {
+    "BlobServicesName": "default",
+    "accountName": "sto8607",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "parameters": {
+      "properties": {
+        "changeFeed": {
+          "enabled": true,
+          "retentionInDays": 7
+        },
+        "cors": {
+          "corsRules": [
+            {
+              "allowedHeaders": [
+                "x-ms-meta-abc",
+                "x-ms-meta-data*",
+                "x-ms-meta-target*"
+              ],
+              "allowedMethods": [
+                "GET",
+                "HEAD",
+                "POST",
+                "OPTIONS",
+                "MERGE",
+                "PUT"
+              ],
+              "allowedOrigins": [
+                "http://www.contoso.com",
+                "http://www.fabrikam.com"
+              ],
+              "exposedHeaders": [
+                "x-ms-meta-*"
+              ],
+              "maxAgeInSeconds": 100
+            },
+            {
+              "allowedHeaders": [
+                "*"
+              ],
+              "allowedMethods": [
+                "GET"
+              ],
+              "allowedOrigins": [
+                "*"
+              ],
+              "exposedHeaders": [
+                "*"
+              ],
+              "maxAgeInSeconds": 2
+            },
+            {
+              "allowedHeaders": [
+                "x-ms-meta-12345675754564*"
+              ],
+              "allowedMethods": [
+                "GET",
+                "PUT"
+              ],
+              "allowedOrigins": [
+                "http://www.abc23.com",
+                "https://www.fabrikam.com/*"
+              ],
+              "exposedHeaders": [
+                "x-ms-meta-abc",
+                "x-ms-meta-data*",
+                "x -ms-meta-target*"
+              ],
+              "maxAgeInSeconds": 2000
+            }
+          ]
+        },
+        "defaultServiceVersion": "2017-07-29",
+        "deleteRetentionPolicy": {
+          "days": 300,
+          "enabled": true
+        },
+        "isVersioningEnabled": true,
+        "staticWebsite": {
+          "enabled": true,
+          "indexDocument": "home.html",
+          "errorDocument404Path": "site/errors/not-found.html"
+        }
+      }
+    },
+    "resourceGroupName": "res4410",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.Storage/storageAccounts/blobServices",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res4410/providers/Microsoft.Storage/storageAccounts/sto8607/blobServices/default",
+        "properties": {
+          "changeFeed": {
+            "enabled": true,
+            "retentionInDays": 7
+          },
+          "cors": {
+            "corsRules": [
+              {
+                "allowedHeaders": [
+                  "x-ms-meta-abc",
+                  "x-ms-meta-data*",
+                  "x-ms-meta-target*"
+                ],
+                "allowedMethods": [
+                  "GET",
+                  "HEAD",
+                  "POST",
+                  "OPTIONS",
+                  "MERGE",
+                  "PUT"
+                ],
+                "allowedOrigins": [
+                  "http://www.contoso.com",
+                  "http://www.fabrikam.com"
+                ],
+                "exposedHeaders": [
+                  "x-ms-meta-*"
+                ],
+                "maxAgeInSeconds": 100
+              },
+              {
+                "allowedHeaders": [
+                  "*"
+                ],
+                "allowedMethods": [
+                  "GET"
+                ],
+                "allowedOrigins": [
+                  "*"
+                ],
+                "exposedHeaders": [
+                  "*"
+                ],
+                "maxAgeInSeconds": 2
+              },
+              {
+                "allowedHeaders": [
+                  "x-ms-meta-12345675754564*"
+                ],
+                "allowedMethods": [
+                  "GET",
+                  "PUT"
+                ],
+                "allowedOrigins": [
+                  "http://www.abc23.com",
+                  "https://www.fabrikam.com/*"
+                ],
+                "exposedHeaders": [
+                  "x-ms-meta-abc",
+                  "x-ms-meta-data*",
+                  "x -ms-meta-target*"
+                ],
+                "maxAgeInSeconds": 2000
+              }
+            ]
+          },
+          "defaultServiceVersion": "2017-07-29",
+          "deleteRetentionPolicy": {
+            "days": 300,
+            "enabled": true
+          },
+          "isVersioningEnabled": true,
+          "staticWebsite": {
+            "enabled": true,
+            "indexDocument": "home.html",
+            "errorDocument404Path": "site/errors/not-found.html"
+          }
+        },
+        "sku": {
+          "name": "Standard_GRS",
+          "tier": "Standard"
+        }
+      }
+    }
+  },
+  "operationId": "BlobServices_SetServiceProperties",
+  "title": "PutBlobServices"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/BlobServicesPutAllowPermanentDelete.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/BlobServicesPutAllowPermanentDelete.json
@@ -1,0 +1,39 @@
+{
+  "parameters": {
+    "BlobServicesName": "default",
+    "accountName": "sto8607",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "parameters": {
+      "properties": {
+        "deleteRetentionPolicy": {
+          "allowPermanentDelete": true,
+          "days": 300,
+          "enabled": true
+        },
+        "isVersioningEnabled": true
+      }
+    },
+    "resourceGroupName": "res4410",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.Storage/storageAccounts/blobServices",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res4410/providers/Microsoft.Storage/storageAccounts/sto8607/blobServices/default",
+        "properties": {
+          "deleteRetentionPolicy": {
+            "allowPermanentDelete": true,
+            "days": 300,
+            "enabled": true
+          },
+          "isVersioningEnabled": true
+        }
+      }
+    }
+  },
+  "operationId": "BlobServices_SetServiceProperties",
+  "title": "BlobServicesPutAllowPermanentDelete"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/BlobServicesPutLastAccessTimeBasedTracking.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/BlobServicesPutLastAccessTimeBasedTracking.json
@@ -1,0 +1,43 @@
+{
+  "parameters": {
+    "BlobServicesName": "default",
+    "accountName": "sto8607",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "parameters": {
+      "properties": {
+        "lastAccessTimeTrackingPolicy": {
+          "name": "AccessTimeTracking",
+          "blobType": [
+            "blockBlob"
+          ],
+          "enable": true,
+          "trackingGranularityInDays": 1
+        }
+      }
+    },
+    "resourceGroupName": "res4410",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.Storage/storageAccounts/blobServices",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res4410/providers/Microsoft.Storage/storageAccounts/sto8607/blobServices/default",
+        "properties": {
+          "lastAccessTimeTrackingPolicy": {
+            "name": "AccessTimeTracking",
+            "blobType": [
+              "blockBlob"
+            ],
+            "enable": true,
+            "trackingGranularityInDays": 1
+          }
+        }
+      }
+    }
+  },
+  "operationId": "BlobServices_SetServiceProperties",
+  "title": "BlobServicesPutLastAccessTimeBasedTracking"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/DeletedAccountGet.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/DeletedAccountGet.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "api-version": "2026-09-01",
+    "deletedAccountName": "sto1125",
+    "location": "eastus",
+    "monitor": "true",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto1125",
+        "type": "Microsoft.Storage/deletedAccounts",
+        "id": "/subscriptions/{subscription-id}/providers/Microsoft.Storage/locations/eastus/deletedAccounts/sto1125",
+        "properties": {
+          "creationTime": "2020-08-17T03:35:37.4588848Z",
+          "deletionTime": "2020-08-17T04:41:37.3442475Z",
+          "location": "eastus",
+          "restoreReference": "sto1125|2020-08-17T03:35:37.4588848Z",
+          "storageAccountResourceId": "/subscriptions/{subscription-id}/resourceGroups/sto/providers/Microsoft.Storage/storageAccounts/sto1125"
+        }
+      }
+    }
+  },
+  "operationId": "DeletedAccounts_Get",
+  "title": "DeletedAccountGet"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/DeletedAccountList.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/DeletedAccountList.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "sto1125",
+            "type": "Microsoft.Storage/deletedAccounts",
+            "id": "/subscriptions/{subscription-id}/providers/Microsoft.Storage/locations/eastus/deletedAccounts/sto1125",
+            "properties": {
+              "creationTime": "2020-08-17T03:35:37.4588848Z",
+              "deletionTime": "2020-08-17T04:41:37.3442475Z",
+              "location": "eastus",
+              "restoreReference": "sto1125|2020-08-17T03:35:37.4588848Z",
+              "storageAccountResourceId": "/subscriptions/{subscription-id}/resourceGroups/sto/providers/Microsoft.Storage/storageAccounts/sto1125"
+            }
+          },
+          {
+            "name": "sto1126",
+            "type": "Microsoft.Storage/deletedAccounts",
+            "id": "/subscriptions/{subscription-id}/providers/Microsoft.Storage/locations/eastus/deletedAccounts/sto1126",
+            "properties": {
+              "creationTime": "2020-08-19T15:10:21.5902165Z",
+              "deletionTime": "2020-08-20T06:11:55.1957302Z",
+              "location": "eastus",
+              "restoreReference": "sto1126|2020-08-17T03:35:37.4588848Z",
+              "storageAccountResourceId": "/subscriptions/{subscription-id}/resourceGroups/sto/providers/Microsoft.Storage/storageAccounts/sto1126"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "DeletedAccounts_List",
+  "title": "DeletedAccountList"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/DeletedBlobContainersList.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/DeletedBlobContainersList.json
@@ -1,0 +1,52 @@
+{
+  "parameters": {
+    "$include": "deleted",
+    "accountName": "sto1590",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res9290",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "container1644",
+            "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
+            "etag": "\"0x8D589847D51C7DE\"",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/res9290/providers/Microsoft.Storage/storageAccounts/sto1590/blobServices/default/containers/container1644",
+            "properties": {
+              "hasImmutabilityPolicy": false,
+              "hasLegalHold": false,
+              "lastModifiedTime": "2018-03-14T08:20:47Z",
+              "leaseState": "Available",
+              "leaseStatus": "Unlocked",
+              "publicAccess": "Container"
+            }
+          },
+          {
+            "name": "container4052",
+            "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
+            "etag": "\"0x8D589847DAB5AF9\"",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/res9290/providers/Microsoft.Storage/storageAccounts/sto1590/blobServices/default/containers/container4052",
+            "properties": {
+              "deleted": true,
+              "deletedTime": "2019-12-14T08:20:47Z",
+              "hasImmutabilityPolicy": false,
+              "hasLegalHold": false,
+              "lastModifiedTime": "2018-03-14T08:20:47Z",
+              "leaseState": "Expired",
+              "leaseStatus": "Unlocked",
+              "publicAccess": "None",
+              "remainingRetentionDays": 30,
+              "version": "1234567890"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "BlobContainers_List",
+  "title": "ListDeletedContainers"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/DeletedFileSharesList.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/DeletedFileSharesList.json
@@ -1,0 +1,44 @@
+{
+  "parameters": {
+    "$expand": "deleted",
+    "accountName": "sto1590",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res9290",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "share1644",
+            "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+            "etag": "\"0x8D589847D51C7DE\"",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/res9290/providers/Microsoft.Storage/storageAccounts/sto1590/fileServices/default/shares/share1644_1234567890",
+            "properties": {
+              "deleted": true,
+              "deletedTime": "2019-12-14T08:20:47Z",
+              "lastModifiedTime": "2019-05-14T08:20:47Z",
+              "remainingRetentionDays": 30,
+              "shareQuota": 1024,
+              "version": "1234567890"
+            }
+          },
+          {
+            "name": "share4052",
+            "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+            "etag": "\"0x8D589847DAB5AF9\"",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/res9290/providers/Microsoft.Storage/storageAccounts/sto1590/fileServices/default/shares/share4052",
+            "properties": {
+              "lastModifiedTime": "2019-05-14T08:20:47Z",
+              "shareQuota": 1024
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "FileShares_List",
+  "title": "ListDeletedShares"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/FileServicesGet.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/FileServicesGet.json
@@ -1,0 +1,88 @@
+{
+  "parameters": {
+    "FileServicesName": "default",
+    "accountName": "sto8607",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res4410",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.Storage/storageAccounts/fileServices",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res4410/providers/Microsoft.Storage/storageAccounts/sto8607/fileServices/default",
+        "properties": {
+          "cors": {
+            "corsRules": [
+              {
+                "allowedHeaders": [
+                  "x-ms-meta-abc",
+                  "x-ms-meta-data*",
+                  "x-ms-meta-target*"
+                ],
+                "allowedMethods": [
+                  "GET",
+                  "HEAD",
+                  "POST",
+                  "OPTIONS",
+                  "MERGE",
+                  "PUT"
+                ],
+                "allowedOrigins": [
+                  "http://www.contoso.com",
+                  "http://www.fabrikam.com"
+                ],
+                "exposedHeaders": [
+                  "x-ms-meta-*"
+                ],
+                "maxAgeInSeconds": 100
+              },
+              {
+                "allowedHeaders": [
+                  "*"
+                ],
+                "allowedMethods": [
+                  "GET"
+                ],
+                "allowedOrigins": [
+                  "*"
+                ],
+                "exposedHeaders": [
+                  "*"
+                ],
+                "maxAgeInSeconds": 2
+              },
+              {
+                "allowedHeaders": [
+                  "x-ms-meta-12345675754564*"
+                ],
+                "allowedMethods": [
+                  "GET",
+                  "PUT"
+                ],
+                "allowedOrigins": [
+                  "http://www.abc23.com",
+                  "https://www.fabrikam.com/*"
+                ],
+                "exposedHeaders": [
+                  "x-ms-meta-abc",
+                  "x-ms-meta-data*",
+                  "x-ms-meta-target*"
+                ],
+                "maxAgeInSeconds": 2000
+              }
+            ]
+          }
+        },
+        "sku": {
+          "name": "Standard_GRS",
+          "tier": "Standard"
+        }
+      }
+    }
+  },
+  "operationId": "FileServices_GetServiceProperties",
+  "title": "GetFileServices"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/FileServicesGetUsage.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/FileServicesGetUsage.json
@@ -1,0 +1,65 @@
+{
+  "parameters": {
+    "FileServicesName": "default",
+    "accountName": "sto8607",
+    "api-version": "2026-09-01",
+    "fileServiceUsagesName": "default",
+    "monitor": "true",
+    "resourceGroupName": "res4410",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.Storage/storageAccounts/fileServices/usages",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/res4410/providers/Microsoft.Storage/storageAccounts/sto8607/fileServices/default/usages/default",
+        "properties": {
+          "burstingConstants": {
+            "burstFloorIOPS": 10000,
+            "burstIOScalar": 3,
+            "burstTimeframeSeconds": 3600
+          },
+          "fileShareLimits": {
+            "maxProvisionedBandwidthMiBPerSec": 10340,
+            "maxProvisionedIOPS": 102400,
+            "maxProvisionedStorageGiB": 262144,
+            "minProvisionedBandwidthMiBPerSec": 125,
+            "minProvisionedIOPS": 3000,
+            "minProvisionedStorageGiB": 32,
+            "guardrailIOScalar": 5,
+            "guardrailBandwidthScalar": 5
+          },
+          "fileShareRecommendations": {
+            "bandwidthScalar": 0.1,
+            "baseBandwidthMiBPerSec": 125,
+            "baseIOPS": 3000,
+            "ioScalar": 1
+          },
+          "storageAccountLimits": {
+            "maxFileShares": 50,
+            "maxProvisionedBandwidthMiBPerSec": 10340,
+            "maxProvisionedIOPS": 102400,
+            "maxProvisionedStorageGiB": 262144
+          },
+          "storageAccountUsage": {
+            "liveShares": {
+              "fileShareCount": 2,
+              "provisionedBandwidthMiBPerSec": 258,
+              "provisionedIOPS": 6064,
+              "provisionedStorageGiB": 64
+            },
+            "softDeletedShares": {
+              "fileShareCount": 1,
+              "provisionedBandwidthMiBPerSec": 125,
+              "provisionedIOPS": 3000,
+              "provisionedStorageGiB": 100
+            }
+          }
+        }
+      }
+    }
+  },
+  "operationId": "FileServices_GetServiceUsage",
+  "title": "GetFileServiceUsage"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/FileServicesList.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/FileServicesList.json
@@ -1,0 +1,91 @@
+{
+  "parameters": {
+    "accountName": "sto1590",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res9290",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "default",
+            "type": "Microsoft.Storage/storageAccounts/fileServices",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/res4410/providers/Microsoft.Storage/storageAccounts/sto8607/fileServices/default",
+            "properties": {
+              "cors": {
+                "corsRules": [
+                  {
+                    "allowedHeaders": [
+                      "x-ms-meta-abc",
+                      "x-ms-meta-data*",
+                      "x-ms-meta-target*"
+                    ],
+                    "allowedMethods": [
+                      "GET",
+                      "HEAD",
+                      "POST",
+                      "OPTIONS",
+                      "MERGE",
+                      "PUT"
+                    ],
+                    "allowedOrigins": [
+                      "http://www.contoso.com",
+                      "http://www.fabrikam.com"
+                    ],
+                    "exposedHeaders": [
+                      "x-ms-meta-*"
+                    ],
+                    "maxAgeInSeconds": 100
+                  },
+                  {
+                    "allowedHeaders": [
+                      "*"
+                    ],
+                    "allowedMethods": [
+                      "GET"
+                    ],
+                    "allowedOrigins": [
+                      "*"
+                    ],
+                    "exposedHeaders": [
+                      "*"
+                    ],
+                    "maxAgeInSeconds": 2
+                  },
+                  {
+                    "allowedHeaders": [
+                      "x-ms-meta-12345675754564*"
+                    ],
+                    "allowedMethods": [
+                      "GET",
+                      "PUT"
+                    ],
+                    "allowedOrigins": [
+                      "http://www.abc23.com",
+                      "https://www.fabrikam.com/*"
+                    ],
+                    "exposedHeaders": [
+                      "x-ms-meta-abc",
+                      "x-ms-meta-data*",
+                      "x-ms-meta-target*"
+                    ],
+                    "maxAgeInSeconds": 2000
+                  }
+                ]
+              }
+            },
+            "sku": {
+              "name": "Standard_GRS",
+              "tier": "Standard"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "FileServices_List",
+  "title": "ListFileServices"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/FileServicesListUsages.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/FileServicesListUsages.json
@@ -1,0 +1,68 @@
+{
+  "parameters": {
+    "FileServicesName": "default",
+    "accountName": "sto8607",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res4410",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "default",
+            "type": "Microsoft.Storage/storageAccounts/fileServices/usages",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/res4410/providers/Microsoft.Storage/storageAccounts/sto8607/fileServices/default/usages/default",
+            "properties": {
+              "burstingConstants": {
+                "burstFloorIOPS": 10000,
+                "burstIOScalar": 3,
+                "burstTimeframeSeconds": 3600
+              },
+              "fileShareLimits": {
+                "maxProvisionedBandwidthMiBPerSec": 10340,
+                "maxProvisionedIOPS": 102400,
+                "maxProvisionedStorageGiB": 262144,
+                "minProvisionedBandwidthMiBPerSec": 125,
+                "minProvisionedIOPS": 3000,
+                "minProvisionedStorageGiB": 32,
+                "guardrailIOScalar": 5,
+                "guardrailBandwidthScalar": 5
+              },
+              "fileShareRecommendations": {
+                "bandwidthScalar": 0.1,
+                "baseBandwidthMiBPerSec": 125,
+                "baseIOPS": 3000,
+                "ioScalar": 1
+              },
+              "storageAccountLimits": {
+                "maxFileShares": 50,
+                "maxProvisionedBandwidthMiBPerSec": 10340,
+                "maxProvisionedIOPS": 102400,
+                "maxProvisionedStorageGiB": 262144
+              },
+              "storageAccountUsage": {
+                "liveShares": {
+                  "fileShareCount": 2,
+                  "provisionedBandwidthMiBPerSec": 258,
+                  "provisionedIOPS": 6064,
+                  "provisionedStorageGiB": 64
+                },
+                "softDeletedShares": {
+                  "fileShareCount": 1,
+                  "provisionedBandwidthMiBPerSec": 125,
+                  "provisionedIOPS": 3000,
+                  "provisionedStorageGiB": 100
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "FileServices_ListServiceUsages",
+  "title": "ListFileServiceUsages"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/FileServicesPut.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/FileServicesPut.json
@@ -1,0 +1,153 @@
+{
+  "parameters": {
+    "FileServicesName": "default",
+    "accountName": "sto8607",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "parameters": {
+      "properties": {
+        "cors": {
+          "corsRules": [
+            {
+              "allowedHeaders": [
+                "x-ms-meta-abc",
+                "x-ms-meta-data*",
+                "x-ms-meta-target*"
+              ],
+              "allowedMethods": [
+                "GET",
+                "HEAD",
+                "POST",
+                "OPTIONS",
+                "MERGE",
+                "PUT"
+              ],
+              "allowedOrigins": [
+                "http://www.contoso.com",
+                "http://www.fabrikam.com"
+              ],
+              "exposedHeaders": [
+                "x-ms-meta-*"
+              ],
+              "maxAgeInSeconds": 100
+            },
+            {
+              "allowedHeaders": [
+                "*"
+              ],
+              "allowedMethods": [
+                "GET"
+              ],
+              "allowedOrigins": [
+                "*"
+              ],
+              "exposedHeaders": [
+                "*"
+              ],
+              "maxAgeInSeconds": 2
+            },
+            {
+              "allowedHeaders": [
+                "x-ms-meta-12345675754564*"
+              ],
+              "allowedMethods": [
+                "GET",
+                "PUT"
+              ],
+              "allowedOrigins": [
+                "http://www.abc23.com",
+                "https://www.fabrikam.com/*"
+              ],
+              "exposedHeaders": [
+                "x-ms-meta-abc",
+                "x-ms-meta-data*",
+                "x-ms-meta-target*"
+              ],
+              "maxAgeInSeconds": 2000
+            }
+          ]
+        }
+      }
+    },
+    "resourceGroupName": "res4410",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.Storage/storageAccounts/fileServices",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res4410/providers/Microsoft.Storage/storageAccounts/sto8607/fileServices/default",
+        "properties": {
+          "cors": {
+            "corsRules": [
+              {
+                "allowedHeaders": [
+                  "x-ms-meta-abc",
+                  "x-ms-meta-data*",
+                  "x-ms-meta-target*"
+                ],
+                "allowedMethods": [
+                  "GET",
+                  "HEAD",
+                  "POST",
+                  "OPTIONS",
+                  "MERGE",
+                  "PUT"
+                ],
+                "allowedOrigins": [
+                  "http://www.contoso.com",
+                  "http://www.fabrikam.com"
+                ],
+                "exposedHeaders": [
+                  "x-ms-meta-*"
+                ],
+                "maxAgeInSeconds": 100
+              },
+              {
+                "allowedHeaders": [
+                  "*"
+                ],
+                "allowedMethods": [
+                  "GET"
+                ],
+                "allowedOrigins": [
+                  "*"
+                ],
+                "exposedHeaders": [
+                  "*"
+                ],
+                "maxAgeInSeconds": 2
+              },
+              {
+                "allowedHeaders": [
+                  "x-ms-meta-12345675754564*"
+                ],
+                "allowedMethods": [
+                  "GET",
+                  "PUT"
+                ],
+                "allowedOrigins": [
+                  "http://www.abc23.com",
+                  "https://www.fabrikam.com/*"
+                ],
+                "exposedHeaders": [
+                  "x-ms-meta-abc",
+                  "x-ms-meta-data*",
+                  "x-ms-meta-target*"
+                ],
+                "maxAgeInSeconds": 2000
+              }
+            ]
+          }
+        },
+        "sku": {
+          "name": "Standard_GRS",
+          "tier": "Standard"
+        }
+      }
+    }
+  },
+  "operationId": "FileServices_SetServiceProperties",
+  "title": "PutFileServices"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/FileServicesPut_EnableSMBMultichannel.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/FileServicesPut_EnableSMBMultichannel.json
@@ -1,0 +1,45 @@
+{
+  "parameters": {
+    "FileServicesName": "default",
+    "accountName": "sto8607",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "parameters": {
+      "properties": {
+        "protocolSettings": {
+          "smb": {
+            "multichannel": {
+              "enabled": true
+            }
+          }
+        }
+      }
+    },
+    "resourceGroupName": "res4410",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.Storage/storageAccounts/fileServices",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res4410/providers/Microsoft.Storage/storageAccounts/sto8607/fileServices/default",
+        "properties": {
+          "protocolSettings": {
+            "smb": {
+              "multichannel": {
+                "enabled": true
+              }
+            }
+          }
+        },
+        "sku": {
+          "name": "Premium_LRS",
+          "tier": "Premium"
+        }
+      }
+    }
+  },
+  "operationId": "FileServices_SetServiceProperties",
+  "title": "PutFileServices_EnableSMBMultichannel"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/FileServicesPut_EnableSecureSmbFeatures.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/FileServicesPut_EnableSecureSmbFeatures.json
@@ -1,0 +1,47 @@
+{
+  "parameters": {
+    "FileServicesName": "default",
+    "accountName": "sto8607",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "parameters": {
+      "properties": {
+        "protocolSettings": {
+          "smb": {
+            "authenticationMethods": "NTLMv2;Kerberos",
+            "channelEncryption": "AES-128-CCM;AES-128-GCM;AES-256-GCM",
+            "kerberosTicketEncryption": "RC4-HMAC;AES-256",
+            "versions": "SMB2.1;SMB3.0;SMB3.1.1"
+          }
+        }
+      }
+    },
+    "resourceGroupName": "res4410",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.Storage/storageAccounts/fileServices",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res4410/providers/Microsoft.Storage/storageAccounts/sto8607/fileServices/default",
+        "properties": {
+          "protocolSettings": {
+            "smb": {
+              "authenticationMethods": "NTLMv2;Kerberos",
+              "channelEncryption": "AES-128-CCM;AES-128-GCM;AES-256-GCM",
+              "kerberosTicketEncryption": "RC4-HMAC;AES-256",
+              "versions": "SMB2.1;SMB3.0;SMB3.1.1"
+            }
+          }
+        },
+        "sku": {
+          "name": "Premium_LRS",
+          "tier": "Premium"
+        }
+      }
+    }
+  },
+  "operationId": "FileServices_SetServiceProperties",
+  "title": "PutFileServices_EnableSecureSmbFeatures"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/FileServicesPut_EncryptionInTransitRequired.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/FileServicesPut_EncryptionInTransitRequired.json
@@ -1,0 +1,55 @@
+{
+  "parameters": {
+    "FileServicesName": "default",
+    "accountName": "sto8607",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "parameters": {
+      "properties": {
+        "protocolSettings": {
+          "nfs": {
+            "encryptionInTransit": {
+              "required": true
+            }
+          },
+          "smb": {
+            "encryptionInTransit": {
+              "required": true
+            }
+          }
+        }
+      }
+    },
+    "resourceGroupName": "res4410",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.Storage/storageAccounts/fileServices",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res4410/providers/Microsoft.Storage/storageAccounts/sto8607/fileServices/default",
+        "properties": {
+          "protocolSettings": {
+            "nfs": {
+              "encryptionInTransit": {
+                "required": true
+              }
+            },
+            "smb": {
+              "encryptionInTransit": {
+                "required": true
+              }
+            }
+          }
+        },
+        "sku": {
+          "name": "Premium_LRS",
+          "tier": "Premium"
+        }
+      }
+    }
+  },
+  "operationId": "FileServices_SetServiceProperties",
+  "title": "PutFileServices_EncryptionInTransitRequired"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/FileShareAclsPatch.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/FileShareAclsPatch.json
@@ -1,0 +1,47 @@
+{
+  "parameters": {
+    "accountName": "sto328",
+    "api-version": "2026-09-01",
+    "fileShare": {
+      "properties": {
+        "signedIdentifiers": [
+          {
+            "accessPolicy": {
+              "expiryTime": "2021-05-01T08:49:37.0000000Z",
+              "permission": "rwd",
+              "startTime": "2021-04-01T08:49:37.0000000Z"
+            },
+            "id": "MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI"
+          }
+        ]
+      }
+    },
+    "monitor": "true",
+    "resourceGroupName": "res3376",
+    "shareName": "share6185",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "share6185",
+        "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res3376/providers/Microsoft.Storage/storageAccounts/sto328/fileServices/default/shares/share6185",
+        "properties": {
+          "signedIdentifiers": [
+            {
+              "accessPolicy": {
+                "expiryTime": "2021-05-01T08:49:37.0000000Z",
+                "permission": "rwd",
+                "startTime": "2021-04-01T08:49:37.0000000Z"
+              },
+              "id": "MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "FileShares_Update",
+  "title": "UpdateShareAcls"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/FileShareSnapshotsList.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/FileShareSnapshotsList.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "$expand": "snapshots",
+    "accountName": "sto1590",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res9290",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "share4052",
+            "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+            "etag": "\"0x8D589847DAB5AF9\"",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/res9290/providers/Microsoft.Storage/storageAccounts/sto1590/fileServices/default/shares/share4052",
+            "properties": {
+              "lastModifiedTime": "2020-10-26T05:47:05.0000000Z",
+              "shareQuota": 1024
+            }
+          },
+          {
+            "name": "share4052",
+            "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+            "etag": "\"0x8D589847DAB5AF9\"",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/res9290/providers/Microsoft.Storage/storageAccounts/sto1590/fileServices/default/shares/share4052",
+            "properties": {
+              "lastModifiedTime": "2020-10-26T05:47:05.0000000Z",
+              "shareQuota": 1024,
+              "snapshotTime": "2020-10-26T05:48:07.0000000Z"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "FileShares_List",
+  "title": "ListShareSnapshots"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/FileSharesDelete.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/FileSharesDelete.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "accountName": "sto4506",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res4079",
+    "shareName": "share9689",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "FileShares_Delete",
+  "title": "DeleteShares"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/FileSharesGet.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/FileSharesGet.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "accountName": "sto6217",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res9871",
+    "shareName": "share1634",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "share1634",
+        "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+        "etag": "\"0x8D592D74CC20EBA\"",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9871/providers/Microsoft.Storage/storageAccounts/sto6217/fileServices/default/shares/share1634",
+        "properties": {
+          "lastModifiedTime": "2019-05-26T05:06:14Z",
+          "shareQuota": 1024
+        }
+      }
+    }
+  },
+  "operationId": "FileShares_Get",
+  "title": "GetShares"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/FileSharesGet_PaidBursting.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/FileSharesGet_PaidBursting.json
@@ -1,0 +1,31 @@
+{
+  "parameters": {
+    "accountName": "sto6217",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res9871",
+    "shareName": "share1634",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "share1634",
+        "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+        "etag": "\"0x8D592D74CC20EBA\"",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9871/providers/Microsoft.Storage/storageAccounts/sto6217/fileServices/default/shares/share1634",
+        "properties": {
+          "fileSharePaidBursting": {
+            "paidBurstingEnabled": true,
+            "paidBurstingMaxBandwidthMibps": 10340,
+            "paidBurstingMaxIops": 102400
+          },
+          "lastModifiedTime": "2019-05-26T05:06:14Z",
+          "shareQuota": 1024
+        }
+      }
+    }
+  },
+  "operationId": "FileShares_Get",
+  "title": "GetSharePaidBursting"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/FileSharesGet_ProvisionedV2.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/FileSharesGet_ProvisionedV2.json
@@ -1,0 +1,33 @@
+{
+  "parameters": {
+    "accountName": "sto6217",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res9871",
+    "shareName": "share1634",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "share1634",
+        "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+        "etag": "\"0x8D592D74CC20EBA\"",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9871/providers/Microsoft.Storage/storageAccounts/sto6217/fileServices/default/shares/share1634",
+        "properties": {
+          "includedBurstIops": 15000,
+          "lastModifiedTime": "2024-10-25T01:50:50.0000000Z",
+          "maxBurstCreditsForIops": 36000000,
+          "nextAllowedProvisionedBandwidthDowngradeTime": "Fri, 25 Oct 2024 01:48:09 GMT",
+          "nextAllowedProvisionedIopsDowngradeTime": "Fri, 25 Oct 2024 01:48:09 GMT",
+          "nextAllowedQuotaDowngradeTime": "Sat, 26 Oct 2024 01:50:50 GMT",
+          "provisionedBandwidthMibps": 200,
+          "provisionedIops": 5000,
+          "shareQuota": 100
+        }
+      }
+    }
+  },
+  "operationId": "FileShares_Get",
+  "title": "GetShareProvisionedV2"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/FileSharesGet_Stats.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/FileSharesGet_Stats.json
@@ -1,0 +1,28 @@
+{
+  "parameters": {
+    "$expand": "stats",
+    "accountName": "sto6217",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res9871",
+    "shareName": "share1634",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "share1634",
+        "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+        "etag": "\"0x8D592D74CC20EBA\"",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9871/providers/Microsoft.Storage/storageAccounts/sto6217/fileServices/default/shares/share1634",
+        "properties": {
+          "lastModifiedTime": "2019-05-26T05:06:14Z",
+          "shareQuota": 1024,
+          "shareUsageBytes": 652945
+        }
+      }
+    }
+  },
+  "operationId": "FileShares_Get",
+  "title": "GetShareStats"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/FileSharesLease_Acquire.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/FileSharesLease_Acquire.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "accountName": "sto328",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "parameters": {
+      "action": "Acquire",
+      "breakPeriod": null,
+      "leaseDuration": -1,
+      "leaseId": null,
+      "proposedLeaseId": null
+    },
+    "resourceGroupName": "res3376",
+    "shareName": "share124",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "leaseId": "8698f513-fa75-44a1-b8eb-30ba336af27d"
+      }
+    }
+  },
+  "operationId": "FileShares_Lease",
+  "title": "Acquire a lease on a share"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/FileSharesLease_Break.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/FileSharesLease_Break.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "accountName": "sto328",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "parameters": {
+      "action": "Break",
+      "breakPeriod": null,
+      "leaseDuration": null,
+      "leaseId": "8698f513-fa75-44a1-b8eb-30ba336af27d",
+      "proposedLeaseId": null
+    },
+    "resourceGroupName": "res3376",
+    "shareName": "share12",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "leaseTimeSeconds": "0"
+      }
+    }
+  },
+  "operationId": "FileShares_Lease",
+  "title": "Break a lease on a share"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/FileSharesList.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/FileSharesList.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "accountName": "sto1590",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res9290",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://sto1590endpoint/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res9290/providers/Microsoft.Storage/storageAccounts/sto1590/fileServices/default/shares?api-version=2022-09-01&$maxpagesize=2&$skipToken=/sto1590/share5103",
+        "value": [
+          {
+            "name": "share1644",
+            "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+            "etag": "\"0x8D589847D51C7DE\"",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res9290/providers/Microsoft.Storage/storageAccounts/sto1590/fileServices/default/shares/share1644",
+            "properties": {
+              "lastModifiedTime": "2019-05-14T08:20:47Z",
+              "shareQuota": 1024
+            }
+          },
+          {
+            "name": "share4052",
+            "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+            "etag": "\"0x8D589847DAB5AF9\"",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res9290/providers/Microsoft.Storage/storageAccounts/sto1590/fileServices/default/shares/share4052",
+            "properties": {
+              "lastModifiedTime": "2019-05-14T08:20:47Z",
+              "shareQuota": 1024
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "FileShares_List",
+  "title": "ListShares"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/FileSharesList_PaidBursting.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/FileSharesList_PaidBursting.json
@@ -1,0 +1,50 @@
+{
+  "parameters": {
+    "accountName": "sto1590",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res9290",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://sto1590endpoint/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res9290/providers/Microsoft.Storage/storageAccounts/sto1590/fileServices/default/shares?api-version=2022-09-01&$maxpagesize=2&$skipToken=/sto1590/share5103",
+        "value": [
+          {
+            "name": "share1644",
+            "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+            "etag": "\"0x8D589847D51C7DE\"",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res9290/providers/Microsoft.Storage/storageAccounts/sto1590/fileServices/default/shares/share1644",
+            "properties": {
+              "fileSharePaidBursting": {
+                "paidBurstingEnabled": true,
+                "paidBurstingMaxBandwidthMibps": 10340,
+                "paidBurstingMaxIops": 102400
+              },
+              "lastModifiedTime": "2019-05-14T08:20:47Z",
+              "shareQuota": 1024
+            }
+          },
+          {
+            "name": "share4052",
+            "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+            "etag": "\"0x8D589847DAB5AF9\"",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res9290/providers/Microsoft.Storage/storageAccounts/sto1590/fileServices/default/shares/share4052",
+            "properties": {
+              "fileSharePaidBursting": {
+                "paidBurstingEnabled": true,
+                "paidBurstingMaxBandwidthMibps": 10340,
+                "paidBurstingMaxIops": 102400
+              },
+              "lastModifiedTime": "2019-05-14T08:20:47Z",
+              "shareQuota": 1024
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "FileShares_List",
+  "title": "ListSharesPaidBursting"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/FileSharesList_ProvisionedV2.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/FileSharesList_ProvisionedV2.json
@@ -1,0 +1,54 @@
+{
+  "parameters": {
+    "accountName": "sto1590",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res9290",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://sto1590endpoint/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res9290/providers/Microsoft.Storage/storageAccounts/sto1590/fileServices/default/shares?api-version=2022-09-01&$maxpagesize=2&$skipToken=/sto1590/share5103",
+        "value": [
+          {
+            "name": "share1644",
+            "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+            "etag": "\"0x8D589847D51C7DE\"",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res9290/providers/Microsoft.Storage/storageAccounts/sto1590/fileServices/default/shares/share1644",
+            "properties": {
+              "includedBurstIops": 15000,
+              "lastModifiedTime": "2024-10-25T01:50:50.0000000Z",
+              "maxBurstCreditsForIops": 36000000,
+              "nextAllowedProvisionedBandwidthDowngradeTime": "Fri, 25 Oct 2024 01:48:09 GMT",
+              "nextAllowedProvisionedIopsDowngradeTime": "Fri, 25 Oct 2024 01:48:09 GMT",
+              "nextAllowedQuotaDowngradeTime": "Sat, 26 Oct 2024 01:50:50 GMT",
+              "provisionedBandwidthMibps": 200,
+              "provisionedIops": 5000,
+              "shareQuota": 100
+            }
+          },
+          {
+            "name": "share4052",
+            "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+            "etag": "\"0x8D589847DAB5AF9\"",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res9290/providers/Microsoft.Storage/storageAccounts/sto1590/fileServices/default/shares/share4052",
+            "properties": {
+              "includedBurstIops": 15000,
+              "lastModifiedTime": "2024-10-25T01:50:50.0000000Z",
+              "maxBurstCreditsForIops": 36000000,
+              "nextAllowedProvisionedBandwidthDowngradeTime": "Fri, 25 Oct 2024 01:48:09 GMT",
+              "nextAllowedProvisionedIopsDowngradeTime": "Fri, 25 Oct 2024 01:48:09 GMT",
+              "nextAllowedQuotaDowngradeTime": "Sat, 26 Oct 2024 01:50:50 GMT",
+              "provisionedBandwidthMibps": 200,
+              "provisionedIops": 5000,
+              "shareQuota": 100
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "FileShares_List",
+  "title": "ListSharesProvisionedV2"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/FileSharesPatch.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/FileSharesPatch.json
@@ -1,0 +1,33 @@
+{
+  "parameters": {
+    "accountName": "sto328",
+    "api-version": "2026-09-01",
+    "fileShare": {
+      "properties": {
+        "metadata": {
+          "type": "image"
+        }
+      }
+    },
+    "monitor": "true",
+    "resourceGroupName": "res3376",
+    "shareName": "share6185",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "share6185",
+        "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res3376/providers/Microsoft.Storage/storageAccounts/sto328/fileServices/default/shares/share6185",
+        "properties": {
+          "metadata": {
+            "type": "image"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "FileShares_Update",
+  "title": "UpdateShares"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/FileSharesPatch_PaidBursting.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/FileSharesPatch_PaidBursting.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "accountName": "sto328",
+    "api-version": "2026-09-01",
+    "fileShare": {
+      "properties": {
+        "fileSharePaidBursting": {
+          "paidBurstingEnabled": true,
+          "paidBurstingMaxBandwidthMibps": 10340,
+          "paidBurstingMaxIops": 102400
+        }
+      }
+    },
+    "monitor": "true",
+    "resourceGroupName": "res3376",
+    "shareName": "share6185",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "share6185",
+        "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res3376/providers/Microsoft.Storage/storageAccounts/sto328/fileServices/default/shares/share6185",
+        "properties": {
+          "fileSharePaidBursting": {
+            "paidBurstingEnabled": true,
+            "paidBurstingMaxBandwidthMibps": 10340,
+            "paidBurstingMaxIops": 102400
+          }
+        }
+      }
+    }
+  },
+  "operationId": "FileShares_Update",
+  "title": "UpdateSharePaidBursting"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/FileSharesPatch_ProvisionedV2.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/FileSharesPatch_ProvisionedV2.json
@@ -1,0 +1,38 @@
+{
+  "parameters": {
+    "accountName": "sto328",
+    "api-version": "2026-09-01",
+    "fileShare": {
+      "properties": {
+        "provisionedBandwidthMibps": 200,
+        "provisionedIops": 5000,
+        "shareQuota": 100
+      }
+    },
+    "monitor": "true",
+    "resourceGroupName": "res3376",
+    "shareName": "share6185",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "share6185",
+        "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res3376/providers/Microsoft.Storage/storageAccounts/sto328/fileServices/default/shares/share6185",
+        "properties": {
+          "includedBurstIops": 15000,
+          "maxBurstCreditsForIops": 36000000,
+          "nextAllowedProvisionedBandwidthDowngradeTime": "Fri, 25 Oct 2024 01:48:09 GMT",
+          "nextAllowedProvisionedIopsDowngradeTime": "Fri, 25 Oct 2024 01:48:09 GMT",
+          "nextAllowedQuotaDowngradeTime": "Sat, 26 Oct 2024 01:50:50 GMT",
+          "provisionedBandwidthMibps": 200,
+          "provisionedIops": 5000,
+          "shareQuota": 100
+        }
+      }
+    }
+  },
+  "operationId": "FileShares_Update",
+  "title": "UpdateShareProvisionedV2"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/FileSharesPut.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/FileSharesPut.json
@@ -1,0 +1,29 @@
+{
+  "parameters": {
+    "accountName": "sto328",
+    "api-version": "2026-09-01",
+    "fileShare": {},
+    "monitor": "true",
+    "resourceGroupName": "res3376",
+    "shareName": "share6185",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "share6185",
+        "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res3376/providers/Microsoft.Storage/storageAccounts/sto328/fileServices/default/shares/share6185"
+      }
+    },
+    "201": {
+      "body": {
+        "name": "share6185",
+        "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res3376/providers/Microsoft.Storage/storageAccounts/sto328/fileServices/default/shares/share6185"
+      }
+    }
+  },
+  "operationId": "FileShares_Create",
+  "title": "PutShares"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/FileSharesPut_AccessTier.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/FileSharesPut_AccessTier.json
@@ -1,0 +1,39 @@
+{
+  "parameters": {
+    "accountName": "sto666",
+    "api-version": "2026-09-01",
+    "fileShare": {
+      "properties": {
+        "accessTier": "Hot"
+      }
+    },
+    "monitor": "true",
+    "resourceGroupName": "res346",
+    "shareName": "share1235",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "share1235",
+        "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res346/providers/Microsoft.Storage/storageAccounts/sto666/fileServices/default/shares/share1235",
+        "properties": {
+          "accessTier": "Hot"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "share1235",
+        "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res346/providers/Microsoft.Storage/storageAccounts/sto666/fileServices/default/shares/share1235",
+        "properties": {
+          "accessTier": "Hot"
+        }
+      }
+    }
+  },
+  "operationId": "FileShares_Create",
+  "title": "PutShares with Access Tier"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/FileSharesPut_NFS.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/FileSharesPut_NFS.json
@@ -1,0 +1,39 @@
+{
+  "parameters": {
+    "accountName": "sto666",
+    "api-version": "2026-09-01",
+    "fileShare": {
+      "properties": {
+        "enabledProtocols": "NFS"
+      }
+    },
+    "monitor": "true",
+    "resourceGroupName": "res346",
+    "shareName": "share1235",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "share1235",
+        "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res346/providers/Microsoft.Storage/storageAccounts/sto666/fileServices/default/shares/share1235",
+        "properties": {
+          "enabledProtocols": "NFS"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "share1235",
+        "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res346/providers/Microsoft.Storage/storageAccounts/sto666/fileServices/default/shares/share1235",
+        "properties": {
+          "enabledProtocols": "NFS"
+        }
+      }
+    }
+  },
+  "operationId": "FileShares_Create",
+  "title": "Create NFS Shares"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/FileSharesPut_PaidBursting.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/FileSharesPut_PaidBursting.json
@@ -1,0 +1,51 @@
+{
+  "parameters": {
+    "accountName": "sto666",
+    "api-version": "2026-09-01",
+    "fileShare": {
+      "properties": {
+        "fileSharePaidBursting": {
+          "paidBurstingEnabled": true,
+          "paidBurstingMaxBandwidthMibps": 10340,
+          "paidBurstingMaxIops": 102400
+        }
+      }
+    },
+    "monitor": "true",
+    "resourceGroupName": "res346",
+    "shareName": "share1235",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "share1235",
+        "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res346/providers/Microsoft.Storage/storageAccounts/sto666/fileServices/default/shares/share1235",
+        "properties": {
+          "fileSharePaidBursting": {
+            "paidBurstingEnabled": true,
+            "paidBurstingMaxBandwidthMibps": 10340,
+            "paidBurstingMaxIops": 102400
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "share1235",
+        "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res346/providers/Microsoft.Storage/storageAccounts/sto666/fileServices/default/shares/share1235",
+        "properties": {
+          "fileSharePaidBursting": {
+            "paidBurstingEnabled": true,
+            "paidBurstingMaxBandwidthMibps": 10340,
+            "paidBurstingMaxIops": 102400
+          }
+        }
+      }
+    }
+  },
+  "operationId": "FileShares_Create",
+  "title": "PutShares with Paid Bursting"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/FileSharesPut_ProvisionedV2.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/FileSharesPut_ProvisionedV2.json
@@ -1,0 +1,49 @@
+{
+  "parameters": {
+    "accountName": "sto666",
+    "api-version": "2026-09-01",
+    "fileShare": {
+      "properties": {
+        "provisionedBandwidthMibps": 200,
+        "provisionedIops": 5000,
+        "shareQuota": 100
+      }
+    },
+    "monitor": "true",
+    "resourceGroupName": "res346",
+    "shareName": "share1235",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "share1235",
+        "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res346/providers/Microsoft.Storage/storageAccounts/sto666/fileServices/default/shares/share1235",
+        "properties": {
+          "includedBurstIops": 15000,
+          "maxBurstCreditsForIops": 36000000,
+          "provisionedBandwidthMibps": 200,
+          "provisionedIops": 5000,
+          "shareQuota": 100
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "share1235",
+        "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res346/providers/Microsoft.Storage/storageAccounts/sto666/fileServices/default/shares/share1235",
+        "properties": {
+          "includedBurstIops": 15000,
+          "maxBurstCreditsForIops": 36000000,
+          "provisionedBandwidthMibps": 200,
+          "provisionedIops": 5000,
+          "shareQuota": 100
+        }
+      }
+    }
+  },
+  "operationId": "FileShares_Create",
+  "title": "PutSharesProvisionedV2"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/FileSharesRestore.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/FileSharesRestore.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "accountName": "sto328",
+    "api-version": "2026-09-01",
+    "deletedShare": {
+      "deletedShareName": "share1249",
+      "deletedShareVersion": "1234567890"
+    },
+    "monitor": "true",
+    "resourceGroupName": "res3376",
+    "shareName": "share1249",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {}
+  },
+  "operationId": "FileShares_Restore",
+  "title": "RestoreShares"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/LocalUserCreate.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/LocalUserCreate.json
@@ -1,0 +1,72 @@
+{
+  "parameters": {
+    "accountName": "sto2527",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "properties": {
+      "properties": {
+        "allowAclAuthorization": true,
+        "groupId": 2000,
+        "hasSshPassword": true,
+        "homeDirectory": "homedirectory",
+        "permissionScopes": [
+          {
+            "permissions": "rwd",
+            "resourceName": "share1",
+            "service": "file"
+          },
+          {
+            "permissions": "rw",
+            "resourceName": "share2",
+            "service": "file"
+          }
+        ],
+        "sshAuthorizedKeys": [
+          {
+            "description": "key name",
+            "key": "ssh-rsa keykeykeykeykey="
+          }
+        ]
+      }
+    },
+    "resourceGroupName": "res6977",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "username": "user1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "user1",
+        "type": "Microsoft.Storage/storageAccounts/localUsers",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res6977/providers/Microsoft.Storage/storageAccounts/sto2527/loalUsers/user1",
+        "properties": {
+          "allowAclAuthorization": true,
+          "groupId": 2000,
+          "homeDirectory": "homedirectory",
+          "permissionScopes": [
+            {
+              "permissions": "rwd",
+              "resourceName": "share1",
+              "service": "file"
+            },
+            {
+              "permissions": "rw",
+              "resourceName": "share2",
+              "service": "file"
+            }
+          ],
+          "sid": "S-1-2-0-125132-153423-36235-1000",
+          "sshAuthorizedKeys": [
+            {
+              "description": "key name",
+              "key": "ssh-rsa keykeykeykeykey="
+            }
+          ],
+          "userId": 1000
+        }
+      }
+    }
+  },
+  "operationId": "LocalUsers_CreateOrUpdate",
+  "title": "CreateLocalUser"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/LocalUserCreateNFSv3Enabled.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/LocalUserCreateNFSv3Enabled.json
@@ -1,0 +1,62 @@
+{
+  "parameters": {
+    "accountName": "sto2527",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "properties": {
+      "properties": {
+        "extendedGroups": [
+          1001,
+          1005,
+          2005
+        ],
+        "isNFSv3Enabled": true
+      }
+    },
+    "resourceGroupName": "res6977",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "username": "user1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "user1",
+        "type": "Microsoft.Storage/storageAccounts/localUsers",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res6977/providers/Microsoft.Storage/storageAccounts/sto2527/loalUsers/user1",
+        "properties": {
+          "allowAclAuthorization": true,
+          "extendedGroups": [
+            1001,
+            1005,
+            2005
+          ],
+          "groupId": 2000,
+          "homeDirectory": "homedirectory",
+          "isNFSv3Enabled": true,
+          "permissionScopes": [
+            {
+              "permissions": "rwd",
+              "resourceName": "share1",
+              "service": "file"
+            },
+            {
+              "permissions": "rw",
+              "resourceName": "share2",
+              "service": "file"
+            }
+          ],
+          "sid": "S-1-2-0-125132-153423-36235-1000",
+          "sshAuthorizedKeys": [
+            {
+              "description": "key name",
+              "key": "ssh-rsa keykeykeykeykey="
+            }
+          ],
+          "userId": 1000
+        }
+      }
+    }
+  },
+  "operationId": "LocalUsers_CreateOrUpdate",
+  "title": "CreateNFSv3EnabledLocalUser"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/LocalUserDelete.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/LocalUserDelete.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "accountName": "sto2527",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res6977",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "username": "user1"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "LocalUsers_Delete",
+  "title": "DeleteLocalUser"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/LocalUserGet.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/LocalUserGet.json
@@ -1,0 +1,49 @@
+{
+  "parameters": {
+    "accountName": "sto2527",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res6977",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "username": "user1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "user1",
+        "type": "Microsoft.Storage/storageAccounts/localUsers",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res6977/providers/Microsoft.Storage/storageAccounts/sto2527/loalUsers/user1",
+        "properties": {
+          "allowAclAuthorization": true,
+          "extendedGroups": [
+            1001,
+            1005,
+            2005
+          ],
+          "groupId": 2000,
+          "hasSharedKey": true,
+          "hasSshKey": true,
+          "hasSshPassword": true,
+          "homeDirectory": "homedirectory",
+          "isNFSv3Enabled": true,
+          "permissionScopes": [
+            {
+              "permissions": "rwd",
+              "resourceName": "share1",
+              "service": "file"
+            },
+            {
+              "permissions": "rw",
+              "resourceName": "share2",
+              "service": "file"
+            }
+          ],
+          "sid": "S-1-2-0-125132-153423-36235-1000",
+          "userId": 1000
+        }
+      }
+    }
+  },
+  "operationId": "LocalUsers_Get",
+  "title": "GetLocalUser"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/LocalUserListKeys.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/LocalUserListKeys.json
@@ -1,0 +1,25 @@
+{
+  "parameters": {
+    "accountName": "sto2527",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res6977",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "username": "user1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "sharedKey": "<REDACTED>",
+        "sshAuthorizedKeys": [
+          {
+            "description": "key name",
+            "key": "ssh-rsa keykeykeykeykew="
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "LocalUsers_ListKeys",
+  "title": "ListLocalUserKeys"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/LocalUserRegeneratePassword.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/LocalUserRegeneratePassword.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "accountName": "sto2527",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res6977",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "username": "user1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "sshPassword": "<REDACTED>"
+      }
+    }
+  },
+  "operationId": "LocalUsers_RegeneratePassword",
+  "title": "RegenerateLocalUserPassword"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/LocalUserUpdate.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/LocalUserUpdate.json
@@ -1,0 +1,53 @@
+{
+  "parameters": {
+    "accountName": "sto2527",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "properties": {
+      "properties": {
+        "allowAclAuthorization": false,
+        "extendedGroups": [
+          1001,
+          1005,
+          2005
+        ],
+        "groupId": 3000,
+        "hasSharedKey": false,
+        "hasSshKey": false,
+        "hasSshPassword": false,
+        "homeDirectory": "homedirectory2",
+        "isNFSv3Enabled": true
+      }
+    },
+    "resourceGroupName": "res6977",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "username": "user1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "user1",
+        "type": "Microsoft.Storage/storageAccounts/localUsers",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res6977/providers/Microsoft.Storage/storageAccounts/sto2527/loalUsers/user1",
+        "properties": {
+          "allowAclAuthorization": false,
+          "extendedGroups": [
+            1001,
+            1005,
+            2005
+          ],
+          "groupId": 3000,
+          "hasSharedKey": false,
+          "hasSshKey": false,
+          "hasSshPassword": false,
+          "homeDirectory": "homedirectory2",
+          "isNFSv3Enabled": true,
+          "sid": "S-1-2-0-3528686663-1788730862-2791910117-1000",
+          "userId": 1000
+        }
+      }
+    }
+  },
+  "operationId": "LocalUsers_CreateOrUpdate",
+  "title": "UpdateLocalUser"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/LocalUsersList.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/LocalUsersList.json
@@ -1,0 +1,68 @@
+{
+  "parameters": {
+    "accountName": "sto2527",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res6977",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": null,
+        "value": [
+          {
+            "name": "user1",
+            "type": "Microsoft.Storage/storageAccounts/localUsers",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/res6977/providers/Microsoft.Storage/storageAccounts/sto2527/loalUsers/user1",
+            "properties": {
+              "allowAclAuthorization": true,
+              "groupId": 2000,
+              "hasSharedKey": true,
+              "hasSshKey": true,
+              "hasSshPassword": true,
+              "homeDirectory": "homedirectory",
+              "permissionScopes": [
+                {
+                  "permissions": "rwd",
+                  "resourceName": "share1",
+                  "service": "file"
+                },
+                {
+                  "permissions": "rw",
+                  "resourceName": "share2",
+                  "service": "file"
+                }
+              ],
+              "sid": "S-1-2-0-125132-153423-36235-1000",
+              "userId": 1000
+            }
+          },
+          {
+            "name": "user2",
+            "type": "Microsoft.Storage/storageAccounts/localUsers",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/res9290/providers/Microsoft.Storage/storageAccounts/sto1590/loalUsers/user2",
+            "properties": {
+              "allowAclAuthorization": true,
+              "groupId": 2000,
+              "hasSharedKey": true,
+              "hasSshKey": false,
+              "hasSshPassword": true,
+              "permissionScopes": [
+                {
+                  "permissions": "rw",
+                  "resourceName": "resourcename",
+                  "service": "blob"
+                }
+              ],
+              "sid": "S-1-2-0-533672-235636-66334-1001",
+              "userId": 1001
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "LocalUsers_List",
+  "title": "ListLocalUsers"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/LocalUsersListNFSv3Enabled.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/LocalUsersListNFSv3Enabled.json
@@ -1,0 +1,80 @@
+{
+  "parameters": {
+    "$include": "nfsv3",
+    "accountName": "sto2527",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res6977",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "user1",
+            "type": "Microsoft.Storage/storageAccounts/localUsers",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/res6977/providers/Microsoft.Storage/storageAccounts/sto2527/loalUsers/user1",
+            "properties": {
+              "allowAclAuthorization": true,
+              "extendedGroups": [
+                1001,
+                1005,
+                2005
+              ],
+              "groupId": 2000,
+              "hasSharedKey": true,
+              "hasSshKey": true,
+              "hasSshPassword": true,
+              "homeDirectory": "homedirectory",
+              "isNFSv3Enabled": true,
+              "permissionScopes": [
+                {
+                  "permissions": "rwd",
+                  "resourceName": "share1",
+                  "service": "file"
+                },
+                {
+                  "permissions": "rw",
+                  "resourceName": "share2",
+                  "service": "file"
+                }
+              ],
+              "sid": "S-1-2-0-125132-153423-36235-1000",
+              "userId": 1000
+            }
+          },
+          {
+            "name": "user2",
+            "type": "Microsoft.Storage/storageAccounts/localUsers",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/res9290/providers/Microsoft.Storage/storageAccounts/sto1590/loalUsers/user2",
+            "properties": {
+              "allowAclAuthorization": true,
+              "extendedGroups": [
+                1001,
+                1005,
+                2005
+              ],
+              "groupId": 2000,
+              "hasSharedKey": true,
+              "hasSshKey": false,
+              "hasSshPassword": true,
+              "isNFSv3Enabled": true,
+              "permissionScopes": [
+                {
+                  "permissions": "rw",
+                  "resourceName": "resourcename",
+                  "service": "blob"
+                }
+              ],
+              "sid": "S-1-2-0-533672-235636-66334-1001",
+              "userId": 1001
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "LocalUsers_List",
+  "title": "ListNFSv3EnabledLocalUsers"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/NetworkSecurityPerimeterConfigurationGet.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/NetworkSecurityPerimeterConfigurationGet.json
@@ -1,0 +1,64 @@
+{
+  "parameters": {
+    "accountName": "sto8607",
+    "api-version": "2026-09-01",
+    "networkSecurityPerimeterConfigurationName": "dbedb4e0-40e6-4145-81f3-f1314c150774.resourceAssociation1",
+    "resourceGroupName": "res4410",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "dbedb4e0-40e6-4145-81f3-f1314c150774.resourceAssociation1",
+        "type": "Microsoft.Storage/storageAccounts/networkSecurityPerimeterConfigurations",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/res4410/providers/Microsoft.Storage/storageAccounts/sto8607/networkSecurityPerimeterConfigurations/dbedb4e0-40e6-4145-81f3-f1314c150774.resourceAssociation1",
+        "properties": {
+          "networkSecurityPerimeter": {
+            "id": "/subscriptions/dbedb4e0-40e6-4145-81f3-f1314c150774/resourceGroups/res4794/providers/Microsoft.Network/networkSecurityPerimeters/nsp1",
+            "location": "East US",
+            "perimeterGuid": "ce2d5953-5c15-40ca-9d51-cc3f4a63b0f5"
+          },
+          "profile": {
+            "name": "profile1",
+            "accessRules": [
+              {
+                "name": "allowedSubscriptions",
+                "properties": {
+                  "direction": "Inbound",
+                  "subscriptions": [
+                    {
+                      "id": "/subscriptions/dbedb4e0-40e6-4145-81f3-f1314c150774"
+                    }
+                  ]
+                }
+              }
+            ],
+            "accessRulesVersion": 10,
+            "diagnosticSettingsVersion": 5,
+            "enabledLogCategories": [
+              "NspPublicInboundPerimeterRulesAllowed",
+              "NspPublicInboundPerimeterRulesDenied"
+            ]
+          },
+          "provisioningIssues": [
+            {
+              "name": "ConfigurationPropagationFailure",
+              "properties": {
+                "description": "Failed to update Network Security Perimeter association.",
+                "issueType": "ConfigurationPropagationFailure",
+                "severity": "Error"
+              }
+            }
+          ],
+          "provisioningState": "Succeeded",
+          "resourceAssociation": {
+            "name": "resourceAssociation1",
+            "accessMode": "Enforced"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeterConfigurations_Get",
+  "title": "NetworkSecurityPerimeterConfigurationGet"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/NetworkSecurityPerimeterConfigurationList.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/NetworkSecurityPerimeterConfigurationList.json
@@ -1,0 +1,56 @@
+{
+  "parameters": {
+    "accountName": "sto8607",
+    "api-version": "2026-09-01",
+    "resourceGroupName": "res4410",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "dbedb4e0-40e6-4145-81f3-f1314c150774.resourceAssociation1",
+            "type": "Microsoft.Storage/storageAccounts/networkSecurityPerimeterConfigurations",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/res4410/providers/Microsoft.Storage/storageAccounts/sto8607/networkSecurityPerimeterConfigurations/dbedb4e0-40e6-4145-81f3-f1314c150774.resourceAssociation1",
+            "properties": {
+              "networkSecurityPerimeter": {
+                "id": "/subscriptions/dbedb4e0-40e6-4145-81f3-f1314c150774/resourceGroups/res4794/providers/Microsoft.Network/networkSecurityPerimeters/nsp1",
+                "location": "East US",
+                "perimeterGuid": "ce2d5953-5c15-40ca-9d51-cc3f4a63b0f5"
+              },
+              "profile": {
+                "name": "profile1",
+                "accessRules": [
+                  {
+                    "name": "inVpnRule",
+                    "properties": {
+                      "addressPrefixes": [
+                        "148.0.0.0/8",
+                        "152.4.6.0/24"
+                      ],
+                      "direction": "Inbound"
+                    }
+                  }
+                ],
+                "accessRulesVersion": 10,
+                "diagnosticSettingsVersion": 5,
+                "enabledLogCategories": [
+                  "NspPublicInboundPerimeterRulesAllowed",
+                  "NspPublicInboundPerimeterRulesDenied"
+                ]
+              },
+              "provisioningState": "Succeeded",
+              "resourceAssociation": {
+                "name": "association1",
+                "accessMode": "Enforced"
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeterConfigurations_List",
+  "title": "NetworkSecurityPerimeterConfigurationList"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/NetworkSecurityPerimeterConfigurationReconcile.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/NetworkSecurityPerimeterConfigurationReconcile.json
@@ -1,0 +1,18 @@
+{
+  "parameters": {
+    "accountName": "sto8607",
+    "api-version": "2026-09-01",
+    "networkSecurityPerimeterConfigurationName": "dbedb4e0-40e6-4145-81f3-f1314c150774.resourceAssociation1",
+    "resourceGroupName": "res4410",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://endpoint:port/subscriptions/00000000-1111-2222-3333-444444444444/providers/Microsoft.Storage/locations/{location}/asyncoperations/{operationid}?monitor=true&api-version=2022-09-01"
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeterConfigurations_Reconcile",
+  "title": "NetworkSecurityPerimeterConfigurationReconcile"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/NfsV3AccountCreate.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/NfsV3AccountCreate.json
@@ -1,0 +1,65 @@
+{
+  "parameters": {
+    "accountName": "sto4445",
+    "api-version": "2026-09-01",
+    "parameters": {
+      "kind": "BlockBlobStorage",
+      "location": "eastus",
+      "properties": {
+        "enableExtendedGroups": true,
+        "isHnsEnabled": true,
+        "isNfsV3Enabled": true,
+        "networkAcls": {
+          "bypass": "AzureServices",
+          "defaultAction": "Allow",
+          "ipRules": [],
+          "virtualNetworkRules": [
+            {
+              "id": "/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.Network/virtualNetworks/net123/subnets/subnet12"
+            }
+          ]
+        },
+        "supportsHttpsTrafficOnly": false
+      },
+      "sku": {
+        "name": "Premium_LRS"
+      }
+    },
+    "resourceGroupName": "res9101",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto4445",
+        "type": "Microsoft.Storage/storageAccounts",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.Storage/storageAccounts/sto4445",
+        "kind": "BlockBlobStorage",
+        "location": "eastus",
+        "properties": {
+          "enableExtendedGroups": true,
+          "isHnsEnabled": true,
+          "isNfsV3Enabled": true,
+          "networkAcls": {
+            "bypass": "AzureServices",
+            "defaultAction": "Allow",
+            "ipRules": [],
+            "virtualNetworkRules": [
+              {
+                "id": "/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.Network/virtualNetworks/net123/subnets/subnet12"
+              }
+            ]
+          },
+          "supportsHttpsTrafficOnly": false
+        },
+        "sku": {
+          "name": "Premium_LRS",
+          "tier": "Premium"
+        }
+      }
+    },
+    "202": {}
+  },
+  "operationId": "StorageAccounts_Create",
+  "title": "NfsV3AccountCreate"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/ObjectLevelWormContainerMigration.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/ObjectLevelWormContainerMigration.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "accountName": "sto7069",
+    "api-version": "2026-09-01",
+    "containerName": "container6397",
+    "immutabilityPolicyName": "default",
+    "monitor": "true",
+    "resourceGroupName": "res1782",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "https://endpoint:port/subscriptions/{subscription-id}/providers/Microsoft.Storage/locations/{location}/asyncoperations/{operationid}?monitor=true&api-version=2022-09-01"
+      }
+    }
+  },
+  "operationId": "BlobContainers_ObjectLevelWorm",
+  "title": "VersionLevelWormContainerMigration"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/OperationsList.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/OperationsList.json
@@ -1,0 +1,475 @@
+{
+  "parameters": {
+    "api-version": "2026-09-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Microsoft.Storage/storageAccounts/write",
+            "display": {
+              "description": "Creates a storage account with the specified parameters or update the properties or tags or adds custom domain for the specified storage account.",
+              "operation": "Create/Update Storage Account",
+              "provider": "Microsoft Storage",
+              "resource": "Storage Accounts"
+            }
+          },
+          {
+            "name": "Microsoft.Storage/storageAccounts/delete",
+            "display": {
+              "description": "Deletes an existing storage account.",
+              "operation": "Delete Storage Account",
+              "provider": "Microsoft Storage",
+              "resource": "Storage Accounts"
+            }
+          },
+          {
+            "name": "Microsoft.Storage/storageAccounts/listkeys/action",
+            "display": {
+              "description": "Returns the access keys for the specified storage account.",
+              "operation": "List Storage Account Keys",
+              "provider": "Microsoft Storage",
+              "resource": "Storage Accounts"
+            }
+          },
+          {
+            "name": "Microsoft.Storage/storageAccounts/regeneratekey/action",
+            "display": {
+              "description": "Regenerates the access keys for the specified storage account.",
+              "operation": "Regenerate Storage Account Keys",
+              "provider": "Microsoft Storage",
+              "resource": "Storage Accounts"
+            }
+          },
+          {
+            "name": "Microsoft.Storage/checknameavailability/read",
+            "display": {
+              "description": "Checks that account name is valid and is not in use.",
+              "operation": "Check Name Availability",
+              "provider": "Microsoft Storage",
+              "resource": "Name Availability"
+            }
+          },
+          {
+            "name": "Microsoft.Storage/storageAccounts/read",
+            "display": {
+              "description": "Returns the list of storage accounts or gets the properties for the specified storage account.",
+              "operation": "List/Get Storage Account(s)",
+              "provider": "Microsoft Storage",
+              "resource": "Storage Accounts"
+            }
+          },
+          {
+            "name": "Microsoft.Storage/usages/read",
+            "display": {
+              "description": "Returns the limit and the current usage count for resources in the specified subscription",
+              "operation": "Get Subscription Usages",
+              "provider": "Microsoft Storage",
+              "resource": "Usage Metrics"
+            }
+          },
+          {
+            "name": "Microsoft.Storage/storageAccounts/listAccountSas/action",
+            "display": {
+              "description": "Returns the Account SAS token for the specified storage account.",
+              "operation": "Returns Storage Account SAS Token",
+              "provider": "Microsoft Storage",
+              "resource": "Storage Account SAS Token"
+            }
+          },
+          {
+            "name": "Microsoft.Storage/storageAccounts/listServiceSas/action",
+            "display": {
+              "description": "Storage Service SAS Token",
+              "operation": "Returns Storage Service SAS Token",
+              "provider": "Microsoft Storage",
+              "resource": "Returns the Service SAS token for the specified storage account."
+            }
+          },
+          {
+            "name": "Microsoft.Storage/locations/deleteVirtualNetworkOrSubnets/action",
+            "display": {
+              "description": "Notifies Microsoft.Storage that virtual network or subnet is being deleted",
+              "operation": "Delete virtual network or subnets notifications",
+              "provider": "Microsoft Storage",
+              "resource": "Location"
+            }
+          },
+          {
+            "name": "Microsoft.Storage/operations/read",
+            "display": {
+              "description": "Polls the status of an asynchronous operation.",
+              "operation": "Poll Asynchronous Operation",
+              "provider": "Microsoft Storage",
+              "resource": "Operations"
+            }
+          },
+          {
+            "name": "Microsoft.Storage/register/action",
+            "display": {
+              "description": "Registers the subscription for the storage resource provider and enables the creation of storage accounts.",
+              "operation": "Registers the Storage Resource Provider",
+              "provider": "Microsoft Storage",
+              "resource": "Storage Resource Provider"
+            }
+          },
+          {
+            "name": "Microsoft.Storage/skus/read",
+            "display": {
+              "description": "Lists the Skus supported by Microsoft.Storage.",
+              "operation": "List Skus",
+              "provider": "Microsoft Storage",
+              "resource": "Skus"
+            }
+          },
+          {
+            "name": "Microsoft.Storage/storageAccounts/services/diagnosticSettings/write",
+            "display": {
+              "description": "Create/Update storage account diagnostic settings.",
+              "operation": "Create/Update Diagnostic Settings",
+              "provider": "Microsoft Storage",
+              "resource": "Storage Accounts"
+            }
+          },
+          {
+            "name": "Microsoft.Storage/storageAccounts/providers/Microsoft.Insights/metricDefinitions/read",
+            "display": {
+              "description": "Get list of Microsoft Storage Metrics definitions.",
+              "operation": "Get list of Microsoft Storage Metrics definitions",
+              "provider": "Microsoft Storage",
+              "resource": "Storage Accounts"
+            },
+            "origin": "system",
+            "properties": {
+              "serviceSpecification": {
+                "metricSpecifications": [
+                  {
+                    "name": "UsedCapacity",
+                    "aggregationType": "Average",
+                    "category": "Capacity",
+                    "displayDescription": "Account used capacity",
+                    "displayName": "Used capacity",
+                    "fillGapWithZero": false,
+                    "resourceIdDimensionNameOverride": "AccountResourceId",
+                    "unit": "Bytes"
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "name": "Microsoft.Storage/storageAccounts/providers/Microsoft.Insights/diagnosticSettings/read",
+            "display": {
+              "description": "Gets the diagnostic setting for the resource.",
+              "operation": "Read diagnostic setting",
+              "provider": "Microsoft Storage",
+              "resource": "Storage Accounts"
+            },
+            "origin": "system"
+          },
+          {
+            "name": "Microsoft.Storage/storageAccounts/providers/Microsoft.Insights/diagnosticSettings/write",
+            "display": {
+              "description": "Creates or updates the diagnostic setting for the resource.",
+              "operation": "Write diagnostic setting",
+              "provider": "Microsoft Storage",
+              "resource": "Storage Accounts"
+            },
+            "origin": "system"
+          },
+          {
+            "name": "Microsoft.Storage/storageAccounts/blobServices/providers/Microsoft.Insights/metricDefinitions/read",
+            "display": {
+              "description": "Get list of Microsoft Storage Metrics definitions.",
+              "operation": "Get list of Microsoft Storage Metrics definitions",
+              "provider": "Microsoft Storage",
+              "resource": "Blob service"
+            },
+            "origin": "system",
+            "properties": {
+              "serviceSpecification": {
+                "metricSpecifications": [
+                  {
+                    "name": "BlobCapacity",
+                    "aggregationType": "Average",
+                    "category": "Capacity",
+                    "dimensions": [
+                      {
+                        "name": "BlobType",
+                        "displayName": "Blob type"
+                      }
+                    ],
+                    "displayDescription": "The amount of storage used by the storage account’s Blob service in bytes.",
+                    "displayName": "Blob Capacity",
+                    "fillGapWithZero": false,
+                    "unit": "Bytes"
+                  },
+                  {
+                    "name": "BlobCount",
+                    "aggregationType": "Average",
+                    "category": "Capacity",
+                    "dimensions": [
+                      {
+                        "name": "BlobType",
+                        "displayName": "Blob type"
+                      }
+                    ],
+                    "displayDescription": "The number of Blob in the storage account’s Blob service.",
+                    "displayName": "Blob Count",
+                    "fillGapWithZero": false,
+                    "unit": "Count"
+                  },
+                  {
+                    "name": "ContainerCount",
+                    "aggregationType": "Average",
+                    "category": "Capacity",
+                    "displayDescription": "The number of containers in the storage account’s Blob service.",
+                    "displayName": "Blob Container Count",
+                    "fillGapWithZero": false,
+                    "unit": "Count"
+                  },
+                  {
+                    "name": "BlobProvisionedSize",
+                    "aggregationType": "Average",
+                    "category": "Capacity",
+                    "dimensions": [
+                      {
+                        "name": "BlobType",
+                        "displayName": "Blob type"
+                      }
+                    ],
+                    "displayDescription": "The amount of storage provisioned in the storage account’s Blob service in bytes.",
+                    "displayName": "Blob Provisioned Size",
+                    "fillGapWithZero": false,
+                    "unit": "Bytes"
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "name": "Microsoft.Storage/storageAccounts/blobServices/providers/Microsoft.Insights/diagnosticSettings/read",
+            "display": {
+              "description": "Gets the diagnostic setting for the resource.",
+              "operation": "Read diagnostic setting",
+              "provider": "Microsoft Storage",
+              "resource": "Blob service"
+            },
+            "origin": "system"
+          },
+          {
+            "name": "Microsoft.Storage/storageAccounts/blobServices/providers/Microsoft.Insights/diagnosticSettings/write",
+            "display": {
+              "description": "Creates or updates the diagnostic setting for the resource.",
+              "operation": "Write diagnostic setting",
+              "provider": "Microsoft Storage",
+              "resource": "Blob service"
+            },
+            "origin": "system"
+          },
+          {
+            "name": "Microsoft.Storage/storageAccounts/tableServices/providers/Microsoft.Insights/metricDefinitions/read",
+            "display": {
+              "description": "Get list of Microsoft Storage Metrics definitions.",
+              "operation": "Get list of Microsoft Storage Metrics definitions",
+              "provider": "Microsoft Storage",
+              "resource": "Table service"
+            },
+            "origin": "system",
+            "properties": {
+              "serviceSpecification": {
+                "metricSpecifications": [
+                  {
+                    "name": "TableCapacity",
+                    "aggregationType": "Average",
+                    "category": "Capacity",
+                    "displayDescription": "The amount of storage used by the storage account’s Table service in bytes.",
+                    "displayName": "Table Capacity",
+                    "fillGapWithZero": false,
+                    "unit": "Bytes"
+                  },
+                  {
+                    "name": "TableCount",
+                    "aggregationType": "Average",
+                    "category": "Capacity",
+                    "displayDescription": "The number of table in the storage account’s Table service.",
+                    "displayName": "Table Count",
+                    "fillGapWithZero": false,
+                    "unit": "Count"
+                  },
+                  {
+                    "name": "TableEntityCount",
+                    "aggregationType": "Average",
+                    "category": "Capacity",
+                    "displayDescription": "The number of table entities in the storage account’s Table service.",
+                    "displayName": "Table Entity Count",
+                    "fillGapWithZero": false,
+                    "unit": "Count"
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "name": "Microsoft.Storage/storageAccounts/tableServices/providers/Microsoft.Insights/diagnosticSettings/read",
+            "display": {
+              "description": "Gets the diagnostic setting for the resource.",
+              "operation": "Read diagnostic setting",
+              "provider": "Microsoft Storage",
+              "resource": "Table service"
+            },
+            "origin": "system"
+          },
+          {
+            "name": "Microsoft.Storage/storageAccounts/tableServices/providers/Microsoft.Insights/diagnosticSettings/write",
+            "display": {
+              "description": "Creates or updates the diagnostic setting for the resource.",
+              "operation": "Write diagnostic setting",
+              "provider": "Microsoft Storage",
+              "resource": "Table service"
+            },
+            "origin": "system"
+          },
+          {
+            "name": "Microsoft.Storage/storageAccounts/queueServices/providers/Microsoft.Insights/metricDefinitions/read",
+            "display": {
+              "description": "Get list of Microsoft Storage Metrics definitions.",
+              "operation": "Get list of Microsoft Storage Metrics definitions",
+              "provider": "Microsoft Storage",
+              "resource": "Queue service"
+            },
+            "origin": "system",
+            "properties": {
+              "serviceSpecification": {
+                "metricSpecifications": [
+                  {
+                    "name": "QueueCapacity",
+                    "aggregationType": "Average",
+                    "category": "Capacity",
+                    "displayDescription": "The amount of storage used by the storage account’s Queue service in bytes.",
+                    "displayName": "Queue Capacity",
+                    "fillGapWithZero": false,
+                    "unit": "Bytes"
+                  },
+                  {
+                    "name": "QueueCount",
+                    "aggregationType": "Average",
+                    "category": "Capacity",
+                    "displayDescription": "The number of queue in the storage account’s Queue service.",
+                    "displayName": "Queue Count",
+                    "fillGapWithZero": false,
+                    "unit": "Count"
+                  },
+                  {
+                    "name": "QueueMessageCount",
+                    "aggregationType": "Average",
+                    "category": "Capacity",
+                    "displayDescription": "The approximate number of queue messages in the storage account’s Queue service.",
+                    "displayName": "Queue Message Count",
+                    "fillGapWithZero": false,
+                    "unit": "Count"
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "name": "Microsoft.Storage/storageAccounts/queueServices/providers/Microsoft.Insights/diagnosticSettings/read",
+            "display": {
+              "description": "Gets the diagnostic setting for the resource.",
+              "operation": "Read diagnostic setting",
+              "provider": "Microsoft Storage",
+              "resource": "Queue service"
+            },
+            "origin": "system"
+          },
+          {
+            "name": "Microsoft.Storage/storageAccounts/queueServices/providers/Microsoft.Insights/diagnosticSettings/write",
+            "display": {
+              "description": "Creates or updates the diagnostic setting for the resource.",
+              "operation": "Write diagnostic setting",
+              "provider": "Microsoft Storage",
+              "resource": "Queue service"
+            },
+            "origin": "system"
+          },
+          {
+            "name": "Microsoft.Storage/storageAccounts/fileServices/providers/Microsoft.Insights/metricDefinitions/read",
+            "display": {
+              "description": "Get list of Microsoft Storage Metrics definitions.",
+              "operation": "Get list of Microsoft Storage Metrics definitions",
+              "provider": "Microsoft Storage",
+              "resource": "File service"
+            },
+            "origin": "system",
+            "properties": {
+              "serviceSpecification": {
+                "metricSpecifications": [
+                  {
+                    "name": "FileCapacity",
+                    "aggregationType": "Average",
+                    "category": "Capacity",
+                    "displayDescription": "The amount of storage used by the storage account’s File service in bytes.",
+                    "displayName": "File Capacity",
+                    "fillGapWithZero": false,
+                    "unit": "Bytes"
+                  },
+                  {
+                    "name": "FileProvisionedSize",
+                    "aggregationType": "Average",
+                    "category": "Capacity",
+                    "displayDescription": "The amount of storage provisioned in the storage account’s File service in bytes.",
+                    "displayName": "File Provisioned Size",
+                    "fillGapWithZero": false,
+                    "unit": "Bytes"
+                  },
+                  {
+                    "name": "FileCount",
+                    "aggregationType": "Average",
+                    "category": "Capacity",
+                    "displayDescription": "The number of file in the storage account’s File service.",
+                    "displayName": "File Count",
+                    "fillGapWithZero": false,
+                    "unit": "Count"
+                  },
+                  {
+                    "name": "FileShareCount",
+                    "aggregationType": "Average",
+                    "category": "Capacity",
+                    "displayDescription": "The number of file shares in the storage account’s File service.",
+                    "displayName": "File Share Count",
+                    "fillGapWithZero": false,
+                    "unit": "Count"
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "name": "Microsoft.Storage/storageAccounts/fileServices/providers/Microsoft.Insights/diagnosticSettings/read",
+            "display": {
+              "description": "Gets the diagnostic setting for the resource.",
+              "operation": "Read diagnostic setting",
+              "provider": "Microsoft Storage",
+              "resource": "File service"
+            },
+            "origin": "system"
+          },
+          {
+            "name": "Microsoft.Storage/storageAccounts/fileServices/providers/Microsoft.Insights/diagnosticSettings/write",
+            "display": {
+              "description": "Creates or updates the diagnostic setting for the resource.",
+              "operation": "Write diagnostic setting",
+              "provider": "Microsoft Storage",
+              "resource": "File service"
+            },
+            "origin": "system"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Operations_List",
+  "title": "OperationsList"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/QueueOperationDelete.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/QueueOperationDelete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "accountName": "sto328",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "queueName": "queue6185",
+    "resourceGroupName": "res3376",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "204": {}
+  },
+  "operationId": "Queue_Delete",
+  "title": "QueueOperationDelete"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/QueueOperationGet.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/QueueOperationGet.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "accountName": "sto328",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "queueName": "queue6185",
+    "resourceGroupName": "res3376",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "queue6185",
+        "type": "Microsoft.Storage/storageAccounts/queueServices/queues",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res3376/providers/Microsoft.Storage/storageAccounts/sto328/queueServices/default/queues/queue6185",
+        "properties": {
+          "metadata": {
+            "sample1": "meta1",
+            "sample2": "meta2"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "Queue_Get",
+  "title": "QueueOperationGet"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/QueueOperationList.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/QueueOperationList.json
@@ -1,0 +1,42 @@
+{
+  "parameters": {
+    "accountName": "sto328",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res9290",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://sto1590endpoint/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res9290/providers/Microsoft.Storage/storageAccounts/sto328/queueServices/default/queues?api-version=2022-09-01&$maxpagesize=2&$skipToken=/sto328/queue6187",
+        "value": [
+          {
+            "name": "queue6185",
+            "type": "Microsoft.Storage/storageAccounts/queueServices/queues",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res3376/providers/Microsoft.Storage/storageAccounts/sto328/queueServices/default/queues/queue6185",
+            "properties": {
+              "metadata": {
+                "sample1": "meta1",
+                "sample2": "meta2"
+              }
+            }
+          },
+          {
+            "name": "queue6186",
+            "type": "Microsoft.Storage/storageAccounts/queueServices/queues",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res3376/providers/Microsoft.Storage/storageAccounts/sto328/queueServices/default/queues/queue6186",
+            "properties": {
+              "metadata": {
+                "sample1": "meta1",
+                "sample2": "meta2"
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Queue_List",
+  "title": "QueueOperationList"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/QueueOperationPatch.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/QueueOperationPatch.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "accountName": "sto328",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "queue": {},
+    "queueName": "queue6185",
+    "resourceGroupName": "res3376",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "queue6185",
+        "type": "Microsoft.Storage/storageAccounts/queueServices/queues",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res3376/providers/Microsoft.Storage/storageAccounts/sto328/queueServices/default/queues/queue6185"
+      }
+    }
+  },
+  "operationId": "Queue_Update",
+  "title": "QueueOperationPatch"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/QueueOperationPut.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/QueueOperationPut.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "accountName": "sto328",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "queue": {},
+    "queueName": "queue6185",
+    "resourceGroupName": "res3376",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "queue6185",
+        "type": "Microsoft.Storage/storageAccounts/queueServices/queues",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res3376/providers/Microsoft.Storage/storageAccounts/sto328/queueServices/default/queues/queue6185"
+      }
+    }
+  },
+  "operationId": "Queue_Create",
+  "title": "QueueOperationPut"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/QueueOperationPutWithMetadata.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/QueueOperationPutWithMetadata.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "accountName": "sto328",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "queue": {
+      "properties": {
+        "metadata": {
+          "sample1": "meta1",
+          "sample2": "meta2"
+        }
+      }
+    },
+    "queueName": "queue6185",
+    "resourceGroupName": "res3376",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "queue6185",
+        "type": "Microsoft.Storage/storageAccounts/queueServices/queues",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res3376/providers/Microsoft.Storage/storageAccounts/sto328/queueServices/default/queues/queue6185",
+        "properties": {
+          "metadata": {
+            "sample1": "meta1",
+            "sample2": "meta2"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "Queue_Create",
+  "title": "QueueOperationPutWithMetadata"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/QueueServicesGet.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/QueueServicesGet.json
@@ -1,0 +1,84 @@
+{
+  "parameters": {
+    "accountName": "sto8607",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "queueServiceName": "default",
+    "resourceGroupName": "res4410",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.Storage/storageAccounts/queueServices",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res4410/providers/Microsoft.Storage/storageAccounts/sto8607/queueServices/default",
+        "properties": {
+          "cors": {
+            "corsRules": [
+              {
+                "allowedHeaders": [
+                  "x-ms-meta-abc",
+                  "x-ms-meta-data*",
+                  "x-ms-meta-target*"
+                ],
+                "allowedMethods": [
+                  "GET",
+                  "HEAD",
+                  "POST",
+                  "OPTIONS",
+                  "MERGE",
+                  "PUT"
+                ],
+                "allowedOrigins": [
+                  "http://www.contoso.com",
+                  "http://www.fabrikam.com"
+                ],
+                "exposedHeaders": [
+                  "x-ms-meta-*"
+                ],
+                "maxAgeInSeconds": 100
+              },
+              {
+                "allowedHeaders": [
+                  "*"
+                ],
+                "allowedMethods": [
+                  "GET"
+                ],
+                "allowedOrigins": [
+                  "*"
+                ],
+                "exposedHeaders": [
+                  "*"
+                ],
+                "maxAgeInSeconds": 2
+              },
+              {
+                "allowedHeaders": [
+                  "x-ms-meta-12345675754564*"
+                ],
+                "allowedMethods": [
+                  "GET",
+                  "PUT"
+                ],
+                "allowedOrigins": [
+                  "http://www.abc23.com",
+                  "https://www.fabrikam.com/*"
+                ],
+                "exposedHeaders": [
+                  "x-ms-meta-abc",
+                  "x-ms-meta-data*",
+                  "x-ms-meta-target*"
+                ],
+                "maxAgeInSeconds": 2000
+              }
+            ]
+          }
+        }
+      }
+    }
+  },
+  "operationId": "QueueServices_GetServiceProperties",
+  "title": "QueueServicesGet"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/QueueServicesList.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/QueueServicesList.json
@@ -1,0 +1,87 @@
+{
+  "parameters": {
+    "accountName": "sto1590",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res9290",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "default",
+            "type": "Microsoft.Storage/storageAccounts/queueServices",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/res4410/providers/Microsoft.Storage/storageAccounts/sto8607/queueServices/default",
+            "properties": {
+              "cors": {
+                "corsRules": [
+                  {
+                    "allowedHeaders": [
+                      "x-ms-meta-abc",
+                      "x-ms-meta-data*",
+                      "x-ms-meta-target*"
+                    ],
+                    "allowedMethods": [
+                      "GET",
+                      "HEAD",
+                      "POST",
+                      "OPTIONS",
+                      "MERGE",
+                      "PUT"
+                    ],
+                    "allowedOrigins": [
+                      "http://www.contoso.com",
+                      "http://www.fabrikam.com"
+                    ],
+                    "exposedHeaders": [
+                      "x-ms-meta-*"
+                    ],
+                    "maxAgeInSeconds": 100
+                  },
+                  {
+                    "allowedHeaders": [
+                      "*"
+                    ],
+                    "allowedMethods": [
+                      "GET"
+                    ],
+                    "allowedOrigins": [
+                      "*"
+                    ],
+                    "exposedHeaders": [
+                      "*"
+                    ],
+                    "maxAgeInSeconds": 2
+                  },
+                  {
+                    "allowedHeaders": [
+                      "x-ms-meta-12345675754564*"
+                    ],
+                    "allowedMethods": [
+                      "GET",
+                      "PUT"
+                    ],
+                    "allowedOrigins": [
+                      "http://www.abc23.com",
+                      "https://www.fabrikam.com/*"
+                    ],
+                    "exposedHeaders": [
+                      "x-ms-meta-abc",
+                      "x-ms-meta-data*",
+                      "x-ms-meta-target*"
+                    ],
+                    "maxAgeInSeconds": 2000
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "QueueServices_List",
+  "title": "QueueServicesList"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/QueueServicesPut.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/QueueServicesPut.json
@@ -1,0 +1,149 @@
+{
+  "parameters": {
+    "accountName": "sto8607",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "parameters": {
+      "properties": {
+        "cors": {
+          "corsRules": [
+            {
+              "allowedHeaders": [
+                "x-ms-meta-abc",
+                "x-ms-meta-data*",
+                "x-ms-meta-target*"
+              ],
+              "allowedMethods": [
+                "GET",
+                "HEAD",
+                "POST",
+                "OPTIONS",
+                "MERGE",
+                "PUT"
+              ],
+              "allowedOrigins": [
+                "http://www.contoso.com",
+                "http://www.fabrikam.com"
+              ],
+              "exposedHeaders": [
+                "x-ms-meta-*"
+              ],
+              "maxAgeInSeconds": 100
+            },
+            {
+              "allowedHeaders": [
+                "*"
+              ],
+              "allowedMethods": [
+                "GET"
+              ],
+              "allowedOrigins": [
+                "*"
+              ],
+              "exposedHeaders": [
+                "*"
+              ],
+              "maxAgeInSeconds": 2
+            },
+            {
+              "allowedHeaders": [
+                "x-ms-meta-12345675754564*"
+              ],
+              "allowedMethods": [
+                "GET",
+                "PUT"
+              ],
+              "allowedOrigins": [
+                "http://www.abc23.com",
+                "https://www.fabrikam.com/*"
+              ],
+              "exposedHeaders": [
+                "x-ms-meta-abc",
+                "x-ms-meta-data*",
+                "x-ms-meta-target*"
+              ],
+              "maxAgeInSeconds": 2000
+            }
+          ]
+        }
+      }
+    },
+    "queueServiceName": "default",
+    "resourceGroupName": "res4410",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.Storage/storageAccounts/queueServices",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res4410/providers/Microsoft.Storage/storageAccounts/sto8607/queueServices/default",
+        "properties": {
+          "cors": {
+            "corsRules": [
+              {
+                "allowedHeaders": [
+                  "x-ms-meta-abc",
+                  "x-ms-meta-data*",
+                  "x-ms-meta-target*"
+                ],
+                "allowedMethods": [
+                  "GET",
+                  "HEAD",
+                  "POST",
+                  "OPTIONS",
+                  "MERGE",
+                  "PUT"
+                ],
+                "allowedOrigins": [
+                  "http://www.contoso.com",
+                  "http://www.fabrikam.com"
+                ],
+                "exposedHeaders": [
+                  "x-ms-meta-*"
+                ],
+                "maxAgeInSeconds": 100
+              },
+              {
+                "allowedHeaders": [
+                  "*"
+                ],
+                "allowedMethods": [
+                  "GET"
+                ],
+                "allowedOrigins": [
+                  "*"
+                ],
+                "exposedHeaders": [
+                  "*"
+                ],
+                "maxAgeInSeconds": 2
+              },
+              {
+                "allowedHeaders": [
+                  "x-ms-meta-12345675754564*"
+                ],
+                "allowedMethods": [
+                  "GET",
+                  "PUT"
+                ],
+                "allowedOrigins": [
+                  "http://www.abc23.com",
+                  "https://www.fabrikam.com/*"
+                ],
+                "exposedHeaders": [
+                  "x-ms-meta-abc",
+                  "x-ms-meta-data*",
+                  "x-ms-meta-target*"
+                ],
+                "maxAgeInSeconds": 2000
+              }
+            ]
+          }
+        }
+      }
+    }
+  },
+  "operationId": "QueueServices_SetServiceProperties",
+  "title": "QueueServicesPut"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/SKUList.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/SKUList.json
@@ -1,0 +1,6456 @@
+{
+  "parameters": {
+    "api-version": "2026-09-01",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "eastus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_ZRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "eastus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "eastus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "eastus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Premium_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "eastus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Premium"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsarchivepreview",
+                "value": "false"
+              },
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "eastus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "eastus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "eastus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "eastus2"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_ZRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "eastus2"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "eastus2"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "eastus2"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Premium_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "eastus2"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Premium"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsarchivepreview",
+                "value": "true"
+              },
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "eastus2"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "eastus2"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "eastus2"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "true"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "eastus2(stage)"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_ZRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "true"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "eastus2(stage)"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "true"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "eastus2(stage)"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "eastus2(stage)"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Premium_LRS",
+            "capabilities": [
+              {
+                "name": "supportsnetworkacls",
+                "value": "true"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "eastus2(stage)"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Premium"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsarchivepreview",
+                "value": "false"
+              },
+              {
+                "name": "supportschangenotification",
+                "value": "true"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "true"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "eastus2(stage)"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "true"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "true"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "eastus2(stage)"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "true"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "eastus2(stage)"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "westus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_ZRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "westus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "westus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "westus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Premium_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "westus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Premium"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsarchivepreview",
+                "value": "false"
+              },
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "westus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "westus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "westus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "westeurope"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_ZRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "westeurope"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "westeurope"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "westeurope"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Premium_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "westeurope"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Premium"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsarchivepreview",
+                "value": "false"
+              },
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "westeurope"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "westeurope"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "westeurope"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "eastasia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_ZRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "eastasia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "eastasia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "eastasia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Premium_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "eastasia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Premium"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsarchivepreview",
+                "value": "false"
+              },
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "eastasia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "eastasia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "eastasia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "southeastasia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_ZRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "southeastasia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "southeastasia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "southeastasia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Premium_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "southeastasia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Premium"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsarchivepreview",
+                "value": "false"
+              },
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "southeastasia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "southeastasia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "southeastasia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "japaneast"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_ZRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "japaneast"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "japaneast"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "japaneast"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Premium_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "japaneast"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Premium"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsarchivepreview",
+                "value": "false"
+              },
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "japaneast"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "japaneast"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "japaneast"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "japanwest"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_ZRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "japanwest"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "japanwest"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "japanwest"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Premium_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "japanwest"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Premium"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsarchivepreview",
+                "value": "false"
+              },
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "japanwest"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "japanwest"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "japanwest"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "northcentralus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_ZRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "northcentralus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "northcentralus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "northcentralus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Premium_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "northcentralus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Premium"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsarchivepreview",
+                "value": "false"
+              },
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "northcentralus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "northcentralus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "northcentralus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "southcentralus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_ZRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "southcentralus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "southcentralus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "southcentralus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Premium_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "southcentralus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Premium"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsarchivepreview",
+                "value": "false"
+              },
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "southcentralus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "southcentralus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "southcentralus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "centralus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_ZRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "centralus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "centralus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "centralus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Premium_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "centralus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Premium"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsarchivepreview",
+                "value": "false"
+              },
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "centralus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "centralus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "centralus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "northeurope"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_ZRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "northeurope"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "northeurope"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "northeurope"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Premium_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "northeurope"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Premium"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsarchivepreview",
+                "value": "false"
+              },
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "northeurope"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "northeurope"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "northeurope"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "brazilsouth"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_ZRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "brazilsouth"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "brazilsouth"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "brazilsouth"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Premium_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "brazilsouth"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Premium"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsarchivepreview",
+                "value": "false"
+              },
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "brazilsouth"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "brazilsouth"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "brazilsouth"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "australiaeast"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_ZRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "australiaeast"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "australiaeast"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "australiaeast"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Premium_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "australiaeast"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Premium"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsarchivepreview",
+                "value": "false"
+              },
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "australiaeast"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "australiaeast"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "australiaeast"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "australiasoutheast"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_ZRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "australiasoutheast"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "australiasoutheast"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "australiasoutheast"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Premium_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "australiasoutheast"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Premium"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsarchivepreview",
+                "value": "false"
+              },
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "australiasoutheast"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "australiasoutheast"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "australiasoutheast"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "southindia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_ZRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "southindia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "southindia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "southindia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Premium_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "southindia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Premium"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsarchivepreview",
+                "value": "false"
+              },
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "southindia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "southindia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "southindia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "centralindia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_ZRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "centralindia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "centralindia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "centralindia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Premium_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "centralindia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Premium"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsarchivepreview",
+                "value": "false"
+              },
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "centralindia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "centralindia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "centralindia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "westindia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_ZRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "westindia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "westindia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "westindia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Premium_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "westindia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Premium"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsarchivepreview",
+                "value": "false"
+              },
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "westindia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "westindia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "westindia"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "canadaeast"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_ZRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "canadaeast"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "canadaeast"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "canadaeast"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Premium_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "canadaeast"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Premium"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsarchivepreview",
+                "value": "false"
+              },
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "canadaeast"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "canadaeast"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "canadaeast"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "canadacentral"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_ZRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "canadacentral"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "canadacentral"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "canadacentral"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Premium_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "canadacentral"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Premium"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsarchivepreview",
+                "value": "false"
+              },
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "canadacentral"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "canadacentral"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "canadacentral"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "westus2"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_ZRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "westus2"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "westus2"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "westus2"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Premium_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "westus2"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Premium"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsarchivepreview",
+                "value": "false"
+              },
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "westus2"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "westus2"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "westus2"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "true"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "westcentralus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_ZRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "true"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "westcentralus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "true"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "westcentralus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "westcentralus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Premium_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "true"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "westcentralus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Premium"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsarchivepreview",
+                "value": "false"
+              },
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "true"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "westcentralus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "true"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "westcentralus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "true"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "westcentralus"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "uksouth"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_ZRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "uksouth"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "uksouth"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "uksouth"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Premium_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "uksouth"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Premium"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsarchivepreview",
+                "value": "false"
+              },
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "uksouth"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "uksouth"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "uksouth"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "ukwest"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_ZRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "ukwest"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "ukwest"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "ukwest"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Premium_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "ukwest"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Premium"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsarchivepreview",
+                "value": "false"
+              },
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "ukwest"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "ukwest"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "ukwest"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "koreacentral"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_ZRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "koreacentral"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "koreacentral"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "koreacentral"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Premium_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "koreacentral"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Premium"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsarchivepreview",
+                "value": "false"
+              },
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "koreacentral"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "koreacentral"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "koreacentral"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "koreasouth"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_ZRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "koreasouth"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "koreasouth"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "koreasouth"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Premium_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "koreasouth"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Premium"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsarchivepreview",
+                "value": "false"
+              },
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "koreasouth"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "koreasouth"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "koreasouth"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "uknorth"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_ZRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "uknorth"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "uknorth"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "uknorth"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Premium_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "uknorth"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Premium"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsarchivepreview",
+                "value": "false"
+              },
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "uknorth"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "uknorth"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "uknorth"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "uksouth2"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_ZRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "uksouth2"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "uksouth2"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "uksouth2"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Premium_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "uksouth2"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Premium"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsarchivepreview",
+                "value": "false"
+              },
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "uksouth2"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "uksouth2"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "false"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "uksouth2"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "true"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "eastus2euap"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_ZRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "true"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "eastus2euap"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "true"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "eastus2euap"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "eastus2euap"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Premium_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "true"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "eastus2euap"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Premium"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsarchivepreview",
+                "value": "false"
+              },
+              {
+                "name": "supportschangenotification",
+                "value": "true"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "true"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "eastus2euap"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "true"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "true"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "eastus2euap"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "true"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "eastus2euap"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "true"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "centraluseuap"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_ZRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "true"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "centraluseuap"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "true"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "centraluseuap"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "true"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "centraluseuap"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Premium_LRS",
+            "capabilities": [
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "true"
+              }
+            ],
+            "kind": "Storage",
+            "locations": [
+              "centraluseuap"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Premium"
+          },
+          {
+            "name": "Standard_LRS",
+            "capabilities": [
+              {
+                "name": "supportsarchivepreview",
+                "value": "false"
+              },
+              {
+                "name": "supportschangenotification",
+                "value": "true"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "true"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "centraluseuap"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_GRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "true"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "true"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "centraluseuap"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "true"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "BlobStorage",
+            "locations": [
+              "centraluseuap"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Standard"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Skus_List",
+  "title": "SkuList"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/SKUListWithLocationInfo.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/SKUListWithLocationInfo.json
@@ -1,0 +1,54 @@
+{
+  "parameters": {
+    "api-version": "2026-09-01",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Premium_LRS",
+            "capabilities": [
+              {
+                "name": "supportschangenotification",
+                "value": "true"
+              },
+              {
+                "name": "supportsfileencryption",
+                "value": "false"
+              },
+              {
+                "name": "supportshoeboxcapacitymetrics",
+                "value": "false"
+              },
+              {
+                "name": "supportsnetworkacls",
+                "value": "false"
+              }
+            ],
+            "kind": "FileStorage",
+            "locationInfo": [
+              {
+                "location": "centraluseuap",
+                "zones": [
+                  "1",
+                  "2",
+                  "3"
+                ]
+              }
+            ],
+            "locations": [
+              "centraluseuap"
+            ],
+            "resourceType": "storageAccounts",
+            "restrictions": [],
+            "tier": "Premium"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Skus_List",
+  "title": "SKUListWithLocationInfo"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountAbortHierarchicalNamespaceMigration.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountAbortHierarchicalNamespaceMigration.json
@@ -1,0 +1,18 @@
+{
+  "parameters": {
+    "accountName": "sto2434",
+    "api-version": "2026-09-01",
+    "resourceGroupName": "res4228",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "https://endpoint:port/subscriptions/{subscription-id}/providers/Microsoft.Storage/locations/{location}/asyncoperations/{operationid}?monitor=true&api-version=2022-09-01"
+      }
+    }
+  },
+  "operationId": "StorageAccounts_AbortHierarchicalNamespaceMigration",
+  "title": "StorageAccountAbortHierarchicalNamespaceMigration"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountCheckNameAvailability.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountCheckNameAvailability.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "accountName": {
+      "name": "sto3363",
+      "type": "Microsoft.Storage/storageAccounts"
+    },
+    "api-version": "2026-09-01",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nameAvailable": true
+      }
+    }
+  },
+  "operationId": "StorageAccounts_CheckNameAvailability",
+  "title": "StorageAccountCheckNameAvailability"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountCreate.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountCreate.json
@@ -1,0 +1,191 @@
+{
+  "parameters": {
+    "accountName": "sto4445",
+    "api-version": "2026-09-01",
+    "parameters": {
+      "extendedLocation": {
+        "name": "losangeles001",
+        "type": "EdgeZone"
+      },
+      "kind": "Storage",
+      "location": "eastus",
+      "properties": {
+        "allowBlobPublicAccess": false,
+        "allowSharedKeyAccess": true,
+        "defaultToOAuthAuthentication": false,
+        "encryption": {
+          "keySource": "Microsoft.Storage",
+          "requireInfrastructureEncryption": false,
+          "services": {
+            "blob": {
+              "enabled": true,
+              "keyType": "Account"
+            },
+            "file": {
+              "enabled": true,
+              "keyType": "Account"
+            }
+          }
+        },
+        "isHnsEnabled": true,
+        "isSftpEnabled": true,
+        "keyPolicy": {
+          "keyExpirationPeriodInDays": 20
+        },
+        "minimumTlsVersion": "TLS1_2",
+        "routingPreference": {
+          "publishInternetEndpoints": true,
+          "publishMicrosoftEndpoints": true,
+          "routingChoice": "MicrosoftRouting"
+        },
+        "sasPolicy": {
+          "expirationAction": "Log",
+          "sasExpirationPeriod": "1.15:59:59",
+          "requireUserBoundUserDelegationSas": true,
+          "requireUserBoundUserDelegationSasAction": "Block"
+        },
+        "geoPriorityReplicationStatus": {
+          "isBlobEnabled": true
+        },
+        "allowSharedKeyAccessForServices": {
+          "blob": {
+            "enabled": true
+          },
+          "file": {
+            "enabled": false
+          },
+          "queue": {
+            "enabled": true
+          },
+          "table": {
+            "enabled": false
+          }
+        },
+        "allowCrossTenantDelegationSas": false
+      },
+      "sku": {
+        "name": "Standard_GRS"
+      },
+      "tags": {
+        "key1": "value1",
+        "key2": "value2"
+      }
+    },
+    "resourceGroupName": "res9101",
+    "subscriptionId": "a3f7c2b9-4e1d-4c8a-9d6f-8b2a5e41c7f3"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto4445",
+        "type": "Microsoft.Storage/storageAccounts",
+        "extendedLocation": {
+          "name": "losangeles001",
+          "type": "EdgeZone"
+        },
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.Storage/storageAccounts/sto4445",
+        "kind": "Storage",
+        "location": "eastus",
+        "properties": {
+          "allowBlobPublicAccess": false,
+          "allowSharedKeyAccess": true,
+          "creationTime": "2017-05-24T13:25:33.4863236Z",
+          "encryption": {
+            "keySource": "Microsoft.Storage",
+            "requireInfrastructureEncryption": false,
+            "services": {
+              "blob": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              },
+              "file": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              }
+            }
+          },
+          "isHnsEnabled": true,
+          "isSftpEnabled": true,
+          "keyCreationTime": {
+            "key1": "2021-03-18T04:42:22.4322836Z",
+            "key2": "2021-03-18T04:42:22.4322836Z"
+          },
+          "keyPolicy": {
+            "keyExpirationPeriodInDays": 20
+          },
+          "minimumTlsVersion": "TLS1_2",
+          "primaryEndpoints": {
+            "blob": "https://sto4445.blob.core.windows.net/",
+            "dfs": "https://sto4445.dfs.core.windows.net/",
+            "file": "https://sto4445.file.core.windows.net/",
+            "internetEndpoints": {
+              "blob": "https://sto4445-internetrouting.blob.core.windows.net/",
+              "dfs": "https://sto4445-internetrouting.dfs.core.windows.net/",
+              "file": "https://sto4445-internetrouting.file.core.windows.net/",
+              "web": "https://sto4445-internetrouting.web.core.windows.net/"
+            },
+            "microsoftEndpoints": {
+              "blob": "https://sto4445-microsoftrouting.blob.core.windows.net/",
+              "dfs": "https://sto4445-microsoftrouting.dfs.core.windows.net/",
+              "file": "https://sto4445-microsoftrouting.file.core.windows.net/",
+              "queue": "https://sto4445-microsoftrouting.queue.core.windows.net/",
+              "table": "https://sto4445-microsoftrouting.table.core.windows.net/",
+              "web": "https://sto4445-microsoftrouting.web.core.windows.net/"
+            },
+            "queue": "https://sto4445.queue.core.windows.net/",
+            "table": "https://sto4445.table.core.windows.net/",
+            "web": "https://sto4445.web.core.windows.net/"
+          },
+          "primaryLocation": "eastus2euap",
+          "provisioningState": "Succeeded",
+          "routingPreference": {
+            "publishInternetEndpoints": true,
+            "publishMicrosoftEndpoints": true,
+            "routingChoice": "MicrosoftRouting"
+          },
+          "sasPolicy": {
+            "expirationAction": "Log",
+            "sasExpirationPeriod": "1.15:59:59",
+            "requireUserBoundUserDelegationSas": true,
+            "requireUserBoundUserDelegationSasAction": "Block"
+          },
+          "secondaryLocation": "centraluseuap",
+          "statusOfPrimary": "available",
+          "statusOfSecondary": "available",
+          "supportsHttpsTrafficOnly": true,
+          "geoPriorityReplicationStatus": {
+            "isBlobEnabled": true
+          },
+          "allowSharedKeyAccessForServices": {
+            "blob": {
+              "enabled": true
+            },
+            "file": {
+              "enabled": false
+            },
+            "queue": {
+              "enabled": true
+            },
+            "table": {
+              "enabled": false
+            }
+          },
+          "allowCrossTenantDelegationSas": false
+        },
+        "sku": {
+          "name": "Standard_GRS",
+          "tier": "Standard"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        }
+      }
+    },
+    "202": {}
+  },
+  "operationId": "StorageAccounts_Create",
+  "title": "StorageAccountCreate"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountCreateAllowedCopyScopeToAAD.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountCreateAllowedCopyScopeToAAD.json
@@ -1,0 +1,146 @@
+{
+  "parameters": {
+    "accountName": "sto4445",
+    "api-version": "2026-09-01",
+    "parameters": {
+      "kind": "Storage",
+      "location": "eastus",
+      "properties": {
+        "allowBlobPublicAccess": false,
+        "allowSharedKeyAccess": true,
+        "allowedCopyScope": "AAD",
+        "encryption": {
+          "keySource": "Microsoft.Storage",
+          "requireInfrastructureEncryption": false,
+          "services": {
+            "blob": {
+              "enabled": true,
+              "keyType": "Account"
+            },
+            "file": {
+              "enabled": true,
+              "keyType": "Account"
+            }
+          }
+        },
+        "isHnsEnabled": true,
+        "keyPolicy": {
+          "keyExpirationPeriodInDays": 20
+        },
+        "minimumTlsVersion": "TLS1_2",
+        "routingPreference": {
+          "publishInternetEndpoints": true,
+          "publishMicrosoftEndpoints": true,
+          "routingChoice": "MicrosoftRouting"
+        },
+        "sasPolicy": {
+          "expirationAction": "Log",
+          "sasExpirationPeriod": "1.15:59:59"
+        }
+      },
+      "sku": {
+        "name": "Standard_GRS"
+      },
+      "tags": {
+        "key1": "value1",
+        "key2": "value2"
+      }
+    },
+    "resourceGroupName": "res9101",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto4445",
+        "type": "Microsoft.Storage/storageAccounts",
+        "extendedLocation": {
+          "name": "losangeles001",
+          "type": "EdgeZone"
+        },
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.Storage/storageAccounts/sto4445",
+        "kind": "Storage",
+        "location": "eastus",
+        "properties": {
+          "allowBlobPublicAccess": false,
+          "allowSharedKeyAccess": true,
+          "allowedCopyScope": "AAD",
+          "creationTime": "2017-05-24T13:25:33.4863236Z",
+          "encryption": {
+            "keySource": "Microsoft.Storage",
+            "requireInfrastructureEncryption": false,
+            "services": {
+              "blob": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              },
+              "file": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              }
+            }
+          },
+          "isHnsEnabled": true,
+          "keyCreationTime": {
+            "key1": "2021-03-18T04:42:22.4322836Z",
+            "key2": "2021-03-18T04:42:22.4322836Z"
+          },
+          "keyPolicy": {
+            "keyExpirationPeriodInDays": 20
+          },
+          "minimumTlsVersion": "TLS1_2",
+          "primaryEndpoints": {
+            "blob": "https://sto4445.blob.core.windows.net/",
+            "dfs": "https://sto4445.dfs.core.windows.net/",
+            "file": "https://sto4445.file.core.windows.net/",
+            "internetEndpoints": {
+              "blob": "https://sto4445-internetrouting.blob.core.windows.net/",
+              "dfs": "https://sto4445-internetrouting.dfs.core.windows.net/",
+              "file": "https://sto4445-internetrouting.file.core.windows.net/",
+              "web": "https://sto4445-internetrouting.web.core.windows.net/"
+            },
+            "microsoftEndpoints": {
+              "blob": "https://sto4445-microsoftrouting.blob.core.windows.net/",
+              "dfs": "https://sto4445-microsoftrouting.dfs.core.windows.net/",
+              "file": "https://sto4445-microsoftrouting.file.core.windows.net/",
+              "queue": "https://sto4445-microsoftrouting.queue.core.windows.net/",
+              "table": "https://sto4445-microsoftrouting.table.core.windows.net/",
+              "web": "https://sto4445-microsoftrouting.web.core.windows.net/"
+            },
+            "queue": "https://sto4445.queue.core.windows.net/",
+            "table": "https://sto4445.table.core.windows.net/",
+            "web": "https://sto4445.web.core.windows.net/"
+          },
+          "primaryLocation": "eastus2euap",
+          "provisioningState": "Succeeded",
+          "routingPreference": {
+            "publishInternetEndpoints": true,
+            "publishMicrosoftEndpoints": true,
+            "routingChoice": "MicrosoftRouting"
+          },
+          "sasPolicy": {
+            "expirationAction": "Log",
+            "sasExpirationPeriod": "1.15:59:59"
+          },
+          "secondaryLocation": "centraluseuap",
+          "statusOfPrimary": "available",
+          "statusOfSecondary": "available",
+          "supportsHttpsTrafficOnly": true
+        },
+        "sku": {
+          "name": "Standard_GRS",
+          "tier": "Standard"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        }
+      }
+    },
+    "202": {}
+  },
+  "operationId": "StorageAccounts_Create",
+  "title": "StorageAccountCreateAllowedCopyScopeToAAD"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountCreateAllowedCopyScopeToPrivateLink.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountCreateAllowedCopyScopeToPrivateLink.json
@@ -1,0 +1,146 @@
+{
+  "parameters": {
+    "accountName": "sto4445",
+    "api-version": "2026-09-01",
+    "parameters": {
+      "kind": "Storage",
+      "location": "eastus",
+      "properties": {
+        "allowBlobPublicAccess": false,
+        "allowSharedKeyAccess": true,
+        "allowedCopyScope": "PrivateLink",
+        "encryption": {
+          "keySource": "Microsoft.Storage",
+          "requireInfrastructureEncryption": false,
+          "services": {
+            "blob": {
+              "enabled": true,
+              "keyType": "Account"
+            },
+            "file": {
+              "enabled": true,
+              "keyType": "Account"
+            }
+          }
+        },
+        "isHnsEnabled": true,
+        "keyPolicy": {
+          "keyExpirationPeriodInDays": 20
+        },
+        "minimumTlsVersion": "TLS1_2",
+        "routingPreference": {
+          "publishInternetEndpoints": true,
+          "publishMicrosoftEndpoints": true,
+          "routingChoice": "MicrosoftRouting"
+        },
+        "sasPolicy": {
+          "expirationAction": "Log",
+          "sasExpirationPeriod": "1.15:59:59"
+        }
+      },
+      "sku": {
+        "name": "Standard_GRS"
+      },
+      "tags": {
+        "key1": "value1",
+        "key2": "value2"
+      }
+    },
+    "resourceGroupName": "res9101",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto4445",
+        "type": "Microsoft.Storage/storageAccounts",
+        "extendedLocation": {
+          "name": "losangeles001",
+          "type": "EdgeZone"
+        },
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.Storage/storageAccounts/sto4445",
+        "kind": "Storage",
+        "location": "eastus",
+        "properties": {
+          "allowBlobPublicAccess": false,
+          "allowSharedKeyAccess": true,
+          "allowedCopyScope": "PrivateLink",
+          "creationTime": "2017-05-24T13:25:33.4863236Z",
+          "encryption": {
+            "keySource": "Microsoft.Storage",
+            "requireInfrastructureEncryption": false,
+            "services": {
+              "blob": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              },
+              "file": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              }
+            }
+          },
+          "isHnsEnabled": true,
+          "keyCreationTime": {
+            "key1": "2021-03-18T04:42:22.4322836Z",
+            "key2": "2021-03-18T04:42:22.4322836Z"
+          },
+          "keyPolicy": {
+            "keyExpirationPeriodInDays": 20
+          },
+          "minimumTlsVersion": "TLS1_2",
+          "primaryEndpoints": {
+            "blob": "https://sto4445.blob.core.windows.net/",
+            "dfs": "https://sto4445.dfs.core.windows.net/",
+            "file": "https://sto4445.file.core.windows.net/",
+            "internetEndpoints": {
+              "blob": "https://sto4445-internetrouting.blob.core.windows.net/",
+              "dfs": "https://sto4445-internetrouting.dfs.core.windows.net/",
+              "file": "https://sto4445-internetrouting.file.core.windows.net/",
+              "web": "https://sto4445-internetrouting.web.core.windows.net/"
+            },
+            "microsoftEndpoints": {
+              "blob": "https://sto4445-microsoftrouting.blob.core.windows.net/",
+              "dfs": "https://sto4445-microsoftrouting.dfs.core.windows.net/",
+              "file": "https://sto4445-microsoftrouting.file.core.windows.net/",
+              "queue": "https://sto4445-microsoftrouting.queue.core.windows.net/",
+              "table": "https://sto4445-microsoftrouting.table.core.windows.net/",
+              "web": "https://sto4445-microsoftrouting.web.core.windows.net/"
+            },
+            "queue": "https://sto4445.queue.core.windows.net/",
+            "table": "https://sto4445.table.core.windows.net/",
+            "web": "https://sto4445.web.core.windows.net/"
+          },
+          "primaryLocation": "eastus2euap",
+          "provisioningState": "Succeeded",
+          "routingPreference": {
+            "publishInternetEndpoints": true,
+            "publishMicrosoftEndpoints": true,
+            "routingChoice": "MicrosoftRouting"
+          },
+          "sasPolicy": {
+            "expirationAction": "Log",
+            "sasExpirationPeriod": "1.15:59:59"
+          },
+          "secondaryLocation": "centraluseuap",
+          "statusOfPrimary": "available",
+          "statusOfSecondary": "available",
+          "supportsHttpsTrafficOnly": true
+        },
+        "sku": {
+          "name": "Standard_GRS",
+          "tier": "Standard"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        }
+      }
+    },
+    "202": {}
+  },
+  "operationId": "StorageAccounts_Create",
+  "title": "StorageAccountCreateAllowedCopyScopeToPrivateLink"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountCreateDisallowPublicNetworkAccess.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountCreateDisallowPublicNetworkAccess.json
@@ -1,0 +1,150 @@
+{
+  "parameters": {
+    "accountName": "sto4445",
+    "api-version": "2026-09-01",
+    "parameters": {
+      "extendedLocation": {
+        "name": "losangeles001",
+        "type": "EdgeZone"
+      },
+      "kind": "Storage",
+      "location": "eastus",
+      "properties": {
+        "allowBlobPublicAccess": false,
+        "allowSharedKeyAccess": true,
+        "encryption": {
+          "keySource": "Microsoft.Storage",
+          "requireInfrastructureEncryption": false,
+          "services": {
+            "blob": {
+              "enabled": true,
+              "keyType": "Account"
+            },
+            "file": {
+              "enabled": true,
+              "keyType": "Account"
+            }
+          }
+        },
+        "isHnsEnabled": true,
+        "keyPolicy": {
+          "keyExpirationPeriodInDays": 20
+        },
+        "minimumTlsVersion": "TLS1_2",
+        "publicNetworkAccess": "Disabled",
+        "routingPreference": {
+          "publishInternetEndpoints": true,
+          "publishMicrosoftEndpoints": true,
+          "routingChoice": "MicrosoftRouting"
+        },
+        "sasPolicy": {
+          "expirationAction": "Log",
+          "sasExpirationPeriod": "1.15:59:59"
+        }
+      },
+      "sku": {
+        "name": "Standard_GRS"
+      },
+      "tags": {
+        "key1": "value1",
+        "key2": "value2"
+      }
+    },
+    "resourceGroupName": "res9101",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto4445",
+        "type": "Microsoft.Storage/storageAccounts",
+        "extendedLocation": {
+          "name": "losangeles001",
+          "type": "EdgeZone"
+        },
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.Storage/storageAccounts/sto4445",
+        "kind": "Storage",
+        "location": "eastus",
+        "properties": {
+          "allowBlobPublicAccess": false,
+          "allowSharedKeyAccess": true,
+          "creationTime": "2017-05-24T13:25:33.4863236Z",
+          "encryption": {
+            "keySource": "Microsoft.Storage",
+            "requireInfrastructureEncryption": false,
+            "services": {
+              "blob": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              },
+              "file": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              }
+            }
+          },
+          "isHnsEnabled": true,
+          "keyCreationTime": {
+            "key1": "2021-03-18T04:42:22.4322836Z",
+            "key2": "2021-03-18T04:42:22.4322836Z"
+          },
+          "keyPolicy": {
+            "keyExpirationPeriodInDays": 20
+          },
+          "minimumTlsVersion": "TLS1_2",
+          "primaryEndpoints": {
+            "blob": "https://sto4445.blob.core.windows.net/",
+            "dfs": "https://sto4445.dfs.core.windows.net/",
+            "file": "https://sto4445.file.core.windows.net/",
+            "internetEndpoints": {
+              "blob": "https://sto4445-internetrouting.blob.core.windows.net/",
+              "dfs": "https://sto4445-internetrouting.dfs.core.windows.net/",
+              "file": "https://sto4445-internetrouting.file.core.windows.net/",
+              "web": "https://sto4445-internetrouting.web.core.windows.net/"
+            },
+            "microsoftEndpoints": {
+              "blob": "https://sto4445-microsoftrouting.blob.core.windows.net/",
+              "dfs": "https://sto4445-microsoftrouting.dfs.core.windows.net/",
+              "file": "https://sto4445-microsoftrouting.file.core.windows.net/",
+              "queue": "https://sto4445-microsoftrouting.queue.core.windows.net/",
+              "table": "https://sto4445-microsoftrouting.table.core.windows.net/",
+              "web": "https://sto4445-microsoftrouting.web.core.windows.net/"
+            },
+            "queue": "https://sto4445.queue.core.windows.net/",
+            "table": "https://sto4445.table.core.windows.net/",
+            "web": "https://sto4445.web.core.windows.net/"
+          },
+          "primaryLocation": "eastus2euap",
+          "provisioningState": "Succeeded",
+          "publicNetworkAccess": "Disabled",
+          "routingPreference": {
+            "publishInternetEndpoints": true,
+            "publishMicrosoftEndpoints": true,
+            "routingChoice": "MicrosoftRouting"
+          },
+          "sasPolicy": {
+            "expirationAction": "Log",
+            "sasExpirationPeriod": "1.15:59:59"
+          },
+          "secondaryLocation": "centraluseuap",
+          "statusOfPrimary": "available",
+          "statusOfSecondary": "available",
+          "supportsHttpsTrafficOnly": true
+        },
+        "sku": {
+          "name": "Standard_GRS",
+          "tier": "Standard"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        }
+      }
+    },
+    "202": {}
+  },
+  "operationId": "StorageAccounts_Create",
+  "title": "StorageAccountCreateDisallowPublicNetworkAccess"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountCreateDnsEndpointTypeToAzureDnsZone.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountCreateDnsEndpointTypeToAzureDnsZone.json
@@ -1,0 +1,153 @@
+{
+  "parameters": {
+    "accountName": "sto4445",
+    "api-version": "2026-09-01",
+    "parameters": {
+      "extendedLocation": {
+        "name": "losangeles001",
+        "type": "EdgeZone"
+      },
+      "kind": "Storage",
+      "location": "eastus",
+      "properties": {
+        "allowBlobPublicAccess": false,
+        "allowSharedKeyAccess": true,
+        "defaultToOAuthAuthentication": false,
+        "dnsEndpointType": "AzureDnsZone",
+        "encryption": {
+          "keySource": "Microsoft.Storage",
+          "requireInfrastructureEncryption": false,
+          "services": {
+            "blob": {
+              "enabled": true,
+              "keyType": "Account"
+            },
+            "file": {
+              "enabled": true,
+              "keyType": "Account"
+            }
+          }
+        },
+        "isHnsEnabled": true,
+        "isSftpEnabled": true,
+        "keyPolicy": {
+          "keyExpirationPeriodInDays": 20
+        },
+        "minimumTlsVersion": "TLS1_2",
+        "routingPreference": {
+          "publishInternetEndpoints": true,
+          "publishMicrosoftEndpoints": true,
+          "routingChoice": "MicrosoftRouting"
+        },
+        "sasPolicy": {
+          "expirationAction": "Log",
+          "sasExpirationPeriod": "1.15:59:59"
+        }
+      },
+      "sku": {
+        "name": "Standard_GRS"
+      },
+      "tags": {
+        "key1": "value1",
+        "key2": "value2"
+      }
+    },
+    "resourceGroupName": "res9101",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto4445",
+        "type": "Microsoft.Storage/storageAccounts",
+        "extendedLocation": {
+          "name": "losangeles001",
+          "type": "EdgeZone"
+        },
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.Storage/storageAccounts/sto4445",
+        "kind": "Storage",
+        "location": "eastus",
+        "properties": {
+          "allowBlobPublicAccess": false,
+          "allowSharedKeyAccess": true,
+          "creationTime": "2017-05-24T13:25:33.4863236Z",
+          "dnsEndpointType": "AzureDnsZone",
+          "encryption": {
+            "keySource": "Microsoft.Storage",
+            "requireInfrastructureEncryption": false,
+            "services": {
+              "blob": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              },
+              "file": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              }
+            }
+          },
+          "isHnsEnabled": true,
+          "isSftpEnabled": true,
+          "keyCreationTime": {
+            "key1": "2021-03-18T04:42:22.4322836Z",
+            "key2": "2021-03-18T04:42:22.4322836Z"
+          },
+          "keyPolicy": {
+            "keyExpirationPeriodInDays": 20
+          },
+          "minimumTlsVersion": "TLS1_2",
+          "primaryEndpoints": {
+            "blob": "https://sto4445.z24.blob.storage.azure.net/",
+            "dfs": "https://sto4445.z24.dfs.storage.azure.net/",
+            "file": "https://sto4445.z24.file.storage.azure.net/",
+            "internetEndpoints": {
+              "blob": "https://sto4445-internetrouting.z24.blob.storage.azure.net/",
+              "dfs": "https://sto4445-internetrouting.z24.dfs.storage.azure.net/",
+              "file": "https://sto4445-internetrouting.z24.file.storage.azure.net/",
+              "web": "https://sto4445-internetrouting.z24.web.storage.azure.net/"
+            },
+            "microsoftEndpoints": {
+              "blob": "https://sto4445-microsoftrouting.z24.blob.storage.azure.net/",
+              "dfs": "https://sto4445-microsoftrouting.z24.dfs.storage.azure.net/",
+              "file": "https://sto4445-microsoftrouting.z24.file.storage.azure.net/",
+              "queue": "https://sto4445-microsoftrouting.z24.queue.storage.azure.net/",
+              "table": "https://sto4445-microsoftrouting.z24.table.storage.azure.net/",
+              "web": "https://sto4445-microsoftrouting.z24.web.storage.azure.net/"
+            },
+            "queue": "https://sto4445.z24.queue.storage.azure.net/",
+            "table": "https://sto4445.z24.table.storage.azure.net/",
+            "web": "https://sto4445.z24.web.storage.azure.net/"
+          },
+          "primaryLocation": "eastus2euap",
+          "provisioningState": "Succeeded",
+          "routingPreference": {
+            "publishInternetEndpoints": true,
+            "publishMicrosoftEndpoints": true,
+            "routingChoice": "MicrosoftRouting"
+          },
+          "sasPolicy": {
+            "expirationAction": "Log",
+            "sasExpirationPeriod": "1.15:59:59"
+          },
+          "secondaryLocation": "centraluseuap",
+          "statusOfPrimary": "available",
+          "statusOfSecondary": "available",
+          "supportsHttpsTrafficOnly": true
+        },
+        "sku": {
+          "name": "Standard_GRS",
+          "tier": "Standard"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        }
+      }
+    },
+    "202": {}
+  },
+  "operationId": "StorageAccounts_Create",
+  "title": "StorageAccountCreateDnsEndpointTypeToAzureDnsZone"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountCreateDnsEndpointTypeToStandard.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountCreateDnsEndpointTypeToStandard.json
@@ -1,0 +1,153 @@
+{
+  "parameters": {
+    "accountName": "sto4445",
+    "api-version": "2026-09-01",
+    "parameters": {
+      "extendedLocation": {
+        "name": "losangeles001",
+        "type": "EdgeZone"
+      },
+      "kind": "Storage",
+      "location": "eastus",
+      "properties": {
+        "allowBlobPublicAccess": false,
+        "allowSharedKeyAccess": true,
+        "defaultToOAuthAuthentication": false,
+        "dnsEndpointType": "Standard",
+        "encryption": {
+          "keySource": "Microsoft.Storage",
+          "requireInfrastructureEncryption": false,
+          "services": {
+            "blob": {
+              "enabled": true,
+              "keyType": "Account"
+            },
+            "file": {
+              "enabled": true,
+              "keyType": "Account"
+            }
+          }
+        },
+        "isHnsEnabled": true,
+        "isSftpEnabled": true,
+        "keyPolicy": {
+          "keyExpirationPeriodInDays": 20
+        },
+        "minimumTlsVersion": "TLS1_2",
+        "routingPreference": {
+          "publishInternetEndpoints": true,
+          "publishMicrosoftEndpoints": true,
+          "routingChoice": "MicrosoftRouting"
+        },
+        "sasPolicy": {
+          "expirationAction": "Log",
+          "sasExpirationPeriod": "1.15:59:59"
+        }
+      },
+      "sku": {
+        "name": "Standard_GRS"
+      },
+      "tags": {
+        "key1": "value1",
+        "key2": "value2"
+      }
+    },
+    "resourceGroupName": "res9101",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto4445",
+        "type": "Microsoft.Storage/storageAccounts",
+        "extendedLocation": {
+          "name": "losangeles001",
+          "type": "EdgeZone"
+        },
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.Storage/storageAccounts/sto4445",
+        "kind": "Storage",
+        "location": "eastus",
+        "properties": {
+          "allowBlobPublicAccess": false,
+          "allowSharedKeyAccess": true,
+          "creationTime": "2017-05-24T13:25:33.4863236Z",
+          "dnsEndpointType": "Standard",
+          "encryption": {
+            "keySource": "Microsoft.Storage",
+            "requireInfrastructureEncryption": false,
+            "services": {
+              "blob": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              },
+              "file": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              }
+            }
+          },
+          "isHnsEnabled": true,
+          "isSftpEnabled": true,
+          "keyCreationTime": {
+            "key1": "2021-03-18T04:42:22.4322836Z",
+            "key2": "2021-03-18T04:42:22.4322836Z"
+          },
+          "keyPolicy": {
+            "keyExpirationPeriodInDays": 20
+          },
+          "minimumTlsVersion": "TLS1_2",
+          "primaryEndpoints": {
+            "blob": "https://sto4445.blob.core.windows.net/",
+            "dfs": "https://sto4445.dfs.core.windows.net/",
+            "file": "https://sto4445.file.core.windows.net/",
+            "internetEndpoints": {
+              "blob": "https://sto4445-internetrouting.blob.core.windows.net/",
+              "dfs": "https://sto4445-internetrouting.dfs.core.windows.net/",
+              "file": "https://sto4445-internetrouting.file.core.windows.net/",
+              "web": "https://sto4445-internetrouting.web.core.windows.net/"
+            },
+            "microsoftEndpoints": {
+              "blob": "https://sto4445-microsoftrouting.blob.core.windows.net/",
+              "dfs": "https://sto4445-microsoftrouting.dfs.core.windows.net/",
+              "file": "https://sto4445-microsoftrouting.file.core.windows.net/",
+              "queue": "https://sto4445-microsoftrouting.queue.core.windows.net/",
+              "table": "https://sto4445-microsoftrouting.table.core.windows.net/",
+              "web": "https://sto4445-microsoftrouting.web.core.windows.net/"
+            },
+            "queue": "https://sto4445.queue.core.windows.net/",
+            "table": "https://sto4445.table.core.windows.net/",
+            "web": "https://sto4445.web.core.windows.net/"
+          },
+          "primaryLocation": "eastus2euap",
+          "provisioningState": "Succeeded",
+          "routingPreference": {
+            "publishInternetEndpoints": true,
+            "publishMicrosoftEndpoints": true,
+            "routingChoice": "MicrosoftRouting"
+          },
+          "sasPolicy": {
+            "expirationAction": "Log",
+            "sasExpirationPeriod": "1.15:59:59"
+          },
+          "secondaryLocation": "centraluseuap",
+          "statusOfPrimary": "available",
+          "statusOfSecondary": "available",
+          "supportsHttpsTrafficOnly": true
+        },
+        "sku": {
+          "name": "Standard_GRS",
+          "tier": "Standard"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        }
+      }
+    },
+    "202": {}
+  },
+  "operationId": "StorageAccounts_Create",
+  "title": "StorageAccountCreateDnsEndpointTypeToStandard"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountCreateEnablePublicNetworkAccess.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountCreateEnablePublicNetworkAccess.json
@@ -1,0 +1,150 @@
+{
+  "parameters": {
+    "accountName": "sto4445",
+    "api-version": "2026-09-01",
+    "parameters": {
+      "extendedLocation": {
+        "name": "losangeles001",
+        "type": "EdgeZone"
+      },
+      "kind": "Storage",
+      "location": "eastus",
+      "properties": {
+        "allowBlobPublicAccess": false,
+        "allowSharedKeyAccess": true,
+        "encryption": {
+          "keySource": "Microsoft.Storage",
+          "requireInfrastructureEncryption": false,
+          "services": {
+            "blob": {
+              "enabled": true,
+              "keyType": "Account"
+            },
+            "file": {
+              "enabled": true,
+              "keyType": "Account"
+            }
+          }
+        },
+        "isHnsEnabled": true,
+        "keyPolicy": {
+          "keyExpirationPeriodInDays": 20
+        },
+        "minimumTlsVersion": "TLS1_2",
+        "publicNetworkAccess": "Enabled",
+        "routingPreference": {
+          "publishInternetEndpoints": true,
+          "publishMicrosoftEndpoints": true,
+          "routingChoice": "MicrosoftRouting"
+        },
+        "sasPolicy": {
+          "expirationAction": "Log",
+          "sasExpirationPeriod": "1.15:59:59"
+        }
+      },
+      "sku": {
+        "name": "Standard_GRS"
+      },
+      "tags": {
+        "key1": "value1",
+        "key2": "value2"
+      }
+    },
+    "resourceGroupName": "res9101",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto4445",
+        "type": "Microsoft.Storage/storageAccounts",
+        "extendedLocation": {
+          "name": "losangeles001",
+          "type": "EdgeZone"
+        },
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.Storage/storageAccounts/sto4445",
+        "kind": "Storage",
+        "location": "eastus",
+        "properties": {
+          "allowBlobPublicAccess": false,
+          "allowSharedKeyAccess": true,
+          "creationTime": "2017-05-24T13:25:33.4863236Z",
+          "encryption": {
+            "keySource": "Microsoft.Storage",
+            "requireInfrastructureEncryption": false,
+            "services": {
+              "blob": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              },
+              "file": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              }
+            }
+          },
+          "isHnsEnabled": true,
+          "keyCreationTime": {
+            "key1": "2021-03-18T04:42:22.4322836Z",
+            "key2": "2021-03-18T04:42:22.4322836Z"
+          },
+          "keyPolicy": {
+            "keyExpirationPeriodInDays": 20
+          },
+          "minimumTlsVersion": "TLS1_2",
+          "primaryEndpoints": {
+            "blob": "https://sto4445.blob.core.windows.net/",
+            "dfs": "https://sto4445.dfs.core.windows.net/",
+            "file": "https://sto4445.file.core.windows.net/",
+            "internetEndpoints": {
+              "blob": "https://sto4445-internetrouting.blob.core.windows.net/",
+              "dfs": "https://sto4445-internetrouting.dfs.core.windows.net/",
+              "file": "https://sto4445-internetrouting.file.core.windows.net/",
+              "web": "https://sto4445-internetrouting.web.core.windows.net/"
+            },
+            "microsoftEndpoints": {
+              "blob": "https://sto4445-microsoftrouting.blob.core.windows.net/",
+              "dfs": "https://sto4445-microsoftrouting.dfs.core.windows.net/",
+              "file": "https://sto4445-microsoftrouting.file.core.windows.net/",
+              "queue": "https://sto4445-microsoftrouting.queue.core.windows.net/",
+              "table": "https://sto4445-microsoftrouting.table.core.windows.net/",
+              "web": "https://sto4445-microsoftrouting.web.core.windows.net/"
+            },
+            "queue": "https://sto4445.queue.core.windows.net/",
+            "table": "https://sto4445.table.core.windows.net/",
+            "web": "https://sto4445.web.core.windows.net/"
+          },
+          "primaryLocation": "eastus2euap",
+          "provisioningState": "Succeeded",
+          "publicNetworkAccess": "Enabled",
+          "routingPreference": {
+            "publishInternetEndpoints": true,
+            "publishMicrosoftEndpoints": true,
+            "routingChoice": "MicrosoftRouting"
+          },
+          "sasPolicy": {
+            "expirationAction": "Log",
+            "sasExpirationPeriod": "1.15:59:59"
+          },
+          "secondaryLocation": "centraluseuap",
+          "statusOfPrimary": "available",
+          "statusOfSecondary": "available",
+          "supportsHttpsTrafficOnly": true
+        },
+        "sku": {
+          "name": "Standard_GRS",
+          "tier": "Standard"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        }
+      }
+    },
+    "202": {}
+  },
+  "operationId": "StorageAccounts_Create",
+  "title": "StorageAccountCreateEnablePublicNetworkAccess"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountCreateObjectReplicationPolicyOnDestination.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountCreateObjectReplicationPolicyOnDestination.json
@@ -1,0 +1,75 @@
+{
+  "parameters": {
+    "accountName": "dst112",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "objectReplicationPolicyId": "default",
+    "properties": {
+      "properties": {
+        "destinationAccount": "dst112",
+        "metrics": {
+          "enabled": true
+        },
+        "priorityReplication": {
+          "enabled": true
+        },
+        "rules": [
+          {
+            "destinationContainer": "dcont139",
+            "filters": {
+              "prefixMatch": [
+                "blobA",
+                "blobB"
+              ]
+            },
+            "sourceContainer": "scont139"
+          }
+        ],
+        "sourceAccount": "src1122",
+        "tagsReplication": {
+          "enabled": true
+        }
+      }
+    },
+    "resourceGroupName": "res7687",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "2a20bb73-5717-4635-985a-5d4cf777438f",
+        "type": "Microsoft.Storage/storageAccounts/objectReplicationPolicies",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res7687/providers/Microsoft.Storage/storageAccounts/dst112/objectReplicationPolicies/2a20bb73-5717-4635-985a-5d4cf777438f",
+        "properties": {
+          "destinationAccount": "dst112",
+          "metrics": {
+            "enabled": true
+          },
+          "priorityReplication": {
+            "enabled": true
+          },
+          "policyId": "2a20bb73-5717-4635-985a-5d4cf777438f",
+          "rules": [
+            {
+              "destinationContainer": "destContainer1",
+              "filters": {
+                "prefixMatch": [
+                  "blobA",
+                  "blobB"
+                ]
+              },
+              "ruleId": "d5d18a48-8801-4554-aeaa-74faf65f5ef9",
+              "sourceContainer": "sourceContainer1"
+            }
+          ],
+          "sourceAccount": "src1122",
+          "tagsReplication": {
+            "enabled": true
+          }
+        }
+      }
+    }
+  },
+  "operationId": "ObjectReplicationPolicies_CreateOrUpdate",
+  "title": "StorageAccountCreateObjectReplicationPolicyOnDestination"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountCreateObjectReplicationPolicyOnSource.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountCreateObjectReplicationPolicyOnSource.json
@@ -1,0 +1,79 @@
+{
+  "parameters": {
+    "accountName": "src1122",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "objectReplicationPolicyId": "2a20bb73-5717-4635-985a-5d4cf777438f",
+    "properties": {
+      "properties": {
+        "destinationAccount": "dst112",
+        "metrics": {
+          "enabled": true
+        },
+        "priorityReplication": {
+          "enabled": true
+        },
+        "rules": [
+          {
+            "destinationContainer": "dcont139",
+            "filters": {
+              "minCreationTime": "2020-02-19T16:05:00Z",
+              "prefixMatch": [
+                "blobA",
+                "blobB"
+              ]
+            },
+            "ruleId": "d5d18a48-8801-4554-aeaa-74faf65f5ef9",
+            "sourceContainer": "scont139"
+          }
+        ],
+        "sourceAccount": "src1122",
+        "tagsReplication": {
+          "enabled": true
+        }
+      }
+    },
+    "resourceGroupName": "res7687",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "2a20bb73-5717-4635-985a-5d4cf777438f",
+        "type": "Microsoft.Storage/storageAccounts/objectReplicationPolicies",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res7687/providers/Microsoft.Storage/storageAccounts/src1122/objectReplicationPolicies/2a20bb73-5717-4635-985a-5d4cf777438f",
+        "properties": {
+          "destinationAccount": "dst112",
+          "enabledTime": "2019-06-08T03:01:55.7168089Z",
+          "metrics": {
+            "enabled": true
+          },
+          "priorityReplication": {
+            "enabled": true
+          },
+          "policyId": "2a20bb73-5717-4635-985a-5d4cf777438f",
+          "rules": [
+            {
+              "destinationContainer": "destContainer1",
+              "filters": {
+                "minCreationTime": "2020-02-19T16:05:00Z",
+                "prefixMatch": [
+                  "blobA",
+                  "blobB"
+                ]
+              },
+              "ruleId": "d5d18a48-8801-4554-aeaa-74faf65f5ef9",
+              "sourceContainer": "sourceContainer1"
+            }
+          ],
+          "sourceAccount": "src1122",
+          "tagsReplication": {
+            "enabled": true
+          }
+        }
+      }
+    }
+  },
+  "operationId": "ObjectReplicationPolicies_CreateOrUpdate",
+  "title": "StorageAccountCreateObjectReplicationPolicyOnSource"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountCreatePremiumBlockBlobStorage.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountCreatePremiumBlockBlobStorage.json
@@ -1,0 +1,91 @@
+{
+  "parameters": {
+    "accountName": "sto4445",
+    "api-version": "2026-09-01",
+    "parameters": {
+      "kind": "BlockBlobStorage",
+      "location": "eastus",
+      "properties": {
+        "allowSharedKeyAccess": true,
+        "encryption": {
+          "keySource": "Microsoft.Storage",
+          "requireInfrastructureEncryption": false,
+          "services": {
+            "blob": {
+              "enabled": true,
+              "keyType": "Account"
+            },
+            "file": {
+              "enabled": true,
+              "keyType": "Account"
+            }
+          }
+        },
+        "minimumTlsVersion": "TLS1_2"
+      },
+      "sku": {
+        "name": "Premium_LRS"
+      },
+      "tags": {
+        "key1": "value1",
+        "key2": "value2"
+      }
+    },
+    "resourceGroupName": "res9101",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto4445",
+        "type": "Microsoft.Storage/storageAccounts",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.Storage/storageAccounts/sto4445",
+        "kind": "Storage",
+        "location": "eastus",
+        "properties": {
+          "accessTier": "Premium",
+          "allowBlobPublicAccess": false,
+          "creationTime": "2017-05-24T13:25:33.4863236Z",
+          "encryption": {
+            "keySource": "Microsoft.Storage",
+            "requireInfrastructureEncryption": false,
+            "services": {
+              "blob": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              },
+              "file": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              }
+            }
+          },
+          "minimumTlsVersion": "TLS1_2",
+          "primaryEndpoints": {
+            "blob": "https://sto4445.blob.core.windows.net/",
+            "dfs": "https://sto4445.dfs.core.windows.net/",
+            "web": "https://sto4445.web.core.windows.net/"
+          },
+          "primaryLocation": "eastus2euap",
+          "provisioningState": "Succeeded",
+          "statusOfPrimary": "available",
+          "statusOfSecondary": "available",
+          "supportsHttpsTrafficOnly": true
+        },
+        "sku": {
+          "name": "Premium_LRS",
+          "tier": "Premium"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        }
+      }
+    },
+    "202": {}
+  },
+  "operationId": "StorageAccounts_Create",
+  "title": "StorageAccountCreatePremiumBlockBlobStorage"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountCreateUserAssignedEncryptionIdentityWithCMK.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountCreateUserAssignedEncryptionIdentityWithCMK.json
@@ -1,0 +1,120 @@
+{
+  "parameters": {
+    "accountName": "sto4445",
+    "api-version": "2026-09-01",
+    "parameters": {
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{managed-identity-name}": {}
+        }
+      },
+      "kind": "Storage",
+      "location": "eastus",
+      "properties": {
+        "encryption": {
+          "identity": {
+            "userAssignedIdentity": "/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{managed-identity-name}"
+          },
+          "keySource": "Microsoft.Keyvault",
+          "keyvaultproperties": {
+            "keyname": "wrappingKey",
+            "keyvaulturi": "https://myvault8569.vault.azure.net",
+            "keyversion": ""
+          },
+          "services": {
+            "blob": {
+              "enabled": true,
+              "keyType": "Account"
+            },
+            "file": {
+              "enabled": true,
+              "keyType": "Account"
+            }
+          }
+        }
+      },
+      "sku": {
+        "name": "Standard_LRS"
+      }
+    },
+    "resourceGroupName": "res9101",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto4445",
+        "type": "Microsoft.Storage/storageAccounts",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.Storage/storageAccounts/sto4445",
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{managed-identity-name}": {
+              "clientId": "fbaa6278-1ecc-415c-819f-6e2058d3acb5",
+              "principalId": "8d823284-1060-42a5-9ec4-ed3d831e24d7"
+            }
+          }
+        },
+        "kind": "StorageV2",
+        "location": "eastus",
+        "properties": {
+          "accessTier": "Hot",
+          "creationTime": "2020-12-15T00:43:14.0839093Z",
+          "encryption": {
+            "identity": {
+              "userAssignedIdentity": "/subscriptions/{subscription-id}/resourcegroups/res9101/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{managed-identity-name}"
+            },
+            "keySource": "Microsoft.Keyvault",
+            "keyvaultproperties": {
+              "currentVersionedKeyIdentifier": "https://myvault8569.vault.azure.net/keys/wrappingKey/0682afdd9c104f4285df20107e956cad",
+              "keyname": "wrappingKey",
+              "keyvaulturi": "https://myvault8569.vault.azure.net",
+              "keyversion": "",
+              "lastKeyRotationTimestamp": "2019-12-13T20:36:23.7023290Z"
+            },
+            "services": {
+              "blob": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2020-12-15T00:43:14.1739587Z"
+              },
+              "file": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2020-12-15T00:43:14.1739587Z"
+              }
+            }
+          },
+          "networkAcls": {
+            "bypass": "AzureServices",
+            "defaultAction": "Allow",
+            "ipRules": [],
+            "virtualNetworkRules": []
+          },
+          "primaryEndpoints": {
+            "blob": "https://sto4445.blob.core.windows.net/",
+            "dfs": "https://sto4445.dfs.core.windows.net/",
+            "file": "https://sto4445.file.core.windows.net/",
+            "queue": "https://sto4445.queue.core.windows.net/",
+            "table": "https://sto4445.table.core.windows.net/",
+            "web": "https://sto4445.web.core.windows.net/"
+          },
+          "primaryLocation": "eastus",
+          "privateEndpointConnections": [],
+          "provisioningState": "Succeeded",
+          "statusOfPrimary": "available",
+          "supportsHttpsTrafficOnly": true
+        },
+        "sku": {
+          "name": "Standard_LRS",
+          "tier": "Standard"
+        },
+        "tags": {}
+      }
+    },
+    "202": {}
+  },
+  "operationId": "StorageAccounts_Create",
+  "title": "StorageAccountCreateUserAssignedEncryptionIdentityWithCMK"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountCreateUserAssignedIdentityWithFederatedIdentityClientId.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountCreateUserAssignedIdentityWithFederatedIdentityClientId.json
@@ -1,0 +1,122 @@
+{
+  "parameters": {
+    "accountName": "sto131918",
+    "api-version": "2026-09-01",
+    "parameters": {
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{managed-identity-name}": {}
+        }
+      },
+      "kind": "Storage",
+      "location": "eastus",
+      "properties": {
+        "encryption": {
+          "identity": {
+            "federatedIdentityClientId": "f83c6b1b-4d34-47e4-bb34-9d83df58b540",
+            "userAssignedIdentity": "/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{managed-identity-name}"
+          },
+          "keySource": "Microsoft.Keyvault",
+          "keyvaultproperties": {
+            "keyname": "wrappingKey",
+            "keyvaulturi": "https://myvault8569.vault.azure.net",
+            "keyversion": ""
+          },
+          "services": {
+            "blob": {
+              "enabled": true,
+              "keyType": "Account"
+            },
+            "file": {
+              "enabled": true,
+              "keyType": "Account"
+            }
+          }
+        }
+      },
+      "sku": {
+        "name": "Standard_LRS"
+      }
+    },
+    "resourceGroupName": "res131918",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto4445",
+        "type": "Microsoft.Storage/storageAccounts",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.Storage/storageAccounts/sto4445",
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{managed-identity-name}": {
+              "clientId": "fbaa6278-1ecc-415c-819f-6e2058d3acb5",
+              "principalId": "8d823284-1060-42a5-9ec4-ed3d831e24d7"
+            }
+          }
+        },
+        "kind": "StorageV2",
+        "location": "eastus",
+        "properties": {
+          "accessTier": "Hot",
+          "creationTime": "2020-12-15T00:43:14.0839093Z",
+          "encryption": {
+            "identity": {
+              "federatedIdentityClientId": "f83c6b1b-4d34-47e4-bb34-9d83df58b540",
+              "userAssignedIdentity": "/subscriptions/{subscription-id}/resourcegroups/res9101/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{managed-identity-name}"
+            },
+            "keySource": "Microsoft.Keyvault",
+            "keyvaultproperties": {
+              "currentVersionedKeyIdentifier": "https://myvault8569.vault.azure.net/keys/wrappingKey/0682afdd9c104f4285df20107e956cad",
+              "keyname": "wrappingKey",
+              "keyvaulturi": "https://myvault8569.vault.azure.net",
+              "keyversion": "",
+              "lastKeyRotationTimestamp": "2019-12-13T20:36:23.7023290Z"
+            },
+            "services": {
+              "blob": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2020-12-15T00:43:14.1739587Z"
+              },
+              "file": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2020-12-15T00:43:14.1739587Z"
+              }
+            }
+          },
+          "networkAcls": {
+            "bypass": "AzureServices",
+            "defaultAction": "Allow",
+            "ipRules": [],
+            "virtualNetworkRules": []
+          },
+          "primaryEndpoints": {
+            "blob": "https://sto4445.blob.core.windows.net/",
+            "dfs": "https://sto4445.dfs.core.windows.net/",
+            "file": "https://sto4445.file.core.windows.net/",
+            "queue": "https://sto4445.queue.core.windows.net/",
+            "table": "https://sto4445.table.core.windows.net/",
+            "web": "https://sto4445.web.core.windows.net/"
+          },
+          "primaryLocation": "eastus",
+          "privateEndpointConnections": [],
+          "provisioningState": "Succeeded",
+          "statusOfPrimary": "available",
+          "supportsHttpsTrafficOnly": true
+        },
+        "sku": {
+          "name": "Standard_LRS",
+          "tier": "Standard"
+        },
+        "tags": {}
+      }
+    },
+    "202": {}
+  },
+  "operationId": "StorageAccounts_Create",
+  "title": "StorageAccountCreateUserAssignedIdentityWithFederatedIdentityClientId."
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountCreateWithDataCollaborationPolicy.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountCreateWithDataCollaborationPolicy.json
@@ -1,0 +1,58 @@
+{
+  "parameters": {
+    "accountName": "sto4445",
+    "api-version": "2026-09-01",
+    "parameters": {
+      "kind": "Storage",
+      "location": "eastus",
+      "properties": {
+        "dataCollaborationPolicyProperties": {
+          "allowStorageConnectors": true,
+          "allowStorageDataShares": true,
+          "allowCrossTenantDataSharing": false
+        }
+      },
+      "sku": {
+        "name": "Standard_GRS"
+      }
+    },
+    "resourceGroupName": "res9101",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto4445",
+        "type": "Microsoft.Storage/storageAccounts",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.Storage/storageAccounts/sto4445",
+        "kind": "Storage",
+        "location": "eastus",
+        "properties": {
+          "creationTime": "2017-05-24T13:25:33.4863236Z",
+          "primaryEndpoints": {
+            "blob": "https://sto4445.blob.core.windows.net/",
+            "dfs": "https://sto4445.dfs.core.windows.net/",
+            "file": "https://sto4445.file.core.windows.net/",
+            "queue": "https://sto4445.queue.core.windows.net/",
+            "table": "https://sto4445.table.core.windows.net/",
+            "web": "https://sto4445.web.core.windows.net/"
+          },
+          "primaryLocation": "eastus2euap",
+          "provisioningState": "Succeeded",
+          "dataCollaborationPolicyProperties": {
+            "allowStorageConnectors": true,
+            "allowStorageDataShares": true,
+            "allowCrossTenantDataSharing": false
+          }
+        },
+        "sku": {
+          "name": "Standard_GRS",
+          "tier": "Standard"
+        }
+      }
+    },
+    "202": {}
+  },
+  "operationId": "StorageAccounts_Create",
+  "title": "StorageAccountCreateWithDataCollaborationPolicy"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountCreateWithImmutabilityPolicy.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountCreateWithImmutabilityPolicy.json
@@ -1,0 +1,72 @@
+{
+  "parameters": {
+    "accountName": "sto4445",
+    "api-version": "2026-09-01",
+    "parameters": {
+      "extendedLocation": {
+        "name": "losangeles001",
+        "type": "EdgeZone"
+      },
+      "kind": "Storage",
+      "location": "eastus",
+      "properties": {
+        "immutableStorageWithVersioning": {
+          "enabled": true,
+          "immutabilityPolicy": {
+            "allowProtectedAppendWrites": true,
+            "immutabilityPeriodSinceCreationInDays": 15,
+            "state": "Unlocked"
+          }
+        }
+      },
+      "sku": {
+        "name": "Standard_GRS"
+      }
+    },
+    "resourceGroupName": "res9101",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto4445",
+        "type": "Microsoft.Storage/storageAccounts",
+        "extendedLocation": {
+          "name": "losangeles001",
+          "type": "EdgeZone"
+        },
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.Storage/storageAccounts/sto4445",
+        "kind": "Storage",
+        "location": "eastus",
+        "properties": {
+          "creationTime": "2017-05-24T13:25:33.4863236Z",
+          "immutableStorageWithVersioning": {
+            "enabled": true,
+            "immutabilityPolicy": {
+              "allowProtectedAppendWrites": true,
+              "immutabilityPeriodSinceCreationInDays": 15,
+              "state": "Unlocked"
+            }
+          },
+          "primaryEndpoints": {
+            "blob": "https://sto4445.blob.core.windows.net/",
+            "dfs": "https://sto4445.dfs.core.windows.net/",
+            "file": "https://sto4445.file.core.windows.net/",
+            "queue": "https://sto4445.queue.core.windows.net/",
+            "table": "https://sto4445.table.core.windows.net/",
+            "web": "https://sto4445.web.core.windows.net/"
+          },
+          "primaryLocation": "eastus2euap",
+          "provisioningState": "Succeeded"
+        },
+        "sku": {
+          "name": "Standard_GRS",
+          "tier": "Standard"
+        }
+      }
+    },
+    "202": {}
+  },
+  "operationId": "StorageAccounts_Create",
+  "title": "StorageAccountCreateWithImmutabilityPolicy"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountCreateWithSmartAccessTier.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountCreateWithSmartAccessTier.json
@@ -1,0 +1,158 @@
+{
+  "parameters": {
+    "accountName": "sto4445",
+    "api-version": "2026-09-01",
+    "parameters": {
+      "extendedLocation": {
+        "name": "losangeles001",
+        "type": "EdgeZone"
+      },
+      "kind": "Storage",
+      "location": "eastus",
+      "properties": {
+        "accessTier": "Smart",
+        "allowBlobPublicAccess": false,
+        "allowSharedKeyAccess": true,
+        "defaultToOAuthAuthentication": false,
+        "encryption": {
+          "keySource": "Microsoft.Storage",
+          "requireInfrastructureEncryption": false,
+          "services": {
+            "blob": {
+              "enabled": true,
+              "keyType": "Account"
+            },
+            "file": {
+              "enabled": true,
+              "keyType": "Account"
+            }
+          }
+        },
+        "isHnsEnabled": true,
+        "isSftpEnabled": true,
+        "keyPolicy": {
+          "keyExpirationPeriodInDays": 20
+        },
+        "minimumTlsVersion": "TLS1_2",
+        "routingPreference": {
+          "publishInternetEndpoints": true,
+          "publishMicrosoftEndpoints": true,
+          "routingChoice": "MicrosoftRouting"
+        },
+        "sasPolicy": {
+          "expirationAction": "Log",
+          "sasExpirationPeriod": "1.15:59:59"
+        },
+        "geoPriorityReplicationStatus": {
+          "isBlobEnabled": true
+        }
+      },
+      "sku": {
+        "name": "Standard_GRS"
+      },
+      "tags": {
+        "key1": "value1",
+        "key2": "value2"
+      }
+    },
+    "resourceGroupName": "res9101",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto4445",
+        "type": "Microsoft.Storage/storageAccounts",
+        "extendedLocation": {
+          "name": "losangeles001",
+          "type": "EdgeZone"
+        },
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.Storage/storageAccounts/sto4445",
+        "kind": "Storage",
+        "location": "eastus",
+        "properties": {
+          "allowBlobPublicAccess": false,
+          "allowSharedKeyAccess": true,
+          "creationTime": "2017-05-24T13:25:33.4863236Z",
+          "encryption": {
+            "keySource": "Microsoft.Storage",
+            "requireInfrastructureEncryption": false,
+            "services": {
+              "blob": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              },
+              "file": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              }
+            }
+          },
+          "isHnsEnabled": true,
+          "isSftpEnabled": true,
+          "keyCreationTime": {
+            "key1": "2021-03-18T04:42:22.4322836Z",
+            "key2": "2021-03-18T04:42:22.4322836Z"
+          },
+          "keyPolicy": {
+            "keyExpirationPeriodInDays": 20
+          },
+          "minimumTlsVersion": "TLS1_2",
+          "primaryEndpoints": {
+            "blob": "https://sto4445.blob.core.windows.net/",
+            "dfs": "https://sto4445.dfs.core.windows.net/",
+            "file": "https://sto4445.file.core.windows.net/",
+            "internetEndpoints": {
+              "blob": "https://sto4445-internetrouting.blob.core.windows.net/",
+              "dfs": "https://sto4445-internetrouting.dfs.core.windows.net/",
+              "file": "https://sto4445-internetrouting.file.core.windows.net/",
+              "web": "https://sto4445-internetrouting.web.core.windows.net/"
+            },
+            "microsoftEndpoints": {
+              "blob": "https://sto4445-microsoftrouting.blob.core.windows.net/",
+              "dfs": "https://sto4445-microsoftrouting.dfs.core.windows.net/",
+              "file": "https://sto4445-microsoftrouting.file.core.windows.net/",
+              "queue": "https://sto4445-microsoftrouting.queue.core.windows.net/",
+              "table": "https://sto4445-microsoftrouting.table.core.windows.net/",
+              "web": "https://sto4445-microsoftrouting.web.core.windows.net/"
+            },
+            "queue": "https://sto4445.queue.core.windows.net/",
+            "table": "https://sto4445.table.core.windows.net/",
+            "web": "https://sto4445.web.core.windows.net/"
+          },
+          "primaryLocation": "eastus2euap",
+          "provisioningState": "Succeeded",
+          "routingPreference": {
+            "publishInternetEndpoints": true,
+            "publishMicrosoftEndpoints": true,
+            "routingChoice": "MicrosoftRouting"
+          },
+          "sasPolicy": {
+            "expirationAction": "Log",
+            "sasExpirationPeriod": "1.15:59:59"
+          },
+          "secondaryLocation": "centraluseuap",
+          "statusOfPrimary": "available",
+          "statusOfSecondary": "available",
+          "supportsHttpsTrafficOnly": true,
+          "geoPriorityReplicationStatus": {
+            "isBlobEnabled": true
+          }
+        },
+        "sku": {
+          "name": "Standard_GRS",
+          "tier": "Standard"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        }
+      }
+    },
+    "202": {}
+  },
+  "operationId": "StorageAccounts_Create",
+  "title": "StorageAccountCreateWithSmartAccessTier"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountCreate_placement.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountCreate_placement.json
@@ -1,0 +1,160 @@
+{
+  "parameters": {
+    "accountName": "sto4445",
+    "api-version": "2026-09-01",
+    "parameters": {
+      "extendedLocation": {
+        "name": "losangeles001",
+        "type": "EdgeZone"
+      },
+      "kind": "Storage",
+      "location": "eastus",
+      "placement": {
+        "zonePlacementPolicy": "Any"
+      },
+      "properties": {
+        "allowBlobPublicAccess": false,
+        "allowSharedKeyAccess": true,
+        "defaultToOAuthAuthentication": false,
+        "encryption": {
+          "keySource": "Microsoft.Storage",
+          "requireInfrastructureEncryption": false,
+          "services": {
+            "blob": {
+              "enabled": true,
+              "keyType": "Account"
+            },
+            "file": {
+              "enabled": true,
+              "keyType": "Account"
+            }
+          }
+        },
+        "isHnsEnabled": true,
+        "isSftpEnabled": true,
+        "keyPolicy": {
+          "keyExpirationPeriodInDays": 20
+        },
+        "minimumTlsVersion": "TLS1_2",
+        "routingPreference": {
+          "publishInternetEndpoints": true,
+          "publishMicrosoftEndpoints": true,
+          "routingChoice": "MicrosoftRouting"
+        },
+        "sasPolicy": {
+          "expirationAction": "Log",
+          "sasExpirationPeriod": "1.15:59:59"
+        }
+      },
+      "sku": {
+        "name": "Standard_GRS"
+      },
+      "tags": {
+        "key1": "value1",
+        "key2": "value2"
+      }
+    },
+    "resourceGroupName": "res9101",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto4445",
+        "type": "Microsoft.Storage/storageAccounts",
+        "extendedLocation": {
+          "name": "losangeles001",
+          "type": "EdgeZone"
+        },
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.Storage/storageAccounts/sto4445",
+        "kind": "Storage",
+        "location": "eastus",
+        "placement": {
+          "zonePlacementPolicy": "Any"
+        },
+        "properties": {
+          "allowBlobPublicAccess": false,
+          "allowSharedKeyAccess": true,
+          "creationTime": "2017-05-24T13:25:33.4863236Z",
+          "encryption": {
+            "keySource": "Microsoft.Storage",
+            "requireInfrastructureEncryption": false,
+            "services": {
+              "blob": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              },
+              "file": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              }
+            }
+          },
+          "isHnsEnabled": true,
+          "isSftpEnabled": true,
+          "keyCreationTime": {
+            "key1": "2021-03-18T04:42:22.4322836Z",
+            "key2": "2021-03-18T04:42:22.4322836Z"
+          },
+          "keyPolicy": {
+            "keyExpirationPeriodInDays": 20
+          },
+          "minimumTlsVersion": "TLS1_2",
+          "primaryEndpoints": {
+            "blob": "https://sto4445.blob.core.windows.net/",
+            "dfs": "https://sto4445.dfs.core.windows.net/",
+            "file": "https://sto4445.file.core.windows.net/",
+            "internetEndpoints": {
+              "blob": "https://sto4445-internetrouting.blob.core.windows.net/",
+              "dfs": "https://sto4445-internetrouting.dfs.core.windows.net/",
+              "file": "https://sto4445-internetrouting.file.core.windows.net/",
+              "web": "https://sto4445-internetrouting.web.core.windows.net/"
+            },
+            "microsoftEndpoints": {
+              "blob": "https://sto4445-microsoftrouting.blob.core.windows.net/",
+              "dfs": "https://sto4445-microsoftrouting.dfs.core.windows.net/",
+              "file": "https://sto4445-microsoftrouting.file.core.windows.net/",
+              "queue": "https://sto4445-microsoftrouting.queue.core.windows.net/",
+              "table": "https://sto4445-microsoftrouting.table.core.windows.net/",
+              "web": "https://sto4445-microsoftrouting.web.core.windows.net/"
+            },
+            "queue": "https://sto4445.queue.core.windows.net/",
+            "table": "https://sto4445.table.core.windows.net/",
+            "web": "https://sto4445.web.core.windows.net/"
+          },
+          "primaryLocation": "eastus2euap",
+          "provisioningState": "Succeeded",
+          "routingPreference": {
+            "publishInternetEndpoints": true,
+            "publishMicrosoftEndpoints": true,
+            "routingChoice": "MicrosoftRouting"
+          },
+          "sasPolicy": {
+            "expirationAction": "Log",
+            "sasExpirationPeriod": "1.15:59:59"
+          },
+          "secondaryLocation": "centraluseuap",
+          "statusOfPrimary": "available",
+          "statusOfSecondary": "available",
+          "supportsHttpsTrafficOnly": true
+        },
+        "sku": {
+          "name": "Standard_GRS",
+          "tier": "Standard"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        },
+        "zones": [
+          "1"
+        ]
+      }
+    },
+    "202": {}
+  },
+  "operationId": "StorageAccounts_Create",
+  "title": "StorageAccountCreate_placement"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountCreate_zones.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountCreate_zones.json
@@ -1,0 +1,157 @@
+{
+  "parameters": {
+    "accountName": "sto4445",
+    "api-version": "2026-09-01",
+    "parameters": {
+      "extendedLocation": {
+        "name": "losangeles001",
+        "type": "EdgeZone"
+      },
+      "kind": "Storage",
+      "location": "eastus",
+      "properties": {
+        "allowBlobPublicAccess": false,
+        "allowSharedKeyAccess": true,
+        "defaultToOAuthAuthentication": false,
+        "encryption": {
+          "keySource": "Microsoft.Storage",
+          "requireInfrastructureEncryption": false,
+          "services": {
+            "blob": {
+              "enabled": true,
+              "keyType": "Account"
+            },
+            "file": {
+              "enabled": true,
+              "keyType": "Account"
+            }
+          }
+        },
+        "isHnsEnabled": true,
+        "isSftpEnabled": true,
+        "keyPolicy": {
+          "keyExpirationPeriodInDays": 20
+        },
+        "minimumTlsVersion": "TLS1_2",
+        "routingPreference": {
+          "publishInternetEndpoints": true,
+          "publishMicrosoftEndpoints": true,
+          "routingChoice": "MicrosoftRouting"
+        },
+        "sasPolicy": {
+          "expirationAction": "Log",
+          "sasExpirationPeriod": "1.15:59:59"
+        }
+      },
+      "sku": {
+        "name": "Standard_GRS"
+      },
+      "tags": {
+        "key1": "value1",
+        "key2": "value2"
+      },
+      "zones": [
+        "1"
+      ]
+    },
+    "resourceGroupName": "res9101",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto4445",
+        "type": "Microsoft.Storage/storageAccounts",
+        "extendedLocation": {
+          "name": "losangeles001",
+          "type": "EdgeZone"
+        },
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.Storage/storageAccounts/sto4445",
+        "kind": "Storage",
+        "location": "eastus",
+        "properties": {
+          "allowBlobPublicAccess": false,
+          "allowSharedKeyAccess": true,
+          "creationTime": "2017-05-24T13:25:33.4863236Z",
+          "encryption": {
+            "keySource": "Microsoft.Storage",
+            "requireInfrastructureEncryption": false,
+            "services": {
+              "blob": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              },
+              "file": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              }
+            }
+          },
+          "isHnsEnabled": true,
+          "isSftpEnabled": true,
+          "keyCreationTime": {
+            "key1": "2021-03-18T04:42:22.4322836Z",
+            "key2": "2021-03-18T04:42:22.4322836Z"
+          },
+          "keyPolicy": {
+            "keyExpirationPeriodInDays": 20
+          },
+          "minimumTlsVersion": "TLS1_2",
+          "primaryEndpoints": {
+            "blob": "https://sto4445.blob.core.windows.net/",
+            "dfs": "https://sto4445.dfs.core.windows.net/",
+            "file": "https://sto4445.file.core.windows.net/",
+            "internetEndpoints": {
+              "blob": "https://sto4445-internetrouting.blob.core.windows.net/",
+              "dfs": "https://sto4445-internetrouting.dfs.core.windows.net/",
+              "file": "https://sto4445-internetrouting.file.core.windows.net/",
+              "web": "https://sto4445-internetrouting.web.core.windows.net/"
+            },
+            "microsoftEndpoints": {
+              "blob": "https://sto4445-microsoftrouting.blob.core.windows.net/",
+              "dfs": "https://sto4445-microsoftrouting.dfs.core.windows.net/",
+              "file": "https://sto4445-microsoftrouting.file.core.windows.net/",
+              "queue": "https://sto4445-microsoftrouting.queue.core.windows.net/",
+              "table": "https://sto4445-microsoftrouting.table.core.windows.net/",
+              "web": "https://sto4445-microsoftrouting.web.core.windows.net/"
+            },
+            "queue": "https://sto4445.queue.core.windows.net/",
+            "table": "https://sto4445.table.core.windows.net/",
+            "web": "https://sto4445.web.core.windows.net/"
+          },
+          "primaryLocation": "eastus2euap",
+          "provisioningState": "Succeeded",
+          "routingPreference": {
+            "publishInternetEndpoints": true,
+            "publishMicrosoftEndpoints": true,
+            "routingChoice": "MicrosoftRouting"
+          },
+          "sasPolicy": {
+            "expirationAction": "Log",
+            "sasExpirationPeriod": "1.15:59:59"
+          },
+          "secondaryLocation": "centraluseuap",
+          "statusOfPrimary": "available",
+          "statusOfSecondary": "available",
+          "supportsHttpsTrafficOnly": true
+        },
+        "sku": {
+          "name": "Standard_GRS",
+          "tier": "Standard"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        },
+        "zones": [
+          "1"
+        ]
+      }
+    },
+    "202": {}
+  },
+  "operationId": "StorageAccounts_Create",
+  "title": "StorageAccountCreate_zones"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountDelete.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountDelete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "accountName": "sto2434",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res4228",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "StorageAccounts_Delete",
+  "title": "StorageAccountDelete"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountDeleteBlobInventoryPolicy.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountDeleteBlobInventoryPolicy.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "accountName": "sto2527",
+    "api-version": "2026-09-01",
+    "blobInventoryPolicyName": "default",
+    "monitor": "true",
+    "resourceGroupName": "res6977",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "BlobInventoryPolicies_Delete",
+  "title": "StorageAccountDeleteBlobInventoryPolicy"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountDeleteManagementPolicy.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountDeleteManagementPolicy.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "accountName": "sto2527",
+    "api-version": "2026-09-01",
+    "managementPolicyName": "default",
+    "monitor": "true",
+    "resourceGroupName": "res6977",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "ManagementPolicies_Delete",
+  "title": "StorageAccountDeleteManagementPolicies"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountDeleteObjectReplicationPolicy.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountDeleteObjectReplicationPolicy.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "accountName": "sto2527",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "objectReplicationPolicyId": "{objectReplicationPolicy-Id}",
+    "resourceGroupName": "res6977",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "ObjectReplicationPolicies_Delete",
+  "title": "StorageAccountDeleteObjectReplicationPolicies"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountDeletePrivateEndpointConnection.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountDeletePrivateEndpointConnection.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "accountName": "sto2527",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "privateEndpointConnectionName": "{privateEndpointConnectionName}",
+    "resourceGroupName": "res6977",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "PrivateEndpointConnections_Delete",
+  "title": "StorageAccountDeletePrivateEndpointConnection"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountEnableAD.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountEnableAD.json
@@ -1,0 +1,77 @@
+{
+  "parameters": {
+    "accountName": "sto8596",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "parameters": {
+      "properties": {
+        "azureFilesIdentityBasedAuthentication": {
+          "activeDirectoryProperties": {
+            "accountType": "User",
+            "azureStorageSid": "S-1-5-21-2400535526-2334094090-2402026252-0012",
+            "domainGuid": "aebfc118-9fa9-4732-a21f-d98e41a77ae1",
+            "domainName": "adtest.com",
+            "domainSid": "S-1-5-21-2400535526-2334094090-2402026252",
+            "forestName": "adtest.com",
+            "netBiosDomainName": "adtest.com",
+            "samAccountName": "sam12498"
+          },
+          "directoryServiceOptions": "AD"
+        }
+      }
+    },
+    "resourceGroupName": "res9407",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto8596",
+        "type": "Microsoft.Storage/storageAccounts",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9407/providers/Microsoft.Storage/storageAccounts/sto8596",
+        "kind": "Storage",
+        "location": "eastus2(stage)",
+        "properties": {
+          "azureFilesIdentityBasedAuthentication": {
+            "activeDirectoryProperties": {
+              "accountType": "User",
+              "azureStorageSid": "S-1-5-21-2400535526-2334094090-2402026252-0012",
+              "domainGuid": "aebfc118-9fa9-4732-a21f-d98e41a77ae1",
+              "domainName": "adtest.com",
+              "domainSid": "S-1-5-21-2400535526-2334094090-2402026252",
+              "forestName": "adtest.com",
+              "netBiosDomainName": "adtest.com",
+              "samAccountName": "sam12498"
+            },
+            "directoryServiceOptions": "AD"
+          },
+          "creationTime": "2017-06-01T02:42:41.7633306Z",
+          "primaryEndpoints": {
+            "blob": "https://sto8596.blob.core.windows.net/",
+            "dfs": "https://sto8596.dfs.core.windows.net/",
+            "file": "https://sto8596.file.core.windows.net/",
+            "queue": "https://sto8596.queue.core.windows.net/",
+            "table": "https://sto8596.table.core.windows.net/",
+            "web": "https://sto8596.web.core.windows.net/"
+          },
+          "primaryLocation": "eastus2(stage)",
+          "provisioningState": "Succeeded",
+          "secondaryLocation": "northcentralus(stage)",
+          "statusOfPrimary": "available",
+          "statusOfSecondary": "available",
+          "supportsHttpsTrafficOnly": false
+        },
+        "sku": {
+          "name": "Standard_GRS",
+          "tier": "Standard"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "StorageAccounts_Update",
+  "title": "StorageAccountEnableAD"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountEnableCMK.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountEnableCMK.json
@@ -1,0 +1,96 @@
+{
+  "parameters": {
+    "accountName": "sto8596",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "parameters": {
+      "properties": {
+        "encryption": {
+          "keySource": "Microsoft.Keyvault",
+          "keyvaultproperties": {
+            "keyname": "wrappingKey",
+            "keyvaulturi": "https://myvault8569.vault.azure.net",
+            "keyversion": ""
+          },
+          "services": {
+            "blob": {
+              "enabled": true,
+              "keyType": "Account"
+            },
+            "file": {
+              "enabled": true,
+              "keyType": "Account"
+            }
+          }
+        }
+      }
+    },
+    "resourceGroupName": "res9407",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto8596",
+        "type": "Microsoft.Storage/storageAccounts",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9407/providers/Microsoft.Storage/storageAccounts/sto8596",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "911871cc-ffd1-4fc4-ac11-7a316433ea66",
+          "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+        },
+        "kind": "Storage",
+        "location": "eastus2(stage)",
+        "properties": {
+          "creationTime": "2017-06-01T02:42:41.7633306Z",
+          "encryption": {
+            "keySource": "Microsoft.Keyvault",
+            "keyvaultproperties": {
+              "currentVersionedKeyIdentifier": "https://myvault8569.vault.azure.net/keys/wrappingKey/0682afdd9c104f4285df20107e956cad",
+              "keyname": "wrappingKey",
+              "keyvaulturi": "https://myvault8569.vault.azure.net",
+              "keyversion": "",
+              "lastKeyRotationTimestamp": "2019-12-13T20:36:23.7023290Z"
+            },
+            "services": {
+              "blob": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              },
+              "file": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              }
+            }
+          },
+          "primaryEndpoints": {
+            "blob": "https://sto8596.blob.core.windows.net/",
+            "dfs": "https://sto8596.dfs.core.windows.net/",
+            "file": "https://sto8596.file.core.windows.net/",
+            "queue": "https://sto8596.queue.core.windows.net/",
+            "table": "https://sto8596.table.core.windows.net/",
+            "web": "https://sto8596.web.core.windows.net/"
+          },
+          "primaryLocation": "eastus2(stage)",
+          "provisioningState": "Succeeded",
+          "secondaryLocation": "northcentralus(stage)",
+          "statusOfPrimary": "available",
+          "statusOfSecondary": "available",
+          "supportsHttpsTrafficOnly": false
+        },
+        "sku": {
+          "name": "Standard_GRS",
+          "tier": "Standard"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "StorageAccounts_Update",
+  "title": "StorageAccountEnableCMK"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountEnableSmbOAuth.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountEnableSmbOAuth.json
@@ -1,0 +1,63 @@
+{
+  "parameters": {
+    "accountName": "sto8596",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "parameters": {
+      "properties": {
+        "azureFilesIdentityBasedAuthentication": {
+          "directoryServiceOptions": "None",
+          "smbOAuthSettings": {
+            "isSmbOAuthEnabled": true
+          }
+        }
+      }
+    },
+    "resourceGroupName": "res9407",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto8596",
+        "type": "Microsoft.Storage/storageAccounts",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9407/providers/Microsoft.Storage/storageAccounts/sto8596",
+        "kind": "Storage",
+        "location": "eastus2(stage)",
+        "properties": {
+          "azureFilesIdentityBasedAuthentication": {
+            "directoryServiceOptions": "None",
+            "smbOAuthSettings": {
+              "isSmbOAuthEnabled": true
+            }
+          },
+          "creationTime": "2017-06-01T02:42:41.7633306Z",
+          "primaryEndpoints": {
+            "blob": "https://sto8596.blob.core.windows.net/",
+            "dfs": "https://sto8596.dfs.core.windows.net/",
+            "file": "https://sto8596.file.core.windows.net/",
+            "queue": "https://sto8596.queue.core.windows.net/",
+            "table": "https://sto8596.table.core.windows.net/",
+            "web": "https://sto8596.web.core.windows.net/"
+          },
+          "primaryLocation": "eastus2(stage)",
+          "provisioningState": "Succeeded",
+          "secondaryLocation": "northcentralus(stage)",
+          "statusOfPrimary": "available",
+          "statusOfSecondary": "available",
+          "supportsHttpsTrafficOnly": false
+        },
+        "sku": {
+          "name": "Standard_GRS",
+          "tier": "Standard"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "StorageAccounts_Update",
+  "title": "StorageAccountEnableSmbOAuth"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountEncryptionScopeList.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountEncryptionScopeList.json
@@ -1,0 +1,45 @@
+{
+  "parameters": {
+    "accountName": "accountname",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "resource-group-name",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": null,
+        "value": [
+          {
+            "name": "scope-1",
+            "type": "Microsoft.Storage/storageAccounts/encryptionScopes",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/resource-group-name/providers/Microsoft.Storage/storageAccounts/accountname/encryptionScopes/scope-1",
+            "properties": {
+              "creationTime": "2018-10-16T02:42:41.7633306Z",
+              "lastModifiedTime": "2018-10-16T02:42:41.7633306Z",
+              "source": "Microsoft.Storage",
+              "state": "Enabled"
+            }
+          },
+          {
+            "name": "scope-2",
+            "type": "Microsoft.Storage/storageAccounts/encryptionScopes",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/resource-group-name/providers/Microsoft.Storage/storageAccounts/accountname/encryptionScopes/scope-2",
+            "properties": {
+              "creationTime": "2018-10-16T04:32:14.3355306Z",
+              "keyVaultProperties": {
+                "keyUri": "https://testvault.vault.core.windows.net/keys/key1/863425f1358359c"
+              },
+              "lastModifiedTime": "2018-10-17T06:23:14.4513306Z",
+              "source": "Microsoft.KeyVault",
+              "state": "Enabled"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "EncryptionScopes_List",
+  "title": "StorageAccountEncryptionScopeList"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountFailover.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountFailover.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "accountName": "sto2434",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res4228",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "https://endpoint:port/subscriptions/{subscription-id}/providers/Microsoft.Storage/locations/{location}/asyncoperations/{operationid}?monitor=true&api-version=2022-09-01"
+      }
+    }
+  },
+  "operationId": "StorageAccounts_Failover",
+  "title": "StorageAccountFailover"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountFailoverPlanned.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountFailoverPlanned.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "accountName": "sto2434",
+    "api-version": "2026-09-01",
+    "failoverType": "Planned",
+    "monitor": "true",
+    "resourceGroupName": "res4228",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "https://endpoint:port/subscriptions/{subscription-id}/providers/Microsoft.Storage/locations/{location}/asyncoperations/{operationid}?monitor=true&api-version=2022-09-01"
+      }
+    }
+  },
+  "operationId": "StorageAccounts_Failover",
+  "title": "StorageAccountFailoverPlanned"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountGetAsyncSkuConversionStatus.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountGetAsyncSkuConversionStatus.json
@@ -1,0 +1,36 @@
+{
+  "parameters": {
+    "accountName": "sto8596",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res9407",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto8596",
+        "type": "Microsoft.Storage/storageAccounts",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9407/providers/Microsoft.Storage/storageAccounts/sto8596",
+        "kind": "StorageV2",
+        "location": "eastus",
+        "properties": {
+          "allowBlobPublicAccess": false,
+          "minimumTlsVersion": "TLS1_2",
+          "storageAccountSkuConversionStatus": {
+            "endTime": "2021-09-02T02:53:39.0932539Z",
+            "skuConversionStatus": "InProgress",
+            "startTime": "2022-09-01T02:53:39.0932539Z",
+            "targetSkuName": "Standard_GRS"
+          }
+        },
+        "sku": {
+          "name": "Standard_GRS",
+          "tier": "Standard"
+        }
+      }
+    }
+  },
+  "operationId": "StorageAccounts_GetProperties",
+  "title": "StorageAccountGetAsyncSkuConversionStatus"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountGetBlobInventoryPolicy.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountGetBlobInventoryPolicy.json
@@ -1,0 +1,67 @@
+{
+  "parameters": {
+    "accountName": "sto9699",
+    "api-version": "2026-09-01",
+    "blobInventoryPolicyName": "default",
+    "monitor": "true",
+    "resourceGroupName": "res7687",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "DefaultInventoryPolicy",
+        "type": "Microsoft.Storage/storageAccounts/inventoryPolicies",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res7687/providers/Microsoft.Storage/storageAccounts/sto9699/inventoryPolicies/default",
+        "properties": {
+          "lastModifiedTime": "2020-10-05T02:53:39.0932539Z",
+          "policy": {
+            "type": "Inventory",
+            "enabled": true,
+            "rules": [
+              {
+                "name": "inventoryPolicyRule1",
+                "definition": {
+                  "format": "Csv",
+                  "filters": {
+                    "blobTypes": [
+                      "blockBlob",
+                      "appendBlob",
+                      "pageBlob"
+                    ],
+                    "includeBlobVersions": true,
+                    "includeSnapshots": true,
+                    "prefixMatch": [
+                      "inventoryprefix1",
+                      "inventoryprefix2"
+                    ]
+                  },
+                  "objectType": "Blob",
+                  "schedule": "Daily",
+                  "schemaFields": [
+                    "Name",
+                    "Creation-Time",
+                    "Last-Modified",
+                    "Content-Length",
+                    "Content-MD5",
+                    "BlobType",
+                    "AccessTier",
+                    "AccessTierChangeTime",
+                    "Snapshot",
+                    "VersionId",
+                    "IsCurrentVersion",
+                    "Metadata"
+                  ]
+                },
+                "destination": "container1",
+                "enabled": true
+              }
+            ]
+          }
+        }
+      }
+    }
+  },
+  "operationId": "BlobInventoryPolicies_Get",
+  "title": "StorageAccountGetBlobInventoryPolicy"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountGetEncryptionScope.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountGetEncryptionScope.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "accountName": "accountname",
+    "api-version": "2026-09-01",
+    "encryptionScopeName": "{encryption-scope-name}",
+    "monitor": "true",
+    "resourceGroupName": "resource-group-name",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "{encyrption-scope-name}",
+        "type": "Microsoft.Storage/storageAccounts/encryptionScopes",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/resource-group-name/providers/Microsoft.Storage/storageAccounts/accountname/encryptionScopes/{encryption-scope-name}",
+        "properties": {
+          "creationTime": "2018-10-16T02:42:41.7633306Z",
+          "lastModifiedTime": "2018-10-16T02:42:41.7633306Z",
+          "source": "Microsoft.Storage",
+          "state": "Enabled"
+        }
+      }
+    }
+  },
+  "operationId": "EncryptionScopes_Get",
+  "title": "StorageAccountGetEncryptionScope"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountGetManagementPolicy.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountGetManagementPolicy.json
@@ -1,0 +1,61 @@
+{
+  "parameters": {
+    "accountName": "sto2527",
+    "api-version": "2026-09-01",
+    "managementPolicyName": "default",
+    "monitor": "true",
+    "resourceGroupName": "res6977",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "DefaultManagementPolicy",
+        "type": "Microsoft.Storage/storageAccounts/managementPolicies",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res7231/providers/Microsoft.Storage/storageAccounts/sto288/managementPolicies/default",
+        "properties": {
+          "lastModifiedTime": "2018-06-08T03:01:55.7168089Z",
+          "policy": {
+            "rules": [
+              {
+                "name": "olcmtest",
+                "type": "Lifecycle",
+                "definition": {
+                  "actions": {
+                    "baseBlob": {
+                      "delete": {
+                        "daysAfterModificationGreaterThan": 1000
+                      },
+                      "tierToArchive": {
+                        "daysAfterModificationGreaterThan": 90
+                      },
+                      "tierToCool": {
+                        "daysAfterModificationGreaterThan": 30
+                      }
+                    },
+                    "snapshot": {
+                      "delete": {
+                        "daysAfterCreationGreaterThan": 30
+                      }
+                    }
+                  },
+                  "filters": {
+                    "blobTypes": [
+                      "blockBlob"
+                    ],
+                    "prefixMatch": [
+                      "olcmtestcontainer"
+                    ]
+                  }
+                },
+                "enabled": true
+              }
+            ]
+          }
+        }
+      }
+    }
+  },
+  "operationId": "ManagementPolicies_Get",
+  "title": "StorageAccountGetManagementPolicies"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountGetMigrationFailed.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountGetMigrationFailed.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "accountName": "accountname",
+    "api-version": "2026-09-01",
+    "migrationName": "default",
+    "monitor": "true",
+    "resourceGroupName": "resource-group-name",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.Storage/storageAccounts/accountMigrations",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/resource-group-name/providers/Microsoft.Storage/storageAccounts/accountname/accountMigrations/default",
+        "properties": {
+          "migrationFailedDetailedReason": "ZRS is not supported for accounts with archive data.",
+          "migrationFailedReason": "ZrsNotSupportedForAccountWithArchiveData",
+          "migrationStatus": "Failed",
+          "targetSkuName": "Standard_ZRS"
+        }
+      }
+    }
+  },
+  "operationId": "StorageAccounts_GetCustomerInitiatedMigration",
+  "title": "StorageAccountGetMigrationFailed"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountGetMigrationInProgress.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountGetMigrationInProgress.json
@@ -1,0 +1,25 @@
+{
+  "parameters": {
+    "accountName": "accountname",
+    "api-version": "2026-09-01",
+    "migrationName": "default",
+    "monitor": "true",
+    "resourceGroupName": "resource-group-name",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.Storage/storageAccounts/accountMigrations",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/resource-group-name/providers/Microsoft.Storage/storageAccounts/accountname/accountMigrations/default",
+        "properties": {
+          "migrationStatus": "InProgress",
+          "targetSkuName": "Standard_ZRS"
+        }
+      }
+    }
+  },
+  "operationId": "StorageAccounts_GetCustomerInitiatedMigration",
+  "title": "StorageAccountGetMigrationInProgress"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountGetObjectReplicationPolicy.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountGetObjectReplicationPolicy.json
@@ -1,0 +1,58 @@
+{
+  "parameters": {
+    "accountName": "sto2527",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "objectReplicationPolicyId": "{objectReplicationPolicy-Id}",
+    "resourceGroupName": "res6977",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "{objectReplicationPolicy-Id}",
+        "type": "Microsoft.Storage/storageAccounts/objectReplicationPolicies",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res6977/providers/Microsoft.Storage/storageAccounts/sto2527/objectReplicationPolicies/{objectReplicationPolicy-Id}",
+        "properties": {
+          "destinationAccount": "destAccount1",
+          "enabledTime": "2019-06-08T03:01:55.7168089Z",
+          "metrics": {
+            "enabled": true
+          },
+          "priorityReplication": {
+            "enabled": true
+          },
+          "policyId": "{objectReplicationPolicy-Id}",
+          "rules": [
+            {
+              "destinationContainer": "destContainer1",
+              "filters": {
+                "prefixMatch": [
+                  "blobA",
+                  "blobB"
+                ]
+              },
+              "sourceContainer": "sourceContainer1"
+            },
+            {
+              "destinationContainer": "destContainer1",
+              "filters": {
+                "prefixMatch": [
+                  "blobC",
+                  "blobD"
+                ]
+              },
+              "sourceContainer": "sourceContainer1"
+            }
+          ],
+          "sourceAccount": "sto2527",
+          "tagsReplication": {
+            "enabled": true
+          }
+        }
+      }
+    }
+  },
+  "operationId": "ObjectReplicationPolicies_Get",
+  "title": "StorageAccountGetObjectReplicationPolicies"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountGetPrivateEndpointConnection.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountGetPrivateEndpointConnection.json
@@ -1,0 +1,32 @@
+{
+  "parameters": {
+    "accountName": "sto2527",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "privateEndpointConnectionName": "{privateEndpointConnectionName}",
+    "resourceGroupName": "res6977",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "{privateEndpointConnectionName}",
+        "type": "Microsoft.Storage/storageAccounts/privateEndpointConnections",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res7231/providers/Microsoft.Storage/storageAccounts/sto288/privateEndpointConnections/{privateEndpointConnectionName}",
+        "properties": {
+          "privateEndpoint": {
+            "id": "/subscriptions/{subscription-id}/resourceGroups/res7231/providers/Microsoft.Network/privateEndpoints/petest01"
+          },
+          "privateLinkServiceConnectionState": {
+            "description": "Auto-Approved",
+            "actionRequired": "None",
+            "status": "Approved"
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "PrivateEndpointConnections_Get",
+  "title": "StorageAccountGetPrivateEndpointConnection"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountGetProperties.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountGetProperties.json
@@ -1,0 +1,115 @@
+{
+  "parameters": {
+    "accountName": "sto8596",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res9407",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto8596",
+        "type": "Microsoft.Storage/storageAccounts",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9407/providers/Microsoft.Storage/storageAccounts/sto8596",
+        "kind": "Storage",
+        "location": "eastus2(stage)",
+        "properties": {
+          "accountMigrationInProgress": false,
+          "creationTime": "2017-06-01T02:42:41.7633306Z",
+          "encryption": {
+            "keySource": "Microsoft.Storage",
+            "services": {
+              "blob": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              },
+              "file": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              }
+            }
+          },
+          "geoReplicationStats": {
+            "canFailover": true,
+            "lastSyncTime": "2018-10-30T00:25:34Z",
+            "status": "Live"
+          },
+          "isHnsEnabled": true,
+          "isSkuConversionBlocked": false,
+          "keyCreationTime": {
+            "key1": "2021-03-18T04:42:22.4322836Z",
+            "key2": "2021-03-18T04:42:22.4322836Z"
+          },
+          "networkAcls": {
+            "bypass": "AzureServices",
+            "defaultAction": "Allow",
+            "ipRules": [],
+            "resourceAccessRules": [
+              {
+                "resourceId": "/subscriptions/a7e99807-abbf-4642-bdec-2c809a96a8bc/resourceGroups/res9407/providers/Microsoft.Synapse/workspaces/testworkspace",
+                "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+              }
+            ],
+            "virtualNetworkRules": []
+          },
+          "primaryEndpoints": {
+            "blob": "https://sto8596.blob.core.windows.net/",
+            "dfs": "https://sto8596.dfs.core.windows.net/",
+            "file": "https://sto8596.file.core.windows.net/",
+            "internetEndpoints": {
+              "blob": "https://sto8596-internetrouting.blob.core.windows.net/",
+              "dfs": "https://sto8596-internetrouting.dfs.core.windows.net/",
+              "file": "https://sto8596-internetrouting.file.core.windows.net/",
+              "web": "https://sto8596-internetrouting.web.core.windows.net/"
+            },
+            "microsoftEndpoints": {
+              "blob": "https://sto8596-microsoftrouting.blob.core.windows.net/",
+              "dfs": "https://sto8596-microsoftrouting.dfs.core.windows.net/",
+              "file": "https://sto8596-microsoftrouting.file.core.windows.net/",
+              "queue": "https://sto8596-microsoftrouting.queue.core.windows.net/",
+              "table": "https://sto8596-microsoftrouting.table.core.windows.net/",
+              "web": "https://sto8596-microsoftrouting.web.core.windows.net/"
+            },
+            "queue": "https://sto8596.queue.core.windows.net/",
+            "table": "https://sto8596.table.core.windows.net/",
+            "web": "https://sto8596.web.core.windows.net/"
+          },
+          "primaryLocation": "eastus2(stage)",
+          "provisioningState": "Succeeded",
+          "routingPreference": {
+            "publishInternetEndpoints": true,
+            "publishMicrosoftEndpoints": true,
+            "routingChoice": "MicrosoftRouting"
+          },
+          "secondaryLocation": "northcentralus(stage)",
+          "statusOfPrimary": "available",
+          "statusOfSecondary": "available",
+          "supportsHttpsTrafficOnly": false,
+          "geoPriorityReplicationStatus": {
+            "isBlobEnabled": true
+          },
+          "sasPolicy": {
+            "expirationAction": "Log",
+            "sasExpirationPeriod": "1.15:59:59",
+            "requireUserBoundUserDelegationSas": true,
+            "requireUserBoundUserDelegationSasAction": "Block"
+          },
+          "allowCrossTenantDelegationSas": false
+        },
+        "sku": {
+          "name": "Standard_GRS",
+          "tier": "Standard"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "StorageAccounts_GetProperties",
+  "title": "StorageAccountGetProperties"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountGetPropertiesCMKEnabled.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountGetPropertiesCMKEnabled.json
@@ -1,0 +1,106 @@
+{
+  "parameters": {
+    "accountName": "sto8596",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res9407",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto8596",
+        "type": "Microsoft.Storage/storageAccounts",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9407/providers/Microsoft.Storage/storageAccounts/sto8596",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "911871cc-ffd1-4fc4-ac11-7a316433ea66",
+          "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+        },
+        "kind": "Storage",
+        "location": "eastus2(stage)",
+        "properties": {
+          "creationTime": "2017-06-01T02:42:41.7633306Z",
+          "encryption": {
+            "keySource": "Microsoft.Keyvault",
+            "keyvaultproperties": {
+              "currentVersionedKeyIdentifier": "https://myvault8569.vault.azure.net/keys/wrappingKey/0682afdd9c104f4285df20107e956cad",
+              "keyname": "wrappingKey",
+              "keyvaulturi": "https://myvault8569.vault.azure.net",
+              "keyversion": "",
+              "lastKeyRotationTimestamp": "2019-12-13T20:36:23.7023290Z"
+            },
+            "services": {
+              "blob": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              },
+              "file": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              }
+            }
+          },
+          "geoReplicationStats": {
+            "canFailover": true,
+            "lastSyncTime": "2018-10-30T00:25:34Z",
+            "status": "Live"
+          },
+          "isHnsEnabled": true,
+          "networkAcls": {
+            "bypass": "AzureServices",
+            "defaultAction": "Allow",
+            "ipRules": [],
+            "resourceAccessRules": [],
+            "virtualNetworkRules": []
+          },
+          "primaryEndpoints": {
+            "blob": "https://sto8596.blob.core.windows.net/",
+            "dfs": "https://sto8596.dfs.core.windows.net/",
+            "file": "https://sto8596.file.core.windows.net/",
+            "internetEndpoints": {
+              "blob": "https://sto8596-internetrouting.blob.core.windows.net/",
+              "dfs": "https://sto8596-internetrouting.dfs.core.windows.net/",
+              "file": "https://sto8596-internetrouting.file.core.windows.net/",
+              "web": "https://sto8596-internetrouting.web.core.windows.net/"
+            },
+            "microsoftEndpoints": {
+              "blob": "https://sto8596-microsoftrouting.blob.core.windows.net/",
+              "dfs": "https://sto8596-microsoftrouting.dfs.core.windows.net/",
+              "file": "https://sto8596-microsoftrouting.file.core.windows.net/",
+              "queue": "https://sto8596-microsoftrouting.queue.core.windows.net/",
+              "table": "https://sto8596-microsoftrouting.table.core.windows.net/",
+              "web": "https://sto8596-microsoftrouting.web.core.windows.net/"
+            },
+            "queue": "https://sto8596.queue.core.windows.net/",
+            "table": "https://sto8596.table.core.windows.net/",
+            "web": "https://sto8596.web.core.windows.net/"
+          },
+          "primaryLocation": "eastus2(stage)",
+          "provisioningState": "Succeeded",
+          "routingPreference": {
+            "publishInternetEndpoints": true,
+            "publishMicrosoftEndpoints": true,
+            "routingChoice": "MicrosoftRouting"
+          },
+          "secondaryLocation": "northcentralus(stage)",
+          "statusOfPrimary": "available",
+          "statusOfSecondary": "available",
+          "supportsHttpsTrafficOnly": false
+        },
+        "sku": {
+          "name": "Standard_GRS",
+          "tier": "Standard"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "StorageAccounts_GetProperties",
+  "title": "StorageAccountGetPropertiesCMKEnabled"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountGetPropertiesCMKVersionExpirationTime.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountGetPropertiesCMKVersionExpirationTime.json
@@ -1,0 +1,107 @@
+{
+  "parameters": {
+    "accountName": "sto8596",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res9407",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto8596",
+        "type": "Microsoft.Storage/storageAccounts",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9407/providers/Microsoft.Storage/storageAccounts/sto8596",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "911871cc-ffd1-4fc4-ac11-7a316433ea66",
+          "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+        },
+        "kind": "Storage",
+        "location": "eastus2(stage)",
+        "properties": {
+          "creationTime": "2017-06-01T02:42:41.7633306Z",
+          "encryption": {
+            "keySource": "Microsoft.Keyvault",
+            "keyvaultproperties": {
+              "currentVersionedKeyExpirationTimestamp": "2019-12-13T20:36:23.7023290Z",
+              "currentVersionedKeyIdentifier": "https://myvault8569.vault.azure.net/keys/wrappingKey/0682afdd9c104f4285df20107e956cad",
+              "keyname": "wrappingKey",
+              "keyvaulturi": "https://myvault8569.vault.azure.net",
+              "keyversion": "",
+              "lastKeyRotationTimestamp": "2019-12-13T20:36:23.7023290Z"
+            },
+            "services": {
+              "blob": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              },
+              "file": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              }
+            }
+          },
+          "geoReplicationStats": {
+            "canFailover": true,
+            "lastSyncTime": "2018-10-30T00:25:34Z",
+            "status": "Live"
+          },
+          "isHnsEnabled": true,
+          "networkAcls": {
+            "bypass": "AzureServices",
+            "defaultAction": "Allow",
+            "ipRules": [],
+            "resourceAccessRules": [],
+            "virtualNetworkRules": []
+          },
+          "primaryEndpoints": {
+            "blob": "https://sto8596.blob.core.windows.net/",
+            "dfs": "https://sto8596.dfs.core.windows.net/",
+            "file": "https://sto8596.file.core.windows.net/",
+            "internetEndpoints": {
+              "blob": "https://sto8596-internetrouting.blob.core.windows.net/",
+              "dfs": "https://sto8596-internetrouting.dfs.core.windows.net/",
+              "file": "https://sto8596-internetrouting.file.core.windows.net/",
+              "web": "https://sto8596-internetrouting.web.core.windows.net/"
+            },
+            "microsoftEndpoints": {
+              "blob": "https://sto8596-microsoftrouting.blob.core.windows.net/",
+              "dfs": "https://sto8596-microsoftrouting.dfs.core.windows.net/",
+              "file": "https://sto8596-microsoftrouting.file.core.windows.net/",
+              "queue": "https://sto8596-microsoftrouting.queue.core.windows.net/",
+              "table": "https://sto8596-microsoftrouting.table.core.windows.net/",
+              "web": "https://sto8596-microsoftrouting.web.core.windows.net/"
+            },
+            "queue": "https://sto8596.queue.core.windows.net/",
+            "table": "https://sto8596.table.core.windows.net/",
+            "web": "https://sto8596.web.core.windows.net/"
+          },
+          "primaryLocation": "eastus2(stage)",
+          "provisioningState": "Succeeded",
+          "routingPreference": {
+            "publishInternetEndpoints": true,
+            "publishMicrosoftEndpoints": true,
+            "routingChoice": "MicrosoftRouting"
+          },
+          "secondaryLocation": "northcentralus(stage)",
+          "statusOfPrimary": "available",
+          "statusOfSecondary": "available",
+          "supportsHttpsTrafficOnly": false
+        },
+        "sku": {
+          "name": "Standard_GRS",
+          "tier": "Standard"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "StorageAccounts_GetProperties",
+  "title": "StorageAccountGetPropertiesCMKVersionExpirationTime"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountGetPropertiesGeoReplicationStatscanFailoverFalse.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountGetPropertiesGeoReplicationStatscanFailoverFalse.json
@@ -1,0 +1,109 @@
+{
+  "parameters": {
+    "$expand": "geoReplicationStats",
+    "accountName": "sto8596",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res9407",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto8596",
+        "type": "Microsoft.Storage/storageAccounts",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9407/providers/Microsoft.Storage/storageAccounts/sto8596",
+        "kind": "Storage",
+        "location": "eastus2(stage)",
+        "properties": {
+          "accountMigrationInProgress": false,
+          "creationTime": "2017-06-01T02:42:41.7633306Z",
+          "encryption": {
+            "keySource": "Microsoft.Storage",
+            "services": {
+              "blob": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              },
+              "file": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              }
+            }
+          },
+          "geoReplicationStats": {
+            "canFailover": false,
+            "canPlannedFailover": false,
+            "lastSyncTime": "2018-10-30T00:25:34Z",
+            "postFailoverRedundancy": "Standard_LRS",
+            "postPlannedFailoverRedundancy": "Standard_GRS",
+            "status": "Live"
+          },
+          "isHnsEnabled": true,
+          "isSkuConversionBlocked": false,
+          "keyCreationTime": {
+            "key1": "2021-03-18T04:42:22.4322836Z",
+            "key2": "2021-03-18T04:42:22.4322836Z"
+          },
+          "networkAcls": {
+            "bypass": "AzureServices",
+            "defaultAction": "Allow",
+            "ipRules": [],
+            "resourceAccessRules": [
+              {
+                "resourceId": "/subscriptions/a7e99807-abbf-4642-bdec-2c809a96a8bc/resourceGroups/res9407/providers/Microsoft.Synapse/workspaces/testworkspace",
+                "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+              }
+            ],
+            "virtualNetworkRules": []
+          },
+          "primaryEndpoints": {
+            "blob": "https://sto8596.blob.core.windows.net/",
+            "dfs": "https://sto8596.dfs.core.windows.net/",
+            "file": "https://sto8596.file.core.windows.net/",
+            "internetEndpoints": {
+              "blob": "https://sto8596-internetrouting.blob.core.windows.net/",
+              "dfs": "https://sto8596-internetrouting.dfs.core.windows.net/",
+              "file": "https://sto8596-internetrouting.file.core.windows.net/",
+              "web": "https://sto8596-internetrouting.web.core.windows.net/"
+            },
+            "microsoftEndpoints": {
+              "blob": "https://sto8596-microsoftrouting.blob.core.windows.net/",
+              "dfs": "https://sto8596-microsoftrouting.dfs.core.windows.net/",
+              "file": "https://sto8596-microsoftrouting.file.core.windows.net/",
+              "queue": "https://sto8596-microsoftrouting.queue.core.windows.net/",
+              "table": "https://sto8596-microsoftrouting.table.core.windows.net/",
+              "web": "https://sto8596-microsoftrouting.web.core.windows.net/"
+            },
+            "queue": "https://sto8596.queue.core.windows.net/",
+            "table": "https://sto8596.table.core.windows.net/",
+            "web": "https://sto8596.web.core.windows.net/"
+          },
+          "primaryLocation": "eastus2(stage)",
+          "provisioningState": "Succeeded",
+          "routingPreference": {
+            "publishInternetEndpoints": true,
+            "publishMicrosoftEndpoints": true,
+            "routingChoice": "MicrosoftRouting"
+          },
+          "secondaryLocation": "northcentralus(stage)",
+          "statusOfPrimary": "available",
+          "statusOfSecondary": "available",
+          "supportsHttpsTrafficOnly": false
+        },
+        "sku": {
+          "name": "Standard_GRS",
+          "tier": "Standard"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "StorageAccounts_GetProperties",
+  "title": "StorageAccountGetPropertiesGeoReplicationStatscanFailoverFalse"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountGetPropertiesGeoReplicationStatscanFailoverTrue.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountGetPropertiesGeoReplicationStatscanFailoverTrue.json
@@ -1,0 +1,109 @@
+{
+  "parameters": {
+    "$expand": "geoReplicationStats",
+    "accountName": "sto8596",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res9407",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto8596",
+        "type": "Microsoft.Storage/storageAccounts",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9407/providers/Microsoft.Storage/storageAccounts/sto8596",
+        "kind": "Storage",
+        "location": "eastus2(stage)",
+        "properties": {
+          "accountMigrationInProgress": false,
+          "creationTime": "2017-06-01T02:42:41.7633306Z",
+          "encryption": {
+            "keySource": "Microsoft.Storage",
+            "services": {
+              "blob": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              },
+              "file": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              }
+            }
+          },
+          "geoReplicationStats": {
+            "canFailover": true,
+            "canPlannedFailover": true,
+            "lastSyncTime": "2018-10-30T00:25:34Z",
+            "postFailoverRedundancy": "Standard_LRS",
+            "postPlannedFailoverRedundancy": "Standard_GRS",
+            "status": "Live"
+          },
+          "isHnsEnabled": true,
+          "isSkuConversionBlocked": false,
+          "keyCreationTime": {
+            "key1": "2021-03-18T04:42:22.4322836Z",
+            "key2": "2021-03-18T04:42:22.4322836Z"
+          },
+          "networkAcls": {
+            "bypass": "AzureServices",
+            "defaultAction": "Allow",
+            "ipRules": [],
+            "resourceAccessRules": [
+              {
+                "resourceId": "/subscriptions/a7e99807-abbf-4642-bdec-2c809a96a8bc/resourceGroups/res9407/providers/Microsoft.Synapse/workspaces/testworkspace",
+                "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+              }
+            ],
+            "virtualNetworkRules": []
+          },
+          "primaryEndpoints": {
+            "blob": "https://sto8596.blob.core.windows.net/",
+            "dfs": "https://sto8596.dfs.core.windows.net/",
+            "file": "https://sto8596.file.core.windows.net/",
+            "internetEndpoints": {
+              "blob": "https://sto8596-internetrouting.blob.core.windows.net/",
+              "dfs": "https://sto8596-internetrouting.dfs.core.windows.net/",
+              "file": "https://sto8596-internetrouting.file.core.windows.net/",
+              "web": "https://sto8596-internetrouting.web.core.windows.net/"
+            },
+            "microsoftEndpoints": {
+              "blob": "https://sto8596-microsoftrouting.blob.core.windows.net/",
+              "dfs": "https://sto8596-microsoftrouting.dfs.core.windows.net/",
+              "file": "https://sto8596-microsoftrouting.file.core.windows.net/",
+              "queue": "https://sto8596-microsoftrouting.queue.core.windows.net/",
+              "table": "https://sto8596-microsoftrouting.table.core.windows.net/",
+              "web": "https://sto8596-microsoftrouting.web.core.windows.net/"
+            },
+            "queue": "https://sto8596.queue.core.windows.net/",
+            "table": "https://sto8596.table.core.windows.net/",
+            "web": "https://sto8596.web.core.windows.net/"
+          },
+          "primaryLocation": "eastus2(stage)",
+          "provisioningState": "Succeeded",
+          "routingPreference": {
+            "publishInternetEndpoints": true,
+            "publishMicrosoftEndpoints": true,
+            "routingChoice": "MicrosoftRouting"
+          },
+          "secondaryLocation": "northcentralus(stage)",
+          "statusOfPrimary": "available",
+          "statusOfSecondary": "available",
+          "supportsHttpsTrafficOnly": false
+        },
+        "sku": {
+          "name": "Standard_GRS",
+          "tier": "Standard"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "StorageAccounts_GetProperties",
+  "title": "StorageAccountGetPropertiesGeoReplicationStatscanFailoverTrue"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountHierarchicalNamespaceMigration.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountHierarchicalNamespaceMigration.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "accountName": "sto2434",
+    "api-version": "2026-09-01",
+    "requestType": "HnsOnValidationRequest",
+    "resourceGroupName": "res4228",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "https://endpoint:port/subscriptions/{subscription-id}/providers/Microsoft.Storage/locations/{location}/asyncoperations/{operationid}?monitor=true&api-version=2022-09-01"
+      }
+    }
+  },
+  "operationId": "StorageAccounts_HierarchicalNamespaceMigration",
+  "title": "StorageAccountHierarchicalNamespaceMigration"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountLeverageIPv6Ability.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountLeverageIPv6Ability.json
@@ -1,0 +1,87 @@
+{
+  "parameters": {
+    "accountName": "sto8596",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "parameters": {
+      "properties": {
+        "dualStackEndpointPreference": {
+          "publishIpv6Endpoint": true
+        },
+        "networkAcls": {
+          "defaultAction": "Deny",
+          "ipv6Rules": [
+            {
+              "action": "Allow",
+              "value": "2001:0db8:85a3::/64"
+            }
+          ]
+        }
+      }
+    },
+    "resourceGroupName": "res9407",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto8596",
+        "type": "Microsoft.Storage/storageAccounts",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res9407/providers/Microsoft.Storage/storageAccounts/sto8596",
+        "kind": "Storage",
+        "location": "eastus2(stage)",
+        "properties": {
+          "creationTime": "2017-06-01T02:42:41.7633306Z",
+          "dualStackEndpointPreference": {
+            "publishIpv6Endpoint": true
+          },
+          "keyCreationTime": {
+            "key1": "2021-03-18T04:42:22.4322836Z",
+            "key2": "2021-03-18T04:42:22.4322836Z"
+          },
+          "networkAcls": {
+            "bypass": "AzureServices",
+            "defaultAction": "Deny",
+            "ipRules": [],
+            "ipv6Rules": [
+              {
+                "action": "Allow",
+                "value": "2001:0db8:85a3::/64"
+              }
+            ],
+            "virtualNetworkRules": []
+          },
+          "primaryEndpoints": {
+            "blob": "https://sto8596.blob.core.windows.net/",
+            "dfs": "https://sto8596.dfs.core.windows.net/",
+            "file": "https://sto8596.file.core.windows.net/",
+            "ipv6Endpoints": {
+              "blob": "https://sto8596-ipv6.blob.core.windows.net/",
+              "dfs": "https://sto8596-ipv6.dfs.core.windows.net/",
+              "file": "https://sto8596-ipv6.file.core.windows.net/",
+              "queue": "https://sto8596-ipv6.queue.core.windows.net/",
+              "table": "https://sto8596-ipv6.table.core.windows.net/",
+              "web": "https://sto8596-ipv6.web.core.windows.net/"
+            },
+            "queue": "https://sto8596.queue.core.windows.net/",
+            "table": "https://sto8596.table.core.windows.net/",
+            "web": "https://sto8596.web.core.windows.net/"
+          },
+          "primaryLocation": "eastus2(stage)",
+          "provisioningState": "Succeeded",
+          "statusOfPrimary": "available"
+        },
+        "sku": {
+          "name": "Standard_LRS",
+          "tier": "Standard"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "StorageAccounts_Update",
+  "title": "StorageAccountUpdateEnableIpv6Features"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountList.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountList.json
@@ -1,0 +1,315 @@
+{
+  "parameters": {
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "sto1125",
+            "type": "Microsoft.Storage/storageAccounts",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/res2627/providers/Microsoft.Storage/storageAccounts/sto1125",
+            "kind": "Storage",
+            "location": "eastus",
+            "properties": {
+              "creationTime": "2017-05-24T13:28:53.4540398Z",
+              "encryption": {
+                "keySource": "Microsoft.Storage",
+                "services": {
+                  "blob": {
+                    "enabled": true,
+                    "keyType": "Account",
+                    "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+                  },
+                  "file": {
+                    "enabled": true,
+                    "keyType": "Account",
+                    "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+                  }
+                }
+              },
+              "isHnsEnabled": true,
+              "primaryEndpoints": {
+                "blob": "https://sto1125.blob.core.windows.net/",
+                "dfs": "https://sto1125.dfs.core.windows.net/",
+                "file": "https://sto1125.file.core.windows.net/",
+                "internetEndpoints": {
+                  "blob": "https://sto1125-internetrouting.blob.core.windows.net/",
+                  "dfs": "https://sto1125-internetrouting.dfs.core.windows.net/",
+                  "file": "https://sto1125-internetrouting.file.core.windows.net/",
+                  "web": "https://sto1125-internetrouting.web.core.windows.net/"
+                },
+                "microsoftEndpoints": {
+                  "blob": "https://sto1125-microsoftrouting.blob.core.windows.net/",
+                  "dfs": "https://sto1125-microsoftrouting.dfs.core.windows.net/",
+                  "file": "https://sto1125-microsoftrouting.file.core.windows.net/",
+                  "queue": "https://sto1125-microsoftrouting.queue.core.windows.net/",
+                  "table": "https://sto1125-microsoftrouting.table.core.windows.net/",
+                  "web": "https://sto1125-microsoftrouting.web.core.windows.net/"
+                },
+                "queue": "https://sto1125.queue.core.windows.net/",
+                "table": "https://sto1125.table.core.windows.net/",
+                "web": "https://sto1125.web.core.windows.net/"
+              },
+              "primaryLocation": "eastus",
+              "provisioningState": "Succeeded",
+              "routingPreference": {
+                "publishInternetEndpoints": true,
+                "publishMicrosoftEndpoints": true,
+                "routingChoice": "MicrosoftRouting"
+              },
+              "secondaryLocation": "centraluseuap",
+              "statusOfPrimary": "available",
+              "statusOfSecondary": "available",
+              "supportsHttpsTrafficOnly": false
+            },
+            "sku": {
+              "name": "Standard_GRS",
+              "tier": "Standard"
+            },
+            "tags": {
+              "key1": "value1",
+              "key2": "value2"
+            }
+          },
+          {
+            "name": "sto3699",
+            "type": "Microsoft.Storage/storageAccounts",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/testcmk3/providers/Microsoft.Storage/storageAccounts/sto3699",
+            "identity": {
+              "type": "SystemAssigned",
+              "principalId": "356d057d-cba5-44dd-8a30-b2e547bc416b",
+              "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+            },
+            "kind": "Storage",
+            "location": "eastus",
+            "properties": {
+              "creationTime": "2017-05-24T10:06:30.6093014Z",
+              "primaryEndpoints": {
+                "blob": "https://sto3699.blob.core.windows.net/",
+                "file": "https://sto3699.file.core.windows.net/",
+                "queue": "https://sto3699.queue.core.windows.net/",
+                "table": "https://sto3699.table.core.windows.net/"
+              },
+              "primaryLocation": "eastus",
+              "provisioningState": "Succeeded",
+              "secondaryLocation": "centraluseuap",
+              "statusOfPrimary": "available",
+              "statusOfSecondary": "available",
+              "supportsHttpsTrafficOnly": false
+            },
+            "sku": {
+              "name": "Standard_GRS",
+              "tier": "Standard"
+            },
+            "tags": {
+              "key1": "value1",
+              "key2": "value2"
+            }
+          },
+          {
+            "name": "sto8596",
+            "type": "Microsoft.Storage/storageAccounts",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/res9407/providers/Microsoft.Storage/storageAccounts/sto8596",
+            "identity": {
+              "type": "SystemAssigned",
+              "principalId": "911871cc-ffd1-4fc4-ac11-7a316433ea66",
+              "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+            },
+            "kind": "Storage",
+            "location": "eastus2(stage)",
+            "properties": {
+              "creationTime": "2017-06-01T02:42:41.7633306Z",
+              "encryption": {
+                "keySource": "Microsoft.Keyvault",
+                "keyvaultproperties": {
+                  "currentVersionedKeyIdentifier": "https://myvault8569.vault.azure.net/keys/wrappingKey/0682afdd9c104f4285df20107e956cad",
+                  "keyname": "wrappingKey",
+                  "keyvaulturi": "https://myvault8569.vault.azure.net",
+                  "keyversion": "",
+                  "lastKeyRotationTimestamp": "2019-12-13T20:36:23.7023290Z"
+                },
+                "services": {
+                  "blob": {
+                    "enabled": true,
+                    "keyType": "Account",
+                    "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+                  },
+                  "file": {
+                    "enabled": true,
+                    "keyType": "Account",
+                    "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+                  }
+                }
+              },
+              "geoReplicationStats": {
+                "canFailover": true,
+                "lastSyncTime": "2018-10-30T00:25:34Z",
+                "status": "Live"
+              },
+              "isHnsEnabled": true,
+              "networkAcls": {
+                "bypass": "AzureServices",
+                "defaultAction": "Allow",
+                "ipRules": [],
+                "resourceAccessRules": [
+                  {
+                    "resourceId": "/subscriptions/a7e99807-abbf-4642-bdec-2c809a96a8bc/resourceGroups/res9407/providers/Microsoft.Synapse/workspaces/testworkspace",
+                    "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+                  }
+                ],
+                "virtualNetworkRules": []
+              },
+              "primaryEndpoints": {
+                "blob": "https://sto8596.blob.core.windows.net/",
+                "dfs": "https://sto8596.dfs.core.windows.net/",
+                "file": "https://sto8596.file.core.windows.net/",
+                "internetEndpoints": {
+                  "blob": "https://sto8596-internetrouting.blob.core.windows.net/",
+                  "dfs": "https://sto8596-internetrouting.dfs.core.windows.net/",
+                  "file": "https://sto8596-internetrouting.file.core.windows.net/",
+                  "web": "https://sto8596-internetrouting.web.core.windows.net/"
+                },
+                "microsoftEndpoints": {
+                  "blob": "https://sto8596-microsoftrouting.blob.core.windows.net/",
+                  "dfs": "https://sto8596-microsoftrouting.dfs.core.windows.net/",
+                  "file": "https://sto8596-microsoftrouting.file.core.windows.net/",
+                  "queue": "https://sto8596-microsoftrouting.queue.core.windows.net/",
+                  "table": "https://sto8596-microsoftrouting.table.core.windows.net/",
+                  "web": "https://sto8596-microsoftrouting.web.core.windows.net/"
+                },
+                "queue": "https://sto8596.queue.core.windows.net/",
+                "table": "https://sto8596.table.core.windows.net/",
+                "web": "https://sto8596.web.core.windows.net/"
+              },
+              "primaryLocation": "eastus2(stage)",
+              "provisioningState": "Succeeded",
+              "routingPreference": {
+                "publishInternetEndpoints": true,
+                "publishMicrosoftEndpoints": true,
+                "routingChoice": "MicrosoftRouting"
+              },
+              "secondaryLocation": "northcentralus(stage)",
+              "statusOfPrimary": "available",
+              "statusOfSecondary": "available",
+              "supportsHttpsTrafficOnly": false
+            },
+            "sku": {
+              "name": "Standard_GRS",
+              "tier": "Standard"
+            },
+            "tags": {
+              "key1": "value1",
+              "key2": "value2"
+            }
+          },
+          {
+            "name": "sto6637",
+            "type": "Microsoft.Storage/storageAccounts",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/testcmk3/providers/Microsoft.Storage/storageAccounts/sto6637",
+            "identity": {
+              "type": "SystemAssigned",
+              "principalId": "911871cc-ffd1-4fc4-ac11-7a316433ea66",
+              "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+            },
+            "kind": "Storage",
+            "location": "eastus",
+            "properties": {
+              "creationTime": "2017-05-24T10:09:39.5625175Z",
+              "primaryEndpoints": {
+                "blob": "https://sto6637.blob.core.windows.net/",
+                "file": "https://sto6637.file.core.windows.net/",
+                "queue": "https://sto6637.queue.core.windows.net/",
+                "table": "https://sto6637.table.core.windows.net/"
+              },
+              "primaryLocation": "eastus",
+              "provisioningState": "Succeeded",
+              "secondaryLocation": "centraluseuap",
+              "statusOfPrimary": "available",
+              "statusOfSecondary": "available",
+              "supportsHttpsTrafficOnly": false
+            },
+            "sku": {
+              "name": "Standard_GRS",
+              "tier": "Standard"
+            },
+            "tags": {
+              "key1": "value1",
+              "key2": "value2"
+            }
+          },
+          {
+            "name": "sto834",
+            "type": "Microsoft.Storage/storageAccounts",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/res8186/providers/Microsoft.Storage/storageAccounts/sto834",
+            "kind": "Storage",
+            "location": "eastus",
+            "properties": {
+              "creationTime": "2017-05-24T13:28:20.8686541Z",
+              "primaryEndpoints": {
+                "blob": "https://sto834.blob.core.windows.net/",
+                "file": "https://sto834.file.core.windows.net/",
+                "queue": "https://sto834.queue.core.windows.net/",
+                "table": "https://sto834.table.core.windows.net/"
+              },
+              "primaryLocation": "eastus",
+              "provisioningState": "Succeeded",
+              "secondaryLocation": "centraluseuap",
+              "statusOfPrimary": "available",
+              "statusOfSecondary": "available",
+              "supportsHttpsTrafficOnly": false
+            },
+            "sku": {
+              "name": "Standard_GRS",
+              "tier": "Standard"
+            },
+            "tags": {
+              "key1": "value1",
+              "key2": "value2"
+            }
+          },
+          {
+            "name": "sto9174",
+            "type": "Microsoft.Storage/storageAccounts",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/testcmk3/providers/Microsoft.Storage/storageAccounts/sto9174",
+            "identity": {
+              "type": "SystemAssigned",
+              "principalId": "933e3ddf-1802-4a51-9469-18a33b576f88",
+              "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+            },
+            "kind": "Storage",
+            "location": "eastus",
+            "properties": {
+              "creationTime": "2017-05-24T09:46:19.6556989Z",
+              "primaryEndpoints": {
+                "blob": "https://sto9174.blob.core.windows.net/",
+                "file": "https://sto9174.file.core.windows.net/",
+                "queue": "https://sto9174.queue.core.windows.net/",
+                "table": "https://sto9174.table.core.windows.net/"
+              },
+              "primaryLocation": "eastus",
+              "provisioningState": "Succeeded",
+              "secondaryLocation": "centraluseuap",
+              "statusOfPrimary": "available",
+              "statusOfSecondary": "available",
+              "supportsHttpsTrafficOnly": false
+            },
+            "sku": {
+              "name": "Standard_GRS",
+              "tier": "Standard"
+            },
+            "tags": {
+              "key1": "value1",
+              "key2": "value2"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "StorageAccounts_List",
+  "title": "StorageAccountList"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountListAccountSAS.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountListAccountSAS.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "accountName": "sto8588",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "parameters": {
+      "keyToSign": "key1",
+      "signedExpiry": "2017-05-24T11:42:03.1567373Z",
+      "signedPermission": "r",
+      "signedProtocol": "https,http",
+      "signedResourceTypes": "s",
+      "signedServices": "b",
+      "signedStart": "2017-05-24T10:42:03.1567373Z"
+    },
+    "resourceGroupName": "res7985",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "accountSasToken": "sv=2015-04-05&ss=b&srt=s&sp=r&st=2017-05-24T10%3A42%3A03Z&se=2017-05-24T11%3A42%3A03Z&spr=https,http&sig=Z0I%2BEpM%2BPPlTC8ApfUf%2BcffO2aahMgZim3U0iArqsS0%3D"
+      }
+    }
+  },
+  "operationId": "StorageAccounts_ListAccountSAS",
+  "title": "StorageAccountListAccountSAS"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountListBlobInventoryPolicy.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountListBlobInventoryPolicy.json
@@ -1,0 +1,70 @@
+{
+  "parameters": {
+    "accountName": "sto9699",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res7687",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "DefaultInventoryPolicy",
+            "type": "Microsoft.Storage/storageAccounts/inventoryPolicies",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/res7687/providers/Microsoft.Storage/storageAccounts/sto9699/inventoryPolicies/default",
+            "properties": {
+              "lastModifiedTime": "2020-10-05T02:53:39.0932539Z",
+              "policy": {
+                "type": "Inventory",
+                "enabled": true,
+                "rules": [
+                  {
+                    "name": "inventoryPolicyRule1",
+                    "definition": {
+                      "format": "Csv",
+                      "filters": {
+                        "blobTypes": [
+                          "blockBlob",
+                          "appendBlob",
+                          "pageBlob"
+                        ],
+                        "includeBlobVersions": true,
+                        "includeSnapshots": true,
+                        "prefixMatch": [
+                          "inventoryprefix1",
+                          "inventoryprefix2"
+                        ]
+                      },
+                      "objectType": "Blob",
+                      "schedule": "Daily",
+                      "schemaFields": [
+                        "Name",
+                        "Creation-Time",
+                        "Last-Modified",
+                        "Content-Length",
+                        "Content-MD5",
+                        "BlobType",
+                        "AccessTier",
+                        "AccessTierChangeTime",
+                        "Snapshot",
+                        "VersionId",
+                        "IsCurrentVersion",
+                        "Metadata"
+                      ]
+                    },
+                    "destination": "container1",
+                    "enabled": true
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "BlobInventoryPolicies_List",
+  "title": "StorageAccountGetBlobInventoryPolicy"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountListByResourceGroup.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountListByResourceGroup.json
@@ -1,0 +1,80 @@
+{
+  "parameters": {
+    "api-version": "2026-09-01",
+    "resourceGroupName": "res6117",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "sto4036",
+            "type": "Microsoft.Storage/storageAccounts",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/res6117/providers/Microsoft.Storage/storageAccounts/sto4036",
+            "kind": "Storage",
+            "location": "eastus",
+            "properties": {
+              "creationTime": "2017-05-24T13:24:47.818801Z",
+              "isHnsEnabled": true,
+              "primaryEndpoints": {
+                "blob": "https://sto4036.blob.core.windows.net/",
+                "dfs": "https://sto4036.dfs.core.windows.net/",
+                "file": "https://sto4036.file.core.windows.net/",
+                "queue": "https://sto4036.queue.core.windows.net/",
+                "table": "https://sto4036.table.core.windows.net/",
+                "web": "https://sto4036.web.core.windows.net/"
+              },
+              "primaryLocation": "eastus",
+              "provisioningState": "Succeeded",
+              "secondaryLocation": "centraluseuap",
+              "statusOfPrimary": "available",
+              "statusOfSecondary": "available",
+              "supportsHttpsTrafficOnly": false
+            },
+            "sku": {
+              "name": "Standard_GRS",
+              "tier": "Standard"
+            },
+            "tags": {
+              "key1": "value1",
+              "key2": "value2"
+            }
+          },
+          {
+            "name": "sto4452",
+            "type": "Microsoft.Storage/storageAccounts",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/res6117/providers/Microsoft.Storage/storageAccounts/sto4452",
+            "kind": "Storage",
+            "location": "eastus",
+            "properties": {
+              "creationTime": "2017-05-24T13:24:15.7068366Z",
+              "primaryEndpoints": {
+                "blob": "https://sto4452.blob.core.windows.net/",
+                "file": "https://sto4452.file.core.windows.net/",
+                "queue": "https://sto4452.queue.core.windows.net/",
+                "table": "https://sto4452.table.core.windows.net/"
+              },
+              "primaryLocation": "eastus",
+              "provisioningState": "Succeeded",
+              "secondaryLocation": "centraluseuap",
+              "statusOfPrimary": "available",
+              "statusOfSecondary": "available",
+              "supportsHttpsTrafficOnly": false
+            },
+            "sku": {
+              "name": "Standard_GRS",
+              "tier": "Standard"
+            },
+            "tags": {
+              "key1": "value1",
+              "key2": "value2"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "StorageAccounts_ListByResourceGroup",
+  "title": "StorageAccountListByResourceGroup"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountListKeys.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountListKeys.json
@@ -1,0 +1,29 @@
+{
+  "parameters": {
+    "accountName": "sto2220",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res418",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "keys": [
+          {
+            "keyName": "key1",
+            "permissions": "Full",
+            "value": "<value>"
+          },
+          {
+            "keyName": "key2",
+            "permissions": "Full",
+            "value": "<value>"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "StorageAccounts_ListKeys",
+  "title": "StorageAccountListKeys"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountListLocationUsage.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountListLocationUsage.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "api-version": "2026-09-01",
+    "location": "eastus2(stage)",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": {
+              "localizedValue": "Storage Accounts",
+              "value": "StorageAccounts"
+            },
+            "currentValue": 55,
+            "limit": 250,
+            "unit": "Count"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Usages_ListByLocation",
+  "title": "UsageList"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountListObjectReplicationPolicies.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountListObjectReplicationPolicies.json
@@ -1,0 +1,46 @@
+{
+  "parameters": {
+    "accountName": "sto2527",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res6977",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "c6c23999-fd4e-433a-bcf9-1db69d27cd8a",
+            "type": "Microsoft.Storage/storageAccounts/objectReplicationPolicies",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/res6977/providers/Microsoft.Storage/storageAccounts/sto2527/objectReplicationPolicies/c6c23999-fd4e-433a-bcf9-1db69d27cd8a",
+            "properties": {
+              "destinationAccount": "destAccount1",
+              "sourceAccount": "sto2527"
+            }
+          },
+          {
+            "name": "141d23dc-8958-4b48-b6e6-5a40bf1af116",
+            "type": "Microsoft.Storage/storageAccounts/objectReplicationPolicies",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/res9290/providers/Microsoft.Storage/storageAccounts/sto1590/objectReplicationPolicies/141d23dc-8958-4b48-b6e6-5a40bf1af116",
+            "properties": {
+              "destinationAccount": "destAccount2",
+              "metrics": {
+                "enabled": true
+              },
+              "priorityReplication": {
+                "enabled": true
+              },
+              "sourceAccount": "sto2527",
+              "tagsReplication": {
+                "enabled": true
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ObjectReplicationPolicies_List",
+  "title": "StorageAccountListObjectReplicationPolicies"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountListPrivateEndpointConnections.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountListPrivateEndpointConnections.json
@@ -1,0 +1,51 @@
+{
+  "parameters": {
+    "accountName": "sto2527",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res6977",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "{privateEndpointConnectionName}",
+            "type": "Microsoft.Storage/storageAccounts/privateEndpointConnections",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/res7231/providers/Microsoft.Storage/storageAccounts/sto288/privateEndpointConnections/{privateEndpointConnectionName}",
+            "properties": {
+              "privateEndpoint": {
+                "id": "/subscriptions/{subscription-id}/resourceGroups/res7231/providers/Microsoft.Network/privateEndpoints/petest01"
+              },
+              "privateLinkServiceConnectionState": {
+                "description": "Auto-Approved",
+                "actionRequired": "None",
+                "status": "Approved"
+              },
+              "provisioningState": "Succeeded"
+            }
+          },
+          {
+            "name": "{privateEndpointConnectionName}",
+            "type": "Microsoft.Storage/storageAccounts/privateEndpointConnections",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/res7231/providers/Microsoft.Storage/storageAccounts/sto288/privateEndpointConnections/{privateEndpointConnectionName}",
+            "properties": {
+              "privateEndpoint": {
+                "id": "/subscriptions/{subscription-id}/resourceGroups/res7231/providers/Microsoft.Network/privateEndpoints/petest02"
+              },
+              "privateLinkServiceConnectionState": {
+                "description": "Auto-Approved",
+                "actionRequired": "None",
+                "status": "Approved"
+              },
+              "provisioningState": "Succeeded"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "PrivateEndpointConnections_List",
+  "title": "StorageAccountListPrivateEndpointConnections"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountListPrivateLinkResources.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountListPrivateLinkResources.json
@@ -1,0 +1,103 @@
+{
+  "parameters": {
+    "accountName": "sto2527",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res6977",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "blob",
+            "type": "Microsoft.Storage/storageAccounts/privateLinkResources",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/res6977/providers/Microsoft.Storage/storageAccounts/sto2527/privateLinkResources/blob",
+            "properties": {
+              "groupId": "blob",
+              "requiredMembers": [
+                "blob"
+              ],
+              "requiredZoneNames": [
+                "privatelink.blob.core.windows.net"
+              ]
+            }
+          },
+          {
+            "name": "blob_secondary",
+            "type": "Microsoft.Storage/storageAccounts/privateLinkResources",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/res6977/providers/Microsoft.Storage/storageAccounts/sto2527/privateLinkResources/blob_secondary",
+            "properties": {
+              "groupId": "blob_secondary",
+              "requiredMembers": [
+                "blob_secondary"
+              ],
+              "requiredZoneNames": [
+                "privatelink.blob.core.windows.net"
+              ]
+            }
+          },
+          {
+            "name": "table",
+            "type": "Microsoft.Storage/storageAccounts/privateLinkResources",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/res6977/providers/Microsoft.Storage/storageAccounts/sto2527/privateLinkResources/table",
+            "properties": {
+              "groupId": "table",
+              "requiredMembers": [
+                "table"
+              ],
+              "requiredZoneNames": [
+                "privatelink.table.core.windows.net"
+              ]
+            }
+          },
+          {
+            "name": "table_secondary",
+            "type": "Microsoft.Storage/storageAccounts/privateLinkResources",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/res6977/providers/Microsoft.Storage/storageAccounts/sto2527/privateLinkResources/table_secondary",
+            "properties": {
+              "groupId": "table_secondary",
+              "requiredMembers": [
+                "table_secondary"
+              ],
+              "requiredZoneNames": [
+                "privatelink.table.core.windows.net"
+              ]
+            }
+          },
+          {
+            "name": "dfs",
+            "type": "Microsoft.Storage/storageAccounts/privateLinkResources",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/res6977/providers/Microsoft.Storage/storageAccounts/sto2527/privateLinkResources/dfs",
+            "properties": {
+              "groupId": "dfs",
+              "requiredMembers": [
+                "dfs"
+              ],
+              "requiredZoneNames": [
+                "privatelink.dfs.core.windows.net"
+              ]
+            }
+          },
+          {
+            "name": "dfs_secondary",
+            "type": "Microsoft.Storage/storageAccounts/privateLinkResources",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/res6977/providers/Microsoft.Storage/storageAccounts/sto2527/privateLinkResources/dfs_secondary",
+            "properties": {
+              "groupId": "dfs_secondary",
+              "requiredMembers": [
+                "dfs_secondary"
+              ],
+              "requiredZoneNames": [
+                "privatelink.dfs.core.windows.net"
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "PrivateLinkResources_ListByStorageAccount",
+  "title": "StorageAccountListPrivateLinkResources"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountListServiceSAS.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountListServiceSAS.json
@@ -1,0 +1,24 @@
+{
+  "parameters": {
+    "accountName": "sto1299",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "parameters": {
+      "canonicalizedResource": "/blob/sto1299/music",
+      "signedExpiry": "2017-05-24T11:32:48.8457197Z",
+      "signedPermission": "l",
+      "signedResource": "c"
+    },
+    "resourceGroupName": "res7439",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "serviceSasToken": "sv=2015-04-05&sr=c&se=2017-05-24T11%3A32%3A48Z&sp=l&sig=PoF8yBUGixsjzwroLmw7vG3VbGz4KB2woZC2D4C2oio%3D"
+      }
+    }
+  },
+  "operationId": "StorageAccounts_ListServiceSAS",
+  "title": "StorageAccountListServiceSAS"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountPatchEncryptionScope.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountPatchEncryptionScope.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "accountName": "accountname",
+    "api-version": "2026-09-01",
+    "encryptionScope": {
+      "properties": {
+        "keyVaultProperties": {
+          "keyUri": "https://testvault.vault.core.windows.net/keys/key1/863425f1358359c"
+        },
+        "source": "Microsoft.KeyVault"
+      }
+    },
+    "encryptionScopeName": "{encryption-scope-name}",
+    "monitor": "true",
+    "resourceGroupName": "resource-group-name",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "{encryption-scope-name}",
+        "type": "Microsoft.Storage/storageAccounts/encryptionScopes",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/resource-group-name/providers/Microsoft.Storage/storageAccounts/accountname/encryptionScopes/{encryption-scope-name}",
+        "properties": {
+          "creationTime": "2018-10-16T02:42:41.7633306Z",
+          "keyVaultProperties": {
+            "currentVersionedKeyIdentifier": "https://testvault.vault.core.windows.net/keys/key1/863425f1358359c",
+            "keyUri": "https://testvault.vault.core.windows.net/keys/key1/863425f1358359c",
+            "lastKeyRotationTimestamp": "2019-12-13T20:36:23.7023290Z"
+          },
+          "lastModifiedTime": "2018-10-17T06:23:14.4513306Z",
+          "source": "Microsoft.KeyVault",
+          "state": "Enabled"
+        }
+      }
+    }
+  },
+  "operationId": "EncryptionScopes_Patch",
+  "title": "StorageAccountPatchEncryptionScope"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountPostMigration.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountPostMigration.json
@@ -1,0 +1,24 @@
+{
+  "parameters": {
+    "accountName": "accountname",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "parameters": {
+      "properties": {
+        "targetSkuName": "Standard_ZRS"
+      }
+    },
+    "resourceGroupName": "resource-group-name",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.Storage/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2022-09-01"
+      }
+    }
+  },
+  "operationId": "StorageAccounts_CustomerInitiatedMigration",
+  "title": "StorageAccountPostMigration"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountPutEncryptionScope.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountPutEncryptionScope.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "accountName": "accountname",
+    "api-version": "2026-09-01",
+    "encryptionScope": {},
+    "encryptionScopeName": "{encryption-scope-name}",
+    "monitor": "true",
+    "resourceGroupName": "resource-group-name",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "{encryption-scope-name}",
+        "type": "Microsoft.Storage/storageAccounts/encryptionScopes",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/resource-group-name/providers/Microsoft.Storage/storageAccounts/accountname/encryptionScopes/{encryption-scope-name}",
+        "properties": {
+          "creationTime": "2018-10-16T02:42:41.7633306Z",
+          "lastModifiedTime": "2018-10-16T02:42:41.7633306Z",
+          "source": "Microsoft.Storage",
+          "state": "Enabled"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "{encryption-scope-name}",
+        "type": "Microsoft.Storage/storageAccounts/encryptionScopes",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/resource-group-name/providers/Microsoft.Storage/storageAccounts/accountname/encryptionScopes/{encryption-scope-name}",
+        "properties": {
+          "creationTime": "2018-10-16T02:42:41.7633306Z",
+          "lastModifiedTime": "2018-10-16T02:42:41.7633306Z",
+          "source": "Microsoft.Storage",
+          "state": "Enabled"
+        }
+      }
+    }
+  },
+  "operationId": "EncryptionScopes_Put",
+  "title": "StorageAccountPutEncryptionScope"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountPutEncryptionScopeWithInfrastructureEncryption.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountPutEncryptionScopeWithInfrastructureEncryption.json
@@ -1,0 +1,47 @@
+{
+  "parameters": {
+    "accountName": "accountname",
+    "api-version": "2026-09-01",
+    "encryptionScope": {
+      "properties": {
+        "requireInfrastructureEncryption": true
+      }
+    },
+    "encryptionScopeName": "{encryption-scope-name}",
+    "monitor": "true",
+    "resourceGroupName": "resource-group-name",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "{encryption-scope-name}",
+        "type": "Microsoft.Storage/storageAccounts/encryptionScopes",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/resource-group-name/providers/Microsoft.Storage/storageAccounts/accountname/encryptionScopes/{encryption-scope-name}",
+        "properties": {
+          "creationTime": "2018-10-16T02:42:41.7633306Z",
+          "lastModifiedTime": "2018-10-16T02:42:41.7633306Z",
+          "requireInfrastructureEncryption": true,
+          "source": "Microsoft.Storage",
+          "state": "Enabled"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "{encryption-scope-name}",
+        "type": "Microsoft.Storage/storageAccounts/encryptionScopes",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/resource-group-name/providers/Microsoft.Storage/storageAccounts/accountname/encryptionScopes/{encryption-scope-name}",
+        "properties": {
+          "creationTime": "2018-10-16T02:42:41.7633306Z",
+          "lastModifiedTime": "2018-10-16T02:42:41.7633306Z",
+          "requireInfrastructureEncryption": true,
+          "source": "Microsoft.Storage",
+          "state": "Enabled"
+        }
+      }
+    }
+  },
+  "operationId": "EncryptionScopes_Put",
+  "title": "StorageAccountPutEncryptionScopeWithInfrastructureEncryption"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountPutPrivateEndpointConnection.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountPutPrivateEndpointConnection.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "accountName": "sto9699",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "privateEndpointConnectionName": "{privateEndpointConnectionName}",
+    "properties": {
+      "properties": {
+        "privateLinkServiceConnectionState": {
+          "description": "Auto-Approved",
+          "status": "Approved"
+        }
+      }
+    },
+    "resourceGroupName": "res7687",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "{privateEndpointConnectionName}",
+        "type": "Microsoft.Storage/storageAccounts/privateEndpointConnections",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res7231/providers/Microsoft.Storage/storageAccounts/sto288/privateEndpointConnections/{privateEndpointConnectionName}",
+        "properties": {
+          "privateEndpoint": {
+            "id": "/subscriptions/{subscription-id}/resourceGroups/res7231/providers/Microsoft.Network/privateEndpoints/petest01"
+          },
+          "privateLinkServiceConnectionState": {
+            "description": "Auto-Approved",
+            "actionRequired": "None",
+            "status": "Approved"
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "PrivateEndpointConnections_Put",
+  "title": "StorageAccountPutPrivateEndpointConnection"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountRegenerateKerbKey.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountRegenerateKerbKey.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "accountName": "sto3539",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "regenerateKey": {
+      "keyName": "kerb1"
+    },
+    "resourceGroupName": "res4167",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "keys": [
+          {
+            "keyName": "key1",
+            "permissions": "Full",
+            "value": "<value>"
+          },
+          {
+            "keyName": "key2",
+            "permissions": "Full",
+            "value": "<value>"
+          },
+          {
+            "keyName": "kerb1",
+            "permissions": "Full",
+            "value": "<value>"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "StorageAccounts_RegenerateKey",
+  "title": "StorageAccountRegenerateKerbKey"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountRegenerateKey.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountRegenerateKey.json
@@ -1,0 +1,32 @@
+{
+  "parameters": {
+    "accountName": "sto3539",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "regenerateKey": {
+      "keyName": "key2"
+    },
+    "resourceGroupName": "res4167",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "keys": [
+          {
+            "keyName": "key1",
+            "permissions": "Full",
+            "value": "<value>"
+          },
+          {
+            "keyName": "key2",
+            "permissions": "Full",
+            "value": "<value>"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "StorageAccounts_RegenerateKey",
+  "title": "StorageAccountRegenerateKey"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountRevokeUserDelegationKeys.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountRevokeUserDelegationKeys.json
@@ -1,0 +1,13 @@
+{
+  "parameters": {
+    "accountName": "sto3539",
+    "api-version": "2026-09-01",
+    "resourceGroupName": "res4167",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {}
+  },
+  "operationId": "StorageAccounts_RevokeUserDelegationKeys",
+  "title": "StorageAccountRevokeUserDelegationKeys"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountSetBlobInventoryPolicy.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountSetBlobInventoryPolicy.json
@@ -1,0 +1,162 @@
+{
+  "parameters": {
+    "accountName": "sto9699",
+    "api-version": "2026-09-01",
+    "blobInventoryPolicyName": "default",
+    "monitor": "true",
+    "properties": {
+      "properties": {
+        "policy": {
+          "type": "Inventory",
+          "enabled": true,
+          "rules": [
+            {
+              "name": "inventoryPolicyRule1",
+              "definition": {
+                "format": "Csv",
+                "filters": {
+                  "blobTypes": [
+                    "blockBlob",
+                    "appendBlob",
+                    "pageBlob"
+                  ],
+                  "creationTime": {
+                    "lastNDays": 1000
+                  },
+                  "includeBlobVersions": true,
+                  "includeSnapshots": true,
+                  "prefixMatch": [
+                    "inventoryprefix1",
+                    "inventoryprefix2"
+                  ]
+                },
+                "objectType": "Blob",
+                "schedule": "Daily",
+                "schemaFields": [
+                  "Name",
+                  "Creation-Time",
+                  "Last-Modified",
+                  "Content-Length",
+                  "Content-MD5",
+                  "BlobType",
+                  "AccessTier",
+                  "AccessTierChangeTime",
+                  "Snapshot",
+                  "VersionId",
+                  "IsCurrentVersion",
+                  "Metadata"
+                ]
+              },
+              "destination": "container1",
+              "enabled": true
+            },
+            {
+              "name": "inventoryPolicyRule2",
+              "definition": {
+                "format": "Parquet",
+                "objectType": "Container",
+                "schedule": "Weekly",
+                "schemaFields": [
+                  "Name",
+                  "Last-Modified",
+                  "Metadata",
+                  "LeaseStatus",
+                  "LeaseState",
+                  "LeaseDuration",
+                  "PublicAccess",
+                  "HasImmutabilityPolicy",
+                  "HasLegalHold"
+                ]
+              },
+              "destination": "container2",
+              "enabled": true
+            }
+          ]
+        }
+      }
+    },
+    "resourceGroupName": "res7687",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "DefaultInventoryPolicy",
+        "type": "Microsoft.Storage/storageAccounts/inventoryPolicies",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res7687/providers/Microsoft.Storage/storageAccounts/sto9699/inventoryPolicies/default",
+        "properties": {
+          "lastModifiedTime": "2020-10-05T02:53:39.0932539Z",
+          "policy": {
+            "type": "Inventory",
+            "enabled": true,
+            "rules": [
+              {
+                "name": "inventoryPolicyRule1",
+                "definition": {
+                  "format": "Csv",
+                  "filters": {
+                    "blobTypes": [
+                      "blockBlob",
+                      "appendBlob",
+                      "pageBlob"
+                    ],
+                    "creationTime": {
+                      "lastNDays": 1000
+                    },
+                    "includeBlobVersions": true,
+                    "includeSnapshots": true,
+                    "prefixMatch": [
+                      "inventoryprefix1",
+                      "inventoryprefix2"
+                    ]
+                  },
+                  "objectType": "Blob",
+                  "schedule": "Daily",
+                  "schemaFields": [
+                    "Name",
+                    "Creation-Time",
+                    "Last-Modified",
+                    "Content-Length",
+                    "Content-MD5",
+                    "BlobType",
+                    "AccessTier",
+                    "AccessTierChangeTime",
+                    "Snapshot",
+                    "VersionId",
+                    "IsCurrentVersion",
+                    "Metadata"
+                  ]
+                },
+                "destination": "container1",
+                "enabled": true
+              },
+              {
+                "name": "inventoryPolicyRule2",
+                "definition": {
+                  "format": "Parquet",
+                  "objectType": "Container",
+                  "schedule": "Weekly",
+                  "schemaFields": [
+                    "Name",
+                    "Last-Modified",
+                    "Metadata",
+                    "LeaseStatus",
+                    "LeaseState",
+                    "LeaseDuration",
+                    "PublicAccess",
+                    "HasImmutabilityPolicy",
+                    "HasLegalHold"
+                  ]
+                },
+                "destination": "container2",
+                "enabled": true
+              }
+            ]
+          }
+        }
+      }
+    }
+  },
+  "operationId": "BlobInventoryPolicies_CreateOrUpdate",
+  "title": "StorageAccountSetBlobInventoryPolicy"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountSetBlobInventoryPolicyIncludeDeleteAndNewSchemaForHnsAccount.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountSetBlobInventoryPolicyIncludeDeleteAndNewSchemaForHnsAccount.json
@@ -1,0 +1,199 @@
+{
+  "parameters": {
+    "accountName": "sto9699",
+    "api-version": "2026-09-01",
+    "blobInventoryPolicyName": "default",
+    "monitor": "true",
+    "properties": {
+      "properties": {
+        "policy": {
+          "type": "Inventory",
+          "enabled": true,
+          "rules": [
+            {
+              "name": "inventoryPolicyRule1",
+              "definition": {
+                "format": "Csv",
+                "filters": {
+                  "blobTypes": [
+                    "blockBlob",
+                    "appendBlob",
+                    "pageBlob"
+                  ],
+                  "excludePrefix": [
+                    "excludeprefix1",
+                    "excludeprefix2"
+                  ],
+                  "includeBlobVersions": true,
+                  "includeDeleted": true,
+                  "includeSnapshots": true,
+                  "prefixMatch": [
+                    "inventoryprefix1",
+                    "inventoryprefix2"
+                  ]
+                },
+                "objectType": "Blob",
+                "schedule": "Daily",
+                "schemaFields": [
+                  "Name",
+                  "Creation-Time",
+                  "Last-Modified",
+                  "Content-Length",
+                  "Content-MD5",
+                  "BlobType",
+                  "AccessTier",
+                  "AccessTierChangeTime",
+                  "Snapshot",
+                  "VersionId",
+                  "IsCurrentVersion",
+                  "ContentType",
+                  "ContentEncoding",
+                  "ContentLanguage",
+                  "ContentCRC64",
+                  "CacheControl",
+                  "Metadata",
+                  "DeletionId",
+                  "Deleted",
+                  "DeletedTime",
+                  "RemainingRetentionDays"
+                ]
+              },
+              "destination": "container1",
+              "enabled": true
+            },
+            {
+              "name": "inventoryPolicyRule2",
+              "definition": {
+                "format": "Parquet",
+                "objectType": "Container",
+                "schedule": "Weekly",
+                "schemaFields": [
+                  "Name",
+                  "Last-Modified",
+                  "Metadata",
+                  "LeaseStatus",
+                  "LeaseState",
+                  "LeaseDuration",
+                  "PublicAccess",
+                  "HasImmutabilityPolicy",
+                  "HasLegalHold",
+                  "Etag",
+                  "DefaultEncryptionScope",
+                  "DenyEncryptionScopeOverride",
+                  "ImmutableStorageWithVersioningEnabled",
+                  "Deleted",
+                  "Version",
+                  "DeletedTime",
+                  "RemainingRetentionDays"
+                ]
+              },
+              "destination": "container2",
+              "enabled": true
+            }
+          ]
+        }
+      }
+    },
+    "resourceGroupName": "res7687",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "DefaultInventoryPolicy",
+        "type": "Microsoft.Storage/storageAccounts/inventoryPolicies",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res7687/providers/Microsoft.Storage/storageAccounts/sto9699/inventoryPolicies/default",
+        "properties": {
+          "policy": {
+            "type": "Inventory",
+            "enabled": true,
+            "rules": [
+              {
+                "name": "inventoryPolicyRule1",
+                "definition": {
+                  "format": "Csv",
+                  "filters": {
+                    "blobTypes": [
+                      "blockBlob",
+                      "appendBlob",
+                      "pageBlob"
+                    ],
+                    "excludePrefix": [
+                      "excludeprefix1",
+                      "excludeprefix2"
+                    ],
+                    "includeBlobVersions": true,
+                    "includeDeleted": true,
+                    "includeSnapshots": true,
+                    "prefixMatch": [
+                      "inventoryprefix1",
+                      "inventoryprefix2"
+                    ]
+                  },
+                  "objectType": "Blob",
+                  "schedule": "Daily",
+                  "schemaFields": [
+                    "Name",
+                    "Creation-Time",
+                    "Last-Modified",
+                    "Content-Length",
+                    "Content-MD5",
+                    "BlobType",
+                    "AccessTier",
+                    "AccessTierChangeTime",
+                    "Snapshot",
+                    "VersionId",
+                    "IsCurrentVersion",
+                    "ContentType",
+                    "ContentEncoding",
+                    "ContentLanguage",
+                    "ContentCRC64",
+                    "CacheControl",
+                    "Metadata",
+                    "DeletionId",
+                    "Deleted",
+                    "DeletedTime",
+                    "RemainingRetentionDays"
+                  ]
+                },
+                "destination": "container1",
+                "enabled": true
+              },
+              {
+                "name": "inventoryPolicyRule2",
+                "definition": {
+                  "format": "Parquet",
+                  "objectType": "Container",
+                  "schedule": "Weekly",
+                  "schemaFields": [
+                    "Name",
+                    "Last-Modified",
+                    "Metadata",
+                    "LeaseStatus",
+                    "LeaseState",
+                    "LeaseDuration",
+                    "PublicAccess",
+                    "HasImmutabilityPolicy",
+                    "HasLegalHold",
+                    "Etag",
+                    "DefaultEncryptionScope",
+                    "DenyEncryptionScopeOverride",
+                    "ImmutableStorageWithVersioningEnabled",
+                    "Deleted",
+                    "Version",
+                    "DeletedTime",
+                    "RemainingRetentionDays"
+                  ]
+                },
+                "destination": "container2",
+                "enabled": true
+              }
+            ]
+          }
+        }
+      }
+    }
+  },
+  "operationId": "BlobInventoryPolicies_CreateOrUpdate",
+  "title": "StorageAccountSetBlobInventoryPolicyIncludeDeleteAndNewSchemaForHnsAccount"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountSetBlobInventoryPolicyIncludeDeleteAndNewSchemaForNonHnsAccount.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountSetBlobInventoryPolicyIncludeDeleteAndNewSchemaForNonHnsAccount.json
@@ -1,0 +1,197 @@
+{
+  "parameters": {
+    "accountName": "sto9699",
+    "api-version": "2026-09-01",
+    "blobInventoryPolicyName": "default",
+    "monitor": "true",
+    "properties": {
+      "properties": {
+        "policy": {
+          "type": "Inventory",
+          "enabled": true,
+          "rules": [
+            {
+              "name": "inventoryPolicyRule1",
+              "definition": {
+                "format": "Csv",
+                "filters": {
+                  "blobTypes": [
+                    "blockBlob",
+                    "appendBlob",
+                    "pageBlob"
+                  ],
+                  "excludePrefix": [
+                    "excludeprefix1",
+                    "excludeprefix2"
+                  ],
+                  "includeBlobVersions": true,
+                  "includeDeleted": true,
+                  "includeSnapshots": true,
+                  "prefixMatch": [
+                    "inventoryprefix1",
+                    "inventoryprefix2"
+                  ]
+                },
+                "objectType": "Blob",
+                "schedule": "Daily",
+                "schemaFields": [
+                  "Name",
+                  "Creation-Time",
+                  "Last-Modified",
+                  "Content-Length",
+                  "Content-MD5",
+                  "BlobType",
+                  "AccessTier",
+                  "AccessTierChangeTime",
+                  "Snapshot",
+                  "VersionId",
+                  "IsCurrentVersion",
+                  "Tags",
+                  "ContentType",
+                  "ContentEncoding",
+                  "ContentLanguage",
+                  "ContentCRC64",
+                  "CacheControl",
+                  "Metadata",
+                  "Deleted",
+                  "RemainingRetentionDays"
+                ]
+              },
+              "destination": "container1",
+              "enabled": true
+            },
+            {
+              "name": "inventoryPolicyRule2",
+              "definition": {
+                "format": "Parquet",
+                "objectType": "Container",
+                "schedule": "Weekly",
+                "schemaFields": [
+                  "Name",
+                  "Last-Modified",
+                  "Metadata",
+                  "LeaseStatus",
+                  "LeaseState",
+                  "LeaseDuration",
+                  "PublicAccess",
+                  "HasImmutabilityPolicy",
+                  "HasLegalHold",
+                  "Etag",
+                  "DefaultEncryptionScope",
+                  "DenyEncryptionScopeOverride",
+                  "ImmutableStorageWithVersioningEnabled",
+                  "Deleted",
+                  "Version",
+                  "DeletedTime",
+                  "RemainingRetentionDays"
+                ]
+              },
+              "destination": "container2",
+              "enabled": true
+            }
+          ]
+        }
+      }
+    },
+    "resourceGroupName": "res7687",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "DefaultInventoryPolicy",
+        "type": "Microsoft.Storage/storageAccounts/inventoryPolicies",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res7687/providers/Microsoft.Storage/storageAccounts/sto9699/inventoryPolicies/default",
+        "properties": {
+          "policy": {
+            "type": "Inventory",
+            "enabled": true,
+            "rules": [
+              {
+                "name": "inventoryPolicyRule1",
+                "definition": {
+                  "format": "Csv",
+                  "filters": {
+                    "blobTypes": [
+                      "blockBlob",
+                      "appendBlob",
+                      "pageBlob"
+                    ],
+                    "excludePrefix": [
+                      "excludeprefix1",
+                      "excludeprefix2"
+                    ],
+                    "includeBlobVersions": true,
+                    "includeDeleted": true,
+                    "includeSnapshots": true,
+                    "prefixMatch": [
+                      "inventoryprefix1",
+                      "inventoryprefix2"
+                    ]
+                  },
+                  "objectType": "Blob",
+                  "schedule": "Daily",
+                  "schemaFields": [
+                    "Name",
+                    "Creation-Time",
+                    "Last-Modified",
+                    "Content-Length",
+                    "Content-MD5",
+                    "BlobType",
+                    "AccessTier",
+                    "AccessTierChangeTime",
+                    "Snapshot",
+                    "VersionId",
+                    "IsCurrentVersion",
+                    "Tags",
+                    "ContentType",
+                    "ContentEncoding",
+                    "ContentLanguage",
+                    "ContentCRC64",
+                    "CacheControl",
+                    "Metadata",
+                    "Deleted",
+                    "RemainingRetentionDays"
+                  ]
+                },
+                "destination": "container1",
+                "enabled": true
+              },
+              {
+                "name": "inventoryPolicyRule2",
+                "definition": {
+                  "format": "Parquet",
+                  "objectType": "Container",
+                  "schedule": "Weekly",
+                  "schemaFields": [
+                    "Name",
+                    "Last-Modified",
+                    "Metadata",
+                    "LeaseStatus",
+                    "LeaseState",
+                    "LeaseDuration",
+                    "PublicAccess",
+                    "HasImmutabilityPolicy",
+                    "HasLegalHold",
+                    "Etag",
+                    "DefaultEncryptionScope",
+                    "DenyEncryptionScopeOverride",
+                    "ImmutableStorageWithVersioningEnabled",
+                    "Deleted",
+                    "Version",
+                    "DeletedTime",
+                    "RemainingRetentionDays"
+                  ]
+                },
+                "destination": "container2",
+                "enabled": true
+              }
+            ]
+          }
+        }
+      }
+    }
+  },
+  "operationId": "BlobInventoryPolicies_CreateOrUpdate",
+  "title": "StorageAccountSetBlobInventoryPolicyIncludeDeleteAndNewSchemaForNonHnsAccount"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountSetManagementPolicy.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountSetManagementPolicy.json
@@ -1,0 +1,182 @@
+{
+  "parameters": {
+    "accountName": "sto9699",
+    "api-version": "2026-09-01",
+    "managementPolicyName": "default",
+    "monitor": "true",
+    "properties": {
+      "properties": {
+        "policy": {
+          "rules": [
+            {
+              "name": "olcmtest1",
+              "type": "Lifecycle",
+              "definition": {
+                "actions": {
+                  "baseBlob": {
+                    "delete": {
+                      "daysAfterModificationGreaterThan": 1000
+                    },
+                    "tierToArchive": {
+                      "daysAfterModificationGreaterThan": 90
+                    },
+                    "tierToCool": {
+                      "daysAfterModificationGreaterThan": 30
+                    }
+                  },
+                  "snapshot": {
+                    "delete": {
+                      "daysAfterCreationGreaterThan": 30
+                    }
+                  }
+                },
+                "filters": {
+                  "blobTypes": [
+                    "blockBlob"
+                  ],
+                  "prefixMatch": [
+                    "olcmtestcontainer1"
+                  ]
+                }
+              },
+              "enabled": true
+            },
+            {
+              "name": "olcmtest2",
+              "type": "Lifecycle",
+              "definition": {
+                "actions": {
+                  "baseBlob": {
+                    "delete": {
+                      "daysAfterModificationGreaterThan": 1000
+                    },
+                    "tierToArchive": {
+                      "daysAfterModificationGreaterThan": 90
+                    },
+                    "tierToCool": {
+                      "daysAfterModificationGreaterThan": 30
+                    }
+                  }
+                },
+                "filters": {
+                  "blobIndexMatch": [
+                    {
+                      "name": "tag1",
+                      "op": "==",
+                      "value": "val1"
+                    },
+                    {
+                      "name": "tag2",
+                      "op": "==",
+                      "value": "val2"
+                    }
+                  ],
+                  "blobTypes": [
+                    "blockBlob"
+                  ],
+                  "prefixMatch": [
+                    "olcmtestcontainer2"
+                  ]
+                }
+              },
+              "enabled": true
+            }
+          ]
+        }
+      }
+    },
+    "resourceGroupName": "res7687",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "DefaultManagementPolicy",
+        "type": "Microsoft.Storage/storageAccounts/managementPolicies",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res7231/providers/Microsoft.Storage/storageAccounts/sto288/managementPolicies/default",
+        "properties": {
+          "lastModifiedTime": "2018-06-08T02:53:39.0932539Z",
+          "policy": {
+            "rules": [
+              {
+                "name": "olcmtest1",
+                "type": "Lifecycle",
+                "definition": {
+                  "actions": {
+                    "baseBlob": {
+                      "delete": {
+                        "daysAfterModificationGreaterThan": 1000
+                      },
+                      "tierToArchive": {
+                        "daysAfterModificationGreaterThan": 90
+                      },
+                      "tierToCool": {
+                        "daysAfterModificationGreaterThan": 30
+                      }
+                    },
+                    "snapshot": {
+                      "delete": {
+                        "daysAfterCreationGreaterThan": 30
+                      }
+                    }
+                  },
+                  "filters": {
+                    "blobTypes": [
+                      "blockBlob"
+                    ],
+                    "prefixMatch": [
+                      "olcmtestcontainer1"
+                    ]
+                  }
+                },
+                "enabled": true
+              },
+              {
+                "name": "olcmtest2",
+                "type": "Lifecycle",
+                "definition": {
+                  "actions": {
+                    "baseBlob": {
+                      "delete": {
+                        "daysAfterModificationGreaterThan": 1000
+                      },
+                      "tierToArchive": {
+                        "daysAfterModificationGreaterThan": 90
+                      },
+                      "tierToCool": {
+                        "daysAfterModificationGreaterThan": 30
+                      }
+                    }
+                  },
+                  "filters": {
+                    "blobIndexMatch": [
+                      {
+                        "name": "tag1",
+                        "op": "==",
+                        "value": "val1"
+                      },
+                      {
+                        "name": "tag2",
+                        "op": "==",
+                        "value": "val2"
+                      }
+                    ],
+                    "blobTypes": [
+                      "blockBlob"
+                    ],
+                    "prefixMatch": [
+                      "olcmtestcontainer2"
+                    ]
+                  }
+                },
+                "enabled": true
+              }
+            ]
+          }
+        }
+      }
+    }
+  },
+  "operationId": "ManagementPolicies_CreateOrUpdate",
+  "title": "StorageAccountSetManagementPolicies"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountSetManagementPolicyColdTierActions.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountSetManagementPolicyColdTierActions.json
@@ -1,0 +1,130 @@
+{
+  "parameters": {
+    "accountName": "sto9699",
+    "api-version": "2026-09-01",
+    "managementPolicyName": "default",
+    "monitor": "true",
+    "properties": {
+      "properties": {
+        "policy": {
+          "rules": [
+            {
+              "name": "olcmtest1",
+              "type": "Lifecycle",
+              "definition": {
+                "actions": {
+                  "baseBlob": {
+                    "delete": {
+                      "daysAfterModificationGreaterThan": 1000
+                    },
+                    "tierToArchive": {
+                      "daysAfterModificationGreaterThan": 90
+                    },
+                    "tierToCold": {
+                      "daysAfterModificationGreaterThan": 30
+                    },
+                    "tierToCool": {
+                      "daysAfterModificationGreaterThan": 30
+                    }
+                  },
+                  "snapshot": {
+                    "delete": {
+                      "daysAfterCreationGreaterThan": 30
+                    },
+                    "tierToCold": {
+                      "daysAfterCreationGreaterThan": 30
+                    }
+                  },
+                  "version": {
+                    "delete": {
+                      "daysAfterCreationGreaterThan": 30
+                    },
+                    "tierToCold": {
+                      "daysAfterCreationGreaterThan": 30
+                    }
+                  }
+                },
+                "filters": {
+                  "blobTypes": [
+                    "blockBlob"
+                  ],
+                  "prefixMatch": [
+                    "olcmtestcontainer1"
+                  ]
+                }
+              },
+              "enabled": true
+            }
+          ]
+        }
+      }
+    },
+    "resourceGroupName": "res7687",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "DefaultManagementPolicy",
+        "type": "Microsoft.Storage/storageAccounts/managementPolicies",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res7231/providers/Microsoft.Storage/storageAccounts/sto288/managementPolicies/default",
+        "properties": {
+          "lastModifiedTime": "2021-06-08T02:53:39.0932539Z",
+          "policy": {
+            "rules": [
+              {
+                "name": "olcmtest1",
+                "type": "Lifecycle",
+                "definition": {
+                  "actions": {
+                    "baseBlob": {
+                      "delete": {
+                        "daysAfterModificationGreaterThan": 1000
+                      },
+                      "tierToArchive": {
+                        "daysAfterModificationGreaterThan": 90
+                      },
+                      "tierToCold": {
+                        "daysAfterModificationGreaterThan": 30
+                      },
+                      "tierToCool": {
+                        "daysAfterModificationGreaterThan": 30
+                      }
+                    },
+                    "snapshot": {
+                      "delete": {
+                        "daysAfterCreationGreaterThan": 30
+                      },
+                      "tierToCold": {
+                        "daysAfterCreationGreaterThan": 30
+                      }
+                    },
+                    "version": {
+                      "delete": {
+                        "daysAfterCreationGreaterThan": 30
+                      },
+                      "tierToCold": {
+                        "daysAfterCreationGreaterThan": 30
+                      }
+                    }
+                  },
+                  "filters": {
+                    "blobTypes": [
+                      "blockBlob"
+                    ],
+                    "prefixMatch": [
+                      "olcmtestcontainer1"
+                    ]
+                  }
+                },
+                "enabled": true
+              }
+            ]
+          }
+        }
+      }
+    }
+  },
+  "operationId": "ManagementPolicies_CreateOrUpdate",
+  "title": "StorageAccountSetManagementPolicyColdTierActions"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountSetManagementPolicyForBlockAndAppendBlobs.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountSetManagementPolicyForBlockAndAppendBlobs.json
@@ -1,0 +1,102 @@
+{
+  "parameters": {
+    "accountName": "sto9699",
+    "api-version": "2026-09-01",
+    "managementPolicyName": "default",
+    "monitor": "true",
+    "properties": {
+      "properties": {
+        "policy": {
+          "rules": [
+            {
+              "name": "olcmtest1",
+              "type": "Lifecycle",
+              "definition": {
+                "actions": {
+                  "baseBlob": {
+                    "delete": {
+                      "daysAfterModificationGreaterThan": 90
+                    }
+                  },
+                  "snapshot": {
+                    "delete": {
+                      "daysAfterCreationGreaterThan": 90
+                    }
+                  },
+                  "version": {
+                    "delete": {
+                      "daysAfterCreationGreaterThan": 90
+                    }
+                  }
+                },
+                "filters": {
+                  "blobTypes": [
+                    "blockBlob",
+                    "appendBlob"
+                  ],
+                  "prefixMatch": [
+                    "olcmtestcontainer1"
+                  ]
+                }
+              },
+              "enabled": true
+            }
+          ]
+        }
+      }
+    },
+    "resourceGroupName": "res7687",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "DefaultManagementPolicy",
+        "type": "Microsoft.Storage/storageAccounts/managementPolicies",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res7231/providers/Microsoft.Storage/storageAccounts/sto288/managementPolicies/default",
+        "properties": {
+          "lastModifiedTime": "2018-06-08T02:53:39.0932539Z",
+          "policy": {
+            "rules": [
+              {
+                "name": "olcmtest1",
+                "type": "Lifecycle",
+                "definition": {
+                  "actions": {
+                    "baseBlob": {
+                      "delete": {
+                        "daysAfterModificationGreaterThan": 90
+                      }
+                    },
+                    "snapshot": {
+                      "delete": {
+                        "daysAfterCreationGreaterThan": 90
+                      }
+                    },
+                    "version": {
+                      "delete": {
+                        "daysAfterCreationGreaterThan": 90
+                      }
+                    }
+                  },
+                  "filters": {
+                    "blobTypes": [
+                      "blockBlob",
+                      "appendBlob"
+                    ],
+                    "prefixMatch": [
+                      "olcmtestcontainer1"
+                    ]
+                  }
+                },
+                "enabled": true
+              }
+            ]
+          }
+        }
+      }
+    }
+  },
+  "operationId": "ManagementPolicies_CreateOrUpdate",
+  "title": "StorageAccountSetManagementPolicyForBlockAndAppendBlobs"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountSetManagementPolicyHotTierActions.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountSetManagementPolicyHotTierActions.json
@@ -1,0 +1,100 @@
+{
+  "parameters": {
+    "accountName": "sto9699",
+    "api-version": "2026-09-01",
+    "managementPolicyName": "default",
+    "monitor": "true",
+    "properties": {
+      "properties": {
+        "policy": {
+          "rules": [
+            {
+              "name": "olcmtest1",
+              "type": "Lifecycle",
+              "definition": {
+                "actions": {
+                  "baseBlob": {
+                    "tierToHot": {
+                      "daysAfterModificationGreaterThan": 30
+                    }
+                  },
+                  "snapshot": {
+                    "tierToHot": {
+                      "daysAfterCreationGreaterThan": 30
+                    }
+                  },
+                  "version": {
+                    "tierToHot": {
+                      "daysAfterCreationGreaterThan": 30
+                    }
+                  }
+                },
+                "filters": {
+                  "blobTypes": [
+                    "blockBlob"
+                  ],
+                  "prefixMatch": [
+                    "olcmtestcontainer1"
+                  ]
+                }
+              },
+              "enabled": true
+            }
+          ]
+        }
+      }
+    },
+    "resourceGroupName": "res7687",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "DefaultManagementPolicy",
+        "type": "Microsoft.Storage/storageAccounts/managementPolicies",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res7231/providers/Microsoft.Storage/storageAccounts/sto288/managementPolicies/default",
+        "properties": {
+          "lastModifiedTime": "2021-06-08T02:53:39.0932539Z",
+          "policy": {
+            "rules": [
+              {
+                "name": "olcmtest1",
+                "type": "Lifecycle",
+                "definition": {
+                  "actions": {
+                    "baseBlob": {
+                      "tierToHot": {
+                        "daysAfterModificationGreaterThan": 30
+                      }
+                    },
+                    "snapshot": {
+                      "tierToHot": {
+                        "daysAfterCreationGreaterThan": 30
+                      }
+                    },
+                    "version": {
+                      "tierToHot": {
+                        "daysAfterCreationGreaterThan": 30
+                      }
+                    }
+                  },
+                  "filters": {
+                    "blobTypes": [
+                      "blockBlob"
+                    ],
+                    "prefixMatch": [
+                      "olcmtestcontainer1"
+                    ]
+                  }
+                },
+                "enabled": true
+              }
+            ]
+          }
+        }
+      }
+    }
+  },
+  "operationId": "ManagementPolicies_CreateOrUpdate",
+  "title": "StorageAccountSetManagementPolicyHotTierActions"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountSetManagementPolicyWithSnapshotAndVersion.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountSetManagementPolicyWithSnapshotAndVersion.json
@@ -1,0 +1,136 @@
+{
+  "parameters": {
+    "accountName": "sto9699",
+    "api-version": "2026-09-01",
+    "managementPolicyName": "default",
+    "monitor": "true",
+    "properties": {
+      "properties": {
+        "policy": {
+          "rules": [
+            {
+              "name": "olcmtest1",
+              "type": "Lifecycle",
+              "definition": {
+                "actions": {
+                  "baseBlob": {
+                    "delete": {
+                      "daysAfterModificationGreaterThan": 1000
+                    },
+                    "tierToArchive": {
+                      "daysAfterModificationGreaterThan": 90
+                    },
+                    "tierToCool": {
+                      "daysAfterModificationGreaterThan": 30
+                    }
+                  },
+                  "snapshot": {
+                    "delete": {
+                      "daysAfterCreationGreaterThan": 1000
+                    },
+                    "tierToArchive": {
+                      "daysAfterCreationGreaterThan": 90
+                    },
+                    "tierToCool": {
+                      "daysAfterCreationGreaterThan": 30
+                    }
+                  },
+                  "version": {
+                    "delete": {
+                      "daysAfterCreationGreaterThan": 1000
+                    },
+                    "tierToArchive": {
+                      "daysAfterCreationGreaterThan": 90
+                    },
+                    "tierToCool": {
+                      "daysAfterCreationGreaterThan": 30
+                    }
+                  }
+                },
+                "filters": {
+                  "blobTypes": [
+                    "blockBlob"
+                  ],
+                  "prefixMatch": [
+                    "olcmtestcontainer1"
+                  ]
+                }
+              },
+              "enabled": true
+            }
+          ]
+        }
+      }
+    },
+    "resourceGroupName": "res7687",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "DefaultManagementPolicy",
+        "type": "Microsoft.Storage/storageAccounts/managementPolicies",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res7231/providers/Microsoft.Storage/storageAccounts/sto288/managementPolicies/default",
+        "properties": {
+          "lastModifiedTime": "2018-06-08T02:53:39.0932539Z",
+          "policy": {
+            "rules": [
+              {
+                "name": "olcmtest1",
+                "type": "Lifecycle",
+                "definition": {
+                  "actions": {
+                    "baseBlob": {
+                      "delete": {
+                        "daysAfterModificationGreaterThan": 1000
+                      },
+                      "tierToArchive": {
+                        "daysAfterModificationGreaterThan": 90
+                      },
+                      "tierToCool": {
+                        "daysAfterModificationGreaterThan": 30
+                      }
+                    },
+                    "snapshot": {
+                      "delete": {
+                        "daysAfterCreationGreaterThan": 1000
+                      },
+                      "tierToArchive": {
+                        "daysAfterCreationGreaterThan": 90
+                      },
+                      "tierToCool": {
+                        "daysAfterCreationGreaterThan": 30
+                      }
+                    },
+                    "version": {
+                      "delete": {
+                        "daysAfterCreationGreaterThan": 1000
+                      },
+                      "tierToArchive": {
+                        "daysAfterCreationGreaterThan": 90
+                      },
+                      "tierToCool": {
+                        "daysAfterCreationGreaterThan": 30
+                      }
+                    }
+                  },
+                  "filters": {
+                    "blobTypes": [
+                      "blockBlob"
+                    ],
+                    "prefixMatch": [
+                      "olcmtestcontainer1"
+                    ]
+                  }
+                },
+                "enabled": true
+              }
+            ]
+          }
+        }
+      }
+    }
+  },
+  "operationId": "ManagementPolicies_CreateOrUpdate",
+  "title": "StorageAccountSetManagementPolicyWithSnapshotAndVersion"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountSetManagementPolicy_BaseBlobDaysAfterCreationActions.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountSetManagementPolicy_BaseBlobDaysAfterCreationActions.json
@@ -1,0 +1,92 @@
+{
+  "parameters": {
+    "accountName": "sto9699",
+    "api-version": "2026-09-01",
+    "managementPolicyName": "default",
+    "monitor": "true",
+    "properties": {
+      "properties": {
+        "policy": {
+          "rules": [
+            {
+              "name": "olcmtest1",
+              "type": "Lifecycle",
+              "definition": {
+                "actions": {
+                  "baseBlob": {
+                    "delete": {
+                      "daysAfterCreationGreaterThan": 1000
+                    },
+                    "tierToArchive": {
+                      "daysAfterCreationGreaterThan": 90
+                    },
+                    "tierToCool": {
+                      "daysAfterCreationGreaterThan": 30
+                    }
+                  }
+                },
+                "filters": {
+                  "blobTypes": [
+                    "blockBlob"
+                  ],
+                  "prefixMatch": [
+                    "olcmtestcontainer1"
+                  ]
+                }
+              },
+              "enabled": true
+            }
+          ]
+        }
+      }
+    },
+    "resourceGroupName": "res7687",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "DefaultManagementPolicy",
+        "type": "Microsoft.Storage/storageAccounts/managementPolicies",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res7231/providers/Microsoft.Storage/storageAccounts/sto288/managementPolicies/default",
+        "properties": {
+          "lastModifiedTime": "2021-06-08T02:53:39.0932539Z",
+          "policy": {
+            "rules": [
+              {
+                "name": "olcmtest1",
+                "type": "Lifecycle",
+                "definition": {
+                  "actions": {
+                    "baseBlob": {
+                      "delete": {
+                        "daysAfterCreationGreaterThan": 1000
+                      },
+                      "tierToArchive": {
+                        "daysAfterCreationGreaterThan": 90
+                      },
+                      "tierToCool": {
+                        "daysAfterCreationGreaterThan": 30
+                      }
+                    }
+                  },
+                  "filters": {
+                    "blobTypes": [
+                      "blockBlob"
+                    ],
+                    "prefixMatch": [
+                      "olcmtestcontainer1"
+                    ]
+                  }
+                },
+                "enabled": true
+              }
+            ]
+          }
+        }
+      }
+    }
+  },
+  "operationId": "ManagementPolicies_CreateOrUpdate",
+  "title": "StorageAccountSetManagementPolicy_BaseBlobDaysAfterCreationActions"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountSetManagementPolicy_LastAccessTimeBasedBlobActions.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountSetManagementPolicy_LastAccessTimeBasedBlobActions.json
@@ -1,0 +1,104 @@
+{
+  "parameters": {
+    "accountName": "sto9699",
+    "api-version": "2026-09-01",
+    "managementPolicyName": "default",
+    "monitor": "true",
+    "properties": {
+      "properties": {
+        "policy": {
+          "rules": [
+            {
+              "name": "olcmtest",
+              "type": "Lifecycle",
+              "definition": {
+                "actions": {
+                  "baseBlob": {
+                    "delete": {
+                      "daysAfterLastAccessTimeGreaterThan": 1000
+                    },
+                    "enableAutoTierToHotFromCool": true,
+                    "tierToArchive": {
+                      "daysAfterLastAccessTimeGreaterThan": 90
+                    },
+                    "tierToCool": {
+                      "daysAfterLastAccessTimeGreaterThan": 30
+                    }
+                  },
+                  "snapshot": {
+                    "delete": {
+                      "daysAfterCreationGreaterThan": 30
+                    }
+                  }
+                },
+                "filters": {
+                  "blobTypes": [
+                    "blockBlob"
+                  ],
+                  "prefixMatch": [
+                    "olcmtestcontainer"
+                  ]
+                }
+              },
+              "enabled": true
+            }
+          ]
+        }
+      }
+    },
+    "resourceGroupName": "res7687",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "DefaultManagementPolicy",
+        "type": "Microsoft.Storage/storageAccounts/managementPolicies",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res7231/providers/Microsoft.Storage/storageAccounts/sto288/managementPolicies/default",
+        "properties": {
+          "lastModifiedTime": "2018-06-08T02:53:39.0932539Z",
+          "policy": {
+            "rules": [
+              {
+                "name": "olcmtest",
+                "type": "Lifecycle",
+                "definition": {
+                  "actions": {
+                    "baseBlob": {
+                      "delete": {
+                        "daysAfterLastAccessTimeGreaterThan": 1000
+                      },
+                      "enableAutoTierToHotFromCool": true,
+                      "tierToArchive": {
+                        "daysAfterLastAccessTimeGreaterThan": 90
+                      },
+                      "tierToCool": {
+                        "daysAfterLastAccessTimeGreaterThan": 30
+                      }
+                    },
+                    "snapshot": {
+                      "delete": {
+                        "daysAfterCreationGreaterThan": 30
+                      }
+                    }
+                  },
+                  "filters": {
+                    "blobTypes": [
+                      "blockBlob"
+                    ],
+                    "prefixMatch": [
+                      "olcmtestcontainer"
+                    ]
+                  }
+                },
+                "enabled": true
+              }
+            ]
+          }
+        }
+      }
+    }
+  },
+  "operationId": "ManagementPolicies_CreateOrUpdate",
+  "title": "StorageAccountSetManagementPolicy_LastAccessTimeBasedBlobActions"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountSetManagementPolicy_LastTierChangeTimeActions.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountSetManagementPolicy_LastTierChangeTimeActions.json
@@ -1,0 +1,118 @@
+{
+  "parameters": {
+    "accountName": "sto9699",
+    "api-version": "2026-09-01",
+    "managementPolicyName": "default",
+    "monitor": "true",
+    "properties": {
+      "properties": {
+        "policy": {
+          "rules": [
+            {
+              "name": "olcmtest",
+              "type": "Lifecycle",
+              "definition": {
+                "actions": {
+                  "baseBlob": {
+                    "delete": {
+                      "daysAfterModificationGreaterThan": 1000
+                    },
+                    "tierToArchive": {
+                      "daysAfterLastTierChangeGreaterThan": 120,
+                      "daysAfterModificationGreaterThan": 90
+                    },
+                    "tierToCool": {
+                      "daysAfterModificationGreaterThan": 30
+                    }
+                  },
+                  "snapshot": {
+                    "tierToArchive": {
+                      "daysAfterCreationGreaterThan": 30,
+                      "daysAfterLastTierChangeGreaterThan": 90
+                    }
+                  },
+                  "version": {
+                    "tierToArchive": {
+                      "daysAfterCreationGreaterThan": 30,
+                      "daysAfterLastTierChangeGreaterThan": 90
+                    }
+                  }
+                },
+                "filters": {
+                  "blobTypes": [
+                    "blockBlob"
+                  ],
+                  "prefixMatch": [
+                    "olcmtestcontainer"
+                  ]
+                }
+              },
+              "enabled": true
+            }
+          ]
+        }
+      }
+    },
+    "resourceGroupName": "res7687",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "DefaultManagementPolicy",
+        "type": "Microsoft.Storage/storageAccounts/managementPolicies",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res7231/providers/Microsoft.Storage/storageAccounts/sto288/managementPolicies/default",
+        "properties": {
+          "lastModifiedTime": "2018-06-08T02:53:39.0932539Z",
+          "policy": {
+            "rules": [
+              {
+                "name": "olcmtest",
+                "type": "Lifecycle",
+                "definition": {
+                  "actions": {
+                    "baseBlob": {
+                      "delete": {
+                        "daysAfterModificationGreaterThan": 1000
+                      },
+                      "tierToArchive": {
+                        "daysAfterLastTierChangeGreaterThan": 120,
+                        "daysAfterModificationGreaterThan": 90
+                      },
+                      "tierToCool": {
+                        "daysAfterModificationGreaterThan": 30
+                      }
+                    },
+                    "snapshot": {
+                      "tierToArchive": {
+                        "daysAfterCreationGreaterThan": 30,
+                        "daysAfterLastTierChangeGreaterThan": 90
+                      }
+                    },
+                    "version": {
+                      "tierToArchive": {
+                        "daysAfterCreationGreaterThan": 30,
+                        "daysAfterLastTierChangeGreaterThan": 90
+                      }
+                    }
+                  },
+                  "filters": {
+                    "blobTypes": [
+                      "blockBlob"
+                    ],
+                    "prefixMatch": [
+                      "olcmtestcontainer"
+                    ]
+                  }
+                },
+                "enabled": true
+              }
+            ]
+          }
+        }
+      }
+    }
+  },
+  "operationId": "ManagementPolicies_CreateOrUpdate",
+  "title": "StorageAccountSetManagementPolicy_LastTierChangeTimeActions"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountUpdate.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountUpdate.json
@@ -1,0 +1,196 @@
+{
+  "parameters": {
+    "accountName": "sto8596",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "parameters": {
+      "properties": {
+        "allowBlobPublicAccess": false,
+        "allowSharedKeyAccess": true,
+        "defaultToOAuthAuthentication": false,
+        "enableExtendedGroups": true,
+        "encryption": {
+          "keySource": "Microsoft.Storage",
+          "services": {
+            "blob": {
+              "enabled": true,
+              "keyType": "Account"
+            },
+            "file": {
+              "enabled": true,
+              "keyType": "Account"
+            }
+          }
+        },
+        "isLocalUserEnabled": true,
+        "isSftpEnabled": true,
+        "keyPolicy": {
+          "keyExpirationPeriodInDays": 20
+        },
+        "minimumTlsVersion": "TLS1_2",
+        "networkAcls": {
+          "defaultAction": "Allow",
+          "resourceAccessRules": [
+            {
+              "resourceId": "/subscriptions/a7e99807-abbf-4642-bdec-2c809a96a8bc/resourceGroups/res9407/providers/Microsoft.Synapse/workspaces/testworkspace",
+              "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+            }
+          ]
+        },
+        "routingPreference": {
+          "publishInternetEndpoints": true,
+          "publishMicrosoftEndpoints": true,
+          "routingChoice": "MicrosoftRouting"
+        },
+        "sasPolicy": {
+          "expirationAction": "Log",
+          "sasExpirationPeriod": "1.15:59:59",
+          "requireUserBoundUserDelegationSas": true,
+          "requireUserBoundUserDelegationSasAction": "Block"
+        },
+        "geoPriorityReplicationStatus": {
+          "isBlobEnabled": true
+        },
+        "allowSharedKeyAccessForServices": {
+          "blob": {
+            "enabled": true
+          },
+          "file": {
+            "enabled": false
+          },
+          "queue": {
+            "enabled": true
+          },
+          "table": {
+            "enabled": false
+          }
+        },
+        "allowCrossTenantDelegationSas": false
+      }
+    },
+    "resourceGroupName": "res9407",
+    "subscriptionId": "a3f7c2b9-4e1d-4c8a-9d6f-8b2a5e41c7f3"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto8596",
+        "type": "Microsoft.Storage/storageAccounts",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9407/providers/Microsoft.Storage/storageAccounts/sto8596",
+        "kind": "Storage",
+        "location": "eastus2(stage)",
+        "properties": {
+          "allowBlobPublicAccess": false,
+          "allowSharedKeyAccess": true,
+          "creationTime": "2017-06-01T02:42:41.7633306Z",
+          "enableExtendedGroups": true,
+          "encryption": {
+            "keySource": "Microsoft.Storage",
+            "services": {
+              "blob": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              },
+              "file": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              }
+            }
+          },
+          "isHnsEnabled": true,
+          "isLocalUserEnabled": true,
+          "isSftpEnabled": true,
+          "keyCreationTime": {
+            "key1": "2021-03-18T04:42:22.4322836Z",
+            "key2": "2021-03-18T04:42:22.4322836Z"
+          },
+          "keyPolicy": {
+            "keyExpirationPeriodInDays": 20
+          },
+          "minimumTlsVersion": "TLS1_2",
+          "networkAcls": {
+            "bypass": "AzureServices",
+            "defaultAction": "Allow",
+            "ipRules": [],
+            "resourceAccessRules": [
+              {
+                "resourceId": "/subscriptions/a7e99807-abbf-4642-bdec-2c809a96a8bc/resourceGroups/res9407/providers/Microsoft.Synapse/workspaces/testworkspace",
+                "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+              }
+            ],
+            "virtualNetworkRules": []
+          },
+          "primaryEndpoints": {
+            "blob": "https://sto8596.blob.core.windows.net/",
+            "dfs": "https://sto8596.dfs.core.windows.net/",
+            "file": "https://sto8596.file.core.windows.net/",
+            "internetEndpoints": {
+              "blob": "https://sto8596-internetrouting.blob.core.windows.net/",
+              "dfs": "https://sto8596-internetrouting.dfs.core.windows.net/",
+              "file": "https://sto8596-internetrouting.file.core.windows.net/",
+              "web": "https://sto8596-internetrouting.web.core.windows.net/"
+            },
+            "microsoftEndpoints": {
+              "blob": "https://sto8596-microsoftrouting.blob.core.windows.net/",
+              "dfs": "https://sto8596-microsoftrouting.dfs.core.windows.net/",
+              "file": "https://sto8596-microsoftrouting.file.core.windows.net/",
+              "queue": "https://sto8596-microsoftrouting.queue.core.windows.net/",
+              "table": "https://sto8596-microsoftrouting.table.core.windows.net/",
+              "web": "https://sto8596-microsoftrouting.web.core.windows.net/"
+            },
+            "queue": "https://sto8596.queue.core.windows.net/",
+            "table": "https://sto8596.table.core.windows.net/",
+            "web": "https://sto8596.web.core.windows.net/"
+          },
+          "primaryLocation": "eastus2(stage)",
+          "provisioningState": "Succeeded",
+          "routingPreference": {
+            "publishInternetEndpoints": true,
+            "publishMicrosoftEndpoints": true,
+            "routingChoice": "MicrosoftRouting"
+          },
+          "sasPolicy": {
+            "expirationAction": "Log",
+            "sasExpirationPeriod": "1.15:59:59",
+            "requireUserBoundUserDelegationSas": true,
+            "requireUserBoundUserDelegationSasAction": "Block"
+          },
+          "secondaryLocation": "northcentralus(stage)",
+          "statusOfPrimary": "available",
+          "statusOfSecondary": "available",
+          "supportsHttpsTrafficOnly": false,
+          "geoPriorityReplicationStatus": {
+            "isBlobEnabled": true
+          },
+          "allowSharedKeyAccessForServices": {
+            "blob": {
+              "enabled": true
+            },
+            "file": {
+              "enabled": false
+            },
+            "queue": {
+              "enabled": true
+            },
+            "table": {
+              "enabled": false
+            }
+          },
+          "allowCrossTenantDelegationSas": false
+        },
+        "sku": {
+          "name": "Standard_GRS",
+          "tier": "Standard"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "StorageAccounts_Update",
+  "title": "StorageAccountUpdate"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountUpdateAccessTierToSmart.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountUpdateAccessTierToSmart.json
@@ -1,0 +1,163 @@
+{
+  "parameters": {
+    "accountName": "sto8596",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "parameters": {
+      "properties": {
+        "accessTier": "Smart",
+        "allowBlobPublicAccess": false,
+        "allowSharedKeyAccess": true,
+        "defaultToOAuthAuthentication": false,
+        "enableExtendedGroups": true,
+        "encryption": {
+          "keySource": "Microsoft.Storage",
+          "services": {
+            "blob": {
+              "enabled": true,
+              "keyType": "Account"
+            },
+            "file": {
+              "enabled": true,
+              "keyType": "Account"
+            }
+          }
+        },
+        "isLocalUserEnabled": true,
+        "isSftpEnabled": true,
+        "keyPolicy": {
+          "keyExpirationPeriodInDays": 20
+        },
+        "minimumTlsVersion": "TLS1_2",
+        "networkAcls": {
+          "defaultAction": "Allow",
+          "resourceAccessRules": [
+            {
+              "resourceId": "/subscriptions/a7e99807-abbf-4642-bdec-2c809a96a8bc/resourceGroups/res9407/providers/Microsoft.Synapse/workspaces/testworkspace",
+              "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+            }
+          ]
+        },
+        "routingPreference": {
+          "publishInternetEndpoints": true,
+          "publishMicrosoftEndpoints": true,
+          "routingChoice": "MicrosoftRouting"
+        },
+        "sasPolicy": {
+          "expirationAction": "Log",
+          "sasExpirationPeriod": "1.15:59:59"
+        },
+        "geoPriorityReplicationStatus": {
+          "isBlobEnabled": true
+        }
+      }
+    },
+    "resourceGroupName": "res9407",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto8596",
+        "type": "Microsoft.Storage/storageAccounts",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9407/providers/Microsoft.Storage/storageAccounts/sto8596",
+        "kind": "Storage",
+        "location": "eastus2(stage)",
+        "properties": {
+          "allowBlobPublicAccess": false,
+          "allowSharedKeyAccess": true,
+          "creationTime": "2017-06-01T02:42:41.7633306Z",
+          "enableExtendedGroups": true,
+          "encryption": {
+            "keySource": "Microsoft.Storage",
+            "services": {
+              "blob": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              },
+              "file": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              }
+            }
+          },
+          "isHnsEnabled": true,
+          "isLocalUserEnabled": true,
+          "isSftpEnabled": true,
+          "keyCreationTime": {
+            "key1": "2021-03-18T04:42:22.4322836Z",
+            "key2": "2021-03-18T04:42:22.4322836Z"
+          },
+          "keyPolicy": {
+            "keyExpirationPeriodInDays": 20
+          },
+          "minimumTlsVersion": "TLS1_2",
+          "networkAcls": {
+            "bypass": "AzureServices",
+            "defaultAction": "Allow",
+            "ipRules": [],
+            "resourceAccessRules": [
+              {
+                "resourceId": "/subscriptions/a7e99807-abbf-4642-bdec-2c809a96a8bc/resourceGroups/res9407/providers/Microsoft.Synapse/workspaces/testworkspace",
+                "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+              }
+            ],
+            "virtualNetworkRules": []
+          },
+          "primaryEndpoints": {
+            "blob": "https://sto8596.blob.core.windows.net/",
+            "dfs": "https://sto8596.dfs.core.windows.net/",
+            "file": "https://sto8596.file.core.windows.net/",
+            "internetEndpoints": {
+              "blob": "https://sto8596-internetrouting.blob.core.windows.net/",
+              "dfs": "https://sto8596-internetrouting.dfs.core.windows.net/",
+              "file": "https://sto8596-internetrouting.file.core.windows.net/",
+              "web": "https://sto8596-internetrouting.web.core.windows.net/"
+            },
+            "microsoftEndpoints": {
+              "blob": "https://sto8596-microsoftrouting.blob.core.windows.net/",
+              "dfs": "https://sto8596-microsoftrouting.dfs.core.windows.net/",
+              "file": "https://sto8596-microsoftrouting.file.core.windows.net/",
+              "queue": "https://sto8596-microsoftrouting.queue.core.windows.net/",
+              "table": "https://sto8596-microsoftrouting.table.core.windows.net/",
+              "web": "https://sto8596-microsoftrouting.web.core.windows.net/"
+            },
+            "queue": "https://sto8596.queue.core.windows.net/",
+            "table": "https://sto8596.table.core.windows.net/",
+            "web": "https://sto8596.web.core.windows.net/"
+          },
+          "primaryLocation": "eastus2(stage)",
+          "provisioningState": "Succeeded",
+          "routingPreference": {
+            "publishInternetEndpoints": true,
+            "publishMicrosoftEndpoints": true,
+            "routingChoice": "MicrosoftRouting"
+          },
+          "sasPolicy": {
+            "expirationAction": "Log",
+            "sasExpirationPeriod": "1.15:59:59"
+          },
+          "secondaryLocation": "northcentralus(stage)",
+          "statusOfPrimary": "available",
+          "statusOfSecondary": "available",
+          "supportsHttpsTrafficOnly": false,
+          "geoPriorityReplicationStatus": {
+            "isBlobEnabled": true
+          }
+        },
+        "sku": {
+          "name": "Standard_GRS",
+          "tier": "Standard"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "StorageAccounts_Update",
+  "title": "StorageAccountUpdateAccessTierToSmart"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountUpdateAllowedCopyScopeToAAD.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountUpdateAllowedCopyScopeToAAD.json
@@ -1,0 +1,151 @@
+{
+  "parameters": {
+    "accountName": "sto8596",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "parameters": {
+      "properties": {
+        "allowBlobPublicAccess": false,
+        "allowSharedKeyAccess": true,
+        "allowedCopyScope": "AAD",
+        "encryption": {
+          "keySource": "Microsoft.Storage",
+          "services": {
+            "blob": {
+              "enabled": true,
+              "keyType": "Account"
+            },
+            "file": {
+              "enabled": true,
+              "keyType": "Account"
+            }
+          }
+        },
+        "keyPolicy": {
+          "keyExpirationPeriodInDays": 20
+        },
+        "minimumTlsVersion": "TLS1_2",
+        "networkAcls": {
+          "defaultAction": "Allow",
+          "resourceAccessRules": [
+            {
+              "resourceId": "/subscriptions/a7e99807-abbf-4642-bdec-2c809a96a8bc/resourceGroups/res9407/providers/Microsoft.Synapse/workspaces/testworkspace",
+              "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+            }
+          ]
+        },
+        "routingPreference": {
+          "publishInternetEndpoints": true,
+          "publishMicrosoftEndpoints": true,
+          "routingChoice": "MicrosoftRouting"
+        },
+        "sasPolicy": {
+          "expirationAction": "Log",
+          "sasExpirationPeriod": "1.15:59:59"
+        }
+      }
+    },
+    "resourceGroupName": "res9407",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto8596",
+        "type": "Microsoft.Storage/storageAccounts",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9407/providers/Microsoft.Storage/storageAccounts/sto8596",
+        "kind": "Storage",
+        "location": "eastus2(stage)",
+        "properties": {
+          "allowBlobPublicAccess": false,
+          "allowSharedKeyAccess": true,
+          "allowedCopyScope": "AAD",
+          "creationTime": "2017-06-01T02:42:41.7633306Z",
+          "encryption": {
+            "keySource": "Microsoft.Storage",
+            "services": {
+              "blob": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              },
+              "file": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              }
+            }
+          },
+          "isHnsEnabled": true,
+          "keyCreationTime": {
+            "key1": "2021-03-18T04:42:22.4322836Z",
+            "key2": "2021-03-18T04:42:22.4322836Z"
+          },
+          "keyPolicy": {
+            "keyExpirationPeriodInDays": 20
+          },
+          "minimumTlsVersion": "TLS1_2",
+          "networkAcls": {
+            "bypass": "AzureServices",
+            "defaultAction": "Allow",
+            "ipRules": [],
+            "resourceAccessRules": [
+              {
+                "resourceId": "/subscriptions/a7e99807-abbf-4642-bdec-2c809a96a8bc/resourceGroups/res9407/providers/Microsoft.Synapse/workspaces/testworkspace",
+                "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+              }
+            ],
+            "virtualNetworkRules": []
+          },
+          "primaryEndpoints": {
+            "blob": "https://sto8596.blob.core.windows.net/",
+            "dfs": "https://sto8596.dfs.core.windows.net/",
+            "file": "https://sto8596.file.core.windows.net/",
+            "internetEndpoints": {
+              "blob": "https://sto8596-internetrouting.blob.core.windows.net/",
+              "dfs": "https://sto8596-internetrouting.dfs.core.windows.net/",
+              "file": "https://sto8596-internetrouting.file.core.windows.net/",
+              "web": "https://sto8596-internetrouting.web.core.windows.net/"
+            },
+            "microsoftEndpoints": {
+              "blob": "https://sto8596-microsoftrouting.blob.core.windows.net/",
+              "dfs": "https://sto8596-microsoftrouting.dfs.core.windows.net/",
+              "file": "https://sto8596-microsoftrouting.file.core.windows.net/",
+              "queue": "https://sto8596-microsoftrouting.queue.core.windows.net/",
+              "table": "https://sto8596-microsoftrouting.table.core.windows.net/",
+              "web": "https://sto8596-microsoftrouting.web.core.windows.net/"
+            },
+            "queue": "https://sto8596.queue.core.windows.net/",
+            "table": "https://sto8596.table.core.windows.net/",
+            "web": "https://sto8596.web.core.windows.net/"
+          },
+          "primaryLocation": "eastus2(stage)",
+          "provisioningState": "Succeeded",
+          "routingPreference": {
+            "publishInternetEndpoints": true,
+            "publishMicrosoftEndpoints": true,
+            "routingChoice": "MicrosoftRouting"
+          },
+          "sasPolicy": {
+            "expirationAction": "Log",
+            "sasExpirationPeriod": "1.15:59:59"
+          },
+          "secondaryLocation": "northcentralus(stage)",
+          "statusOfPrimary": "available",
+          "statusOfSecondary": "available",
+          "supportsHttpsTrafficOnly": false
+        },
+        "sku": {
+          "name": "Standard_GRS",
+          "tier": "Standard"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "StorageAccounts_Update",
+  "title": "StorageAccountUpdateAllowedCopyScopeToAAD"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountUpdateDisablePublicNetworkAccess.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountUpdateDisablePublicNetworkAccess.json
@@ -1,0 +1,151 @@
+{
+  "parameters": {
+    "accountName": "sto8596",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "parameters": {
+      "properties": {
+        "allowBlobPublicAccess": false,
+        "allowSharedKeyAccess": true,
+        "encryption": {
+          "keySource": "Microsoft.Storage",
+          "services": {
+            "blob": {
+              "enabled": true,
+              "keyType": "Account"
+            },
+            "file": {
+              "enabled": true,
+              "keyType": "Account"
+            }
+          }
+        },
+        "keyPolicy": {
+          "keyExpirationPeriodInDays": 20
+        },
+        "minimumTlsVersion": "TLS1_2",
+        "networkAcls": {
+          "defaultAction": "Allow",
+          "resourceAccessRules": [
+            {
+              "resourceId": "/subscriptions/a7e99807-abbf-4642-bdec-2c809a96a8bc/resourceGroups/res9407/providers/Microsoft.Synapse/workspaces/testworkspace",
+              "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+            }
+          ]
+        },
+        "publicNetworkAccess": "Disabled",
+        "routingPreference": {
+          "publishInternetEndpoints": true,
+          "publishMicrosoftEndpoints": true,
+          "routingChoice": "MicrosoftRouting"
+        },
+        "sasPolicy": {
+          "expirationAction": "Log",
+          "sasExpirationPeriod": "1.15:59:59"
+        }
+      }
+    },
+    "resourceGroupName": "res9407",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto8596",
+        "type": "Microsoft.Storage/storageAccounts",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9407/providers/Microsoft.Storage/storageAccounts/sto8596",
+        "kind": "Storage",
+        "location": "eastus2(stage)",
+        "properties": {
+          "allowBlobPublicAccess": false,
+          "allowSharedKeyAccess": true,
+          "creationTime": "2017-06-01T02:42:41.7633306Z",
+          "encryption": {
+            "keySource": "Microsoft.Storage",
+            "services": {
+              "blob": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              },
+              "file": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              }
+            }
+          },
+          "isHnsEnabled": true,
+          "keyCreationTime": {
+            "key1": "2021-03-18T04:42:22.4322836Z",
+            "key2": "2021-03-18T04:42:22.4322836Z"
+          },
+          "keyPolicy": {
+            "keyExpirationPeriodInDays": 20
+          },
+          "minimumTlsVersion": "TLS1_2",
+          "networkAcls": {
+            "bypass": "AzureServices",
+            "defaultAction": "Allow",
+            "ipRules": [],
+            "resourceAccessRules": [
+              {
+                "resourceId": "/subscriptions/a7e99807-abbf-4642-bdec-2c809a96a8bc/resourceGroups/res9407/providers/Microsoft.Synapse/workspaces/testworkspace",
+                "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+              }
+            ],
+            "virtualNetworkRules": []
+          },
+          "primaryEndpoints": {
+            "blob": "https://sto8596.blob.core.windows.net/",
+            "dfs": "https://sto8596.dfs.core.windows.net/",
+            "file": "https://sto8596.file.core.windows.net/",
+            "internetEndpoints": {
+              "blob": "https://sto8596-internetrouting.blob.core.windows.net/",
+              "dfs": "https://sto8596-internetrouting.dfs.core.windows.net/",
+              "file": "https://sto8596-internetrouting.file.core.windows.net/",
+              "web": "https://sto8596-internetrouting.web.core.windows.net/"
+            },
+            "microsoftEndpoints": {
+              "blob": "https://sto8596-microsoftrouting.blob.core.windows.net/",
+              "dfs": "https://sto8596-microsoftrouting.dfs.core.windows.net/",
+              "file": "https://sto8596-microsoftrouting.file.core.windows.net/",
+              "queue": "https://sto8596-microsoftrouting.queue.core.windows.net/",
+              "table": "https://sto8596-microsoftrouting.table.core.windows.net/",
+              "web": "https://sto8596-microsoftrouting.web.core.windows.net/"
+            },
+            "queue": "https://sto8596.queue.core.windows.net/",
+            "table": "https://sto8596.table.core.windows.net/",
+            "web": "https://sto8596.web.core.windows.net/"
+          },
+          "primaryLocation": "eastus2(stage)",
+          "provisioningState": "Succeeded",
+          "publicNetworkAccess": "Disabled",
+          "routingPreference": {
+            "publishInternetEndpoints": true,
+            "publishMicrosoftEndpoints": true,
+            "routingChoice": "MicrosoftRouting"
+          },
+          "sasPolicy": {
+            "expirationAction": "Log",
+            "sasExpirationPeriod": "1.15:59:59"
+          },
+          "secondaryLocation": "northcentralus(stage)",
+          "statusOfPrimary": "available",
+          "statusOfSecondary": "available",
+          "supportsHttpsTrafficOnly": false
+        },
+        "sku": {
+          "name": "Standard_GRS",
+          "tier": "Standard"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "StorageAccounts_Update",
+  "title": "StorageAccountUpdateDisablePublicNetworkAccess"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountUpdateObjectReplicationPolicyOnDestination.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountUpdateObjectReplicationPolicyOnDestination.json
@@ -1,0 +1,85 @@
+{
+  "parameters": {
+    "accountName": "dst112",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "objectReplicationPolicyId": "2a20bb73-5717-4635-985a-5d4cf777438f",
+    "properties": {
+      "properties": {
+        "destinationAccount": "dst112",
+        "metrics": {
+          "enabled": true
+        },
+        "priorityReplication": {
+          "enabled": true
+        },
+        "rules": [
+          {
+            "destinationContainer": "dcont139",
+            "filters": {
+              "prefixMatch": [
+                "blobA",
+                "blobB"
+              ]
+            },
+            "ruleId": "d5d18a48-8801-4554-aeaa-74faf65f5ef9",
+            "sourceContainer": "scont139"
+          },
+          {
+            "destinationContainer": "dcont179",
+            "sourceContainer": "scont179"
+          }
+        ],
+        "sourceAccount": "src1122",
+        "tagsReplication": {
+          "enabled": true
+        }
+      }
+    },
+    "resourceGroupName": "res7687",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "2a20bb73-5717-4635-985a-5d4cf777438f",
+        "type": "Microsoft.Storage/storageAccounts/objectReplicationPolicies",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res7687/providers/Microsoft.Storage/storageAccounts/dst112/objectReplicationPolicies/2a20bb73-5717-4635-985a-5d4cf777438f",
+        "properties": {
+          "destinationAccount": "dst112",
+          "metrics": {
+            "enabled": true
+          },
+          "priorityReplication": {
+            "enabled": true
+          },
+          "policyId": "2a20bb73-5717-4635-985a-5d4cf777438f",
+          "rules": [
+            {
+              "destinationContainer": "destContainer1",
+              "filters": {
+                "prefixMatch": [
+                  "blobA",
+                  "blobB"
+                ]
+              },
+              "ruleId": "d5d18a48-8801-4554-aeaa-74faf65f5ef9",
+              "sourceContainer": "sourceContainer1"
+            },
+            {
+              "destinationContainer": "dcont179",
+              "ruleId": "cfbb4bc2-8b60-429f-b05a-d1e0942b33b2",
+              "sourceContainer": "scont179"
+            }
+          ],
+          "sourceAccount": "src1122",
+          "tagsReplication": {
+            "enabled": true
+          }
+        }
+      }
+    }
+  },
+  "operationId": "ObjectReplicationPolicies_CreateOrUpdate",
+  "title": "StorageAccountUpdateObjectReplicationPolicyOnDestination"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountUpdateObjectReplicationPolicyOnSource.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountUpdateObjectReplicationPolicyOnSource.json
@@ -1,0 +1,87 @@
+{
+  "parameters": {
+    "accountName": "src1122",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "objectReplicationPolicyId": "2a20bb73-5717-4635-985a-5d4cf777438f",
+    "properties": {
+      "properties": {
+        "destinationAccount": "dst112",
+        "metrics": {
+          "enabled": true
+        },
+        "priorityReplication": {
+          "enabled": true
+        },
+        "rules": [
+          {
+            "destinationContainer": "dcont139",
+            "filters": {
+              "prefixMatch": [
+                "blobA",
+                "blobB"
+              ]
+            },
+            "ruleId": "d5d18a48-8801-4554-aeaa-74faf65f5ef9",
+            "sourceContainer": "scont139"
+          },
+          {
+            "destinationContainer": "dcont179",
+            "ruleId": "cfbb4bc2-8b60-429f-b05a-d1e0942b33b2",
+            "sourceContainer": "scont179"
+          }
+        ],
+        "sourceAccount": "src1122",
+        "tagsReplication": {
+          "enabled": true
+        }
+      }
+    },
+    "resourceGroupName": "res7687",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "2a20bb73-5717-4635-985a-5d4cf777438f",
+        "type": "Microsoft.Storage/storageAccounts/objectReplicationPolicies",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res7687/providers/Microsoft.Storage/storageAccounts/src1122/objectReplicationPolicies/2a20bb73-5717-4635-985a-5d4cf777438f",
+        "properties": {
+          "destinationAccount": "dst112",
+          "enabledTime": "2019-06-08T03:01:55.7168089Z",
+          "metrics": {
+            "enabled": true
+          },
+          "priorityReplication": {
+            "enabled": true
+          },
+          "policyId": "2a20bb73-5717-4635-985a-5d4cf777438f",
+          "rules": [
+            {
+              "destinationContainer": "destContainer1",
+              "filters": {
+                "prefixMatch": [
+                  "blobA",
+                  "blobB"
+                ]
+              },
+              "ruleId": "d5d18a48-8801-4554-aeaa-74faf65f5ef9",
+              "sourceContainer": "sourceContainer1"
+            },
+            {
+              "destinationContainer": "dcont179",
+              "ruleId": "cfbb4bc2-8b60-429f-b05a-d1e0942b33b2",
+              "sourceContainer": "scont179"
+            }
+          ],
+          "sourceAccount": "src1122",
+          "tagsReplication": {
+            "enabled": true
+          }
+        }
+      }
+    }
+  },
+  "operationId": "ObjectReplicationPolicies_CreateOrUpdate",
+  "title": "StorageAccountUpdateObjectReplicationPolicyOnSource"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountUpdateUserAssignedEncryptionIdentityWithCMK.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountUpdateUserAssignedEncryptionIdentityWithCMK.json
@@ -1,0 +1,118 @@
+{
+  "parameters": {
+    "accountName": "sto4445",
+    "api-version": "2026-09-01",
+    "parameters": {
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{managed-identity-name}": {}
+        }
+      },
+      "kind": "Storage",
+      "properties": {
+        "encryption": {
+          "identity": {
+            "userAssignedIdentity": "/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{managed-identity-name}"
+          },
+          "keySource": "Microsoft.Keyvault",
+          "keyvaultproperties": {
+            "keyname": "wrappingKey",
+            "keyvaulturi": "https://myvault8569.vault.azure.net",
+            "keyversion": ""
+          },
+          "services": {
+            "blob": {
+              "enabled": true,
+              "keyType": "Account"
+            },
+            "file": {
+              "enabled": true,
+              "keyType": "Account"
+            }
+          }
+        }
+      },
+      "sku": {
+        "name": "Standard_LRS"
+      }
+    },
+    "resourceGroupName": "res9101",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto4445",
+        "type": "Microsoft.Storage/storageAccounts",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.Storage/storageAccounts/sto4445",
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{managed-identity-name}": {
+              "clientId": "fbaa6278-1ecc-415c-819f-6e2058d3acb5",
+              "principalId": "8d823284-1060-42a5-9ec4-ed3d831e24d7"
+            }
+          }
+        },
+        "kind": "StorageV2",
+        "location": "eastus",
+        "properties": {
+          "accessTier": "Hot",
+          "creationTime": "2020-12-15T00:43:14.0839093Z",
+          "encryption": {
+            "identity": {
+              "userAssignedIdentity": "/subscriptions/{subscription-id}/resourcegroups/res9101/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{managed-identity-name}"
+            },
+            "keySource": "Microsoft.Keyvault",
+            "keyvaultproperties": {
+              "currentVersionedKeyIdentifier": "https://myvault8569.vault.azure.net/keys/wrappingKey/0682afdd9c104f4285df20107e956cad",
+              "keyname": "wrappingKey",
+              "keyvaulturi": "https://myvault8569.vault.azure.net",
+              "keyversion": "",
+              "lastKeyRotationTimestamp": "2019-12-13T20:36:23.7023290Z"
+            },
+            "services": {
+              "blob": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2020-12-15T00:43:14.1739587Z"
+              },
+              "file": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2020-12-15T00:43:14.1739587Z"
+              }
+            }
+          },
+          "networkAcls": {
+            "bypass": "AzureServices",
+            "defaultAction": "Allow",
+            "ipRules": [],
+            "virtualNetworkRules": []
+          },
+          "primaryEndpoints": {
+            "blob": "https://sto4445.blob.core.windows.net/",
+            "dfs": "https://sto4445.dfs.core.windows.net/",
+            "file": "https://sto4445.file.core.windows.net/",
+            "queue": "https://sto4445.queue.core.windows.net/",
+            "table": "https://sto4445.table.core.windows.net/",
+            "web": "https://sto4445.web.core.windows.net/"
+          },
+          "primaryLocation": "eastus",
+          "privateEndpointConnections": [],
+          "provisioningState": "Succeeded",
+          "statusOfPrimary": "available",
+          "supportsHttpsTrafficOnly": true
+        },
+        "sku": {
+          "name": "Standard_LRS",
+          "tier": "Standard"
+        },
+        "tags": {}
+      }
+    }
+  },
+  "operationId": "StorageAccounts_Update",
+  "title": "StorageAccountUpdateUserAssignedEncryptionIdentityWithCMK"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountUpdateUserAssignedIdentityWithFederatedIdentityClientId.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountUpdateUserAssignedIdentityWithFederatedIdentityClientId.json
@@ -1,0 +1,120 @@
+{
+  "parameters": {
+    "accountName": "sto131918",
+    "api-version": "2026-09-01",
+    "parameters": {
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{managed-identity-name}": {}
+        }
+      },
+      "kind": "Storage",
+      "properties": {
+        "encryption": {
+          "identity": {
+            "federatedIdentityClientId": "3109d1c4-a5de-4d84-8832-feabb916a4b6",
+            "userAssignedIdentity": "/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{managed-identity-name}"
+          },
+          "keySource": "Microsoft.Keyvault",
+          "keyvaultproperties": {
+            "keyname": "wrappingKey",
+            "keyvaulturi": "https://myvault8569.vault.azure.net",
+            "keyversion": ""
+          },
+          "services": {
+            "blob": {
+              "enabled": true,
+              "keyType": "Account"
+            },
+            "file": {
+              "enabled": true,
+              "keyType": "Account"
+            }
+          }
+        }
+      },
+      "sku": {
+        "name": "Standard_LRS"
+      }
+    },
+    "resourceGroupName": "res131918",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto4445",
+        "type": "Microsoft.Storage/storageAccounts",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.Storage/storageAccounts/sto4445",
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{managed-identity-name}": {
+              "clientId": "fbaa6278-1ecc-415c-819f-6e2058d3acb5",
+              "principalId": "8d823284-1060-42a5-9ec4-ed3d831e24d7"
+            }
+          }
+        },
+        "kind": "StorageV2",
+        "location": "eastus",
+        "properties": {
+          "accessTier": "Hot",
+          "creationTime": "2020-12-15T00:43:14.0839093Z",
+          "encryption": {
+            "identity": {
+              "federatedIdentityClientId": "3109d1c4-a5de-4d84-8832-feabb916a4b6",
+              "userAssignedIdentity": "/subscriptions/{subscription-id}/resourcegroups/res9101/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{managed-identity-name}"
+            },
+            "keySource": "Microsoft.Keyvault",
+            "keyvaultproperties": {
+              "currentVersionedKeyIdentifier": "https://myvault8569.vault.azure.net/keys/wrappingKey/0682afdd9c104f4285df20107e956cad",
+              "keyname": "wrappingKey",
+              "keyvaulturi": "https://myvault8569.vault.azure.net",
+              "keyversion": "",
+              "lastKeyRotationTimestamp": "2019-12-13T20:36:23.7023290Z"
+            },
+            "services": {
+              "blob": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2020-12-15T00:43:14.1739587Z"
+              },
+              "file": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2020-12-15T00:43:14.1739587Z"
+              }
+            }
+          },
+          "networkAcls": {
+            "bypass": "AzureServices",
+            "defaultAction": "Allow",
+            "ipRules": [],
+            "virtualNetworkRules": []
+          },
+          "primaryEndpoints": {
+            "blob": "https://sto4445.blob.core.windows.net/",
+            "dfs": "https://sto4445.dfs.core.windows.net/",
+            "file": "https://sto4445.file.core.windows.net/",
+            "queue": "https://sto4445.queue.core.windows.net/",
+            "table": "https://sto4445.table.core.windows.net/",
+            "web": "https://sto4445.web.core.windows.net/"
+          },
+          "primaryLocation": "eastus",
+          "privateEndpointConnections": [],
+          "provisioningState": "Succeeded",
+          "statusOfPrimary": "available",
+          "supportsHttpsTrafficOnly": true
+        },
+        "sku": {
+          "name": "Standard_LRS",
+          "tier": "Standard"
+        },
+        "tags": {}
+      }
+    }
+  },
+  "operationId": "StorageAccounts_Update",
+  "title": "StorageAccountUpdateUserAssignedIdentityWithFederatedIdentityClientId"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountUpdateWithDataCollaborationPolicy.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountUpdateWithDataCollaborationPolicy.json
@@ -1,0 +1,46 @@
+{
+  "parameters": {
+    "accountName": "sto8596",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "parameters": {
+      "properties": {
+        "dataCollaborationPolicyProperties": {
+          "allowStorageConnectors": true,
+          "allowStorageDataShares": true,
+          "allowCrossTenantDataSharing": false
+        }
+      }
+    },
+    "resourceGroupName": "res9407",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto8596",
+        "type": "Microsoft.Storage/storageAccounts",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9407/providers/Microsoft.Storage/storageAccounts/sto8596",
+        "kind": "Storage",
+        "location": "eastus2(stage)",
+        "properties": {
+          "dataCollaborationPolicyProperties": {
+            "allowStorageConnectors": true,
+            "allowStorageDataShares": true,
+            "allowCrossTenantDataSharing": false
+          }
+        },
+        "sku": {
+          "name": "Standard_GRS",
+          "tier": "Standard"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "StorageAccounts_Update",
+  "title": "StorageAccountUpdateWithDataCollaborationPolicy"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountUpdateWithImmutabilityPolicy.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountUpdateWithImmutabilityPolicy.json
@@ -1,0 +1,52 @@
+{
+  "parameters": {
+    "accountName": "sto8596",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "parameters": {
+      "properties": {
+        "immutableStorageWithVersioning": {
+          "enabled": true,
+          "immutabilityPolicy": {
+            "allowProtectedAppendWrites": true,
+            "immutabilityPeriodSinceCreationInDays": 15,
+            "state": "Locked"
+          }
+        }
+      }
+    },
+    "resourceGroupName": "res9407",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto8596",
+        "type": "Microsoft.Storage/storageAccounts",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9407/providers/Microsoft.Storage/storageAccounts/sto8596",
+        "kind": "Storage",
+        "location": "eastus2(stage)",
+        "properties": {
+          "immutableStorageWithVersioning": {
+            "enabled": true,
+            "immutabilityPolicy": {
+              "allowProtectedAppendWrites": true,
+              "immutabilityPeriodSinceCreationInDays": 15,
+              "state": "Locked"
+            }
+          }
+        },
+        "sku": {
+          "name": "Standard_GRS",
+          "tier": "Standard"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "StorageAccounts_Update",
+  "title": "StorageAccountUpdateWithImmutabilityPolicy"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountUpdate_placement.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountUpdate_placement.json
@@ -1,0 +1,165 @@
+{
+  "parameters": {
+    "accountName": "sto8596",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "parameters": {
+      "placement": {
+        "zonePlacementPolicy": "Any"
+      },
+      "properties": {
+        "allowBlobPublicAccess": false,
+        "allowSharedKeyAccess": true,
+        "defaultToOAuthAuthentication": false,
+        "enableExtendedGroups": true,
+        "encryption": {
+          "keySource": "Microsoft.Storage",
+          "services": {
+            "blob": {
+              "enabled": true,
+              "keyType": "Account"
+            },
+            "file": {
+              "enabled": true,
+              "keyType": "Account"
+            }
+          }
+        },
+        "isLocalUserEnabled": true,
+        "isSftpEnabled": true,
+        "keyPolicy": {
+          "keyExpirationPeriodInDays": 20
+        },
+        "minimumTlsVersion": "TLS1_2",
+        "networkAcls": {
+          "defaultAction": "Allow",
+          "resourceAccessRules": [
+            {
+              "resourceId": "/subscriptions/a7e99807-abbf-4642-bdec-2c809a96a8bc/resourceGroups/res9407/providers/Microsoft.Synapse/workspaces/testworkspace",
+              "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+            }
+          ]
+        },
+        "routingPreference": {
+          "publishInternetEndpoints": true,
+          "publishMicrosoftEndpoints": true,
+          "routingChoice": "MicrosoftRouting"
+        },
+        "sasPolicy": {
+          "expirationAction": "Log",
+          "sasExpirationPeriod": "1.15:59:59"
+        }
+      }
+    },
+    "resourceGroupName": "res9407",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto8596",
+        "type": "Microsoft.Storage/storageAccounts",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9407/providers/Microsoft.Storage/storageAccounts/sto8596",
+        "kind": "Storage",
+        "location": "eastus2(stage)",
+        "placement": {
+          "zonePlacementPolicy": "Any"
+        },
+        "properties": {
+          "allowBlobPublicAccess": false,
+          "allowSharedKeyAccess": true,
+          "creationTime": "2017-06-01T02:42:41.7633306Z",
+          "enableExtendedGroups": true,
+          "encryption": {
+            "keySource": "Microsoft.Storage",
+            "services": {
+              "blob": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              },
+              "file": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              }
+            }
+          },
+          "isHnsEnabled": true,
+          "isLocalUserEnabled": true,
+          "isSftpEnabled": true,
+          "keyCreationTime": {
+            "key1": "2021-03-18T04:42:22.4322836Z",
+            "key2": "2021-03-18T04:42:22.4322836Z"
+          },
+          "keyPolicy": {
+            "keyExpirationPeriodInDays": 20
+          },
+          "minimumTlsVersion": "TLS1_2",
+          "networkAcls": {
+            "bypass": "AzureServices",
+            "defaultAction": "Allow",
+            "ipRules": [],
+            "resourceAccessRules": [
+              {
+                "resourceId": "/subscriptions/a7e99807-abbf-4642-bdec-2c809a96a8bc/resourceGroups/res9407/providers/Microsoft.Synapse/workspaces/testworkspace",
+                "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+              }
+            ],
+            "virtualNetworkRules": []
+          },
+          "primaryEndpoints": {
+            "blob": "https://sto8596.blob.core.windows.net/",
+            "dfs": "https://sto8596.dfs.core.windows.net/",
+            "file": "https://sto8596.file.core.windows.net/",
+            "internetEndpoints": {
+              "blob": "https://sto8596-internetrouting.blob.core.windows.net/",
+              "dfs": "https://sto8596-internetrouting.dfs.core.windows.net/",
+              "file": "https://sto8596-internetrouting.file.core.windows.net/",
+              "web": "https://sto8596-internetrouting.web.core.windows.net/"
+            },
+            "microsoftEndpoints": {
+              "blob": "https://sto8596-microsoftrouting.blob.core.windows.net/",
+              "dfs": "https://sto8596-microsoftrouting.dfs.core.windows.net/",
+              "file": "https://sto8596-microsoftrouting.file.core.windows.net/",
+              "queue": "https://sto8596-microsoftrouting.queue.core.windows.net/",
+              "table": "https://sto8596-microsoftrouting.table.core.windows.net/",
+              "web": "https://sto8596-microsoftrouting.web.core.windows.net/"
+            },
+            "queue": "https://sto8596.queue.core.windows.net/",
+            "table": "https://sto8596.table.core.windows.net/",
+            "web": "https://sto8596.web.core.windows.net/"
+          },
+          "primaryLocation": "eastus2(stage)",
+          "provisioningState": "Succeeded",
+          "routingPreference": {
+            "publishInternetEndpoints": true,
+            "publishMicrosoftEndpoints": true,
+            "routingChoice": "MicrosoftRouting"
+          },
+          "sasPolicy": {
+            "expirationAction": "Log",
+            "sasExpirationPeriod": "1.15:59:59"
+          },
+          "secondaryLocation": "northcentralus(stage)",
+          "statusOfPrimary": "available",
+          "statusOfSecondary": "available",
+          "supportsHttpsTrafficOnly": false
+        },
+        "sku": {
+          "name": "Standard_GRS",
+          "tier": "Standard"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        },
+        "zones": [
+          "1"
+        ]
+      }
+    }
+  },
+  "operationId": "StorageAccounts_Update",
+  "title": "StorageAccountUpdate_placement"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountUpdate_zones.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageAccountUpdate_zones.json
@@ -1,0 +1,162 @@
+{
+  "parameters": {
+    "accountName": "sto8596",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "parameters": {
+      "properties": {
+        "allowBlobPublicAccess": false,
+        "allowSharedKeyAccess": true,
+        "defaultToOAuthAuthentication": false,
+        "enableExtendedGroups": true,
+        "encryption": {
+          "keySource": "Microsoft.Storage",
+          "services": {
+            "blob": {
+              "enabled": true,
+              "keyType": "Account"
+            },
+            "file": {
+              "enabled": true,
+              "keyType": "Account"
+            }
+          }
+        },
+        "isLocalUserEnabled": true,
+        "isSftpEnabled": true,
+        "keyPolicy": {
+          "keyExpirationPeriodInDays": 20
+        },
+        "minimumTlsVersion": "TLS1_2",
+        "networkAcls": {
+          "defaultAction": "Allow",
+          "resourceAccessRules": [
+            {
+              "resourceId": "/subscriptions/a7e99807-abbf-4642-bdec-2c809a96a8bc/resourceGroups/res9407/providers/Microsoft.Synapse/workspaces/testworkspace",
+              "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+            }
+          ]
+        },
+        "routingPreference": {
+          "publishInternetEndpoints": true,
+          "publishMicrosoftEndpoints": true,
+          "routingChoice": "MicrosoftRouting"
+        },
+        "sasPolicy": {
+          "expirationAction": "Log",
+          "sasExpirationPeriod": "1.15:59:59"
+        }
+      },
+      "zones": [
+        "1"
+      ]
+    },
+    "resourceGroupName": "res9407",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sto8596",
+        "type": "Microsoft.Storage/storageAccounts",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res9407/providers/Microsoft.Storage/storageAccounts/sto8596",
+        "kind": "Storage",
+        "location": "eastus2(stage)",
+        "properties": {
+          "allowBlobPublicAccess": false,
+          "allowSharedKeyAccess": true,
+          "creationTime": "2017-06-01T02:42:41.7633306Z",
+          "enableExtendedGroups": true,
+          "encryption": {
+            "keySource": "Microsoft.Storage",
+            "services": {
+              "blob": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              },
+              "file": {
+                "enabled": true,
+                "keyType": "Account",
+                "lastEnabledTime": "2019-12-11T20:49:31.7036140Z"
+              }
+            }
+          },
+          "isHnsEnabled": true,
+          "isLocalUserEnabled": true,
+          "isSftpEnabled": true,
+          "keyCreationTime": {
+            "key1": "2021-03-18T04:42:22.4322836Z",
+            "key2": "2021-03-18T04:42:22.4322836Z"
+          },
+          "keyPolicy": {
+            "keyExpirationPeriodInDays": 20
+          },
+          "minimumTlsVersion": "TLS1_2",
+          "networkAcls": {
+            "bypass": "AzureServices",
+            "defaultAction": "Allow",
+            "ipRules": [],
+            "resourceAccessRules": [
+              {
+                "resourceId": "/subscriptions/a7e99807-abbf-4642-bdec-2c809a96a8bc/resourceGroups/res9407/providers/Microsoft.Synapse/workspaces/testworkspace",
+                "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+              }
+            ],
+            "virtualNetworkRules": []
+          },
+          "primaryEndpoints": {
+            "blob": "https://sto8596.blob.core.windows.net/",
+            "dfs": "https://sto8596.dfs.core.windows.net/",
+            "file": "https://sto8596.file.core.windows.net/",
+            "internetEndpoints": {
+              "blob": "https://sto8596-internetrouting.blob.core.windows.net/",
+              "dfs": "https://sto8596-internetrouting.dfs.core.windows.net/",
+              "file": "https://sto8596-internetrouting.file.core.windows.net/",
+              "web": "https://sto8596-internetrouting.web.core.windows.net/"
+            },
+            "microsoftEndpoints": {
+              "blob": "https://sto8596-microsoftrouting.blob.core.windows.net/",
+              "dfs": "https://sto8596-microsoftrouting.dfs.core.windows.net/",
+              "file": "https://sto8596-microsoftrouting.file.core.windows.net/",
+              "queue": "https://sto8596-microsoftrouting.queue.core.windows.net/",
+              "table": "https://sto8596-microsoftrouting.table.core.windows.net/",
+              "web": "https://sto8596-microsoftrouting.web.core.windows.net/"
+            },
+            "queue": "https://sto8596.queue.core.windows.net/",
+            "table": "https://sto8596.table.core.windows.net/",
+            "web": "https://sto8596.web.core.windows.net/"
+          },
+          "primaryLocation": "eastus2(stage)",
+          "provisioningState": "Succeeded",
+          "routingPreference": {
+            "publishInternetEndpoints": true,
+            "publishMicrosoftEndpoints": true,
+            "routingChoice": "MicrosoftRouting"
+          },
+          "sasPolicy": {
+            "expirationAction": "Log",
+            "sasExpirationPeriod": "1.15:59:59"
+          },
+          "secondaryLocation": "northcentralus(stage)",
+          "statusOfPrimary": "available",
+          "statusOfSecondary": "available",
+          "supportsHttpsTrafficOnly": false
+        },
+        "sku": {
+          "name": "Standard_GRS",
+          "tier": "Standard"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        },
+        "zones": [
+          "1"
+        ]
+      }
+    }
+  },
+  "operationId": "StorageAccounts_Update",
+  "title": "StorageAccountUpdate_zones"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageConnectorCRUD/StorageConnectors_Create.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageConnectorCRUD/StorageConnectors_Create.json
@@ -1,0 +1,86 @@
+{
+  "operationId": "Connectors_Create",
+  "title": "CreateConnector",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "testrg",
+    "api-version": "2026-09-01",
+    "connectorName": "testconnector",
+    "accountName": "teststorageaccount",
+    "resource": {
+      "location": "eastus",
+      "properties": {
+        "state": "Active",
+        "description": "Example connector",
+        "dataSourceType": "Azure_DataShare",
+        "source": {
+          "type": "DataShare",
+          "connection": {
+            "type": "DataShare",
+            "dataShareUri": "azds://eastus:datashare1:12345678-1234-1234-1234-123456789123"
+          },
+          "authProperties": {
+            "type": "ManagedIdentity",
+            "identityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testIdentity"
+          }
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/storageAccounts/teststorageaccount/connectors/testconnector",
+        "name": "testconnector",
+        "type": "Microsoft.Storage/storageAccounts/connectors",
+        "location": "eastus",
+        "properties": {
+          "uniqueId": "12345678-1234-1234-1234-12345678912",
+          "state": "Active",
+          "creationTime": "2023-04-01T00:00:00Z",
+          "description": "Example connector",
+          "dataSourceType": "Azure_DataShare",
+          "source": {
+            "type": "DataShare",
+            "connection": {
+              "type": "DataShare",
+              "dataShareUri": "azds://eastus:datashare1:12345678-1234-1234-1234-123456789123"
+            },
+            "authProperties": {
+              "type": "ManagedIdentity",
+              "identityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testIdentity"
+            }
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/storageAccounts/teststorageaccount/connectors/testconnector",
+        "name": "testconnector",
+        "type": "Microsoft.Storage/storageAccounts/connectors",
+        "location": "eastus",
+        "properties": {
+          "uniqueId": "12345678-1234-1234-1234-12345678912",
+          "state": "Active",
+          "creationTime": "2023-04-01T00:00:00Z",
+          "description": "Example connector",
+          "dataSourceType": "Azure_DataShare",
+          "source": {
+            "type": "DataShare",
+            "connection": {
+              "type": "DataShare",
+              "dataShareUri": "azds://eastus:datashare1:12345678-1234-1234-1234-123456789123"
+            },
+            "authProperties": {
+              "type": "ManagedIdentity",
+              "identityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testIdentity"
+            }
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  }
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageConnectorCRUD/StorageConnectors_Delete.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageConnectorCRUD/StorageConnectors_Delete.json
@@ -1,0 +1,22 @@
+{
+  "operationId": "Connectors_Delete",
+  "title": "DeleteConnector",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "testrg",
+    "accountName": "teststorageaccount",
+    "connectorName": "testconnector",
+    "api-version": "2026-09-01"
+  },
+  "responses": {
+    "204": {},
+    "202": {
+      "status": "Accepted",
+      "message": "The resource operation has been received and is being processed.",
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/xxxx/resourceGroups/rg-name/providers/Microsoft.Storage/operations/operation-98765",
+        "Retry-After": 30
+      }
+    }
+  }
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageConnectorCRUD/StorageConnectors_Get.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageConnectorCRUD/StorageConnectors_Get.json
@@ -1,0 +1,40 @@
+{
+  "operationId": "Connectors_Get",
+  "title": "GetConnector",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "testrg",
+    "accountName": "teststorageaccount",
+    "api-version": "2026-09-01",
+    "connectorName": "testconnector"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/storageAccounts/teststorageaccount/connectors/testconnector",
+        "name": "testconnector",
+        "type": "Microsoft.Storage/storageAccounts/connectors",
+        "location": "eastus",
+        "properties": {
+          "uniqueId": "12345678-1234-1234-1234-12345678912",
+          "state": "Active",
+          "creationTime": "2023-04-01T00:00:00Z",
+          "description": "Example connector",
+          "dataSourceType": "Azure_DataShare",
+          "source": {
+            "type": "DataShare",
+            "connection": {
+              "type": "DataShare",
+              "dataShareUri": "azds://eastus:datashare1:12345678-1234-1234-1234-123456789123"
+            },
+            "authProperties": {
+              "type": "ManagedIdentity",
+              "identityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testIdentity"
+            }
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  }
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageConnectorCRUD/StorageConnectors_ListByStorageAccount.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageConnectorCRUD/StorageConnectors_ListByStorageAccount.json
@@ -1,0 +1,68 @@
+{
+  "operationId": "Connectors_ListByStorageAccount",
+  "title": "ListConnectorsByStorageAccount",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "testrg",
+    "accountName": "teststorageaccount",
+    "api-version": "2026-09-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/storageAccounts/teststorageaccount/connectors/testconnector",
+            "name": "testconnector1",
+            "type": "Microsoft.Storage/storageAccounts/connectors",
+            "location": "eastus",
+            "properties": {
+              "uniqueId": "12345678-1234-1234-1234-12345678912",
+              "state": "Active",
+              "creationTime": "2023-04-01T00:00:00Z",
+              "description": "Example connector",
+              "dataSourceType": "Azure_DataShare",
+              "source": {
+                "type": "DataShare",
+                "connection": {
+                  "type": "DataShare",
+                  "dataShareUri": "azds://eastus:datashare1:12345678-1234-1234-1234-123456789123"
+                },
+                "authProperties": {
+                  "type": "ManagedIdentity",
+                  "identityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testIdentity"
+                }
+              },
+              "provisioningState": "Succeeded"
+            }
+          },
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/storageAccounts/teststorageaccount/connectors/Jill",
+            "name": "testconnector2",
+            "type": "Microsoft.Storage/storageAccounts/connectors",
+            "location": "westus",
+            "properties": {
+              "uniqueId": "12345678-1234-1234-1234-12345678912",
+              "state": "Active",
+              "creationTime": "2023-04-01T00:00:00Z",
+              "description": "Example connector",
+              "dataSourceType": "Azure_DataShare",
+              "source": {
+                "type": "DataShare",
+                "connection": {
+                  "type": "DataShare",
+                  "dataShareUri": "azds://eastus:datashare1:12345678-1234-1234-1234-123456789123"
+                },
+                "authProperties": {
+                  "type": "ManagedIdentity",
+                  "identityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testIdentity"
+                }
+              },
+              "provisioningState": "Succeeded"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageConnectorCRUD/StorageConnectors_TestExistingConnection.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageConnectorCRUD/StorageConnectors_TestExistingConnection.json
@@ -1,0 +1,30 @@
+{
+  "operationId": "Connectors_TestExistingConnection",
+  "title": "ExistingConnectionTest",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "testrg",
+    "accountName": "teststorageaccount",
+    "api-version": "2026-09-01",
+    "connectorName": "testconnector",
+    "body": {
+      "uniqueId": "12345678-1234-1234-1234-12345678912"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "storageConnectorMethodName": "TestExistingConnection",
+        "storageConnectorRequestId": "request-id-123"
+      }
+    },
+    "202": {
+      "status": "Accepted",
+      "message": "The resource operation has been received and is being processed.",
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/xxxx/resourceGroups/rg-name/providers/Microsoft.Storage/operations/operation-98765",
+        "Retry-After": 30
+      }
+    }
+  }
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageConnectorCRUD/StorageConnectors_Update.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageConnectorCRUD/StorageConnectors_Update.json
@@ -1,0 +1,59 @@
+{
+  "operationId": "Connectors_Update",
+  "title": "UpdateConnector",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "testrg",
+    "accountName": "teststorageaccount",
+    "api-version": "2026-09-01",
+    "connectorName": "testconnector",
+    "properties": {
+      "properties": {
+        "source": {
+          "type": "DataShare",
+          "authProperties": {
+            "type": "ManagedIdentity",
+            "identityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/newTestIdentity"
+          }
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/storageAccounts/teststorageaccount/connectors/testconnector",
+        "name": "testconnector",
+        "type": "Microsoft.Storage/storageAccounts/connectors",
+        "location": "eastus",
+        "properties": {
+          "uniqueId": "12345678-1234-1234-1234-12345678912",
+          "state": "Active",
+          "creationTime": "2023-04-01T00:00:00Z",
+          "description": "Example connector",
+          "dataSourceType": "Azure_DataShare",
+          "source": {
+            "type": "DataShare",
+            "connection": {
+              "type": "DataShare",
+              "dataShareUri": "azds://eastus:datashare1:12345678-1234-1234-1234-123456789123"
+            },
+            "authProperties": {
+              "type": "ManagedIdentity",
+              "identityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/newTestIdentity"
+            }
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    },
+    "202": {
+      "status": "Accepted",
+      "message": "The resource operation has been received and is being processed.",
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/xxxx/resourceGroups/rg-name/providers/Microsoft.Storage/operations/operation-98765",
+        "Retry-After": 30
+      }
+    }
+  }
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageContextCacheCRUD/ContextCaches_CreateOrUpdate.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageContextCacheCRUD/ContextCaches_CreateOrUpdate.json
@@ -1,0 +1,82 @@
+{
+  "operationId": "ContextCaches_CreateOrUpdate",
+  "title": "Create a Context Cache",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "testrg",
+    "api-version": "2026-09-01",
+    "contextCacheName": "testaccount",
+    "resource": {
+      "location": "eastus",
+      "tags": {
+        "environment": "test"
+      },
+      "properties": {
+        "accountKind": "Regional",
+        "description": "Test Azure Context Cache account"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/contextCaches/testaccount",
+        "name": "testaccount",
+        "type": "Microsoft.Storage/contextCaches",
+        "location": "eastus",
+        "tags": {
+          "environment": "test"
+        },
+        "properties": {
+          "accountKind": "Regional",
+          "description": "Test Azure Context Cache account",
+          "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdBy": "user@example.com",
+          "createdByType": "User",
+          "createdAt": "2026-01-01T00:00:00Z",
+          "lastModifiedBy": "user@example.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-01-01T00:00:00Z"
+        }
+      }
+    },
+    "201": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/eastus/operationStatuses/00000000-0000-0000-0000-000000000000?api-version=2026-06-01",
+        "Retry-After": "10"
+      },
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/contextCaches/testaccount",
+        "name": "testaccount",
+        "type": "Microsoft.Storage/contextCaches",
+        "location": "eastus",
+        "tags": {
+          "environment": "test"
+        },
+        "properties": {
+          "accountKind": "Regional",
+          "description": "Test Azure Context Cache account",
+          "provisioningState": "Creating"
+        },
+        "systemData": {
+          "createdBy": "user@example.com",
+          "createdByType": "User",
+          "createdAt": "2026-01-01T00:00:00Z",
+          "lastModifiedBy": "user@example.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-01-01T00:00:00Z"
+        }
+      }
+    },
+    "default": {
+      "body": {
+        "error": {
+          "code": "InvalidOperation",
+          "message": "Invalid request body or parameters"
+        }
+      }
+    }
+  }
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageContextCacheCRUD/ContextCaches_CreateOrUpdate_SystemIdentity.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageContextCacheCRUD/ContextCaches_CreateOrUpdate_SystemIdentity.json
@@ -1,0 +1,119 @@
+{
+  "operationId": "ContextCaches_CreateOrUpdate",
+  "title": "Create a Azure Context Cache Account with System Assigned Identity",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "testrg",
+    "api-version": "2026-09-01",
+    "contextCacheName": "testaccount",
+    "resource": {
+      "location": "eastus",
+      "tags": {
+        "environment": "test"
+      },
+      "identity": {
+        "type": "SystemAssigned"
+      },
+      "properties": {
+        "accountKind": "Regional",
+        "description": "Test Azure Context Cache account",
+        "encryption": {
+          "customerManagedKeyEncryption": {
+            "keyEncryptionKeyIdentity": {
+              "identityType": "systemAssignedIdentity"
+            },
+            "keyEncryptionKeyUrl": "https://mykeyvault.vault.azure.net/keys/myEncryptionKey"
+          }
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/contextCaches/testaccount",
+        "name": "testaccount",
+        "type": "Microsoft.Storage/contextCaches",
+        "location": "eastus",
+        "tags": {
+          "environment": "test"
+        },
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-0000-0000-0000-000000000000",
+          "tenantId": "00000000-0000-0000-0000-000000000000"
+        },
+        "properties": {
+          "accountKind": "Regional",
+          "description": "Test Azure Context Cache account",
+          "encryption": {
+            "customerManagedKeyEncryption": {
+              "keyEncryptionKeyIdentity": {
+                "identityType": "systemAssignedIdentity"
+              },
+              "keyEncryptionKeyUrl": "https://mykeyvault.vault.azure.net/keys/myEncryptionKey"
+            }
+          },
+          "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdBy": "user@example.com",
+          "createdByType": "User",
+          "createdAt": "2026-01-01T00:00:00Z",
+          "lastModifiedBy": "user@example.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-01-01T00:00:00Z"
+        }
+      }
+    },
+    "201": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/eastus/operationStatuses/00000000-0000-0000-0000-000000000000?api-version=2026-06-01",
+        "Retry-After": "10"
+      },
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/contextCaches/testaccount",
+        "name": "testaccount",
+        "type": "Microsoft.Storage/contextCaches",
+        "location": "eastus",
+        "tags": {
+          "environment": "test"
+        },
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-0000-0000-0000-000000000000",
+          "tenantId": "00000000-0000-0000-0000-000000000000"
+        },
+        "properties": {
+          "accountKind": "Regional",
+          "description": "Test Azure Context Cache account",
+          "encryption": {
+            "customerManagedKeyEncryption": {
+              "keyEncryptionKeyIdentity": {
+                "identityType": "systemAssignedIdentity"
+              },
+              "keyEncryptionKeyUrl": "https://mykeyvault.vault.azure.net/keys/myEncryptionKey"
+            }
+          },
+          "provisioningState": "Creating"
+        },
+        "systemData": {
+          "createdBy": "user@example.com",
+          "createdByType": "User",
+          "createdAt": "2026-01-01T00:00:00Z",
+          "lastModifiedBy": "user@example.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-01-01T00:00:00Z"
+        }
+      }
+    },
+    "default": {
+      "body": {
+        "error": {
+          "code": "InvalidOperation",
+          "message": "Invalid request body or parameters"
+        }
+      }
+    }
+  }
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageContextCacheCRUD/ContextCaches_Delete.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageContextCacheCRUD/ContextCaches_Delete.json
@@ -1,0 +1,27 @@
+{
+  "operationId": "ContextCaches_Delete",
+  "title": "Delete a Context Cache",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "testrg",
+    "api-version": "2026-09-01",
+    "contextCacheName": "testaccount"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/eastus/operationStatuses/00000000-0000-0000-0000-000000000001?api-version=2026-06-01",
+        "Retry-After": "10"
+      }
+    },
+    "204": {},
+    "default": {
+      "body": {
+        "error": {
+          "code": "ResourceNotFound",
+          "message": "Resource testaccount not found"
+        }
+      }
+    }
+  }
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageContextCacheCRUD/ContextCaches_Get.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageContextCacheCRUD/ContextCaches_Get.json
@@ -1,0 +1,44 @@
+{
+  "operationId": "ContextCaches_Get",
+  "title": "Get a Context Cache",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "testrg",
+    "api-version": "2026-09-01",
+    "contextCacheName": "testaccount"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/contextCaches/testaccount",
+        "name": "testaccount",
+        "type": "Microsoft.Storage/contextCaches",
+        "location": "eastus",
+        "tags": {
+          "environment": "test"
+        },
+        "properties": {
+          "accountKind": "Regional",
+          "description": "Test Azure Context Cache account",
+          "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdBy": "user@example.com",
+          "createdByType": "User",
+          "createdAt": "2026-01-01T00:00:00Z",
+          "lastModifiedBy": "user@example.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-01-01T00:00:00Z"
+        }
+      }
+    },
+    "default": {
+      "body": {
+        "error": {
+          "code": "ResourceNotFound",
+          "message": "Resource testaccount not found"
+        }
+      }
+    }
+  }
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageContextCacheCRUD/ContextCaches_ListByResourceGroup.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageContextCacheCRUD/ContextCaches_ListByResourceGroup.json
@@ -1,0 +1,47 @@
+{
+  "operationId": "ContextCaches_ListByResourceGroup",
+  "title": "List Context Caches by Resource Group",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "testrg",
+    "api-version": "2026-09-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/contextCaches/testaccount",
+            "name": "testaccount",
+            "type": "Microsoft.Storage/contextCaches",
+            "location": "eastus",
+            "tags": {
+              "environment": "test"
+            },
+            "properties": {
+              "accountKind": "Regional",
+              "description": "Test Azure Context Cache account",
+              "provisioningState": "Succeeded"
+            },
+            "systemData": {
+              "createdBy": "user@example.com",
+              "createdByType": "User",
+              "createdAt": "2026-01-01T00:00:00Z",
+              "lastModifiedBy": "user@example.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2026-01-01T00:00:00Z"
+            }
+          }
+        ]
+      }
+    },
+    "default": {
+      "body": {
+        "error": {
+          "code": "InternalServerError",
+          "message": "An unexpected error occurred"
+        }
+      }
+    }
+  }
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageContextCacheCRUD/ContextCaches_ListBySubscription.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageContextCacheCRUD/ContextCaches_ListBySubscription.json
@@ -1,0 +1,46 @@
+{
+  "operationId": "ContextCaches_ListBySubscription",
+  "title": "List Context Caches by Subscription",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2026-09-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/contextCaches/testaccount",
+            "name": "testaccount",
+            "type": "Microsoft.Storage/contextCaches",
+            "location": "eastus",
+            "tags": {
+              "environment": "test"
+            },
+            "properties": {
+              "accountKind": "Regional",
+              "description": "Test Azure Context Cache account",
+              "provisioningState": "Succeeded"
+            },
+            "systemData": {
+              "createdBy": "user@example.com",
+              "createdByType": "User",
+              "createdAt": "2026-01-01T00:00:00Z",
+              "lastModifiedBy": "user@example.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2026-01-01T00:00:00Z"
+            }
+          }
+        ]
+      }
+    },
+    "default": {
+      "body": {
+        "error": {
+          "code": "InternalServerError",
+          "message": "An unexpected error occurred"
+        }
+      }
+    }
+  }
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageContextCacheCRUD/ContextCaches_Update.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageContextCacheCRUD/ContextCaches_Update.json
@@ -1,0 +1,76 @@
+{
+  "operationId": "ContextCaches_Update",
+  "title": "Update a Context Cache tags",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "testrg",
+    "api-version": "2026-09-01",
+    "contextCacheName": "testaccount",
+    "properties": {
+      "tags": {
+        "environment": "production",
+        "team": "context-cache"
+      },
+      "identity": {
+        "type": "SystemAssigned"
+      },
+      "properties": {
+        "description": "Updated Prompt Service account description"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/contextCaches/testaccount",
+        "name": "testaccount",
+        "type": "Microsoft.Storage/contextCaches",
+        "location": "eastus",
+        "tags": {
+          "environment": "production",
+          "team": "context-cache"
+        },
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-0000-0000-0000-000000000000",
+          "tenantId": "00000000-0000-0000-0000-000000000000"
+        },
+        "properties": {
+          "accountKind": "Regional",
+          "description": "Updated Prompt Service account description",
+          "encryption": {
+            "customerManagedKeyEncryption": {
+              "keyEncryptionKeyIdentity": {
+                "identityType": "systemAssignedIdentity"
+              },
+              "keyEncryptionKeyUrl": "https://mykeyvault.vault.azure.net/keys/myEncryptionKey"
+            }
+          },
+          "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdBy": "user@example.com",
+          "createdByType": "User",
+          "createdAt": "2026-01-01T00:00:00Z",
+          "lastModifiedBy": "user@example.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-01-01T00:00:00Z"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/contextCaches/testaccount?api-version=2026-06-01",
+        "Retry-After": "10"
+      }
+    },
+    "default": {
+      "body": {
+        "error": {
+          "code": "InvalidOperation",
+          "message": "Invalid request body or parameters"
+        }
+      }
+    }
+  }
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageContextCacheCRUD/ContextCaches_Update_CustomerManagedKey.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageContextCacheCRUD/ContextCaches_Update_CustomerManagedKey.json
@@ -1,0 +1,84 @@
+{
+  "operationId": "ContextCaches_Update",
+  "title": "Update a Azure Context Cache Account's Customer Managed Key Encryption Settings",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "testrg",
+    "api-version": "2026-09-01",
+    "contextCacheName": "testaccount",
+    "properties": {
+      "tags": {
+        "environment": "production",
+        "team": "context-cache"
+      },
+      "identity": {
+        "type": "SystemAssigned"
+      },
+      "properties": {
+        "description": "Updated Prompt Service account description",
+        "encryption": {
+          "customerManagedKeyEncryption": {
+            "keyEncryptionKeyIdentity": {
+              "identityType": "systemAssignedIdentity"
+            },
+            "keyEncryptionKeyUrl": "https://mykeyvault.vault.azure.net/keys/newEncryptionKey"
+          }
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/contextCaches/testaccount",
+        "name": "testaccount",
+        "type": "Microsoft.Storage/contextCaches",
+        "location": "eastus",
+        "tags": {
+          "environment": "production",
+          "team": "context-cache"
+        },
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "00000000-0000-0000-0000-000000000000",
+          "tenantId": "00000000-0000-0000-0000-000000000000"
+        },
+        "properties": {
+          "accountKind": "Regional",
+          "description": "Updated Prompt Service account description",
+          "encryption": {
+            "customerManagedKeyEncryption": {
+              "keyEncryptionKeyIdentity": {
+                "identityType": "systemAssignedIdentity"
+              },
+              "keyEncryptionKeyUrl": "https://mykeyvault.vault.azure.net/keys/newEncryptionKey"
+            }
+          },
+          "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdBy": "user@example.com",
+          "createdByType": "User",
+          "createdAt": "2026-01-01T00:00:00Z",
+          "lastModifiedBy": "user@example.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-01-01T00:00:00Z"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/contextCaches/testaccount?api-version=2026-06-01",
+        "Retry-After": "10"
+      }
+    },
+    "default": {
+      "body": {
+        "error": {
+          "code": "InvalidOperation",
+          "message": "Invalid request body or parameters"
+        }
+      }
+    }
+  }
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageContextCacheContainerCRUD/ContextCacheContainers_CreateOrUpdate.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageContextCacheContainerCRUD/ContextCacheContainers_CreateOrUpdate.json
@@ -1,0 +1,69 @@
+{
+  "operationId": "ContextCacheContainers_CreateOrUpdate",
+  "title": "Create a Context Cache Container",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "testrg",
+    "api-version": "2026-09-01",
+    "contextCacheName": "testaccount",
+    "contextCacheContainerName": "gpt4-prompts",
+    "resource": {
+      "properties": {
+        "description": "Container for GPT-4 prompt caching",
+        "modelName": "gpt-4",
+        "provider": "OpenAI",
+        "timeToLive": 7
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/contextCaches/testaccount/contextCacheContainers/gpt4-prompts",
+        "name": "gpt4-prompts",
+        "type": "Microsoft.Storage/contextCaches/contextCacheContainers",
+        "properties": {
+          "description": "Container for GPT-4 prompt caching",
+          "modelName": "gpt-4",
+          "provider": "OpenAI",
+          "timeToLive": 7,
+          "provisioningState": "Succeeded"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/contextCaches/testaccount/contextCacheContainers/gpt4-prompts",
+        "name": "gpt4-prompts",
+        "type": "Microsoft.Storage/contextCaches/contextCacheContainers",
+        "properties": {
+          "description": "Container for GPT-4 prompt caching",
+          "modelName": "gpt-4",
+          "provider": "OpenAI",
+          "timeToLive": 7,
+          "provisioningState": "Creating"
+        },
+        "systemData": {
+          "createdBy": "user@example.com",
+          "createdByType": "User",
+          "createdAt": "2026-01-01T00:00:00Z",
+          "lastModifiedBy": "user@example.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-01-01T00:00:00Z"
+        }
+      },
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/eastus/operations/00000000-0000-0000-0000-000000000001?api-version=2026-06-01",
+        "Retry-After": 10
+      }
+    },
+    "default": {
+      "body": {
+        "error": {
+          "code": "InvalidContainerName",
+          "message": "Container name must be 3-63 characters, lowercase alphanumeric and hyphens"
+        }
+      }
+    }
+  }
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageContextCacheContainerCRUD/ContextCacheContainers_Delete.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageContextCacheContainerCRUD/ContextCacheContainers_Delete.json
@@ -1,0 +1,28 @@
+{
+  "operationId": "ContextCacheContainers_Delete",
+  "title": "Delete a Context Cache Container",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "testrg",
+    "api-version": "2026-09-01",
+    "contextCacheName": "testaccount",
+    "contextCacheContainerName": "gpt4-prompts"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/eastus/operationStatuses/00000000-0000-0000-0000-000000000002?api-version=2026-06-01",
+        "Retry-After": "10"
+      }
+    },
+    "204": {},
+    "default": {
+      "body": {
+        "error": {
+          "code": "ResourceNotFound",
+          "message": "Container gpt4-prompts not found"
+        }
+      }
+    }
+  }
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageContextCacheContainerCRUD/ContextCacheContainers_Get.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageContextCacheContainerCRUD/ContextCacheContainers_Get.json
@@ -1,0 +1,42 @@
+{
+  "operationId": "ContextCacheContainers_Get",
+  "title": "Get a Context Cache Container",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "testrg",
+    "api-version": "2026-09-01",
+    "contextCacheName": "testaccount",
+    "contextCacheContainerName": "gpt4-prompts"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/contextCaches/testaccount/contextCacheContainers/gpt4-prompts",
+        "name": "gpt4-prompts",
+        "type": "Microsoft.Storage/contextCaches/contextCacheContainers",
+        "properties": {
+          "description": "Container for GPT-4 prompt caching",
+          "modelName": "gpt-4",
+          "provider": "OpenAI",
+          "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdBy": "user@example.com",
+          "createdByType": "User",
+          "createdAt": "2026-01-01T00:00:00Z",
+          "lastModifiedBy": "user@example.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-01-01T00:00:00Z"
+        }
+      }
+    },
+    "default": {
+      "body": {
+        "error": {
+          "code": "ResourceNotFound",
+          "message": "Container gpt4-prompts not found"
+        }
+      }
+    }
+  }
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageContextCacheContainerCRUD/ContextCacheContainers_ListByContextCache.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageContextCacheContainerCRUD/ContextCacheContainers_ListByContextCache.json
@@ -1,0 +1,48 @@
+{
+  "operationId": "ContextCacheContainers_ListByContextCache",
+  "title": "List Context Cache Containers in a Context Cache",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "testrg",
+    "api-version": "2026-09-01",
+    "contextCacheName": "testaccount"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/contextCaches/testaccount/contextCacheContainers/gpt4-prompts",
+            "name": "gpt4-prompts",
+            "type": "Microsoft.Storage/contextCaches/contextCacheContainers",
+            "properties": {
+              "description": "Container for GPT-4 prompt caching",
+              "modelName": "gpt-4",
+              "provider": "OpenAI",
+              "provisioningState": "Succeeded"
+            }
+          },
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/contextCaches/testaccount/contextCacheContainers/claude3-prompts",
+            "name": "claude3-prompts",
+            "type": "Microsoft.Storage/contextCaches/contextCacheContainers",
+            "properties": {
+              "description": "Container for Claude-3 prompt caching",
+              "modelName": "claude-3",
+              "provider": "Anthropic",
+              "provisioningState": "Succeeded"
+            }
+          }
+        ]
+      }
+    },
+    "default": {
+      "body": {
+        "error": {
+          "code": "ResourceNotFound",
+          "message": "Account testaccount not found"
+        }
+      }
+    }
+  }
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageContextCacheContainerCRUD/ContextCacheContainers_Update.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageContextCacheContainerCRUD/ContextCacheContainers_Update.json
@@ -1,0 +1,47 @@
+{
+  "operationId": "ContextCacheContainers_Update",
+  "title": "Update a Context Cache Container",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "testrg",
+    "api-version": "2026-09-01",
+    "contextCacheName": "testaccount",
+    "contextCacheContainerName": "gpt4-prompts",
+    "properties": {
+      "properties": {
+        "description": "Updated container for GPT-4 prompt caching",
+        "timeToLive": 14
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/contextCaches/testaccount/contextCacheContainers/gpt4-prompts",
+        "name": "gpt4-prompts",
+        "type": "Microsoft.Storage/contextCaches/contextCacheContainers",
+        "properties": {
+          "description": "Updated container for GPT-4 prompt caching",
+          "modelName": "gpt-4",
+          "provider": "OpenAI",
+          "timeToLive": 14,
+          "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdBy": "user@example.com",
+          "createdByType": "User",
+          "createdAt": "2026-01-01T00:00:00Z",
+          "lastModifiedBy": "user@example.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-01-01T00:00:00Z"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/contextCaches/testaccount/contextCacheContainers/gpt4-prompts?api-version=2026-06-01",
+        "Retry-After": "10"
+      }
+    }
+  }
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageDataShareCRUD/StorageDataShares_Create.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageDataShareCRUD/StorageDataShares_Create.json
@@ -1,0 +1,86 @@
+{
+  "operationId": "DataShares_Create",
+  "title": "CreateDataShare",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "testrg",
+    "api-version": "2026-09-01",
+    "dataShareName": "testdatashare",
+    "accountName": "teststorageaccount",
+    "resource": {
+      "location": "eastus",
+      "properties": {
+        "description": "Dummy data share",
+        "accessPolicies": [
+          {
+            "principalId": "00000000-0000-0000-0000-000000000000",
+            "tenantId": "00000000-0000-0000-0000-000000000000",
+            "permission": "Read"
+          }
+        ],
+        "assets": [
+          {
+            "assetPath": "/container/folder/foo",
+            "displayName": "virtualFoo"
+          }
+        ]
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/storageAccounts/teststorageaccount/dataShares/testdatashare",
+        "name": "testdatashare",
+        "type": "Microsoft.Storage/storageAccounts/dataShares",
+        "location": "eastus",
+        "properties": {
+          "dataShareIdentifier": "00000000-0000-0000-0000-000000000000",
+          "description": "Dummy data share",
+          "dataShareUri": "azds://eastus:testdatashare:00000000-0000-0000-0000-000000000000",
+          "accessPolicies": [
+            {
+              "principalId": "00000000-0000-0000-0000-000000000000",
+              "tenantId": "00000000-0000-0000-0000-000000000000",
+              "permission": "Read"
+            }
+          ],
+          "assets": [
+            {
+              "assetPath": "/container/folder/foo",
+              "displayName": "virtualFoo"
+            }
+          ],
+          "provisioningState": "Succeeded"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/storageAccounts/teststorageaccount/dataShares/testdatashare",
+        "name": "testdatashare",
+        "type": "Microsoft.Storage/storageAccounts/dataShares",
+        "location": "eastus",
+        "properties": {
+          "dataShareIdentifier": "00000000-0000-0000-0000-000000000000",
+          "description": "Dummy data share",
+          "dataShareUri": "azds://eastus:testdatashare:00000000-0000-0000-0000-000000000000",
+          "accessPolicies": [
+            {
+              "principalId": "00000000-0000-0000-0000-000000000000",
+              "tenantId": "00000000-0000-0000-0000-000000000000",
+              "permission": "Read"
+            }
+          ],
+          "assets": [
+            {
+              "assetPath": "/container/folder/foo",
+              "displayName": "virtualFoo"
+            }
+          ],
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  }
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageDataShareCRUD/StorageDataShares_Delete.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageDataShareCRUD/StorageDataShares_Delete.json
@@ -1,0 +1,22 @@
+{
+  "operationId": "DataShares_Delete",
+  "title": "DeleteDataShare",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "testrg",
+    "accountName": "teststorageaccount",
+    "dataShareName": "testdatashare",
+    "api-version": "2026-09-01"
+  },
+  "responses": {
+    "204": {},
+    "202": {
+      "status": "Accepted",
+      "message": "The resource operation has been received and is being processed.",
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/xxxx/resourceGroups/rg-name/providers/Microsoft.Storage/operations/operation-98765",
+        "Retry-After": 30
+      }
+    }
+  }
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageDataShareCRUD/StorageDataShares_Get.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageDataShareCRUD/StorageDataShares_Get.json
@@ -1,0 +1,40 @@
+{
+  "operationId": "DataShares_Get",
+  "title": "GetDataShare",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "testrg",
+    "accountName": "teststorageaccount",
+    "api-version": "2026-09-01",
+    "dataShareName": "testdatashare"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/storageAccounts/teststorageaccounts/datashares/testdatashare",
+        "name": "testdatashare",
+        "type": "Microsoft.Storage/storageAccounts/dataShares",
+        "location": "eastus",
+        "properties": {
+          "dataShareIdentifier": "00000000-0000-0000-0000-000000000000",
+          "description": "Dummy data share",
+          "dataShareUri": "azds://eastus:testdatashare:00000000-0000-0000-0000-000000000000",
+          "accessPolicies": [
+            {
+              "principalId": "00000000-0000-0000-0000-000000000000",
+              "tenantId": "00000000-0000-0000-0000-000000000000",
+              "permission": "Read"
+            }
+          ],
+          "assets": [
+            {
+              "assetPath": "/container/folder/foo",
+              "displayName": "virtualFoo"
+            }
+          ],
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  }
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageDataShareCRUD/StorageDataShares_ListByStorageAccount.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageDataShareCRUD/StorageDataShares_ListByStorageAccount.json
@@ -1,0 +1,68 @@
+{
+  "operationId": "DataShares_ListByStorageAccount",
+  "title": "ListDataSharesByStorageAccount",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "testrg",
+    "accountName": "teststorageaccount",
+    "api-version": "2026-09-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/storageAccounts/teststorageaccount/dataShares/testdatashare1",
+            "name": "testdatashare1",
+            "type": "Microsoft.Storage/storageAccounts/dataShares",
+            "location": "eastus",
+            "properties": {
+              "dataShareIdentifier": "00000000-0000-0000-0000-000000000000",
+              "description": "Dummy data share",
+              "dataShareUri": "azds://eastus:testdatashare1:00000000-0000-0000-0000-000000000000",
+              "accessPolicies": [
+                {
+                  "principalId": "00000000-0000-0000-0000-000000000000",
+                  "tenantId": "00000000-0000-0000-0000-000000000000",
+                  "permission": "Read"
+                }
+              ],
+              "assets": [
+                {
+                  "assetPath": "/container/folder/foo",
+                  "displayName": "virtualFoo"
+                }
+              ],
+              "provisioningState": "Succeeded"
+            }
+          },
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/storageAccounts/teststorageaccount/dataShares/testdatashare2",
+            "name": "testdatashare2",
+            "type": "Microsoft.Storage/storageAccounts/dataShares",
+            "location": "westus",
+            "properties": {
+              "dataShareIdentifier": "00000000-0000-0000-0000-000000000000",
+              "description": "Dummy data share",
+              "dataShareUri": "azds://eastus:testdatashare2:00000000-0000-0000-0000-000000000000",
+              "accessPolicies": [
+                {
+                  "principalId": "00000000-0000-0000-0000-000000000000",
+                  "tenantId": "00000000-0000-0000-0000-000000000000",
+                  "permission": "Read"
+                }
+              ],
+              "assets": [
+                {
+                  "assetPath": "/container/folder/foo",
+                  "displayName": "virtualFoo"
+                }
+              ],
+              "provisioningState": "Succeeded"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageDataShareCRUD/StorageDataShares_Update.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/StorageDataShareCRUD/StorageDataShares_Update.json
@@ -1,0 +1,66 @@
+{
+  "operationId": "DataShares_Update",
+  "title": "UpdateDataShare",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "testrg",
+    "accountName": "teststorageaccount",
+    "api-version": "2026-09-01",
+    "dataShareName": "testdatashare",
+    "properties": {
+      "properties": {
+        "description": "New dummy data share",
+        "accessPolicies": [
+          {
+            "principalId": "00000000-0000-0000-0000-123456781234",
+            "tenantId": "00000000-0000-0000-0000-987654321987",
+            "permission": "Read"
+          }
+        ],
+        "assets": [
+          {
+            "assetPath": "/container/folder1/bar",
+            "displayName": "virtualBar"
+          }
+        ]
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Storage/storageAccounts/teststorageaccount/dataShares/testdatashare",
+        "name": "testdatashare",
+        "type": "Microsoft.Storage/storageAccounts/dataShares",
+        "location": "eastus",
+        "properties": {
+          "dataShareIdentifier": "00000000-0000-0000-0000-000000000000",
+          "description": "New dummy data share",
+          "dataShareUri": "azds://eastus:testdatashare:00000000-0000-0000-0000-000000000000",
+          "accessPolicies": [
+            {
+              "principalId": "00000000-0000-0000-0000-123456781234",
+              "tenantId": "00000000-0000-0000-0000-987654321987",
+              "permission": "Read"
+            }
+          ],
+          "assets": [
+            {
+              "assetPath": "/container/folder1/bar",
+              "displayName": "virtualBar"
+            }
+          ],
+          "provisioningState": "Succeeded"
+        }
+      }
+    },
+    "202": {
+      "status": "Accepted",
+      "message": "The resource operation has been received and is being processed.",
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/xxxx/resourceGroups/rg-name/providers/Microsoft.Storage/operations/operation-98765",
+        "Retry-After": 30
+      }
+    }
+  }
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/TableOperationDelete.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/TableOperationDelete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "accountName": "sto328",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res3376",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "tableName": "table6185"
+  },
+  "responses": {
+    "204": {}
+  },
+  "operationId": "Table_Delete",
+  "title": "TableOperationDelete"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/TableOperationGet.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/TableOperationGet.json
@@ -1,0 +1,24 @@
+{
+  "parameters": {
+    "accountName": "sto328",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res3376",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "tableName": "table6185"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "table6185",
+        "type": "Microsoft.Storage/storageAccounts/tableServices/tables",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res3376/providers/Microsoft.Storage/storageAccounts/sto328/tableServices/default/tables/table6185",
+        "properties": {
+          "tableName": "table6185"
+        }
+      }
+    }
+  },
+  "operationId": "Table_Get",
+  "title": "TableOperationGet"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/TableOperationList.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/TableOperationList.json
@@ -1,0 +1,36 @@
+{
+  "parameters": {
+    "accountName": "sto328",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res9290",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://sto1590endpoint/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res9290/providers/Microsoft.Storage/storageAccounts/sto328/tableServices/default/tables?api-version=2022-09-01&NextTableName=1!40!bXl0YWJsZXNoYzU0OAEwMWQ2MTI5ZTJmYjVmODFh",
+        "value": [
+          {
+            "name": "table6185",
+            "type": "Microsoft.Storage/storageAccounts/tableServices/tables",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res3376/providers/Microsoft.Storage/storageAccounts/sto328/tableServices/default/tables/table6185",
+            "properties": {
+              "tableName": "table6185"
+            }
+          },
+          {
+            "name": "table6186",
+            "type": "Microsoft.Storage/storageAccounts/tableServices/tables",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res3376/providers/Microsoft.Storage/storageAccounts/sto328/tableServices/default/tables/table6186",
+            "properties": {
+              "tableName": "table6186"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Table_List",
+  "title": "TableOperationList"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/TableOperationPatch.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/TableOperationPatch.json
@@ -1,0 +1,24 @@
+{
+  "parameters": {
+    "accountName": "sto328",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res3376",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "tableName": "table6185"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "table6185",
+        "type": "Microsoft.Storage/storageAccounts/tableServices/tables",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res3376/providers/Microsoft.Storage/storageAccounts/sto328/tableServices/default/tables/table6185",
+        "properties": {
+          "tableName": "table6185"
+        }
+      }
+    }
+  },
+  "operationId": "Table_Update",
+  "title": "TableOperationPatch"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/TableOperationPut.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/TableOperationPut.json
@@ -1,0 +1,24 @@
+{
+  "parameters": {
+    "accountName": "sto328",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res3376",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "tableName": "table6185"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "table6185",
+        "type": "Microsoft.Storage/storageAccounts/tableServices/tables",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res3376/providers/Microsoft.Storage/storageAccounts/sto328/tableServices/default/tables/table6185",
+        "properties": {
+          "tableName": "table6185"
+        }
+      }
+    }
+  },
+  "operationId": "Table_Create",
+  "title": "TableOperationPut"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/TableOperationPutOrPatchAcls.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/TableOperationPutOrPatchAcls.json
@@ -1,0 +1,64 @@
+{
+  "parameters": {
+    "accountName": "sto328",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "parameters": {
+      "properties": {
+        "signedIdentifiers": [
+          {
+            "accessPolicy": {
+              "expiryTime": "2022-03-20T08:49:37.0000000Z",
+              "permission": "raud",
+              "startTime": "2022-03-17T08:49:37.0000000Z"
+            },
+            "id": "MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI"
+          },
+          {
+            "accessPolicy": {
+              "expiryTime": "2022-03-20T08:49:37.0000000Z",
+              "permission": "rad",
+              "startTime": "2022-03-17T08:49:37.0000000Z"
+            },
+            "id": "PTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODklMTI"
+          }
+        ]
+      }
+    },
+    "resourceGroupName": "res3376",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "tableName": "table6185"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "table6185",
+        "type": "Microsoft.Storage/storageAccounts/tableServices/tables",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res3376/providers/Microsoft.Storage/storageAccounts/sto328/tableServices/default/tables/table6185",
+        "properties": {
+          "signedIdentifiers": [
+            {
+              "accessPolicy": {
+                "expiryTime": "2022-03-20T08:49:37.0000000Z",
+                "permission": "raud",
+                "startTime": "2022-03-17T08:49:37.0000000Z"
+              },
+              "id": "MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI"
+            },
+            {
+              "accessPolicy": {
+                "expiryTime": "2022-03-20T08:49:37.0000000Z",
+                "permission": "rad",
+                "startTime": "2022-03-17T08:49:37.0000000Z"
+              },
+              "id": "PTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODklMTI"
+            }
+          ],
+          "tableName": "table6185"
+        }
+      }
+    }
+  },
+  "operationId": "Table_Update",
+  "title": "TableOperationPutOrPatchAcls"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/TableOperationPutOrPatchAclsTableCreate.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/TableOperationPutOrPatchAclsTableCreate.json
@@ -1,0 +1,64 @@
+{
+  "parameters": {
+    "accountName": "sto328",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "parameters": {
+      "properties": {
+        "signedIdentifiers": [
+          {
+            "accessPolicy": {
+              "expiryTime": "2022-03-20T08:49:37.0000000Z",
+              "permission": "raud",
+              "startTime": "2022-03-17T08:49:37.0000000Z"
+            },
+            "id": "MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI"
+          },
+          {
+            "accessPolicy": {
+              "expiryTime": "2022-03-20T08:49:37.0000000Z",
+              "permission": "rad",
+              "startTime": "2022-03-17T08:49:37.0000000Z"
+            },
+            "id": "PTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODklMTI"
+          }
+        ]
+      }
+    },
+    "resourceGroupName": "res3376",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "tableName": "table6185"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "table6185",
+        "type": "Microsoft.Storage/storageAccounts/tableServices/tables",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res3376/providers/Microsoft.Storage/storageAccounts/sto328/tableServices/default/tables/table6185",
+        "properties": {
+          "signedIdentifiers": [
+            {
+              "accessPolicy": {
+                "expiryTime": "2022-03-20T08:49:37.0000000Z",
+                "permission": "raud",
+                "startTime": "2022-03-17T08:49:37.0000000Z"
+              },
+              "id": "MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI"
+            },
+            {
+              "accessPolicy": {
+                "expiryTime": "2022-03-20T08:49:37.0000000Z",
+                "permission": "rad",
+                "startTime": "2022-03-17T08:49:37.0000000Z"
+              },
+              "id": "PTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODklMTI"
+            }
+          ],
+          "tableName": "table6185"
+        }
+      }
+    }
+  },
+  "operationId": "Table_Create",
+  "title": "TableOperationPutOrPatchAcls"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/TableServicesGet.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/TableServicesGet.json
@@ -1,0 +1,84 @@
+{
+  "parameters": {
+    "accountName": "sto8607",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res4410",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "tableServiceName": "default"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.Storage/storageAccounts/tableServices",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res4410/providers/Microsoft.Storage/storageAccounts/sto8607/tableServices/default",
+        "properties": {
+          "cors": {
+            "corsRules": [
+              {
+                "allowedHeaders": [
+                  "x-ms-meta-abc",
+                  "x-ms-meta-data*",
+                  "x-ms-meta-target*"
+                ],
+                "allowedMethods": [
+                  "GET",
+                  "HEAD",
+                  "POST",
+                  "OPTIONS",
+                  "MERGE",
+                  "PUT"
+                ],
+                "allowedOrigins": [
+                  "http://www.contoso.com",
+                  "http://www.fabrikam.com"
+                ],
+                "exposedHeaders": [
+                  "x-ms-meta-*"
+                ],
+                "maxAgeInSeconds": 100
+              },
+              {
+                "allowedHeaders": [
+                  "*"
+                ],
+                "allowedMethods": [
+                  "GET"
+                ],
+                "allowedOrigins": [
+                  "*"
+                ],
+                "exposedHeaders": [
+                  "*"
+                ],
+                "maxAgeInSeconds": 2
+              },
+              {
+                "allowedHeaders": [
+                  "x-ms-meta-12345675754564*"
+                ],
+                "allowedMethods": [
+                  "GET",
+                  "PUT"
+                ],
+                "allowedOrigins": [
+                  "http://www.abc23.com",
+                  "https://www.fabrikam.com/*"
+                ],
+                "exposedHeaders": [
+                  "x-ms-meta-abc",
+                  "x-ms-meta-data*",
+                  "x-ms-meta-target*"
+                ],
+                "maxAgeInSeconds": 2000
+              }
+            ]
+          }
+        }
+      }
+    }
+  },
+  "operationId": "TableServices_GetServiceProperties",
+  "title": "TableServicesGet"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/TableServicesList.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/TableServicesList.json
@@ -1,0 +1,87 @@
+{
+  "parameters": {
+    "accountName": "sto1590",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "resourceGroupName": "res9290",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "default",
+            "type": "Microsoft.Storage/storageAccounts/tableServices",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/res4410/providers/Microsoft.Storage/storageAccounts/sto8607/tableServices/default",
+            "properties": {
+              "cors": {
+                "corsRules": [
+                  {
+                    "allowedHeaders": [
+                      "x-ms-meta-abc",
+                      "x-ms-meta-data*",
+                      "x-ms-meta-target*"
+                    ],
+                    "allowedMethods": [
+                      "GET",
+                      "HEAD",
+                      "POST",
+                      "OPTIONS",
+                      "MERGE",
+                      "PUT"
+                    ],
+                    "allowedOrigins": [
+                      "http://www.contoso.com",
+                      "http://www.fabrikam.com"
+                    ],
+                    "exposedHeaders": [
+                      "x-ms-meta-*"
+                    ],
+                    "maxAgeInSeconds": 100
+                  },
+                  {
+                    "allowedHeaders": [
+                      "*"
+                    ],
+                    "allowedMethods": [
+                      "GET"
+                    ],
+                    "allowedOrigins": [
+                      "*"
+                    ],
+                    "exposedHeaders": [
+                      "*"
+                    ],
+                    "maxAgeInSeconds": 2
+                  },
+                  {
+                    "allowedHeaders": [
+                      "x-ms-meta-12345675754564*"
+                    ],
+                    "allowedMethods": [
+                      "GET",
+                      "PUT"
+                    ],
+                    "allowedOrigins": [
+                      "http://www.abc23.com",
+                      "https://www.fabrikam.com/*"
+                    ],
+                    "exposedHeaders": [
+                      "x-ms-meta-abc",
+                      "x-ms-meta-data*",
+                      "x-ms-meta-target*"
+                    ],
+                    "maxAgeInSeconds": 2000
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "TableServices_List",
+  "title": "TableServicesList"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/TableServicesPut.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/TableServicesPut.json
@@ -1,0 +1,149 @@
+{
+  "parameters": {
+    "accountName": "sto8607",
+    "api-version": "2026-09-01",
+    "monitor": "true",
+    "parameters": {
+      "properties": {
+        "cors": {
+          "corsRules": [
+            {
+              "allowedHeaders": [
+                "x-ms-meta-abc",
+                "x-ms-meta-data*",
+                "x-ms-meta-target*"
+              ],
+              "allowedMethods": [
+                "GET",
+                "HEAD",
+                "POST",
+                "OPTIONS",
+                "MERGE",
+                "PUT"
+              ],
+              "allowedOrigins": [
+                "http://www.contoso.com",
+                "http://www.fabrikam.com"
+              ],
+              "exposedHeaders": [
+                "x-ms-meta-*"
+              ],
+              "maxAgeInSeconds": 100
+            },
+            {
+              "allowedHeaders": [
+                "*"
+              ],
+              "allowedMethods": [
+                "GET"
+              ],
+              "allowedOrigins": [
+                "*"
+              ],
+              "exposedHeaders": [
+                "*"
+              ],
+              "maxAgeInSeconds": 2
+            },
+            {
+              "allowedHeaders": [
+                "x-ms-meta-12345675754564*"
+              ],
+              "allowedMethods": [
+                "GET",
+                "PUT"
+              ],
+              "allowedOrigins": [
+                "http://www.abc23.com",
+                "https://www.fabrikam.com/*"
+              ],
+              "exposedHeaders": [
+                "x-ms-meta-abc",
+                "x-ms-meta-data*",
+                "x-ms-meta-target*"
+              ],
+              "maxAgeInSeconds": 2000
+            }
+          ]
+        }
+      }
+    },
+    "resourceGroupName": "res4410",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "tableServiceName": "default"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.Storage/storageAccounts/tableServices",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/res4410/providers/Microsoft.Storage/storageAccounts/sto8607/tableServices/default",
+        "properties": {
+          "cors": {
+            "corsRules": [
+              {
+                "allowedHeaders": [
+                  "x-ms-meta-abc",
+                  "x-ms-meta-data*",
+                  "x-ms-meta-target*"
+                ],
+                "allowedMethods": [
+                  "GET",
+                  "HEAD",
+                  "POST",
+                  "OPTIONS",
+                  "MERGE",
+                  "PUT"
+                ],
+                "allowedOrigins": [
+                  "http://www.contoso.com",
+                  "http://www.fabrikam.com"
+                ],
+                "exposedHeaders": [
+                  "x-ms-meta-*"
+                ],
+                "maxAgeInSeconds": 100
+              },
+              {
+                "allowedHeaders": [
+                  "*"
+                ],
+                "allowedMethods": [
+                  "GET"
+                ],
+                "allowedOrigins": [
+                  "*"
+                ],
+                "exposedHeaders": [
+                  "*"
+                ],
+                "maxAgeInSeconds": 2
+              },
+              {
+                "allowedHeaders": [
+                  "x-ms-meta-12345675754564*"
+                ],
+                "allowedMethods": [
+                  "GET",
+                  "PUT"
+                ],
+                "allowedOrigins": [
+                  "http://www.abc23.com",
+                  "https://www.fabrikam.com/*"
+                ],
+                "exposedHeaders": [
+                  "x-ms-meta-abc",
+                  "x-ms-meta-data*",
+                  "x-ms-meta-target*"
+                ],
+                "maxAgeInSeconds": 2000
+              }
+            ]
+          }
+        }
+      }
+    }
+  },
+  "operationId": "TableServices_SetServiceProperties",
+  "title": "TableServicesPut"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/storageTaskAssignmentsCrud/DeleteStorageTaskAssignment.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/storageTaskAssignmentsCrud/DeleteStorageTaskAssignment.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "accountName": "sto4445",
+    "api-version": "2026-09-01",
+    "resourceGroupName": "res4228",
+    "storageTaskAssignmentName": "myassignment1",
+    "subscriptionId": "1f31ba14-ce16-4281-b9b4-3e78da6e1616"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.Storage/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-06-01"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "StorageTaskAssignments_Delete",
+  "title": "DeleteStorageTaskAssignment"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/storageTaskAssignmentsCrud/GetStorageTaskAssignment.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/storageTaskAssignmentsCrud/GetStorageTaskAssignment.json
@@ -1,0 +1,44 @@
+{
+  "parameters": {
+    "accountName": "sto4445",
+    "api-version": "2026-09-01",
+    "resourceGroupName": "res4228",
+    "storageTaskAssignmentName": "myassignment1",
+    "subscriptionId": "1f31ba14-ce16-4281-b9b4-3e78da6e1616"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myassignment1",
+        "type": "Microsoft.Storage/storageAccounts/storageTaskAssignments",
+        "id": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourceGroups/res4228/providers/Microsoft.Storage/storageAccounts/sto4445/storageTaskAssignments/myassignment1",
+        "properties": {
+          "description": "My Storage task assignment",
+          "enabled": true,
+          "executionContext": {
+            "target": {
+              "excludePrefix": [],
+              "prefix": [
+                "prefix1",
+                "prefix2"
+              ]
+            },
+            "trigger": {
+              "type": "RunOnce",
+              "parameters": {
+                "startOn": "2022-11-15T21:52:47.8145095Z"
+              }
+            }
+          },
+          "provisioningState": "Succeeded",
+          "report": {
+            "prefix": "container1"
+          },
+          "taskId": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourceGroups/res4228/providers/Microsoft.StorageActions/storageTasks/mytask1"
+        }
+      }
+    }
+  },
+  "operationId": "StorageTaskAssignments_Get",
+  "title": "GetStorageTaskAssignment"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/storageTaskAssignmentsCrud/PatchStorageTaskAssignment.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/storageTaskAssignmentsCrud/PatchStorageTaskAssignment.json
@@ -1,0 +1,73 @@
+{
+  "parameters": {
+    "accountName": "sto4445",
+    "api-version": "2026-09-01",
+    "parameters": {
+      "properties": {
+        "description": "My Storage task assignment",
+        "enabled": true,
+        "executionContext": {
+          "target": {
+            "excludePrefix": [],
+            "prefix": [
+              "prefix1",
+              "prefix2"
+            ]
+          },
+          "trigger": {
+            "type": "RunOnce",
+            "parameters": {
+              "startOn": "2022-11-15T21:52:47.8145095Z"
+            }
+          }
+        },
+        "report": {
+          "prefix": "container1"
+        }
+      }
+    },
+    "resourceGroupName": "res4228",
+    "storageTaskAssignmentName": "myassignment1",
+    "subscriptionId": "1f31ba14-ce16-4281-b9b4-3e78da6e1616"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myassignment1",
+        "type": "Microsoft.Storage/storageAccounts/storageTaskAssignments",
+        "id": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourceGroups/res4228/providers/Microsoft.Storage/storageAccounts/sto4445/storageTaskAssignments/myassignment1",
+        "properties": {
+          "description": "My Storage task assignment",
+          "enabled": true,
+          "executionContext": {
+            "target": {
+              "excludePrefix": [],
+              "prefix": [
+                "prefix1",
+                "prefix2"
+              ]
+            },
+            "trigger": {
+              "type": "RunOnce",
+              "parameters": {
+                "startOn": "2022-11-15T21:52:47.8145095Z"
+              }
+            }
+          },
+          "provisioningState": "Succeeded",
+          "report": {
+            "prefix": "container1"
+          },
+          "taskId": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourceGroups/res4228/providers/Microsoft.StorageActions/storageTasks/mytask1"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.Storage/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-06-01"
+      }
+    }
+  },
+  "operationId": "StorageTaskAssignments_Update",
+  "title": "PatchStorageTaskAssignment"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/storageTaskAssignmentsCrud/PutStorageTaskAssignment.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/storageTaskAssignmentsCrud/PutStorageTaskAssignment.json
@@ -1,0 +1,105 @@
+{
+  "parameters": {
+    "accountName": "sto4445",
+    "api-version": "2026-09-01",
+    "parameters": {
+      "properties": {
+        "description": "My Storage task assignment",
+        "enabled": true,
+        "executionContext": {
+          "target": {
+            "excludePrefix": [],
+            "prefix": [
+              "prefix1",
+              "prefix2"
+            ]
+          },
+          "trigger": {
+            "type": "RunOnce",
+            "parameters": {
+              "startOn": "2022-11-15T21:52:47.8145095Z"
+            }
+          }
+        },
+        "report": {
+          "prefix": "container1"
+        },
+        "taskId": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourceGroups/res4228/providers/Microsoft.StorageActions/storageTasks/mytask1"
+      }
+    },
+    "resourceGroupName": "res4228",
+    "storageTaskAssignmentName": "myassignment1",
+    "subscriptionId": "1f31ba14-ce16-4281-b9b4-3e78da6e1616"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myassignment1",
+        "type": "Microsoft.Storage/storageAccounts/storageTaskAssignments",
+        "id": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourceGroups/res4228/providers/Microsoft.Storage/storageAccounts/sto4445/storageTaskAssignments/myassignment1",
+        "properties": {
+          "description": "My Storage task assignment",
+          "enabled": true,
+          "executionContext": {
+            "target": {
+              "excludePrefix": [],
+              "prefix": [
+                "prefix1",
+                "prefix2"
+              ]
+            },
+            "trigger": {
+              "type": "RunOnce",
+              "parameters": {
+                "startOn": "2022-11-15T21:52:47.8145095Z"
+              }
+            }
+          },
+          "provisioningState": "Succeeded",
+          "report": {
+            "prefix": "container1"
+          },
+          "taskId": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourceGroups/res4228/providers/Microsoft.StorageActions/storageTasks/mytask1"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "myassignment1",
+        "type": "Microsoft.Storage/storageAccounts/storageTaskAssignments",
+        "id": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourceGroups/res4228/providers/Microsoft.Storage/storageAccounts/sto4445/storageTaskAssignments/myassignment1",
+        "properties": {
+          "description": "My Storage task assignment",
+          "enabled": true,
+          "executionContext": {
+            "target": {
+              "excludePrefix": [],
+              "prefix": [
+                "prefix1",
+                "prefix2"
+              ]
+            },
+            "trigger": {
+              "type": "RunOnce",
+              "parameters": {
+                "startOn": "2022-11-15T21:52:47.8145095Z"
+              }
+            }
+          },
+          "provisioningState": "Succeeded",
+          "report": {
+            "prefix": "container1"
+          },
+          "taskId": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourceGroups/res4228/providers/Microsoft.StorageActions/storageTasks/mytask1"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.Storage/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-06-01"
+      }
+    }
+  },
+  "operationId": "StorageTaskAssignments_Create",
+  "title": "PutStorageTaskAssignment"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/storageTaskAssignmentsCrud/PutStorageTaskAssignmentMockRun.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/storageTaskAssignmentsCrud/PutStorageTaskAssignmentMockRun.json
@@ -1,0 +1,96 @@
+{
+  "parameters": {
+    "subscriptionId": "1f31ba14-ce16-4281-b9b4-3e78da6e1616",
+    "resourceGroupName": "res4228",
+    "accountName": "sto4445",
+    "storageTaskAssignmentName": "myassignment1",
+    "api-version": "2026-09-01",
+    "parameters": {
+      "properties": {
+        "taskId": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourceGroups/res4228/providers/Microsoft.StorageActions/storageTasks/myStorageTask",
+        "enabled": true,
+        "description": "My Storage task assignment for testing",
+        "executionContext": {
+          "trigger": {
+            "type": "MockRun",
+            "parameters": {
+              "startOn": "2023-01-01T00:00:00.1234567Z"
+            }
+          },
+          "target": {
+            "prefix": [],
+            "excludePrefix": []
+          }
+        },
+        "report": {
+          "prefix": "reports"
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourceGroups/res4228/providers/Microsoft.Storage/storageAccounts/sto4445/storageTaskAssignments/myassignment1",
+        "name": "myassignment1",
+        "type": "Microsoft.Storage/storageAccounts/storageTaskAssignments",
+        "properties": {
+          "taskId": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourceGroups/res4228/providers/Microsoft.StorageActions/storageTasks/myStorageTask",
+          "enabled": true,
+          "description": "My Storage task assignment for testing",
+          "provisioningState": "ValidateSubscriptionQuotaBegin",
+          "executionContext": {
+            "trigger": {
+              "type": "MockRun",
+              "parameters": {
+                "startOn": "2023-01-01T00:00:00.1234567Z"
+              }
+            },
+            "target": {
+              "prefix": [],
+              "excludePrefix": []
+            }
+          },
+          "report": {
+            "prefix": "reports"
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourceGroups/res4228/providers/Microsoft.Storage/storageAccounts/sto4445/storageTaskAssignments/myassignment1",
+        "name": "myassignment1",
+        "type": "Microsoft.Storage/storageAccounts/storageTaskAssignments",
+        "properties": {
+          "taskId": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourceGroups/res4228/providers/Microsoft.StorageActions/storageTasks/myStorageTask",
+          "enabled": true,
+          "description": "My Storage task assignment for testing",
+          "provisioningState": "ValidateSubscriptionQuotaBegin",
+          "executionContext": {
+            "trigger": {
+              "type": "MockRun",
+              "parameters": {
+                "startOn": "2023-01-01T00:00:00.1234567Z"
+              }
+            },
+            "target": {
+              "prefix": [],
+              "excludePrefix": []
+            }
+          },
+          "report": {
+            "prefix": "reports"
+          }
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/{subscription-id}/resourceGroups/res4228/providers/Microsoft.Storage/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-06-01"
+      }
+    }
+  },
+  "operationId": "StorageTaskAssignments_Create",
+  "title": "PutStorageTaskAssignmentMockRun"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/storageTaskAssignmentsCrud/PutStorageTaskAssignmentRequiredProperties.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/storageTaskAssignmentsCrud/PutStorageTaskAssignmentRequiredProperties.json
@@ -1,0 +1,84 @@
+{
+  "parameters": {
+    "accountName": "sto4445",
+    "api-version": "2026-09-01",
+    "parameters": {
+      "properties": {
+        "description": "My Storage task assignment",
+        "enabled": true,
+        "executionContext": {
+          "trigger": {
+            "type": "RunOnce",
+            "parameters": {
+              "startOn": "2022-11-15T21:52:47.8145095Z"
+            }
+          }
+        },
+        "report": {
+          "prefix": "container1"
+        },
+        "taskId": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourceGroups/res4228/providers/Microsoft.StorageActions/storageTasks/mytask1"
+      }
+    },
+    "resourceGroupName": "res4228",
+    "storageTaskAssignmentName": "myassignment1",
+    "subscriptionId": "1f31ba14-ce16-4281-b9b4-3e78da6e1616"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myassignment1",
+        "type": "Microsoft.Storage/storageAccounts/storageTaskAssignments",
+        "id": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourceGroups/res4228/providers/Microsoft.Storage/storageAccounts/sto4445/storageTaskAssignments/myassignment1",
+        "properties": {
+          "description": "My Storage task assignment",
+          "enabled": true,
+          "executionContext": {
+            "trigger": {
+              "type": "RunOnce",
+              "parameters": {
+                "startOn": "2022-11-15T21:52:47.8145095Z"
+              }
+            }
+          },
+          "provisioningState": "Succeeded",
+          "report": {
+            "prefix": "container1"
+          },
+          "taskId": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourceGroups/res4228/providers/Microsoft.StorageActions/storageTasks/mytask1"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "myassignment1",
+        "type": "Microsoft.Storage/storageAccounts/storageTaskAssignments",
+        "id": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourceGroups/res4228/providers/Microsoft.Storage/storageAccounts/sto4445/storageTaskAssignments/myassignment1",
+        "properties": {
+          "description": "My Storage task assignment",
+          "enabled": true,
+          "executionContext": {
+            "trigger": {
+              "type": "RunOnce",
+              "parameters": {
+                "startOn": "2022-11-15T21:52:47.8145095Z"
+              }
+            }
+          },
+          "provisioningState": "Succeeded",
+          "report": {
+            "prefix": "container1"
+          },
+          "taskId": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourceGroups/res4228/providers/Microsoft.StorageActions/storageTasks/mytask1"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/{subscription-id}/resourceGroups/res9101/providers/Microsoft.Storage/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-06-01"
+      }
+    }
+  },
+  "operationId": "StorageTaskAssignments_Create",
+  "title": "PutStorageTaskAssignmentRequiredProperties"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/storageTaskAssignmentsCrud/StopStorageTaskAssignment.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/storageTaskAssignmentsCrud/StopStorageTaskAssignment.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "accountName": "sto4445",
+    "api-version": "2026-09-01",
+    "resourceGroupName": "res4228",
+    "storageTaskAssignmentName": "myassignment1",
+    "subscriptionId": "1f31ba14-ce16-4281-b9b4-3e78da6e1616"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourceGroups/res4228/providers/Microsoft.Storage/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-06-01"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "StorageTaskAssignments_StopAssignment",
+  "title": "StopStorageTaskAssignment"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/storageTaskAssignmentsList/ListStorageTaskAssignmentInstancesReportSummary.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/storageTaskAssignmentsList/ListStorageTaskAssignmentInstancesReportSummary.json
@@ -1,0 +1,61 @@
+{
+  "parameters": {
+    "accountName": "sto4445",
+    "api-version": "2026-09-01",
+    "resourceGroupName": "res4228",
+    "storageTaskAssignmentName": "myassignment1",
+    "subscriptionId": "1f31ba14-ce16-4281-b9b4-3e78da6e1616"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "instance1",
+            "type": "Microsoft.Storage/storageAccounts/reports",
+            "id": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourceGroups/res4228/providers/Microsoft.Storage/storageAccounts/sto4445/storageTaskAssignments/instance1",
+            "properties": {
+              "finishTime": "2023-06-23T00:40:10.2931264Z",
+              "objectFailedCount": "0",
+              "objectsOperatedOnCount": "150",
+              "objectsSucceededCount": "150",
+              "objectsTargetedCount": "150",
+              "runResult": "Succeeded",
+              "runStatusEnum": "Finished",
+              "runStatusError": "0",
+              "startTime": "2023-06-23T00:30:43.226744Z",
+              "storageAccountId": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourcegroups/res4228/providers/Microsoft.Storage/storageAccounts/sto4445",
+              "summaryReportPath": "https://acc123.blob.core.windows.net/result-container/{folderpath}/SummaryReport.json",
+              "taskAssignmentId": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourcegroups/res4228/providers/Microsoft.Storage/storageAccounts/sto4445/storageTaskAssignments/myassignment1",
+              "taskId": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourcegroups/res4228/providers/Microsoft.StorageActions/storageTasks/mytask1",
+              "taskVersion": "1"
+            }
+          },
+          {
+            "name": "instance2",
+            "type": "Microsoft.Storage/storageAccounts/reports",
+            "id": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourceGroups/res4228/providers/Microsoft.Storage/storageAccounts/sto4445/storageTaskAssignments/instance2",
+            "properties": {
+              "finishTime": "2023-06-23T00:40:10.2931264Z",
+              "objectFailedCount": "0",
+              "objectsOperatedOnCount": "150",
+              "objectsSucceededCount": "150",
+              "objectsTargetedCount": "150",
+              "runResult": "Succeeded",
+              "runStatusEnum": "Finished",
+              "runStatusError": "0",
+              "startTime": "2023-06-23T00:30:43.226744Z",
+              "storageAccountId": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourcegroups/res4228/providers/Microsoft.Storage/storageAccounts/sto4445",
+              "summaryReportPath": "https://acc123.blob.core.windows.net/result-container/{folderpath}/SummaryReport.json",
+              "taskAssignmentId": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourcegroups/res4228/providers/Microsoft.Storage/storageAccounts/sto4445/storageTaskAssignments/myassignment1",
+              "taskId": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourcegroups/res4228/providers/Microsoft.StorageActions/storageTasks/mytask1",
+              "taskVersion": "1"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "StorageTaskAssignmentInstancesReport_List",
+  "title": "ListStorageTaskAssignmentInstancesReportSummary"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/storageTaskAssignmentsList/ListStorageTaskAssignmentsForAccount.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/storageTaskAssignmentsList/ListStorageTaskAssignmentsForAccount.json
@@ -1,0 +1,76 @@
+{
+  "parameters": {
+    "accountName": "sto4445",
+    "api-version": "2026-09-01",
+    "resourceGroupName": "res4228",
+    "subscriptionId": "1f31ba14-ce16-4281-b9b4-3e78da6e1616"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "myassignment1",
+            "type": "Microsoft.Storage/storageAccounts/storageTaskAssignments",
+            "id": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourceGroups/res4228/providers/Microsoft.Storage/storageAccounts/sto4445/storageTaskAssignments/myassignment1",
+            "properties": {
+              "description": "My Storage task assignment #1",
+              "enabled": true,
+              "executionContext": {
+                "target": {
+                  "excludePrefix": [],
+                  "prefix": [
+                    "prefix1",
+                    "prefix2"
+                  ]
+                },
+                "trigger": {
+                  "type": "RunOnce",
+                  "parameters": {
+                    "startOn": "2022-11-15T21:52:47.8145095Z"
+                  }
+                }
+              },
+              "provisioningState": "Succeeded",
+              "report": {
+                "prefix": "container1"
+              },
+              "taskId": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourceGroups/res4228/providers/Microsoft.StorageActions/storageTasks/mytask1"
+            }
+          },
+          {
+            "name": "myassignment2",
+            "type": "Microsoft.Storage/storageAccounts/storageTaskAssignments",
+            "id": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourceGroups/res4228/providers/Microsoft.Storage/storageAccounts/sto4445/storageTaskAssignments/myassignment2",
+            "properties": {
+              "description": "My Storage task assignment #2",
+              "enabled": true,
+              "executionContext": {
+                "target": {
+                  "excludePrefix": [],
+                  "prefix": [
+                    "prefix3",
+                    "prefix4"
+                  ]
+                },
+                "trigger": {
+                  "type": "RunOnce",
+                  "parameters": {
+                    "startOn": "2022-11-15T21:52:47.8145095Z"
+                  }
+                }
+              },
+              "provisioningState": "Succeeded",
+              "report": {
+                "prefix": "container2"
+              },
+              "taskId": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourceGroups/res4228/providers/Microsoft.StorageActions/storageTasks/mytask2"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "StorageTaskAssignments_List",
+  "title": "ListStorageTaskAssignmentsForAccount"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/storageTaskAssignmentsList/ListStorageTaskAssignmentsInstancesReportSummary.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/examples/storageTaskAssignmentsList/ListStorageTaskAssignmentsInstancesReportSummary.json
@@ -1,0 +1,60 @@
+{
+  "parameters": {
+    "accountName": "sto4445",
+    "api-version": "2026-09-01",
+    "resourceGroupName": "res4228",
+    "subscriptionId": "1f31ba14-ce16-4281-b9b4-3e78da6e1616"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "instance1",
+            "type": "Microsoft.Storage/storageAccounts/reports",
+            "id": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourceGroups/res4228/providers/Microsoft.Storage/storageAccounts/sto4445/storageTaskAssignments/instance1",
+            "properties": {
+              "finishTime": "2023-06-23T00:40:10.2931264Z",
+              "objectFailedCount": "0",
+              "objectsOperatedOnCount": "150",
+              "objectsSucceededCount": "150",
+              "objectsTargetedCount": "150",
+              "runResult": "Succeeded",
+              "runStatusEnum": "Finished",
+              "runStatusError": "0",
+              "startTime": "2023-06-23T00:30:43.226744Z",
+              "storageAccountId": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourcegroups/res4228/providers/Microsoft.Storage/storageAccounts/sto4445",
+              "summaryReportPath": "https://acc123.blob.core.windows.net/result-container/{folderpath}/SummaryReport.json",
+              "taskAssignmentId": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourcegroups/res4228/providers/Microsoft.Storage/storageAccounts/sto4445/storageTaskAssignments/myassignment1",
+              "taskId": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourcegroups/res4228/providers/Microsoft.StorageActions/storageTasks/mytask1",
+              "taskVersion": "1"
+            }
+          },
+          {
+            "name": "instance2",
+            "type": "Microsoft.Storage/storageAccounts/reports",
+            "id": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourceGroups/res4228/providers/Microsoft.Storage/storageAccounts/sto4445/storageTaskAssignments/instance2",
+            "properties": {
+              "finishTime": "2023-06-23T00:40:10.2931264Z",
+              "objectFailedCount": "0",
+              "objectsOperatedOnCount": "150",
+              "objectsSucceededCount": "150",
+              "objectsTargetedCount": "150",
+              "runResult": "Succeeded",
+              "runStatusEnum": "Finished",
+              "runStatusError": "0",
+              "startTime": "2023-06-23T00:30:43.226744Z",
+              "storageAccountId": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourcegroups/res4228/providers/Microsoft.Storage/storageAccounts/sto4445",
+              "summaryReportPath": "https://acc123.blob.core.windows.net/result-container/{folderpath}/SummaryReport.json",
+              "taskAssignmentId": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourcegroups/res4228/providers/Microsoft.Storage/storageAccounts/sto4445/storageTaskAssignments/myassignment2",
+              "taskId": "/subscriptions/1f31ba14-ce16-4281-b9b4-3e78da6e1616/resourcegroups/res4228/providers/Microsoft.StorageActions/storageTasks/mytask1",
+              "taskVersion": "1"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "StorageTaskAssignmentsInstancesReport_List",
+  "title": "ListStorageTaskAssignmentsInstancesReportSummary"
+}

--- a/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/openapi.json
+++ b/specification/storage/resource-manager/Microsoft.Storage/stable/2026-09-01/openapi.json
@@ -1,0 +1,17710 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "StorageManagementClient",
+    "version": "2026-09-01",
+    "description": "The Azure Storage Management API.",
+    "x-typespec-generated": [
+      {
+        "emitter": "@azure-tools/typespec-autorest"
+      }
+    ]
+  },
+  "schemes": [
+    "https"
+  ],
+  "host": "management.azure.com",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Operations"
+    },
+    {
+      "name": "BlobContainers"
+    },
+    {
+      "name": "BlobServices"
+    },
+    {
+      "name": "StorageAccounts"
+    },
+    {
+      "name": "ImmutabilityPolicies"
+    },
+    {
+      "name": "FileShares"
+    },
+    {
+      "name": "FileServices"
+    },
+    {
+      "name": "FileServiceUsageOperationGroup"
+    },
+    {
+      "name": "QueueServices"
+    },
+    {
+      "name": "StorageQueues"
+    },
+    {
+      "name": "StorageAccountMigrations"
+    },
+    {
+      "name": "DeletedAccounts"
+    },
+    {
+      "name": "ManagementPolicies"
+    },
+    {
+      "name": "BlobInventoryPolicies"
+    },
+    {
+      "name": "PrivateEndpointConnections"
+    },
+    {
+      "name": "ObjectReplicationPolicyOperationGroup"
+    },
+    {
+      "name": "LocalUserOperationGroup"
+    },
+    {
+      "name": "EncryptionScopes"
+    },
+    {
+      "name": "TableServices"
+    },
+    {
+      "name": "Tables"
+    },
+    {
+      "name": "NetworkSecurityPerimeterConfigurations"
+    },
+    {
+      "name": "StorageTaskAssignments"
+    },
+    {
+      "name": "Connectors"
+    },
+    {
+      "name": "DataShares"
+    },
+    {
+      "name": "ContextCaches"
+    },
+    {
+      "name": "ContextCacheContainers"
+    },
+    {
+      "name": "AdvancedPlatformMetrics"
+    }
+  ],
+  "paths": {
+    "/providers/Microsoft.Storage/operations": {
+      "get": {
+        "operationId": "Operations_List",
+        "tags": [
+          "Operations"
+        ],
+        "description": "Lists all of the available Storage Rest API operations.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/OperationListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "OperationsList": {
+            "$ref": "./examples/OperationsList.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Storage/checkNameAvailability": {
+      "post": {
+        "operationId": "StorageAccounts_CheckNameAvailability",
+        "tags": [
+          "StorageAccounts"
+        ],
+        "description": "Checks that the storage account name is valid and is not already in use.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "body",
+            "description": "The request body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/StorageAccountCheckNameAvailabilityParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/CheckNameAvailabilityResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "StorageAccountCheckNameAvailability": {
+            "$ref": "./examples/StorageAccountCheckNameAvailability.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Storage/contextCaches": {
+      "get": {
+        "operationId": "ContextCaches_ListBySubscription",
+        "tags": [
+          "ContextCaches"
+        ],
+        "description": "List Context Caches by subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ContextCacheListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List Context Caches by Subscription": {
+            "$ref": "./examples/StorageContextCacheCRUD/ContextCaches_ListBySubscription.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Storage/deletedAccounts": {
+      "get": {
+        "operationId": "DeletedAccounts_List",
+        "description": "Lists deleted accounts under the subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/DeletedAccountListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DeletedAccountList": {
+            "$ref": "./examples/DeletedAccountList.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Storage/locations/{location}/deletedAccounts/{deletedAccountName}": {
+      "get": {
+        "operationId": "DeletedAccounts_Get",
+        "tags": [
+          "DeletedAccounts"
+        ],
+        "description": "Get properties of specified deleted account resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+          },
+          {
+            "name": "deletedAccountName",
+            "in": "path",
+            "description": "Name of the deleted storage account.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DeletedAccount"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DeletedAccountGet": {
+            "$ref": "./examples/DeletedAccountGet.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Storage/locations/{location}/usages": {
+      "get": {
+        "operationId": "Usages_ListByLocation",
+        "description": "Gets the current usage count and the limit for the resources of the location under the subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/UsageListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "UsageList": {
+            "$ref": "./examples/StorageAccountListLocationUsage.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Storage/skus": {
+      "get": {
+        "operationId": "Skus_List",
+        "description": "Lists the available SKUs supported by Microsoft.Storage for given subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/StorageSkuListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "SKUListWithLocationInfo": {
+            "$ref": "./examples/SKUListWithLocationInfo.json"
+          },
+          "SkuList": {
+            "$ref": "./examples/SKUList.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Storage/storageAccounts": {
+      "get": {
+        "operationId": "StorageAccounts_List",
+        "tags": [
+          "StorageAccounts"
+        ],
+        "description": "Lists all the storage accounts available under the subscription. Note that storage keys are not returned; use the ListKeys operation for this.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/StorageAccountListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "StorageAccountList": {
+            "$ref": "./examples/StorageAccountList.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/contextCaches": {
+      "get": {
+        "operationId": "ContextCaches_ListByResourceGroup",
+        "tags": [
+          "ContextCaches"
+        ],
+        "description": "List Context Caches by resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ContextCacheListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List Context Caches by Resource Group": {
+            "$ref": "./examples/StorageContextCacheCRUD/ContextCaches_ListByResourceGroup.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/contextCaches/{contextCacheName}": {
+      "get": {
+        "operationId": "ContextCaches_Get",
+        "tags": [
+          "ContextCaches"
+        ],
+        "description": "Get a Context Cache.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "contextCacheName",
+            "in": "path",
+            "description": "The name of the context cache",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-z0-9][a-z0-9-]{1,22}[a-z0-9]$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ContextCache"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get a Context Cache": {
+            "$ref": "./examples/StorageContextCacheCRUD/ContextCaches_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "ContextCaches_CreateOrUpdate",
+        "tags": [
+          "ContextCaches"
+        ],
+        "description": "Create or update a Context Cache.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "contextCacheName",
+            "in": "path",
+            "description": "The name of the context cache",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-z0-9][a-z0-9-]{1,22}[a-z0-9]$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Resource create parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ContextCache"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'ContextCache' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ContextCache"
+            }
+          },
+          "201": {
+            "description": "Resource 'ContextCache' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ContextCache"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create a Azure Context Cache Account with System Assigned Identity": {
+            "$ref": "./examples/StorageContextCacheCRUD/ContextCaches_CreateOrUpdate_SystemIdentity.json"
+          },
+          "Create a Context Cache": {
+            "$ref": "./examples/StorageContextCacheCRUD/ContextCaches_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/ContextCache"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "ContextCaches_Update",
+        "tags": [
+          "ContextCaches"
+        ],
+        "description": "Update a Context Cache.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "contextCacheName",
+            "in": "path",
+            "description": "The name of the context cache",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-z0-9][a-z0-9-]{1,22}[a-z0-9]$"
+          },
+          {
+            "name": "properties",
+            "in": "body",
+            "description": "The resource properties to be updated.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ContextCacheUpdate"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ContextCache"
+            }
+          },
+          "202": {
+            "description": "Resource update request accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Update a Azure Context Cache Account's Customer Managed Key Encryption Settings": {
+            "$ref": "./examples/StorageContextCacheCRUD/ContextCaches_Update_CustomerManagedKey.json"
+          },
+          "Update a Context Cache tags": {
+            "$ref": "./examples/StorageContextCacheCRUD/ContextCaches_Update.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/ContextCache"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "ContextCaches_Delete",
+        "tags": [
+          "ContextCaches"
+        ],
+        "description": "Delete a Context Cache.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "contextCacheName",
+            "in": "path",
+            "description": "The name of the context cache",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-z0-9][a-z0-9-]{1,22}[a-z0-9]$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete a Context Cache": {
+            "$ref": "./examples/StorageContextCacheCRUD/ContextCaches_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/contextCaches/{contextCacheName}/contextCacheContainers": {
+      "get": {
+        "operationId": "ContextCacheContainers_ListByContextCache",
+        "tags": [
+          "ContextCacheContainers"
+        ],
+        "description": "List all containers in a Context Cache.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "contextCacheName",
+            "in": "path",
+            "description": "The name of the context cache",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-z0-9][a-z0-9-]{1,22}[a-z0-9]$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ContextCacheContainerListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List Context Cache Containers in a Context Cache": {
+            "$ref": "./examples/StorageContextCacheContainerCRUD/ContextCacheContainers_ListByContextCache.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/contextCaches/{contextCacheName}/contextCacheContainers/{contextCacheContainerName}": {
+      "get": {
+        "operationId": "ContextCacheContainers_Get",
+        "tags": [
+          "ContextCacheContainers"
+        ],
+        "description": "Get a container in a Context Cache.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "contextCacheName",
+            "in": "path",
+            "description": "The name of the context cache",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-z0-9][a-z0-9-]{1,22}[a-z0-9]$"
+          },
+          {
+            "name": "contextCacheContainerName",
+            "in": "path",
+            "description": "The name of the context cache container",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-z0-9](?!.*--)[a-z0-9-]{1,61}[a-z0-9]$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ContextCacheContainer"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get a Context Cache Container": {
+            "$ref": "./examples/StorageContextCacheContainerCRUD/ContextCacheContainers_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "ContextCacheContainers_CreateOrUpdate",
+        "tags": [
+          "ContextCacheContainers"
+        ],
+        "description": "Create or update a container in a Context Cache.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "contextCacheName",
+            "in": "path",
+            "description": "The name of the context cache",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-z0-9][a-z0-9-]{1,22}[a-z0-9]$"
+          },
+          {
+            "name": "contextCacheContainerName",
+            "in": "path",
+            "description": "The name of the context cache container",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-z0-9](?!.*--)[a-z0-9-]{1,61}[a-z0-9]$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Resource create parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ContextCacheContainer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'ContextCacheContainer' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ContextCacheContainer"
+            }
+          },
+          "201": {
+            "description": "Resource 'ContextCacheContainer' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ContextCacheContainer"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create a Context Cache Container": {
+            "$ref": "./examples/StorageContextCacheContainerCRUD/ContextCacheContainers_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/ContextCacheContainer"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "ContextCacheContainers_Update",
+        "tags": [
+          "ContextCacheContainers"
+        ],
+        "description": "Update a container in a Context Cache.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "contextCacheName",
+            "in": "path",
+            "description": "The name of the context cache",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-z0-9][a-z0-9-]{1,22}[a-z0-9]$"
+          },
+          {
+            "name": "contextCacheContainerName",
+            "in": "path",
+            "description": "The name of the context cache container",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-z0-9](?!.*--)[a-z0-9-]{1,61}[a-z0-9]$"
+          },
+          {
+            "name": "properties",
+            "in": "body",
+            "description": "The resource properties to be updated.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ContextCacheContainerUpdate"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ContextCacheContainer"
+            }
+          },
+          "202": {
+            "description": "Resource update request accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Update a Context Cache Container": {
+            "$ref": "./examples/StorageContextCacheContainerCRUD/ContextCacheContainers_Update.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/ContextCacheContainer"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "ContextCacheContainers_Delete",
+        "tags": [
+          "ContextCacheContainers"
+        ],
+        "description": "Delete a container from a Context Cache.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "contextCacheName",
+            "in": "path",
+            "description": "The name of the context cache",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-z0-9][a-z0-9-]{1,22}[a-z0-9]$"
+          },
+          {
+            "name": "contextCacheContainerName",
+            "in": "path",
+            "description": "The name of the context cache container",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-z0-9](?!.*--)[a-z0-9-]{1,61}[a-z0-9]$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete a Context Cache Container": {
+            "$ref": "./examples/StorageContextCacheContainerCRUD/ContextCacheContainers_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts": {
+      "get": {
+        "operationId": "StorageAccounts_ListByResourceGroup",
+        "tags": [
+          "StorageAccounts"
+        ],
+        "description": "Lists all the storage accounts available under the given resource group. Note that storage keys are not returned; use the ListKeys operation for this.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/StorageAccountListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "StorageAccountListByResourceGroup": {
+            "$ref": "./examples/StorageAccountListByResourceGroup.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}": {
+      "get": {
+        "operationId": "StorageAccounts_GetProperties",
+        "tags": [
+          "StorageAccounts"
+        ],
+        "description": "Returns the properties for the specified storage account including but not limited to name, SKU name, location, and account status. The ListKeys operation should be used to retrieve storage keys.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "May be used to expand the properties within account's properties. By default, data is not included when fetching properties. Currently we only support geoReplicationStats and blobRestoreStatus.",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "geoReplicationStats",
+              "blobRestoreStatus"
+            ],
+            "x-ms-enum": {
+              "name": "StorageAccountExpand",
+              "modelAsString": false
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/StorageAccount"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "StorageAccountGetAsyncSkuConversionStatus": {
+            "$ref": "./examples/StorageAccountGetAsyncSkuConversionStatus.json"
+          },
+          "StorageAccountGetProperties": {
+            "$ref": "./examples/StorageAccountGetProperties.json"
+          },
+          "StorageAccountGetPropertiesCMKEnabled": {
+            "$ref": "./examples/StorageAccountGetPropertiesCMKEnabled.json"
+          },
+          "StorageAccountGetPropertiesCMKVersionExpirationTime": {
+            "$ref": "./examples/StorageAccountGetPropertiesCMKVersionExpirationTime.json"
+          },
+          "StorageAccountGetPropertiesGeoReplicationStatscanFailoverFalse": {
+            "$ref": "./examples/StorageAccountGetPropertiesGeoReplicationStatscanFailoverFalse.json"
+          },
+          "StorageAccountGetPropertiesGeoReplicationStatscanFailoverTrue": {
+            "$ref": "./examples/StorageAccountGetPropertiesGeoReplicationStatscanFailoverTrue.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "StorageAccounts_Create",
+        "tags": [
+          "StorageAccounts"
+        ],
+        "description": "Asynchronously creates a new storage account with the specified parameters. If an account is already created and a subsequent create request is issued with different properties, the account properties will be updated. If an account is already created and a subsequent create or update request is issued with the exact same set of properties, the request will succeed.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The parameters to provide for the created account.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/StorageAccountCreateParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'StorageAccount' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/StorageAccount"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NfsV3AccountCreate": {
+            "$ref": "./examples/NfsV3AccountCreate.json"
+          },
+          "StorageAccountCreate": {
+            "$ref": "./examples/StorageAccountCreate.json"
+          },
+          "StorageAccountCreateAllowedCopyScopeToAAD": {
+            "$ref": "./examples/StorageAccountCreateAllowedCopyScopeToAAD.json"
+          },
+          "StorageAccountCreateAllowedCopyScopeToPrivateLink": {
+            "$ref": "./examples/StorageAccountCreateAllowedCopyScopeToPrivateLink.json"
+          },
+          "StorageAccountCreateDisallowPublicNetworkAccess": {
+            "$ref": "./examples/StorageAccountCreateDisallowPublicNetworkAccess.json"
+          },
+          "StorageAccountCreateDnsEndpointTypeToAzureDnsZone": {
+            "$ref": "./examples/StorageAccountCreateDnsEndpointTypeToAzureDnsZone.json"
+          },
+          "StorageAccountCreateDnsEndpointTypeToStandard": {
+            "$ref": "./examples/StorageAccountCreateDnsEndpointTypeToStandard.json"
+          },
+          "StorageAccountCreateEnablePublicNetworkAccess": {
+            "$ref": "./examples/StorageAccountCreateEnablePublicNetworkAccess.json"
+          },
+          "StorageAccountCreatePremiumBlockBlobStorage": {
+            "$ref": "./examples/StorageAccountCreatePremiumBlockBlobStorage.json"
+          },
+          "StorageAccountCreateUserAssignedEncryptionIdentityWithCMK": {
+            "$ref": "./examples/StorageAccountCreateUserAssignedEncryptionIdentityWithCMK.json"
+          },
+          "StorageAccountCreateUserAssignedIdentityWithFederatedIdentityClientId.": {
+            "$ref": "./examples/StorageAccountCreateUserAssignedIdentityWithFederatedIdentityClientId.json"
+          },
+          "StorageAccountCreateWithDataCollaborationPolicy": {
+            "$ref": "./examples/StorageAccountCreateWithDataCollaborationPolicy.json"
+          },
+          "StorageAccountCreateWithImmutabilityPolicy": {
+            "$ref": "./examples/StorageAccountCreateWithImmutabilityPolicy.json"
+          },
+          "StorageAccountCreateWithSmartAccessTier": {
+            "$ref": "./examples/StorageAccountCreateWithSmartAccessTier.json"
+          },
+          "StorageAccountCreate_placement": {
+            "$ref": "./examples/StorageAccountCreate_placement.json"
+          },
+          "StorageAccountCreate_zones": {
+            "$ref": "./examples/StorageAccountCreate_zones.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/StorageAccount"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "StorageAccounts_Update",
+        "tags": [
+          "StorageAccounts"
+        ],
+        "description": "The update operation can be used to update the SKU, encryption, access tier, or tags for a storage account. It can also be used to map the account to a custom domain. Only one custom domain is supported per storage account; the replacement/change of custom domain is not supported. In order to replace an old custom domain, the old value must be cleared/unregistered before a new value can be set. The update of multiple properties is supported. This call does not change the storage keys for the account. If you want to change the storage account keys, use the regenerate keys operation. The location and name of the storage account cannot be changed after creation.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The parameters to provide for the updated account.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/StorageAccountUpdateParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/StorageAccount"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "StorageAccountEnableAD": {
+            "$ref": "./examples/StorageAccountEnableAD.json"
+          },
+          "StorageAccountEnableCMK": {
+            "$ref": "./examples/StorageAccountEnableCMK.json"
+          },
+          "StorageAccountEnableSmbOAuth": {
+            "$ref": "./examples/StorageAccountEnableSmbOAuth.json"
+          },
+          "StorageAccountUpdate": {
+            "$ref": "./examples/StorageAccountUpdate.json"
+          },
+          "StorageAccountUpdateAccessTierToSmart": {
+            "$ref": "./examples/StorageAccountUpdateAccessTierToSmart.json"
+          },
+          "StorageAccountUpdateAllowedCopyScopeToAAD": {
+            "$ref": "./examples/StorageAccountUpdateAllowedCopyScopeToAAD.json"
+          },
+          "StorageAccountUpdateDisablePublicNetworkAccess": {
+            "$ref": "./examples/StorageAccountUpdateDisablePublicNetworkAccess.json"
+          },
+          "StorageAccountUpdateEnableIpv6Features": {
+            "$ref": "./examples/StorageAccountLeverageIPv6Ability.json"
+          },
+          "StorageAccountUpdateUserAssignedEncryptionIdentityWithCMK": {
+            "$ref": "./examples/StorageAccountUpdateUserAssignedEncryptionIdentityWithCMK.json"
+          },
+          "StorageAccountUpdateUserAssignedIdentityWithFederatedIdentityClientId": {
+            "$ref": "./examples/StorageAccountUpdateUserAssignedIdentityWithFederatedIdentityClientId.json"
+          },
+          "StorageAccountUpdateWithDataCollaborationPolicy": {
+            "$ref": "./examples/StorageAccountUpdateWithDataCollaborationPolicy.json"
+          },
+          "StorageAccountUpdateWithImmutabilityPolicy": {
+            "$ref": "./examples/StorageAccountUpdateWithImmutabilityPolicy.json"
+          },
+          "StorageAccountUpdate_placement": {
+            "$ref": "./examples/StorageAccountUpdate_placement.json"
+          },
+          "StorageAccountUpdate_zones": {
+            "$ref": "./examples/StorageAccountUpdate_zones.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "StorageAccounts_Delete",
+        "tags": [
+          "StorageAccounts"
+        ],
+        "description": "Deletes a storage account in Microsoft Azure.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "StorageAccountDelete": {
+            "$ref": "./examples/StorageAccountDelete.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/aborthnsonmigration": {
+      "post": {
+        "operationId": "StorageAccounts_AbortHierarchicalNamespaceMigration",
+        "tags": [
+          "StorageAccounts"
+        ],
+        "description": "Abort live Migration of storage account to enable Hns",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully."
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "StorageAccountAbortHierarchicalNamespaceMigration": {
+            "$ref": "./examples/StorageAccountAbortHierarchicalNamespaceMigration.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/accountMigrations/{migrationName}": {
+      "get": {
+        "operationId": "StorageAccounts_GetCustomerInitiatedMigration",
+        "tags": [
+          "StorageAccountMigrations"
+        ],
+        "description": "Gets the status of the ongoing migration for the specified storage account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "migrationName",
+            "in": "path",
+            "description": "The name of the Storage Account Migration. It should always be 'default'",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "default"
+            ],
+            "x-ms-enum": {
+              "name": "MigrationName",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "default",
+                  "value": "default"
+                }
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/StorageAccountMigration"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "StorageAccountGetMigrationFailed": {
+            "$ref": "./examples/StorageAccountGetMigrationFailed.json"
+          },
+          "StorageAccountGetMigrationInProgress": {
+            "$ref": "./examples/StorageAccountGetMigrationInProgress.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/advancedPlatformMetrics": {
+      "get": {
+        "operationId": "AdvancedPlatformMetrics_List",
+        "tags": [
+          "AdvancedPlatformMetrics"
+        ],
+        "description": "List the advanced platform metrics rules associated with the storage account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AdvancedPlatformMetricsRuleListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "AdvancedPlatformMetricsRules_List - List advanced platform metrics rules": {
+            "$ref": "./examples/AdvancedPlatformMetricsCRUD/AdvancedPlatformMetricsRules_List.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/advancedPlatformMetrics/{advancedPlatformMetricsRuleType}": {
+      "get": {
+        "operationId": "AdvancedPlatformMetrics_Get",
+        "tags": [
+          "AdvancedPlatformMetrics"
+        ],
+        "description": "Get the advanced platform metrics rule for the storage account by rule type.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "advancedPlatformMetricsRuleType",
+            "in": "path",
+            "description": "The type of the advanced platform metrics rule.",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "ContainerLevelCapacityMetrics"
+            ],
+            "x-ms-enum": {
+              "name": "AdvancedPlatformMetricsRuleType",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "ContainerLevelCapacityMetrics",
+                  "value": "ContainerLevelCapacityMetrics",
+                  "description": "Container level capacity metrics rule type"
+                }
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AdvancedPlatformMetricsRule"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "AdvancedPlatformMetricsRules_Get - Get advanced platform metrics rule": {
+            "$ref": "./examples/AdvancedPlatformMetricsCRUD/AdvancedPlatformMetricsRules_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "AdvancedPlatformMetrics_CreateOrUpdate",
+        "tags": [
+          "AdvancedPlatformMetrics"
+        ],
+        "description": "Create or update the advanced platform metrics rule for the storage account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "advancedPlatformMetricsRuleType",
+            "in": "path",
+            "description": "The type of the advanced platform metrics rule.",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "ContainerLevelCapacityMetrics"
+            ],
+            "x-ms-enum": {
+              "name": "AdvancedPlatformMetricsRuleType",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "ContainerLevelCapacityMetrics",
+                  "value": "ContainerLevelCapacityMetrics",
+                  "description": "Container level capacity metrics rule type"
+                }
+              ]
+            }
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Resource create parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/AdvancedPlatformMetricsRule"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'AdvancedPlatformMetricsRule' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/AdvancedPlatformMetricsRule"
+            }
+          },
+          "201": {
+            "description": "Resource 'AdvancedPlatformMetricsRule' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/AdvancedPlatformMetricsRule"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "AdvancedPlatformMetricsRules_CreateOrUpdate_AllContainers - Create advanced platform metrics rule with all containers filter": {
+            "$ref": "./examples/AdvancedPlatformMetricsCRUD/AdvancedPlatformMetricsRules_CreateOrUpdate_AllContainers.json"
+          },
+          "AdvancedPlatformMetricsRules_CreateOrUpdate_ContainerList - Create advanced platform metrics rule with container list filter": {
+            "$ref": "./examples/AdvancedPlatformMetricsCRUD/AdvancedPlatformMetricsRules_CreateOrUpdate_ContainerList.json"
+          },
+          "AdvancedPlatformMetricsRules_CreateOrUpdate_ContainerPrefix - Create advanced platform metrics rule with container prefix filter": {
+            "$ref": "./examples/AdvancedPlatformMetricsCRUD/AdvancedPlatformMetricsRules_CreateOrUpdate_ContainerPrefix.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "AdvancedPlatformMetrics_Delete",
+        "tags": [
+          "AdvancedPlatformMetrics"
+        ],
+        "description": "Delete the advanced platform metrics rule for the storage account by rule type.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "advancedPlatformMetricsRuleType",
+            "in": "path",
+            "description": "The type of the advanced platform metrics rule.",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "ContainerLevelCapacityMetrics"
+            ],
+            "x-ms-enum": {
+              "name": "AdvancedPlatformMetricsRuleType",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "ContainerLevelCapacityMetrics",
+                  "value": "ContainerLevelCapacityMetrics",
+                  "description": "Container level capacity metrics rule type"
+                }
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "AdvancedPlatformMetricsRules_Delete - Delete advanced platform metrics rule": {
+            "$ref": "./examples/AdvancedPlatformMetricsCRUD/AdvancedPlatformMetricsRules_Delete.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/blobServices": {
+      "get": {
+        "operationId": "BlobServices_List",
+        "tags": [
+          "BlobServices"
+        ],
+        "description": "List blob services of storage account. It returns a collection of one object named default.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/BlobServiceItems"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ListBlobServices": {
+            "$ref": "./examples/BlobServicesList.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/blobServices/default": {
+      "get": {
+        "operationId": "BlobServices_GetServiceProperties",
+        "tags": [
+          "BlobServices"
+        ],
+        "description": "Gets the properties of a storage account’s Blob service, including properties for Storage Analytics and CORS (Cross-Origin Resource Sharing) rules.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/BlobServiceProperties"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "GetBlobServices": {
+            "$ref": "./examples/BlobServicesGet.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "BlobServices_SetServiceProperties",
+        "tags": [
+          "BlobServices"
+        ],
+        "description": "Sets the properties of a storage account’s Blob service, including properties for Storage Analytics and CORS (Cross-Origin Resource Sharing) rules.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The properties of a storage account’s Blob service, including properties for Storage Analytics and CORS (Cross-Origin Resource Sharing) rules.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/BlobServiceProperties"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'BlobServiceProperties' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/BlobServiceProperties"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "BlobServicesPutAllowPermanentDelete": {
+            "$ref": "./examples/BlobServicesPutAllowPermanentDelete.json"
+          },
+          "BlobServicesPutLastAccessTimeBasedTracking": {
+            "$ref": "./examples/BlobServicesPutLastAccessTimeBasedTracking.json"
+          },
+          "PutBlobServices": {
+            "$ref": "./examples/BlobServicesPut.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/blobServices/default/containers": {
+      "get": {
+        "operationId": "BlobContainers_List",
+        "tags": [
+          "BlobServices"
+        ],
+        "description": "Lists all containers and does not support a prefix like data plane. Also SRP today does not return continuation token.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "$maxpagesize",
+            "in": "query",
+            "description": "Optional. Specified maximum number of containers that can be included in the list.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Optional. When specified, only container names starting with the filter will be listed.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$include",
+            "in": "query",
+            "description": "Optional, used to include the properties for soft deleted blob containers.",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "deleted"
+            ],
+            "x-ms-enum": {
+              "name": "ListContainersInclude",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "deleted",
+                  "value": "deleted"
+                }
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ListContainerItems"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ListContainers": {
+            "$ref": "./examples/BlobContainersList.json"
+          },
+          "ListDeletedContainers": {
+            "$ref": "./examples/DeletedBlobContainersList.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/blobServices/default/containers/{containerName}": {
+      "get": {
+        "operationId": "BlobContainers_Get",
+        "tags": [
+          "BlobContainers"
+        ],
+        "description": "Gets properties of a specified container.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "containerName",
+            "in": "path",
+            "description": "The name of the blob container within the specified storage account. Blob container names must be between 3 and 63 characters in length and use numbers, lower-case letters and dash (-) only. Every dash (-) character must be immediately preceded and followed by a letter or number.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 63
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/BlobContainer"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "GetBlobContainersGetWithAllowProtectedAppendWritesAll": {
+            "$ref": "./examples/BlobContainersGetWithAllowProtectedAppendWritesAll.json"
+          },
+          "GetContainers": {
+            "$ref": "./examples/BlobContainersGet.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "BlobContainers_Create",
+        "tags": [
+          "BlobContainers"
+        ],
+        "description": "Creates a new container under the specified account as described by request body. The container resource includes metadata and properties for that container. It does not include a list of the blobs contained by the container.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "containerName",
+            "in": "path",
+            "description": "The name of the blob container within the specified storage account. Blob container names must be between 3 and 63 characters in length and use numbers, lower-case letters and dash (-) only. Every dash (-) character must be immediately preceded and followed by a letter or number.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 63
+          },
+          {
+            "name": "blobContainer",
+            "in": "body",
+            "description": "Properties of the blob container to create.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/BlobContainer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'BlobContainer' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/BlobContainer"
+            }
+          },
+          "201": {
+            "description": "Resource 'BlobContainer' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/BlobContainer"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PutContainerWithDefaultEncryptionScope": {
+            "$ref": "./examples/BlobContainersPutDefaultEncryptionScope.json"
+          },
+          "PutContainerWithObjectLevelWorm": {
+            "$ref": "./examples/BlobContainersPutObjectLevelWorm.json"
+          },
+          "PutContainers": {
+            "$ref": "./examples/BlobContainersPut.json"
+          }
+        }
+      },
+      "patch": {
+        "operationId": "BlobContainers_Update",
+        "tags": [
+          "BlobContainers"
+        ],
+        "description": "Updates container properties as specified in request body. Properties not mentioned in the request will be unchanged. Update fails if the specified container doesn't already exist.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "containerName",
+            "in": "path",
+            "description": "The name of the blob container within the specified storage account. Blob container names must be between 3 and 63 characters in length and use numbers, lower-case letters and dash (-) only. Every dash (-) character must be immediately preceded and followed by a letter or number.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 63
+          },
+          {
+            "name": "blobContainer",
+            "in": "body",
+            "description": "Properties to update for the blob container.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/BlobContainer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/BlobContainer"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "UpdateContainers": {
+            "$ref": "./examples/BlobContainersPatch.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "BlobContainers_Delete",
+        "tags": [
+          "BlobContainers"
+        ],
+        "description": "Deletes specified container under its account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "containerName",
+            "in": "path",
+            "description": "The name of the blob container within the specified storage account. Blob container names must be between 3 and 63 characters in length and use numbers, lower-case letters and dash (-) only. Every dash (-) character must be immediately preceded and followed by a letter or number.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 63
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DeleteContainers": {
+            "$ref": "./examples/BlobContainersDelete.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/blobServices/default/containers/{containerName}/clearLegalHold": {
+      "post": {
+        "operationId": "BlobContainers_ClearLegalHold",
+        "tags": [
+          "BlobContainers"
+        ],
+        "description": "Clears legal hold tags. Clearing the same or non-existent tag results in an idempotent operation. ClearLegalHold clears out only the specified tags in the request.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "containerName",
+            "in": "path",
+            "description": "The name of the blob container within the specified storage account. Blob container names must be between 3 and 63 characters in length and use numbers, lower-case letters and dash (-) only. Every dash (-) character must be immediately preceded and followed by a letter or number.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 63
+          },
+          {
+            "name": "LegalHold",
+            "in": "body",
+            "description": "The LegalHold property that will be clear from a blob container.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/LegalHold"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/LegalHold"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ClearLegalHoldContainers": {
+            "$ref": "./examples/BlobContainersClearLegalHold.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/blobServices/default/containers/{containerName}/immutabilityPolicies/default": {
+      "get": {
+        "operationId": "BlobContainers_GetImmutabilityPolicy",
+        "tags": [
+          "ImmutabilityPolicies"
+        ],
+        "description": "Gets the existing immutability policy along with the corresponding ETag in response headers and body.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "containerName",
+            "in": "path",
+            "description": "The name of the blob container within the specified storage account. Blob container names must be between 3 and 63 characters in length and use numbers, lower-case letters and dash (-) only. Every dash (-) character must be immediately preceded and followed by a letter or number.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 63
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "The entity state (ETag) version of the immutability policy to update must be returned to the server for all update operations. The ETag value must include the leading and trailing double quotes as returned by the service.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/ImmutabilityPolicy"
+            },
+            "headers": {
+              "ETag": {
+                "type": "string",
+                "description": "The ETag HTTP response header. This is an opaque string. You can use it to detect whether the resource has changed between requests. In particular, you can pass the ETag to one of the If-Match or If-None-Match headers."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "GetImmutabilityPolicy": {
+            "$ref": "./examples/BlobContainersGetImmutabilityPolicy.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "BlobContainers_CreateOrUpdateImmutabilityPolicy",
+        "tags": [
+          "ImmutabilityPolicies"
+        ],
+        "description": "Creates or updates an unlocked immutability policy. ETag in If-Match is honored if given but not required for this operation.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "containerName",
+            "in": "path",
+            "description": "The name of the blob container within the specified storage account. Blob container names must be between 3 and 63 characters in length and use numbers, lower-case letters and dash (-) only. Every dash (-) character must be immediately preceded and followed by a letter or number.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 63
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "The entity state (ETag) version of the immutability policy to update must be returned to the server for all update operations. The ETag value must include the leading and trailing double quotes as returned by the service.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The ImmutabilityPolicy Properties that will be created or updated to a blob container.",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/ImmutabilityPolicy"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/ImmutabilityPolicy"
+            },
+            "headers": {
+              "ETag": {
+                "type": "string",
+                "description": "The ETag HTTP response header. This is an opaque string. You can use it to detect whether the resource has changed between requests. In particular, you can pass the ETag to one of the If-Match or If-None-Match headers."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "CreateOrUpdateImmutabilityPolicy": {
+            "$ref": "./examples/BlobContainersPutImmutabilityPolicy.json"
+          },
+          "CreateOrUpdateImmutabilityPolicyWithAllowProtectedAppendWritesAll": {
+            "$ref": "./examples/BlobContainersPutImmutabilityPolicyAllowProtectedAppendWritesAll.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "BlobContainers_DeleteImmutabilityPolicy",
+        "tags": [
+          "ImmutabilityPolicies"
+        ],
+        "description": "Aborts an unlocked immutability policy. The response of delete has immutabilityPeriodSinceCreationInDays set to 0. ETag in If-Match is required for this operation. Deleting a locked immutability policy is not allowed, the only way is to delete the container after deleting all expired blobs inside the policy locked container.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "containerName",
+            "in": "path",
+            "description": "The name of the blob container within the specified storage account. Blob container names must be between 3 and 63 characters in length and use numbers, lower-case letters and dash (-) only. Every dash (-) character must be immediately preceded and followed by a letter or number.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 63
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "The entity state (ETag) version of the immutability policy to update must be returned to the server for all update operations. The ETag value must include the leading and trailing double quotes as returned by the service.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/ImmutabilityPolicy"
+            },
+            "headers": {
+              "ETag": {
+                "type": "string",
+                "description": "The ETag HTTP response header. This is an opaque string. You can use it to detect whether the resource has changed between requests. In particular, you can pass the ETag to one of the If-Match or If-None-Match headers."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DeleteImmutabilityPolicy": {
+            "$ref": "./examples/BlobContainersDeleteImmutabilityPolicy.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/blobServices/default/containers/{containerName}/immutabilityPolicies/default/extend": {
+      "post": {
+        "operationId": "BlobContainers_ExtendImmutabilityPolicy",
+        "tags": [
+          "ImmutabilityPolicies"
+        ],
+        "description": "Extends the immutabilityPeriodSinceCreationInDays of a locked immutabilityPolicy. The only action allowed on a Locked policy will be this action. ETag in If-Match is required for this operation.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "containerName",
+            "in": "path",
+            "description": "The name of the blob container within the specified storage account. Blob container names must be between 3 and 63 characters in length and use numbers, lower-case letters and dash (-) only. Every dash (-) character must be immediately preceded and followed by a letter or number.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 63
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "The entity state (ETag) version of the immutability policy to update must be returned to the server for all update operations. The ETag value must include the leading and trailing double quotes as returned by the service.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The content of the action request",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/ImmutabilityPolicy"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ImmutabilityPolicy"
+            },
+            "headers": {
+              "ETag": {
+                "type": "string",
+                "description": "The ETag HTTP response header. This is an opaque string. You can use it to detect whether the resource has changed between requests. In particular, you can pass the ETag to one of the If-Match or If-None-Match headers."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ExtendImmutabilityPolicy": {
+            "$ref": "./examples/BlobContainersExtendImmutabilityPolicy.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/blobServices/default/containers/{containerName}/immutabilityPolicies/default/lock": {
+      "post": {
+        "operationId": "BlobContainers_LockImmutabilityPolicy",
+        "tags": [
+          "ImmutabilityPolicies"
+        ],
+        "description": "Sets the ImmutabilityPolicy to Locked state. The only action allowed on a Locked policy is ExtendImmutabilityPolicy action. ETag in If-Match is required for this operation.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "containerName",
+            "in": "path",
+            "description": "The name of the blob container within the specified storage account. Blob container names must be between 3 and 63 characters in length and use numbers, lower-case letters and dash (-) only. Every dash (-) character must be immediately preceded and followed by a letter or number.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 63
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "The entity state (ETag) version of the immutability policy to update must be returned to the server for all update operations. The ETag value must include the leading and trailing double quotes as returned by the service.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ImmutabilityPolicy"
+            },
+            "headers": {
+              "ETag": {
+                "type": "string",
+                "description": "The ETag HTTP response header. This is an opaque string. You can use it to detect whether the resource has changed between requests. In particular, you can pass the ETag to one of the If-Match or If-None-Match headers."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "LockImmutabilityPolicy": {
+            "$ref": "./examples/BlobContainersLockImmutabilityPolicy.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/blobServices/default/containers/{containerName}/lease": {
+      "post": {
+        "operationId": "BlobContainers_Lease",
+        "tags": [
+          "BlobContainers"
+        ],
+        "description": "The Lease Container operation establishes and manages a lock on a container for delete operations. The lock duration can be 15 to 60 seconds, or can be infinite.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "containerName",
+            "in": "path",
+            "description": "The name of the blob container within the specified storage account. Blob container names must be between 3 and 63 characters in length and use numbers, lower-case letters and dash (-) only. Every dash (-) character must be immediately preceded and followed by a letter or number.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 63
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The content of the action request",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/LeaseContainerRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/LeaseContainerResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Acquire a lease on a container": {
+            "$ref": "./examples/BlobContainersLease_Acquire.json"
+          },
+          "Break a lease on a container": {
+            "$ref": "./examples/BlobContainersLease_Break.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/blobServices/default/containers/{containerName}/migrate": {
+      "post": {
+        "operationId": "BlobContainers_ObjectLevelWorm",
+        "tags": [
+          "BlobContainers"
+        ],
+        "description": "This operation migrates a blob container from container level WORM to object level immutability enabled container. Prerequisites require a container level immutability policy either in locked or unlocked state, Account level versioning must be enabled and there should be no Legal hold on the container.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "containerName",
+            "in": "path",
+            "description": "The name of the blob container within the specified storage account. Blob container names must be between 3 and 63 characters in length and use numbers, lower-case letters and dash (-) only. Every dash (-) character must be immediately preceded and followed by a letter or number.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 63
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully."
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "VersionLevelWormContainerMigration": {
+            "$ref": "./examples/ObjectLevelWormContainerMigration.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/blobServices/default/containers/{containerName}/setLegalHold": {
+      "post": {
+        "operationId": "BlobContainers_SetLegalHold",
+        "tags": [
+          "BlobContainers"
+        ],
+        "description": "Sets legal hold tags. Setting the same tag results in an idempotent operation. SetLegalHold follows an append pattern and does not clear out the existing tags that are not specified in the request.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "containerName",
+            "in": "path",
+            "description": "The name of the blob container within the specified storage account. Blob container names must be between 3 and 63 characters in length and use numbers, lower-case letters and dash (-) only. Every dash (-) character must be immediately preceded and followed by a letter or number.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 63
+          },
+          {
+            "name": "LegalHold",
+            "in": "body",
+            "description": "The LegalHold property that will be set to a blob container.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/LegalHold"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/LegalHold"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "SetLegalHoldContainers": {
+            "$ref": "./examples/BlobContainersSetLegalHold.json"
+          },
+          "SetLegalHoldContainersWithAllowProtectedAppendWritesAll": {
+            "$ref": "./examples/BlobContainersSetLegalHoldAllowProtectedAppendWritesAll.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/connectors": {
+      "get": {
+        "operationId": "Connectors_ListByStorageAccount",
+        "tags": [
+          "Connectors"
+        ],
+        "description": "List all Storage Connectors in a Storage Account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ConnectorListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ListConnectorsByStorageAccount": {
+            "$ref": "./examples/StorageConnectorCRUD/StorageConnectors_ListByStorageAccount.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/connectors/{connectorName}": {
+      "get": {
+        "operationId": "Connectors_Get",
+        "tags": [
+          "Connectors"
+        ],
+        "description": "Get the specified Storage Connector.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "connectorName",
+            "in": "path",
+            "description": "The name of the Storage Connector.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 63,
+            "pattern": "^[a-z0-9](?!.*--)[a-z0-9-]{1,61}[a-z0-9]$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Connector"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "GetConnector": {
+            "$ref": "./examples/StorageConnectorCRUD/StorageConnectors_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "Connectors_Create",
+        "tags": [
+          "Connectors"
+        ],
+        "description": "Create a Storage Connector if it does not already exist; otherwise, error out. This API will not allow you to replace an already existing resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "connectorName",
+            "in": "path",
+            "description": "The name of the Storage Connector.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 63,
+            "pattern": "^[a-z0-9](?!.*--)[a-z0-9-]{1,61}[a-z0-9]$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Create a Storage Connector if it does not already exist; otherwise, error out. This API will not allow you to replace an already existing resource.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Connector"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'Connector' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Connector"
+            }
+          },
+          "201": {
+            "description": "Resource 'Connector' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Connector"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "CreateConnector": {
+            "$ref": "./examples/StorageConnectorCRUD/StorageConnectors_Create.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/Connector"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "Connectors_Update",
+        "tags": [
+          "Connectors"
+        ],
+        "description": "Update a Storage Connector.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "connectorName",
+            "in": "path",
+            "description": "The name of the Storage Connector.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 63,
+            "pattern": "^[a-z0-9](?!.*--)[a-z0-9-]{1,61}[a-z0-9]$"
+          },
+          {
+            "name": "properties",
+            "in": "body",
+            "description": "The updated properties of the Storage Connector.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ConnectorUpdate"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Connector"
+            }
+          },
+          "202": {
+            "description": "Resource update request accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "UpdateConnector": {
+            "$ref": "./examples/StorageConnectorCRUD/StorageConnectors_Update.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/Connector"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "Connectors_Delete",
+        "tags": [
+          "Connectors"
+        ],
+        "description": "Delete a Storage Connector.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "connectorName",
+            "in": "path",
+            "description": "The name of the Storage Connector.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 63,
+            "pattern": "^[a-z0-9](?!.*--)[a-z0-9-]{1,61}[a-z0-9]$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DeleteConnector": {
+            "$ref": "./examples/StorageConnectorCRUD/StorageConnectors_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/connectors/{connectorName}/testExistingConnection": {
+      "post": {
+        "operationId": "Connectors_TestExistingConnection",
+        "tags": [
+          "Connectors"
+        ],
+        "description": "This method is used to verify that the connection to the backing data store works.\nThis API is designed to be used for monitoring and debugging purposes. From the caller’s perspective,\nthis method does the following: Calls List on the backing data store, attempting to list up to one blob/object/etc.\nIf the above succeeds, and if a blob/object/etc is found, calls Get on that object, attempting to download one byte.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "connectorName",
+            "in": "path",
+            "description": "The name of the Storage Connector.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 63,
+            "pattern": "^[a-z0-9](?!.*--)[a-z0-9-]{1,61}[a-z0-9]$"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "This method is used to verify that the connection to the backing data store works. This API is designed to be used for monitoring and debugging purposes. From the caller’s perspective, this method does the following: Calls List on the backing data store, attempting to list up to one blob/object/etc. If the above succeeds, and if a blob/object/etc is found, calls Get on that object, attempting to download one byte.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/TestExistingConnectionRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/TestConnectionResponse"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ExistingConnectionTest": {
+            "$ref": "./examples/StorageConnectorCRUD/StorageConnectors_TestExistingConnection.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/TestConnectionResponse"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/dataShares": {
+      "get": {
+        "operationId": "DataShares_ListByStorageAccount",
+        "tags": [
+          "DataShares"
+        ],
+        "description": "List all Storage DataShares in a Storage Account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DataShareListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ListDataSharesByStorageAccount": {
+            "$ref": "./examples/StorageDataShareCRUD/StorageDataShares_ListByStorageAccount.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/dataShares/{dataShareName}": {
+      "get": {
+        "operationId": "DataShares_Get",
+        "tags": [
+          "DataShares"
+        ],
+        "description": "Get the specified Storage DataShare.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "dataShareName",
+            "in": "path",
+            "description": "The name of the Storage DataShare.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 63,
+            "pattern": "^[a-z0-9](?!.*--)[a-z0-9-]{1,61}[a-z0-9]$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DataShare"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "GetDataShare": {
+            "$ref": "./examples/StorageDataShareCRUD/StorageDataShares_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "DataShares_Create",
+        "tags": [
+          "DataShares"
+        ],
+        "description": "Create a Storage DataShare if it does not already exist; otherwise, error out. This API will not allow you to replace an already existing resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "dataShareName",
+            "in": "path",
+            "description": "The name of the Storage DataShare.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 63,
+            "pattern": "^[a-z0-9](?!.*--)[a-z0-9-]{1,61}[a-z0-9]$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Create a Storage DataShare if it does not already exist; otherwise, error out. This API will not allow you to replace an already existing resource.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DataShare"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'DataShare' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/DataShare"
+            }
+          },
+          "201": {
+            "description": "Resource 'DataShare' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/DataShare"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "CreateDataShare": {
+            "$ref": "./examples/StorageDataShareCRUD/StorageDataShares_Create.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/DataShare"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "DataShares_Update",
+        "tags": [
+          "DataShares"
+        ],
+        "description": "Update a Storage DataShare.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "dataShareName",
+            "in": "path",
+            "description": "The name of the Storage DataShare.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 63,
+            "pattern": "^[a-z0-9](?!.*--)[a-z0-9-]{1,61}[a-z0-9]$"
+          },
+          {
+            "name": "properties",
+            "in": "body",
+            "description": "The updated properties of the Storage DataShare.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DataShareUpdate"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DataShare"
+            }
+          },
+          "202": {
+            "description": "Resource update request accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "UpdateDataShare": {
+            "$ref": "./examples/StorageDataShareCRUD/StorageDataShares_Update.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/DataShare"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "DataShares_Delete",
+        "tags": [
+          "DataShares"
+        ],
+        "description": "Delete a Storage DataShare.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "dataShareName",
+            "in": "path",
+            "description": "The name of the Storage DataShare.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 63,
+            "pattern": "^[a-z0-9](?!.*--)[a-z0-9-]{1,61}[a-z0-9]$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DeleteDataShare": {
+            "$ref": "./examples/StorageDataShareCRUD/StorageDataShares_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/encryptionScopes": {
+      "get": {
+        "operationId": "EncryptionScopes_List",
+        "tags": [
+          "EncryptionScopes"
+        ],
+        "description": "Lists all the encryption scopes available under the specified storage account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "$maxpagesize",
+            "in": "query",
+            "description": "Optional, specifies the maximum number of encryption scopes that will be included in the list response.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 5000
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Optional. When specified, only encryption scope names starting with the filter will be listed.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$include",
+            "in": "query",
+            "description": "Optional, when specified, will list encryption scopes with the specific state. Defaults to All",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "All",
+              "Enabled",
+              "Disabled"
+            ],
+            "x-ms-enum": {
+              "name": "ListEncryptionScopesInclude",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "All",
+                  "value": "All"
+                },
+                {
+                  "name": "Enabled",
+                  "value": "Enabled"
+                },
+                {
+                  "name": "Disabled",
+                  "value": "Disabled"
+                }
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/EncryptionScopeListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "StorageAccountEncryptionScopeList": {
+            "$ref": "./examples/StorageAccountEncryptionScopeList.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/encryptionScopes/{encryptionScopeName}": {
+      "get": {
+        "operationId": "EncryptionScopes_Get",
+        "tags": [
+          "EncryptionScopes"
+        ],
+        "description": "Returns the properties for the specified encryption scope.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "encryptionScopeName",
+            "in": "path",
+            "description": "The name of the encryption scope within the specified storage account. Encryption scope names must be between 3 and 63 characters in length and use numbers, lower-case letters and dash (-) only. Every dash (-) character must be immediately preceded and followed by a letter or number.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 63
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/EncryptionScope"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "StorageAccountGetEncryptionScope": {
+            "$ref": "./examples/StorageAccountGetEncryptionScope.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "EncryptionScopes_Put",
+        "tags": [
+          "EncryptionScopes"
+        ],
+        "description": "Synchronously creates or updates an encryption scope under the specified storage account. If an encryption scope is already created and a subsequent request is issued with different properties, the encryption scope properties will be updated per the specified request.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "encryptionScopeName",
+            "in": "path",
+            "description": "The name of the encryption scope within the specified storage account. Encryption scope names must be between 3 and 63 characters in length and use numbers, lower-case letters and dash (-) only. Every dash (-) character must be immediately preceded and followed by a letter or number.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 63
+          },
+          {
+            "name": "encryptionScope",
+            "in": "body",
+            "description": "Encryption scope properties to be used for the create or update.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/EncryptionScope"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'EncryptionScope' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/EncryptionScope"
+            }
+          },
+          "201": {
+            "description": "Resource 'EncryptionScope' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/EncryptionScope"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "StorageAccountPutEncryptionScope": {
+            "$ref": "./examples/StorageAccountPutEncryptionScope.json"
+          },
+          "StorageAccountPutEncryptionScopeWithInfrastructureEncryption": {
+            "$ref": "./examples/StorageAccountPutEncryptionScopeWithInfrastructureEncryption.json"
+          }
+        }
+      },
+      "patch": {
+        "operationId": "EncryptionScopes_Patch",
+        "tags": [
+          "EncryptionScopes"
+        ],
+        "description": "Update encryption scope properties as specified in the request body. Update fails if the specified encryption scope does not already exist.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "encryptionScopeName",
+            "in": "path",
+            "description": "The name of the encryption scope within the specified storage account. Encryption scope names must be between 3 and 63 characters in length and use numbers, lower-case letters and dash (-) only. Every dash (-) character must be immediately preceded and followed by a letter or number.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 63
+          },
+          {
+            "name": "encryptionScope",
+            "in": "body",
+            "description": "Encryption scope properties to be used for the update.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/EncryptionScope"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/EncryptionScope"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "StorageAccountPatchEncryptionScope": {
+            "$ref": "./examples/StorageAccountPatchEncryptionScope.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/failover": {
+      "post": {
+        "operationId": "StorageAccounts_Failover",
+        "tags": [
+          "StorageAccounts"
+        ],
+        "description": "A failover request can be triggered for a storage account in the event a primary endpoint becomes unavailable for any reason. The failover occurs from the storage account's primary cluster to the secondary cluster for RA-GRS accounts. The secondary cluster will become primary after failover and the account is converted to LRS. In the case of a Planned Failover, the primary and secondary clusters are swapped after failover and the account remains geo-replicated. Failover should continue to be used in the event of availability issues as Planned failover is only available while the primary and secondary endpoints are available. The primary use case of a Planned Failover is disaster recovery testing drills. This type of failover is invoked by setting FailoverType parameter to 'Planned'. Learn more about the failover options here- https://learn.microsoft.com/azure/storage/common/storage-disaster-recovery-guidance",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "failoverType",
+            "in": "query",
+            "description": "The parameter is set to 'Planned' to indicate whether a Planned failover is requested.",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "Planned"
+            ],
+            "x-ms-enum": {
+              "modelAsString": false
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully."
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "StorageAccountFailover": {
+            "$ref": "./examples/StorageAccountFailover.json"
+          },
+          "StorageAccountFailoverPlanned": {
+            "$ref": "./examples/StorageAccountFailoverPlanned.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/fileServices": {
+      "get": {
+        "operationId": "FileServices_List",
+        "tags": [
+          "FileServices"
+        ],
+        "description": "List all file services in storage accounts",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/FileServiceItems"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ListFileServices": {
+            "$ref": "./examples/FileServicesList.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/fileServices/default": {
+      "get": {
+        "operationId": "FileServices_GetServiceProperties",
+        "tags": [
+          "FileServices"
+        ],
+        "description": "Gets the properties of file services in storage accounts, including CORS (Cross-Origin Resource Sharing) rules.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/FileServiceProperties"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "GetFileServices": {
+            "$ref": "./examples/FileServicesGet.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "FileServices_SetServiceProperties",
+        "tags": [
+          "FileServices"
+        ],
+        "description": "Sets the properties of file services in storage accounts, including CORS (Cross-Origin Resource Sharing) rules.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The properties of file services in storage accounts, including CORS (Cross-Origin Resource Sharing) rules.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/FileServiceProperties"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'FileServiceProperties' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/FileServiceProperties"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PutFileServices": {
+            "$ref": "./examples/FileServicesPut.json"
+          },
+          "PutFileServices_EnableSMBMultichannel": {
+            "$ref": "./examples/FileServicesPut_EnableSMBMultichannel.json"
+          },
+          "PutFileServices_EnableSecureSmbFeatures": {
+            "$ref": "./examples/FileServicesPut_EnableSecureSmbFeatures.json"
+          },
+          "PutFileServices_EncryptionInTransitRequired": {
+            "$ref": "./examples/FileServicesPut_EncryptionInTransitRequired.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/fileServices/default/shares": {
+      "get": {
+        "operationId": "FileShares_List",
+        "tags": [
+          "FileServices"
+        ],
+        "description": "Lists all shares.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "$maxpagesize",
+            "in": "query",
+            "description": "Optional. Specified maximum number of shares that can be included in the list.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Optional. When specified, only share names starting with the filter will be listed.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Optional, used to expand the properties within share's properties. Valid values are: deleted, snapshots. Should be passed as a string with delimiter ','",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/FileShareItems"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ListDeletedShares": {
+            "$ref": "./examples/DeletedFileSharesList.json"
+          },
+          "ListShareSnapshots": {
+            "$ref": "./examples/FileShareSnapshotsList.json"
+          },
+          "ListShares": {
+            "$ref": "./examples/FileSharesList.json"
+          },
+          "ListSharesPaidBursting": {
+            "$ref": "./examples/FileSharesList_PaidBursting.json"
+          },
+          "ListSharesProvisionedV2": {
+            "$ref": "./examples/FileSharesList_ProvisionedV2.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/fileServices/default/shares/{shareName}": {
+      "get": {
+        "operationId": "FileShares_Get",
+        "tags": [
+          "FileShares"
+        ],
+        "description": "Gets properties of a specified share.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "shareName",
+            "in": "path",
+            "description": "The name of the file share within the specified storage account. File share names must be between 3 and 63 characters in length and use numbers, lower-case letters and dash (-) only. Every dash (-) character must be immediately preceded and followed by a letter or number.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 63
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Optional, used to expand the properties within share's properties. Valid values are: stats. Should be passed as a string with delimiter ','.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "x-ms-snapshot",
+            "in": "header",
+            "description": "Optional, used to retrieve properties of a snapshot.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/FileShare"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "GetSharePaidBursting": {
+            "$ref": "./examples/FileSharesGet_PaidBursting.json"
+          },
+          "GetShareProvisionedV2": {
+            "$ref": "./examples/FileSharesGet_ProvisionedV2.json"
+          },
+          "GetShareStats": {
+            "$ref": "./examples/FileSharesGet_Stats.json"
+          },
+          "GetShares": {
+            "$ref": "./examples/FileSharesGet.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "FileShares_Create",
+        "tags": [
+          "FileShares"
+        ],
+        "description": "Creates a new share under the specified account as described by request body. The share resource includes metadata and properties for that share. It does not include a list of the files contained by the share.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "shareName",
+            "in": "path",
+            "description": "The name of the file share within the specified storage account. File share names must be between 3 and 63 characters in length and use numbers, lower-case letters and dash (-) only. Every dash (-) character must be immediately preceded and followed by a letter or number.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 63
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Optional, used to expand the properties within share's properties. Valid values are: snapshots. Should be passed as a string with delimiter ','",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "fileShare",
+            "in": "body",
+            "description": "Properties of the file share to create.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/FileShare"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'FileShare' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/FileShare"
+            }
+          },
+          "201": {
+            "description": "Resource 'FileShare' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/FileShare"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create NFS Shares": {
+            "$ref": "./examples/FileSharesPut_NFS.json"
+          },
+          "PutShares": {
+            "$ref": "./examples/FileSharesPut.json"
+          },
+          "PutShares with Access Tier": {
+            "$ref": "./examples/FileSharesPut_AccessTier.json"
+          },
+          "PutShares with Paid Bursting": {
+            "$ref": "./examples/FileSharesPut_PaidBursting.json"
+          },
+          "PutSharesProvisionedV2": {
+            "$ref": "./examples/FileSharesPut_ProvisionedV2.json"
+          }
+        }
+      },
+      "patch": {
+        "operationId": "FileShares_Update",
+        "tags": [
+          "FileShares"
+        ],
+        "description": "Updates share properties as specified in request body. Properties not mentioned in the request will not be changed. Update fails if the specified share does not already exist.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "shareName",
+            "in": "path",
+            "description": "The name of the file share within the specified storage account. File share names must be between 3 and 63 characters in length and use numbers, lower-case letters and dash (-) only. Every dash (-) character must be immediately preceded and followed by a letter or number.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 63
+          },
+          {
+            "name": "fileShare",
+            "in": "body",
+            "description": "Properties to update for the file share.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/FileShare"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/FileShare"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "UpdateShareAcls": {
+            "$ref": "./examples/FileShareAclsPatch.json"
+          },
+          "UpdateSharePaidBursting": {
+            "$ref": "./examples/FileSharesPatch_PaidBursting.json"
+          },
+          "UpdateShareProvisionedV2": {
+            "$ref": "./examples/FileSharesPatch_ProvisionedV2.json"
+          },
+          "UpdateShares": {
+            "$ref": "./examples/FileSharesPatch.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "FileShares_Delete",
+        "tags": [
+          "FileShares"
+        ],
+        "description": "Deletes specified share under its account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "shareName",
+            "in": "path",
+            "description": "The name of the file share within the specified storage account. File share names must be between 3 and 63 characters in length and use numbers, lower-case letters and dash (-) only. Every dash (-) character must be immediately preceded and followed by a letter or number.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 63
+          },
+          {
+            "name": "x-ms-snapshot",
+            "in": "header",
+            "description": "Optional, used to delete a snapshot.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$include",
+            "in": "query",
+            "description": "Optional. Valid values are: snapshots, leased-snapshots, none. The default value is snapshots. For 'snapshots', the file share is deleted including all of its file share snapshots. If the file share contains leased-snapshots, the deletion fails. For 'leased-snapshots', the file share is deleted included all of its file share snapshots (leased/unleased). For 'none', the file share is deleted if it has no share snapshots. If the file share contains any snapshots (leased or unleased), the deletion fails.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DeleteShares": {
+            "$ref": "./examples/FileSharesDelete.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/fileServices/default/shares/{shareName}/lease": {
+      "post": {
+        "operationId": "FileShares_Lease",
+        "tags": [
+          "FileShares"
+        ],
+        "description": "The Lease Share operation establishes and manages a lock on a share for delete operations. The lock duration can be 15 to 60 seconds, or can be infinite.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "shareName",
+            "in": "path",
+            "description": "The name of the file share within the specified storage account. File share names must be between 3 and 63 characters in length and use numbers, lower-case letters and dash (-) only. Every dash (-) character must be immediately preceded and followed by a letter or number.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 63
+          },
+          {
+            "name": "x-ms-snapshot",
+            "in": "header",
+            "description": "Optional. Specify the snapshot time to lease a snapshot.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The content of the action request",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/LeaseShareRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/LeaseShareResponse"
+            },
+            "headers": {
+              "ETag": {
+                "type": "string",
+                "description": "The ETag HTTP response header. This is an opaque string. You can use it to detect whether the resource has changed between requests. In particular, you can pass the ETag to one of the If-Match or If-None-Match headers."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Acquire a lease on a share": {
+            "$ref": "./examples/FileSharesLease_Acquire.json"
+          },
+          "Break a lease on a share": {
+            "$ref": "./examples/FileSharesLease_Break.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/fileServices/default/shares/{shareName}/restore": {
+      "post": {
+        "operationId": "FileShares_Restore",
+        "tags": [
+          "FileShares"
+        ],
+        "description": "Restore a file share within a valid retention days if share soft delete is enabled",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "shareName",
+            "in": "path",
+            "description": "The name of the file share within the specified storage account. File share names must be between 3 and 63 characters in length and use numbers, lower-case letters and dash (-) only. Every dash (-) character must be immediately preceded and followed by a letter or number.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 63
+          },
+          {
+            "name": "deletedShare",
+            "in": "body",
+            "description": "",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DeletedShare"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RestoreShares": {
+            "$ref": "./examples/FileSharesRestore.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/fileServices/default/usages": {
+      "get": {
+        "operationId": "FileServices_ListServiceUsages",
+        "tags": [
+          "FileServiceUsageOperationGroup"
+        ],
+        "description": "Gets the usages of file service in storage account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "$maxpagesize",
+            "in": "query",
+            "description": "Optional, specifies the maximum number of file service usages to be included in the list response.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/FileServiceUsages"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ListFileServiceUsages": {
+            "$ref": "./examples/FileServicesListUsages.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/fileServices/default/usages/default": {
+      "get": {
+        "operationId": "FileServices_GetServiceUsage",
+        "tags": [
+          "FileServiceUsageOperationGroup"
+        ],
+        "description": "Gets the usage of file service in storage account including account limits, file share limits and constants used in recommendations and bursting formula.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/FileServiceUsage"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "GetFileServiceUsage": {
+            "$ref": "./examples/FileServicesGetUsage.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/hnsonmigration": {
+      "post": {
+        "operationId": "StorageAccounts_HierarchicalNamespaceMigration",
+        "tags": [
+          "StorageAccounts"
+        ],
+        "description": "Live Migration of storage account to enable Hns",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "requestType",
+            "in": "query",
+            "description": "Required. Hierarchical namespace migration type can either be a hierarchical namespace validation request 'HnsOnValidationRequest' or a hydration request 'HnsOnHydrationRequest'. The validation request will validate the migration whereas the hydration request will migrate the account.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully."
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "StorageAccountHierarchicalNamespaceMigration": {
+            "$ref": "./examples/StorageAccountHierarchicalNamespaceMigration.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/inventoryPolicies": {
+      "get": {
+        "operationId": "BlobInventoryPolicies_List",
+        "tags": [
+          "BlobInventoryPolicies"
+        ],
+        "description": "Gets the blob inventory policy associated with the specified storage account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ListBlobInventoryPolicy"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "StorageAccountGetBlobInventoryPolicy": {
+            "$ref": "./examples/StorageAccountListBlobInventoryPolicy.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/inventoryPolicies/{blobInventoryPolicyName}": {
+      "get": {
+        "operationId": "BlobInventoryPolicies_Get",
+        "tags": [
+          "BlobInventoryPolicies"
+        ],
+        "description": "Gets the blob inventory policy associated with the specified storage account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "blobInventoryPolicyName",
+            "in": "path",
+            "description": "The name of the storage account blob inventory policy. It should always be 'default'",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "default"
+            ],
+            "x-ms-enum": {
+              "name": "BlobInventoryPolicyName",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "default",
+                  "value": "default"
+                }
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/BlobInventoryPolicy"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "StorageAccountGetBlobInventoryPolicy": {
+            "$ref": "./examples/StorageAccountGetBlobInventoryPolicy.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "BlobInventoryPolicies_CreateOrUpdate",
+        "tags": [
+          "BlobInventoryPolicies"
+        ],
+        "description": "Sets the blob inventory policy to the specified storage account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "blobInventoryPolicyName",
+            "in": "path",
+            "description": "The name of the storage account blob inventory policy. It should always be 'default'",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "default"
+            ],
+            "x-ms-enum": {
+              "name": "BlobInventoryPolicyName",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "default",
+                  "value": "default"
+                }
+              ]
+            }
+          },
+          {
+            "name": "properties",
+            "in": "body",
+            "description": "The blob inventory policy set to a storage account.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/BlobInventoryPolicy"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'BlobInventoryPolicy' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/BlobInventoryPolicy"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "StorageAccountSetBlobInventoryPolicy": {
+            "$ref": "./examples/StorageAccountSetBlobInventoryPolicy.json"
+          },
+          "StorageAccountSetBlobInventoryPolicyIncludeDeleteAndNewSchemaForHnsAccount": {
+            "$ref": "./examples/StorageAccountSetBlobInventoryPolicyIncludeDeleteAndNewSchemaForHnsAccount.json"
+          },
+          "StorageAccountSetBlobInventoryPolicyIncludeDeleteAndNewSchemaForNonHnsAccount": {
+            "$ref": "./examples/StorageAccountSetBlobInventoryPolicyIncludeDeleteAndNewSchemaForNonHnsAccount.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "BlobInventoryPolicies_Delete",
+        "tags": [
+          "BlobInventoryPolicies"
+        ],
+        "description": "Deletes the blob inventory policy associated with the specified storage account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "blobInventoryPolicyName",
+            "in": "path",
+            "description": "The name of the storage account blob inventory policy. It should always be 'default'",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "default"
+            ],
+            "x-ms-enum": {
+              "name": "BlobInventoryPolicyName",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "default",
+                  "value": "default"
+                }
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "StorageAccountDeleteBlobInventoryPolicy": {
+            "$ref": "./examples/StorageAccountDeleteBlobInventoryPolicy.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/listAccountSas": {
+      "post": {
+        "operationId": "StorageAccounts_ListAccountSAS",
+        "tags": [
+          "StorageAccounts"
+        ],
+        "description": "List SAS credentials of a storage account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The parameters to provide to list SAS credentials for the storage account.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/AccountSasParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ListAccountSasResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "StorageAccountListAccountSAS": {
+            "$ref": "./examples/StorageAccountListAccountSAS.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/listKeys": {
+      "post": {
+        "operationId": "StorageAccounts_ListKeys",
+        "tags": [
+          "StorageAccounts"
+        ],
+        "description": "Lists the access keys or Kerberos keys (if active directory enabled) for the specified storage account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Specifies type of the key to be listed. Possible value is kerb.",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "kerb"
+            ],
+            "x-ms-enum": {
+              "modelAsString": false
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/StorageAccountListKeysResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "StorageAccountListKeys": {
+            "$ref": "./examples/StorageAccountListKeys.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/listServiceSas": {
+      "post": {
+        "operationId": "StorageAccounts_ListServiceSAS",
+        "tags": [
+          "StorageAccounts"
+        ],
+        "description": "List service SAS credentials of a specific resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The parameters to provide to list service SAS credentials.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ServiceSasParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ListServiceSasResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "StorageAccountListServiceSAS": {
+            "$ref": "./examples/StorageAccountListServiceSAS.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/localUsers": {
+      "get": {
+        "operationId": "LocalUsers_List",
+        "tags": [
+          "LocalUserOperationGroup"
+        ],
+        "description": "List the local users associated with the storage account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "$maxpagesize",
+            "in": "query",
+            "description": "Optional, specifies the maximum number of local users that will be included in the list response.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 5000
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Optional. When specified, only local user names starting with the filter will be listed.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$include",
+            "in": "query",
+            "description": "Optional, when specified, will list local users enabled for the specific protocol. Lists all users by default.",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "nfsv3"
+            ],
+            "x-ms-enum": {
+              "name": "ListLocalUserIncludeParam",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "nfsv3",
+                  "value": "nfsv3"
+                }
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/LocalUsers"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ListLocalUsers": {
+            "$ref": "./examples/LocalUsersList.json"
+          },
+          "ListNFSv3EnabledLocalUsers": {
+            "$ref": "./examples/LocalUsersListNFSv3Enabled.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/localUsers/{username}": {
+      "get": {
+        "operationId": "LocalUsers_Get",
+        "tags": [
+          "LocalUserOperationGroup"
+        ],
+        "description": "Get the local user of the storage account by username.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "username",
+            "in": "path",
+            "description": "The name of local user. The username must contain lowercase letters and numbers only. It must be unique only within the storage account.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 64
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/LocalUser"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "GetLocalUser": {
+            "$ref": "./examples/LocalUserGet.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "LocalUsers_CreateOrUpdate",
+        "tags": [
+          "LocalUserOperationGroup"
+        ],
+        "description": "Create or update the properties of a local user associated with the storage account. Properties for NFSv3 enablement and extended groups cannot be set with other properties.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "username",
+            "in": "path",
+            "description": "The name of local user. The username must contain lowercase letters and numbers only. It must be unique only within the storage account.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 64
+          },
+          {
+            "name": "properties",
+            "in": "body",
+            "description": "The local user associated with a storage account.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/LocalUser"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'LocalUser' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/LocalUser"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "CreateLocalUser": {
+            "$ref": "./examples/LocalUserCreate.json"
+          },
+          "CreateNFSv3EnabledLocalUser": {
+            "$ref": "./examples/LocalUserCreateNFSv3Enabled.json"
+          },
+          "UpdateLocalUser": {
+            "$ref": "./examples/LocalUserUpdate.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "LocalUsers_Delete",
+        "tags": [
+          "LocalUserOperationGroup"
+        ],
+        "description": "Deletes the local user associated with the specified storage account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "username",
+            "in": "path",
+            "description": "The name of local user. The username must contain lowercase letters and numbers only. It must be unique only within the storage account.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 64
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DeleteLocalUser": {
+            "$ref": "./examples/LocalUserDelete.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/localUsers/{username}/listKeys": {
+      "post": {
+        "operationId": "LocalUsers_ListKeys",
+        "tags": [
+          "LocalUserOperationGroup"
+        ],
+        "description": "List SSH authorized keys and shared key of the local user.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "username",
+            "in": "path",
+            "description": "The name of local user. The username must contain lowercase letters and numbers only. It must be unique only within the storage account.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 64
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/LocalUserKeys"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ListLocalUserKeys": {
+            "$ref": "./examples/LocalUserListKeys.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/localUsers/{username}/regeneratePassword": {
+      "post": {
+        "operationId": "LocalUsers_RegeneratePassword",
+        "tags": [
+          "LocalUserOperationGroup"
+        ],
+        "description": "Regenerate the local user SSH password.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "username",
+            "in": "path",
+            "description": "The name of local user. The username must contain lowercase letters and numbers only. It must be unique only within the storage account.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 64
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/LocalUserRegeneratePasswordResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RegenerateLocalUserPassword": {
+            "$ref": "./examples/LocalUserRegeneratePassword.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/managementPolicies/{managementPolicyName}": {
+      "get": {
+        "operationId": "ManagementPolicies_Get",
+        "tags": [
+          "ManagementPolicies"
+        ],
+        "description": "Gets the managementpolicy associated with the specified storage account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "managementPolicyName",
+            "in": "path",
+            "description": "The name of the Storage Account Management Policy. It should always be 'default'",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "default"
+            ],
+            "x-ms-enum": {
+              "name": "ManagementPolicyName",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "default",
+                  "value": "default"
+                }
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ManagementPolicy"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "StorageAccountGetManagementPolicies": {
+            "$ref": "./examples/StorageAccountGetManagementPolicy.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "ManagementPolicies_CreateOrUpdate",
+        "tags": [
+          "ManagementPolicies"
+        ],
+        "description": "Sets the managementpolicy to the specified storage account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "managementPolicyName",
+            "in": "path",
+            "description": "The name of the Storage Account Management Policy. It should always be 'default'",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "default"
+            ],
+            "x-ms-enum": {
+              "name": "ManagementPolicyName",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "default",
+                  "value": "default"
+                }
+              ]
+            }
+          },
+          {
+            "name": "properties",
+            "in": "body",
+            "description": "The ManagementPolicy set to a storage account.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ManagementPolicy"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'ManagementPolicy' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ManagementPolicy"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "StorageAccountSetManagementPolicies": {
+            "$ref": "./examples/StorageAccountSetManagementPolicy.json"
+          },
+          "StorageAccountSetManagementPolicyColdTierActions": {
+            "$ref": "./examples/StorageAccountSetManagementPolicyColdTierActions.json"
+          },
+          "StorageAccountSetManagementPolicyForBlockAndAppendBlobs": {
+            "$ref": "./examples/StorageAccountSetManagementPolicyForBlockAndAppendBlobs.json"
+          },
+          "StorageAccountSetManagementPolicyHotTierActions": {
+            "$ref": "./examples/StorageAccountSetManagementPolicyHotTierActions.json"
+          },
+          "StorageAccountSetManagementPolicyWithSnapshotAndVersion": {
+            "$ref": "./examples/StorageAccountSetManagementPolicyWithSnapshotAndVersion.json"
+          },
+          "StorageAccountSetManagementPolicy_BaseBlobDaysAfterCreationActions": {
+            "$ref": "./examples/StorageAccountSetManagementPolicy_BaseBlobDaysAfterCreationActions.json"
+          },
+          "StorageAccountSetManagementPolicy_LastAccessTimeBasedBlobActions": {
+            "$ref": "./examples/StorageAccountSetManagementPolicy_LastAccessTimeBasedBlobActions.json"
+          },
+          "StorageAccountSetManagementPolicy_LastTierChangeTimeActions": {
+            "$ref": "./examples/StorageAccountSetManagementPolicy_LastTierChangeTimeActions.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "ManagementPolicies_Delete",
+        "tags": [
+          "ManagementPolicies"
+        ],
+        "description": "Deletes the managementpolicy associated with the specified storage account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "managementPolicyName",
+            "in": "path",
+            "description": "The name of the Storage Account Management Policy. It should always be 'default'",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "default"
+            ],
+            "x-ms-enum": {
+              "name": "ManagementPolicyName",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "default",
+                  "value": "default"
+                }
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "StorageAccountDeleteManagementPolicies": {
+            "$ref": "./examples/StorageAccountDeleteManagementPolicy.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/networkSecurityPerimeterConfigurations": {
+      "get": {
+        "operationId": "NetworkSecurityPerimeterConfigurations_List",
+        "tags": [
+          "NetworkSecurityPerimeterConfigurations"
+        ],
+        "description": "Gets list of effective NetworkSecurityPerimeterConfiguration for storage account",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkSecurityPerimeterConfigurationList"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NetworkSecurityPerimeterConfigurationList": {
+            "$ref": "./examples/NetworkSecurityPerimeterConfigurationList.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/networkSecurityPerimeterConfigurations/{networkSecurityPerimeterConfigurationName}": {
+      "get": {
+        "operationId": "NetworkSecurityPerimeterConfigurations_Get",
+        "tags": [
+          "NetworkSecurityPerimeterConfigurations"
+        ],
+        "description": "Gets effective NetworkSecurityPerimeterConfiguration for association",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "networkSecurityPerimeterConfigurationName",
+            "in": "path",
+            "description": "The name for Network Security Perimeter configuration",
+            "required": true,
+            "type": "string",
+            "pattern": "^.*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkSecurityPerimeterConfiguration"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NetworkSecurityPerimeterConfigurationGet": {
+            "$ref": "./examples/NetworkSecurityPerimeterConfigurationGet.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/networkSecurityPerimeterConfigurations/{networkSecurityPerimeterConfigurationName}/reconcile": {
+      "post": {
+        "operationId": "NetworkSecurityPerimeterConfigurations_Reconcile",
+        "tags": [
+          "NetworkSecurityPerimeterConfigurations"
+        ],
+        "description": "Refreshes any information about the association.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "networkSecurityPerimeterConfigurationName",
+            "in": "path",
+            "description": "The name for Network Security Perimeter configuration",
+            "required": true,
+            "type": "string",
+            "pattern": "^.*$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NetworkSecurityPerimeterConfigurationReconcile": {
+            "$ref": "./examples/NetworkSecurityPerimeterConfigurationReconcile.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/objectReplicationPolicies": {
+      "get": {
+        "operationId": "ObjectReplicationPolicies_List",
+        "tags": [
+          "ObjectReplicationPolicyOperationGroup"
+        ],
+        "description": "List the object replication policies associated with the storage account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ObjectReplicationPolicies"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "StorageAccountListObjectReplicationPolicies": {
+            "$ref": "./examples/StorageAccountListObjectReplicationPolicies.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/objectReplicationPolicies/{objectReplicationPolicyId}": {
+      "get": {
+        "operationId": "ObjectReplicationPolicies_Get",
+        "tags": [
+          "ObjectReplicationPolicyOperationGroup"
+        ],
+        "description": "Get the object replication policy of the storage account by policy ID.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "objectReplicationPolicyId",
+            "in": "path",
+            "description": "For the destination account, provide the value 'default'. Configure the policy on the destination account first. For the source account, provide the value of the policy ID that is returned when you download the policy that was defined on the destination account. The policy is downloaded as a JSON file.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ObjectReplicationPolicy"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "StorageAccountGetObjectReplicationPolicies": {
+            "$ref": "./examples/StorageAccountGetObjectReplicationPolicy.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "ObjectReplicationPolicies_CreateOrUpdate",
+        "tags": [
+          "ObjectReplicationPolicyOperationGroup"
+        ],
+        "description": "Create or update the object replication policy of the storage account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "objectReplicationPolicyId",
+            "in": "path",
+            "description": "For the destination account, provide the value 'default'. Configure the policy on the destination account first. For the source account, provide the value of the policy ID that is returned when you download the policy that was defined on the destination account. The policy is downloaded as a JSON file.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          },
+          {
+            "name": "properties",
+            "in": "body",
+            "description": "The object replication policy set to a storage account. A unique policy ID will be created if absent.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ObjectReplicationPolicy"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'ObjectReplicationPolicy' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ObjectReplicationPolicy"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "StorageAccountCreateObjectReplicationPolicyOnDestination": {
+            "$ref": "./examples/StorageAccountCreateObjectReplicationPolicyOnDestination.json"
+          },
+          "StorageAccountCreateObjectReplicationPolicyOnSource": {
+            "$ref": "./examples/StorageAccountCreateObjectReplicationPolicyOnSource.json"
+          },
+          "StorageAccountUpdateObjectReplicationPolicyOnDestination": {
+            "$ref": "./examples/StorageAccountUpdateObjectReplicationPolicyOnDestination.json"
+          },
+          "StorageAccountUpdateObjectReplicationPolicyOnSource": {
+            "$ref": "./examples/StorageAccountUpdateObjectReplicationPolicyOnSource.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "ObjectReplicationPolicies_Delete",
+        "tags": [
+          "ObjectReplicationPolicyOperationGroup"
+        ],
+        "description": "Deletes the object replication policy associated with the specified storage account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "objectReplicationPolicyId",
+            "in": "path",
+            "description": "For the destination account, provide the value 'default'. Configure the policy on the destination account first. For the source account, provide the value of the policy ID that is returned when you download the policy that was defined on the destination account. The policy is downloaded as a JSON file.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "StorageAccountDeleteObjectReplicationPolicies": {
+            "$ref": "./examples/StorageAccountDeleteObjectReplicationPolicy.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/privateEndpointConnections": {
+      "get": {
+        "operationId": "PrivateEndpointConnections_List",
+        "tags": [
+          "PrivateEndpointConnections"
+        ],
+        "description": "List all the private endpoint connections associated with the storage account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnectionListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "StorageAccountListPrivateEndpointConnections": {
+            "$ref": "./examples/StorageAccountListPrivateEndpointConnections.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/privateEndpointConnections/{privateEndpointConnectionName}": {
+      "get": {
+        "operationId": "PrivateEndpointConnections_Get",
+        "tags": [
+          "PrivateEndpointConnections"
+        ],
+        "description": "Gets the specified private endpoint connection associated with the storage account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "privateEndpointConnectionName",
+            "in": "path",
+            "description": "The name of the private endpoint connection associated with the Azure resource",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "StorageAccountGetPrivateEndpointConnection": {
+            "$ref": "./examples/StorageAccountGetPrivateEndpointConnection.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "PrivateEndpointConnections_Put",
+        "tags": [
+          "PrivateEndpointConnections"
+        ],
+        "description": "Update the state of specified private endpoint connection associated with the storage account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "privateEndpointConnectionName",
+            "in": "path",
+            "description": "The name of the private endpoint connection associated with the Azure resource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "properties",
+            "in": "body",
+            "description": "The private endpoint connection properties.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnection"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'PrivateEndpointConnection' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "StorageAccountPutPrivateEndpointConnection": {
+            "$ref": "./examples/StorageAccountPutPrivateEndpointConnection.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "PrivateEndpointConnections_Delete",
+        "tags": [
+          "PrivateEndpointConnections"
+        ],
+        "description": "Deletes the specified private endpoint connection associated with the storage account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "privateEndpointConnectionName",
+            "in": "path",
+            "description": "The name of the private endpoint connection associated with the Azure resource",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "StorageAccountDeletePrivateEndpointConnection": {
+            "$ref": "./examples/StorageAccountDeletePrivateEndpointConnection.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/privateLinkResources": {
+      "get": {
+        "operationId": "PrivateLinkResources_ListByStorageAccount",
+        "tags": [
+          "StorageAccounts"
+        ],
+        "description": "Gets the private link resources that need to be created for a storage account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PrivateLinkResourceListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "StorageAccountListPrivateLinkResources": {
+            "$ref": "./examples/StorageAccountListPrivateLinkResources.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/queueServices": {
+      "get": {
+        "operationId": "QueueServices_List",
+        "tags": [
+          "QueueServices"
+        ],
+        "description": "List all queue services for the storage account",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ListQueueServices"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "QueueServicesList": {
+            "$ref": "./examples/QueueServicesList.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/queueServices/default": {
+      "get": {
+        "operationId": "QueueServices_GetServiceProperties",
+        "tags": [
+          "QueueServices"
+        ],
+        "description": "Gets the properties of a storage account’s Queue service, including properties for Storage Analytics and CORS (Cross-Origin Resource Sharing) rules.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/QueueServiceProperties"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "QueueServicesGet": {
+            "$ref": "./examples/QueueServicesGet.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "QueueServices_SetServiceProperties",
+        "tags": [
+          "QueueServices"
+        ],
+        "description": "Sets the properties of a storage account’s Queue service, including properties for Storage Analytics and CORS (Cross-Origin Resource Sharing) rules.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The properties of a storage account’s Queue service, only properties for Storage Analytics and CORS (Cross-Origin Resource Sharing) rules can be specified.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/QueueServiceProperties"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'QueueServiceProperties' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/QueueServiceProperties"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "QueueServicesPut": {
+            "$ref": "./examples/QueueServicesPut.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/queueServices/default/queues": {
+      "get": {
+        "operationId": "Queue_List",
+        "tags": [
+          "QueueServices"
+        ],
+        "description": "Gets a list of all the queues under the specified storage account",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "$maxpagesize",
+            "in": "query",
+            "description": "Optional, a maximum number of queues that should be included in a list queue response",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Optional, When specified, only the queues with a name starting with the given filter will be listed.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ListQueueResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "QueueOperationList": {
+            "$ref": "./examples/QueueOperationList.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/queueServices/default/queues/{queueName}": {
+      "get": {
+        "operationId": "Queue_Get",
+        "tags": [
+          "StorageQueues"
+        ],
+        "description": "Gets the queue with the specified queue name, under the specified account if it exists.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "queueName",
+            "in": "path",
+            "description": "A queue name must be unique within a storage account and must be between 3 and 63 characters.The name must comprise of lowercase alphanumeric and dash(-) characters only, it should begin and end with an alphanumeric character and it cannot have two consecutive dash(-) characters.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 63,
+            "pattern": "^[a-z0-9]([a-z0-9]|(-(?!-))){1,61}[a-z0-9]$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/StorageQueue"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "QueueOperationGet": {
+            "$ref": "./examples/QueueOperationGet.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "Queue_Create",
+        "tags": [
+          "StorageQueues"
+        ],
+        "description": "Creates a new queue with the specified queue name, under the specified account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "queueName",
+            "in": "path",
+            "description": "A queue name must be unique within a storage account and must be between 3 and 63 characters.The name must comprise of lowercase alphanumeric and dash(-) characters only, it should begin and end with an alphanumeric character and it cannot have two consecutive dash(-) characters.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 63,
+            "pattern": "^[a-z0-9]([a-z0-9]|(-(?!-))){1,61}[a-z0-9]$"
+          },
+          {
+            "name": "queue",
+            "in": "body",
+            "description": "Queue properties and metadata to be created with",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/StorageQueue"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'StorageQueue' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/StorageQueue"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "QueueOperationPut": {
+            "$ref": "./examples/QueueOperationPut.json"
+          },
+          "QueueOperationPutWithMetadata": {
+            "$ref": "./examples/QueueOperationPutWithMetadata.json"
+          }
+        }
+      },
+      "patch": {
+        "operationId": "Queue_Update",
+        "tags": [
+          "StorageQueues"
+        ],
+        "description": "Creates a new queue with the specified queue name, under the specified account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "queueName",
+            "in": "path",
+            "description": "A queue name must be unique within a storage account and must be between 3 and 63 characters.The name must comprise of lowercase alphanumeric and dash(-) characters only, it should begin and end with an alphanumeric character and it cannot have two consecutive dash(-) characters.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 63,
+            "pattern": "^[a-z0-9]([a-z0-9]|(-(?!-))){1,61}[a-z0-9]$"
+          },
+          {
+            "name": "queue",
+            "in": "body",
+            "description": "Queue properties and metadata to be created with",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/StorageQueue"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/StorageQueue"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "QueueOperationPatch": {
+            "$ref": "./examples/QueueOperationPatch.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "Queue_Delete",
+        "tags": [
+          "StorageQueues"
+        ],
+        "description": "Deletes the queue with the specified queue name, under the specified account if it exists.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "queueName",
+            "in": "path",
+            "description": "A queue name must be unique within a storage account and must be between 3 and 63 characters.The name must comprise of lowercase alphanumeric and dash(-) characters only, it should begin and end with an alphanumeric character and it cannot have two consecutive dash(-) characters.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 63,
+            "pattern": "^[a-z0-9]([a-z0-9]|(-(?!-))){1,61}[a-z0-9]$"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "QueueOperationDelete": {
+            "$ref": "./examples/QueueOperationDelete.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/regenerateKey": {
+      "post": {
+        "operationId": "StorageAccounts_RegenerateKey",
+        "tags": [
+          "StorageAccounts"
+        ],
+        "description": "Regenerates one of the access keys or Kerberos keys for the specified storage account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "regenerateKey",
+            "in": "body",
+            "description": "Specifies name of the key which should be regenerated -- key1, key2, kerb1, kerb2.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/StorageAccountRegenerateKeyParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/StorageAccountListKeysResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "StorageAccountRegenerateKerbKey": {
+            "$ref": "./examples/StorageAccountRegenerateKerbKey.json"
+          },
+          "StorageAccountRegenerateKey": {
+            "$ref": "./examples/StorageAccountRegenerateKey.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/reports": {
+      "get": {
+        "operationId": "StorageTaskAssignmentsInstancesReport_List",
+        "tags": [
+          "StorageAccounts"
+        ],
+        "description": "Fetch the report summary of all the storage task assignments and instances in an account",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "$maxpagesize",
+            "in": "query",
+            "description": "Optional, specifies the maximum number of storage task assignment instances to be included in the list response.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Optional. When specified, it can be used to query using reporting properties. See [Constructing Filter Strings](https://learn.microsoft.com/rest/api/storageservices/querying-tables-and-entities#constructing-filter-strings) for details.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/StorageTaskReportSummary"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ListStorageTaskAssignmentsInstancesReportSummary": {
+            "$ref": "./examples/storageTaskAssignmentsList/ListStorageTaskAssignmentsInstancesReportSummary.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/restoreBlobRanges": {
+      "post": {
+        "operationId": "StorageAccounts_RestoreBlobRanges",
+        "tags": [
+          "StorageAccounts"
+        ],
+        "description": "Restore blobs in the specified blob ranges",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The parameters to provide for restore blob ranges.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/BlobRestoreParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/BlobRestoreStatus"
+            }
+          },
+          "202": {
+            "description": "The request has been accepted for processing, but processing has not yet completed.",
+            "schema": {
+              "$ref": "#/definitions/BlobRestoreStatus"
+            },
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "BlobRangesRestore": {
+            "$ref": "./examples/BlobRangesRestore.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/BlobRestoreStatus"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/revokeUserDelegationKeys": {
+      "post": {
+        "operationId": "StorageAccounts_RevokeUserDelegationKeys",
+        "tags": [
+          "StorageAccounts"
+        ],
+        "description": "Revoke user delegation keys.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "StorageAccountRevokeUserDelegationKeys": {
+            "$ref": "./examples/StorageAccountRevokeUserDelegationKeys.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/startAccountMigration": {
+      "post": {
+        "operationId": "StorageAccounts_CustomerInitiatedMigration",
+        "tags": [
+          "StorageAccounts"
+        ],
+        "description": "Account Migration request can be triggered for a storage account to change its redundancy level. The migration updates the non-zonal redundant storage account to a zonal redundant account or vice-versa in order to have better reliability and availability. Zone-redundant storage (ZRS) replicates your storage account synchronously across three Azure availability zones in the primary region.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The request parameters required to perform storage account migration.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/StorageAccountMigration"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully."
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "StorageAccountPostMigration": {
+            "$ref": "./examples/StorageAccountPostMigration.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/storageTaskAssignments": {
+      "get": {
+        "operationId": "StorageTaskAssignments_List",
+        "tags": [
+          "StorageTaskAssignments"
+        ],
+        "description": "List all the storage task assignments in an account",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "Optional, specifies the maximum number of storage task assignment Ids to be included in the list response.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/StorageTaskAssignmentsList"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ListStorageTaskAssignmentsForAccount": {
+            "$ref": "./examples/storageTaskAssignmentsList/ListStorageTaskAssignmentsForAccount.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/storageTaskAssignments/{storageTaskAssignmentName}": {
+      "get": {
+        "operationId": "StorageTaskAssignments_Get",
+        "tags": [
+          "StorageTaskAssignments"
+        ],
+        "description": "Get the storage task assignment properties",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "storageTaskAssignmentName",
+            "in": "path",
+            "description": "The name of the storage task assignment within the specified resource group. Storage task assignment names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z][a-z0-9]{2,23}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/StorageTaskAssignment"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "GetStorageTaskAssignment": {
+            "$ref": "./examples/storageTaskAssignmentsCrud/GetStorageTaskAssignment.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "StorageTaskAssignments_Create",
+        "tags": [
+          "StorageTaskAssignments"
+        ],
+        "description": "Asynchronously creates a new storage task assignment sub-resource with the specified parameters. If a storage task assignment is already created and a subsequent create request is issued with different properties, the storage task assignment properties will be updated. If a storage task assignment is already created and a subsequent create or update request is issued with the exact same set of properties, the request will succeed.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "storageTaskAssignmentName",
+            "in": "path",
+            "description": "The name of the storage task assignment within the specified resource group. Storage task assignment names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z][a-z0-9]{2,23}$"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The parameters to create a Storage Task Assignment.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/StorageTaskAssignment"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'StorageTaskAssignment' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/StorageTaskAssignment"
+            }
+          },
+          "201": {
+            "description": "Resource 'StorageTaskAssignment' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/StorageTaskAssignment"
+            },
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PutStorageTaskAssignment": {
+            "$ref": "./examples/storageTaskAssignmentsCrud/PutStorageTaskAssignment.json"
+          },
+          "PutStorageTaskAssignmentMockRun": {
+            "$ref": "./examples/storageTaskAssignmentsCrud/PutStorageTaskAssignmentMockRun.json"
+          },
+          "PutStorageTaskAssignmentRequiredProperties": {
+            "$ref": "./examples/storageTaskAssignmentsCrud/PutStorageTaskAssignmentRequiredProperties.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/StorageTaskAssignment"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "StorageTaskAssignments_Update",
+        "tags": [
+          "StorageTaskAssignments"
+        ],
+        "description": "Update storage task assignment properties",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "storageTaskAssignmentName",
+            "in": "path",
+            "description": "The name of the storage task assignment within the specified resource group. Storage task assignment names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z][a-z0-9]{2,23}$"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The parameters to update a Storage Task Assignment.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/StorageTaskAssignmentUpdateParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/StorageTaskAssignment"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PatchStorageTaskAssignment": {
+            "$ref": "./examples/storageTaskAssignmentsCrud/PatchStorageTaskAssignment.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/StorageTaskAssignment"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "StorageTaskAssignments_Delete",
+        "tags": [
+          "StorageTaskAssignments"
+        ],
+        "description": "Delete the storage task assignment sub-resource",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "storageTaskAssignmentName",
+            "in": "path",
+            "description": "The name of the storage task assignment within the specified resource group. Storage task assignment names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z][a-z0-9]{2,23}$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "There is no content to send for this request, but the headers may be useful."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DeleteStorageTaskAssignment": {
+            "$ref": "./examples/storageTaskAssignmentsCrud/DeleteStorageTaskAssignment.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/storageTaskAssignments/{storageTaskAssignmentName}/reports": {
+      "get": {
+        "operationId": "StorageTaskAssignmentInstancesReport_List",
+        "tags": [
+          "StorageTaskAssignments"
+        ],
+        "description": "Fetch the report summary of a single storage task assignment's instances",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "storageTaskAssignmentName",
+            "in": "path",
+            "description": "The name of the storage task assignment within the specified resource group. Storage task assignment names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z][a-z0-9]{2,23}$"
+          },
+          {
+            "name": "$maxpagesize",
+            "in": "query",
+            "description": "Optional, specifies the maximum number of storage task assignment instances to be included in the list response.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Optional. When specified, it can be used to query using reporting properties. See [Constructing Filter Strings](https://learn.microsoft.com/rest/api/storageservices/querying-tables-and-entities#constructing-filter-strings) for details.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/StorageTaskReportSummary"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ListStorageTaskAssignmentInstancesReportSummary": {
+            "$ref": "./examples/storageTaskAssignmentsList/ListStorageTaskAssignmentInstancesReportSummary.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/storageTaskAssignments/{storageTaskAssignmentName}/stopAssignment": {
+      "post": {
+        "operationId": "StorageTaskAssignments_StopAssignment",
+        "tags": [
+          "StorageTaskAssignments"
+        ],
+        "description": "Stops any active running storage action for the storage task assignment",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "storageTaskAssignmentName",
+            "in": "path",
+            "description": "The name of the storage task assignment within the specified resource group. Storage task assignment names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z][a-z0-9]{2,23}$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Azure operation completed successfully."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "StopStorageTaskAssignment": {
+            "$ref": "./examples/storageTaskAssignmentsCrud/StopStorageTaskAssignment.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/tableServices": {
+      "get": {
+        "operationId": "TableServices_List",
+        "tags": [
+          "TableServices"
+        ],
+        "description": "List all table services for the storage account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ListTableServices"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "TableServicesList": {
+            "$ref": "./examples/TableServicesList.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/tableServices/default": {
+      "get": {
+        "operationId": "TableServices_GetServiceProperties",
+        "tags": [
+          "TableServices"
+        ],
+        "description": "Gets the properties of a storage account’s Table service, including properties for Storage Analytics and CORS (Cross-Origin Resource Sharing) rules.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/TableServiceProperties"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "TableServicesGet": {
+            "$ref": "./examples/TableServicesGet.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "TableServices_SetServiceProperties",
+        "tags": [
+          "TableServices"
+        ],
+        "description": "Sets the properties of a storage account’s Table service, including properties for Storage Analytics and CORS (Cross-Origin Resource Sharing) rules.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The properties of a storage account’s Table service, only properties for Storage Analytics and CORS (Cross-Origin Resource Sharing) rules can be specified.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/TableServiceProperties"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'TableServiceProperties' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/TableServiceProperties"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "TableServicesPut": {
+            "$ref": "./examples/TableServicesPut.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/tableServices/default/tables": {
+      "get": {
+        "operationId": "Table_List",
+        "tags": [
+          "Tables"
+        ],
+        "description": "Gets a list of all the tables under the specified storage account",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ListTableResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "TableOperationList": {
+            "$ref": "./examples/TableOperationList.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/tableServices/default/tables/{tableName}": {
+      "get": {
+        "operationId": "Table_Get",
+        "tags": [
+          "Tables"
+        ],
+        "description": "Gets the table with the specified table name, under the specified account if it exists.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "tableName",
+            "in": "path",
+            "description": "A table name must be unique within a storage account and must be between 3 and 63 characters.The name must comprise of only alphanumeric characters and it cannot begin with a numeric character.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 63,
+            "pattern": "^[A-Za-z][A-Za-z0-9]{2,62}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Table"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "TableOperationGet": {
+            "$ref": "./examples/TableOperationGet.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "Table_Create",
+        "tags": [
+          "Tables"
+        ],
+        "description": "Creates a new table with the specified table name, under the specified account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "tableName",
+            "in": "path",
+            "description": "A table name must be unique within a storage account and must be between 3 and 63 characters.The name must comprise of only alphanumeric characters and it cannot begin with a numeric character.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 63,
+            "pattern": "^[A-Za-z][A-Za-z0-9]{2,62}$"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The parameters to provide to create a table.",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/Table"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'Table' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Table"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "TableOperationPut": {
+            "$ref": "./examples/TableOperationPut.json"
+          },
+          "TableOperationPutOrPatchAcls": {
+            "$ref": "./examples/TableOperationPutOrPatchAclsTableCreate.json"
+          }
+        }
+      },
+      "patch": {
+        "operationId": "Table_Update",
+        "tags": [
+          "Tables"
+        ],
+        "description": "Creates a new table with the specified table name, under the specified account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "tableName",
+            "in": "path",
+            "description": "A table name must be unique within a storage account and must be between 3 and 63 characters.The name must comprise of only alphanumeric characters and it cannot begin with a numeric character.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 63,
+            "pattern": "^[A-Za-z][A-Za-z0-9]{2,62}$"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The parameters to provide to create a table.",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/Table"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'Table' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Table"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "TableOperationPatch": {
+            "$ref": "./examples/TableOperationPatch.json"
+          },
+          "TableOperationPutOrPatchAcls": {
+            "$ref": "./examples/TableOperationPutOrPatchAcls.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "Table_Delete",
+        "tags": [
+          "Tables"
+        ],
+        "description": "Deletes the table with the specified table name, under the specified account if it exists.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          {
+            "name": "tableName",
+            "in": "path",
+            "description": "A table name must be unique within a storage account and must be between 3 and 63 characters.The name must comprise of only alphanumeric characters and it cannot begin with a numeric character.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 63,
+            "pattern": "^[A-Za-z][A-Za-z0-9]{2,62}$"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "TableOperationDelete": {
+            "$ref": "./examples/TableOperationDelete.json"
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "AccessPolicy": {
+      "type": "object",
+      "properties": {
+        "startTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Start time of the access policy"
+        },
+        "expiryTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expiry time of the access policy"
+        },
+        "permission": {
+          "type": "string",
+          "description": "List of abbreviated permissions."
+        }
+      }
+    },
+    "AccessTier": {
+      "type": "string",
+      "description": "The default access tier for block blobs in the storage account. Required for storage accounts where kind = BlobStorage. See more details in: https://learn.microsoft.com/azure/storage/blobs/access-tiers-overview.",
+      "enum": [
+        "Hot",
+        "Cool",
+        "Premium",
+        "Cold",
+        "Smart"
+      ],
+      "x-ms-enum": {
+        "name": "AccessTier",
+        "modelAsString": false
+      }
+    },
+    "AccountImmutabilityPolicyProperties": {
+      "type": "object",
+      "description": "This defines account-level immutability policy properties.",
+      "properties": {
+        "immutabilityPeriodSinceCreationInDays": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The immutability period for the blobs in the container since the policy creation, in days.",
+          "minimum": 1,
+          "maximum": 146000
+        },
+        "state": {
+          "$ref": "#/definitions/AccountImmutabilityPolicyState",
+          "description": "The ImmutabilityPolicy state defines the mode of the policy. Disabled state disables the policy, Unlocked state allows increase and decrease of immutability retention time and also allows toggling allowProtectedAppendWrites property, Locked state only allows the increase of the immutability retention time. A policy can only be created in a Disabled or Unlocked state and can be toggled between the two states. Only a policy in an Unlocked state can transition to a Locked state which cannot be reverted."
+        },
+        "allowProtectedAppendWrites": {
+          "type": "boolean",
+          "description": "This property can only be changed for disabled and unlocked time-based retention policies. When enabled, new blocks can be written to an append blob while maintaining immutability protection and compliance. Only new blocks can be added and any existing blocks cannot be modified or deleted."
+        }
+      }
+    },
+    "AccountImmutabilityPolicyState": {
+      "type": "string",
+      "description": "The ImmutabilityPolicy state defines the mode of the policy. Disabled state disables the policy, Unlocked state allows increase and decrease of immutability retention time and also allows toggling allowProtectedAppendWrites property, Locked state only allows the increase of the immutability retention time. A policy can only be created in a Disabled or Unlocked state and can be toggled between the two states. Only a policy in an Unlocked state can transition to a Locked state which cannot be reverted.",
+      "enum": [
+        "Unlocked",
+        "Locked",
+        "Disabled"
+      ],
+      "x-ms-enum": {
+        "name": "AccountImmutabilityPolicyState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Unlocked",
+            "value": "Unlocked"
+          },
+          {
+            "name": "Locked",
+            "value": "Locked"
+          },
+          {
+            "name": "Disabled",
+            "value": "Disabled"
+          }
+        ]
+      }
+    },
+    "AccountLimits": {
+      "type": "object",
+      "description": "Maximum provisioned storage, IOPS, bandwidth and number of file shares limits for the storage account.",
+      "properties": {
+        "maxFileShares": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The maximum number of file shares limit for the storage account.",
+          "readOnly": true
+        },
+        "maxProvisionedStorageGiB": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The maximum provisioned storage quota limit in gibibytes for the storage account.",
+          "readOnly": true
+        },
+        "maxProvisionedIOPS": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The maximum provisioned IOPS limit for the storage account.",
+          "readOnly": true
+        },
+        "maxProvisionedBandwidthMiBPerSec": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The maximum provisioned bandwidth limit in mebibytes per second for the storage account.",
+          "readOnly": true
+        }
+      }
+    },
+    "AccountSasParameters": {
+      "type": "object",
+      "description": "The parameters to list SAS credentials of a storage account.",
+      "properties": {
+        "signedServices": {
+          "$ref": "#/definitions/Services",
+          "description": "The signed services accessible with the account SAS. Possible values include: Blob (b), Queue (q), Table (t), File (f).",
+          "x-ms-client-name": "Services"
+        },
+        "signedResourceTypes": {
+          "$ref": "#/definitions/SignedResourceTypes",
+          "description": "The signed resource types that are accessible with the account SAS. Service (s): Access to service-level APIs; Container (c): Access to container-level APIs; Object (o): Access to object-level APIs for blobs, queue messages, table entities, and files.",
+          "x-ms-client-name": "ResourceTypes"
+        },
+        "signedPermission": {
+          "$ref": "#/definitions/Permissions",
+          "description": "The signed permissions for the account SAS. Possible values include: Read (r), Write (w), Delete (d), List (l), Add (a), Create (c), Update (u) and Process (p).",
+          "x-ms-client-name": "Permissions"
+        },
+        "signedIp": {
+          "type": "string",
+          "description": "An IP address or a range of IP addresses from which to accept requests.",
+          "x-ms-client-name": "IPAddressOrRange"
+        },
+        "signedProtocol": {
+          "$ref": "#/definitions/HttpProtocol",
+          "description": "The protocol permitted for a request made with the account SAS.",
+          "x-ms-client-name": "Protocols"
+        },
+        "signedStart": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The time at which the SAS becomes valid.",
+          "x-ms-client-name": "SharedAccessStartTime"
+        },
+        "signedExpiry": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The time at which the shared access signature becomes invalid.",
+          "x-ms-client-name": "SharedAccessExpiryTime"
+        },
+        "keyToSign": {
+          "type": "string",
+          "description": "The key to sign the account SAS token with."
+        }
+      },
+      "required": [
+        "signedServices",
+        "signedResourceTypes",
+        "signedPermission",
+        "signedExpiry"
+      ]
+    },
+    "AccountStatus": {
+      "type": "string",
+      "description": "Gets the status indicating whether the primary location of the storage account is available or unavailable.",
+      "enum": [
+        "available",
+        "unavailable"
+      ],
+      "x-ms-enum": {
+        "name": "AccountStatus",
+        "modelAsString": false
+      }
+    },
+    "AccountType": {
+      "type": "string",
+      "description": "Specifies the Active Directory account type for Azure Storage. If directoryServiceOptions is set to AD (AD DS authentication), this property is optional. If provided, samAccountName should also be provided. For directoryServiceOptions AADDS (Entra DS authentication) or AADKERB (Entra authentication), this property can be omitted.",
+      "enum": [
+        "User",
+        "Computer"
+      ],
+      "x-ms-enum": {
+        "name": "AccountType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "User",
+            "value": "User"
+          },
+          {
+            "name": "Computer",
+            "value": "Computer"
+          }
+        ]
+      }
+    },
+    "AccountUsage": {
+      "type": "object",
+      "description": "Usage of provisioned storage, IOPS, bandwidth and number of file shares across all live shares and soft-deleted shares in the account.",
+      "properties": {
+        "liveShares": {
+          "$ref": "#/definitions/AccountUsageElements",
+          "description": "Usage of provisioned storage, IOPS, bandwidth and number of file shares across all live shares or soft-deleted shares in the account."
+        },
+        "softDeletedShares": {
+          "$ref": "#/definitions/AccountUsageElements",
+          "description": "Usage of provisioned storage, IOPS, bandwidth and number of file shares across all live shares or soft-deleted shares in the account."
+        }
+      }
+    },
+    "AccountUsageElements": {
+      "type": "object",
+      "description": "Usage of provisioned storage, IOPS, bandwidth and number of file shares across all live shares or soft-deleted shares in the account.",
+      "properties": {
+        "fileShareCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The total number of file shares.",
+          "readOnly": true
+        },
+        "provisionedStorageGiB": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The total provisioned storage quota in gibibytes.",
+          "readOnly": true
+        },
+        "provisionedIOPS": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The total provisioned IOPS.",
+          "readOnly": true
+        },
+        "provisionedBandwidthMiBPerSec": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The total provisioned bandwidth in mebibytes per second.",
+          "readOnly": true
+        }
+      }
+    },
+    "ActiveDirectoryProperties": {
+      "type": "object",
+      "description": "Settings properties for Active Directory (AD).",
+      "properties": {
+        "domainName": {
+          "type": "string",
+          "description": "Specifies the primary domain that the AD DNS server is authoritative for. This property is required if directoryServiceOptions is set to AD (AD DS authentication). If directoryServiceOptions is set to AADDS (Entra DS authentication), providing this property is optional, as it will be inferred automatically if omitted. If directoryServiceOptions is set to AADKERB (Entra authentication), this property is optional; it is needed to support configuration of directory- and file-level permissions via Windows File Explorer, but is not required for authentication."
+        },
+        "netBiosDomainName": {
+          "type": "string",
+          "description": "Specifies the NetBIOS domain name. If directoryServiceOptions is set to AD (AD DS authentication), this property is required. Otherwise, it can be omitted."
+        },
+        "forestName": {
+          "type": "string",
+          "description": "Specifies the Active Directory forest to get. If directoryServiceOptions is set to AD (AD DS authentication), this property is required. Otherwise, it can be omitted."
+        },
+        "domainGuid": {
+          "type": "string",
+          "description": "Specifies the domain GUID. If directoryServiceOptions is set to AD (AD DS authentication), this property is required. If directoryServiceOptions is set to AADDS (Entra DS authentication), this property can be omitted. If directoryServiceOptions is set to AADKERB (Entra authentication), this property is optional; it is needed to support configuration of directory- and file-level permissions via Windows File Explorer, but is not required for authentication."
+        },
+        "domainSid": {
+          "type": "string",
+          "description": "Specifies the security identifier (SID) of the AD domain. If directoryServiceOptions is set to AD (AD DS authentication), this property is required. Otherwise, it can be omitted."
+        },
+        "azureStorageSid": {
+          "type": "string",
+          "description": "Specifies the security identifier (SID) for Azure Storage. If directoryServiceOptions is set to AD (AD DS authentication), this property is required. Otherwise, it can be omitted."
+        },
+        "samAccountName": {
+          "type": "string",
+          "description": "Specifies the Active Directory SAMAccountName for Azure Storage. If directoryServiceOptions is set to AD (AD DS authentication), this property is optional. If provided, accountType should also be provided. For directoryServiceOptions AADDS (Entra DS authentication) or AADKERB (Entra authentication), this property can be omitted."
+        },
+        "accountType": {
+          "$ref": "#/definitions/AccountType",
+          "description": "Specifies the Active Directory account type for Azure Storage. If directoryServiceOptions is set to AD (AD DS authentication), this property is optional. If provided, samAccountName should also be provided. For directoryServiceOptions AADDS (Entra DS authentication) or AADKERB (Entra authentication), this property can be omitted."
+        }
+      }
+    },
+    "AdvancedPlatformMetricsFilterType": {
+      "type": "string",
+      "description": "The type of filter applied to the advanced platform metrics rule.",
+      "enum": [
+        "AllContainersFilter",
+        "ContainerPrefixFilter",
+        "ContainerListFilter"
+      ],
+      "x-ms-enum": {
+        "name": "AdvancedPlatformMetricsFilterType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "AllContainersFilter",
+            "value": "AllContainersFilter",
+            "description": "Filter applies to all containers"
+          },
+          {
+            "name": "ContainerPrefixFilter",
+            "value": "ContainerPrefixFilter",
+            "description": "Filter applies to containers matching a prefix"
+          },
+          {
+            "name": "ContainerListFilter",
+            "value": "ContainerListFilter",
+            "description": "Filter applies to a specific list of containers"
+          }
+        ]
+      }
+    },
+    "AdvancedPlatformMetricsRule": {
+      "type": "object",
+      "description": "The advanced platform metrics rule for the storage account.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/AdvancedPlatformMetricsRuleProperties",
+          "description": "Returns the advanced platform metrics rule."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "AdvancedPlatformMetricsRuleConfig": {
+      "type": "object",
+      "description": "Configuration for the advanced platform metrics rule.",
+      "properties": {
+        "filterType": {
+          "$ref": "#/definitions/AdvancedPlatformMetricsFilterType",
+          "description": "The type of filter applied to the rule. Possible values include: AllContainersFilter, ContainerPrefixFilter, ContainerListFilter."
+        },
+        "filterValues": {
+          "type": "array",
+          "description": "The values for the filter applied to the rule. If filter type is AllContainersFilter, filter values should be empty. If filter type is ContainerPrefixFilter, filter values should contain a list of container prefixes. If filter type is ContainerListFilter, filter values should contain a list of container names.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "AdvancedPlatformMetricsRuleListResult": {
+      "type": "object",
+      "description": "The response of a AdvancedPlatformMetricsRule list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The AdvancedPlatformMetricsRule items on this page",
+          "items": {
+            "$ref": "#/definitions/AdvancedPlatformMetricsRule"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "AdvancedPlatformMetricsRuleProperties": {
+      "type": "object",
+      "description": "An object that defines the advanced platform metrics rule.",
+      "properties": {
+        "ruleType": {
+          "$ref": "#/definitions/AdvancedPlatformMetricsRuleType",
+          "description": "Indicates the type of the advanced platform metrics rule. Possible values include: ContainerLevelCapacityMetrics.",
+          "readOnly": true
+        },
+        "enabled": {
+          "type": "boolean",
+          "description": "A boolean flag which enables the advanced platform metrics rule."
+        },
+        "lastModifiedTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Gets the last modification date and time of the advanced platform metrics rule in UTC.",
+          "readOnly": true
+        },
+        "metricsEmitted": {
+          "type": "array",
+          "description": "The metrics emitted by the rule. Metrics are mapped according to the rule type from RuleTypeProperty. Rule type to metrics mapping: ContainerLevelCapacityMetrics => {ContainerUsedSize, ContainerBlobCount}.",
+          "items": {
+            "$ref": "#/definitions/MetricsEmitted"
+          },
+          "readOnly": true
+        },
+        "ruleConfig": {
+          "$ref": "#/definitions/AdvancedPlatformMetricsRuleConfig",
+          "description": "Configuration for the advanced platform metrics rule."
+        }
+      },
+      "required": [
+        "enabled",
+        "ruleConfig"
+      ]
+    },
+    "AdvancedPlatformMetricsRuleType": {
+      "type": "string",
+      "description": "The type of the advanced platform metrics rule.",
+      "enum": [
+        "ContainerLevelCapacityMetrics"
+      ],
+      "x-ms-enum": {
+        "name": "AdvancedPlatformMetricsRuleType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "ContainerLevelCapacityMetrics",
+            "value": "ContainerLevelCapacityMetrics",
+            "description": "Container level capacity metrics rule type"
+          }
+        ]
+      }
+    },
+    "AiProvider": {
+      "type": "string",
+      "description": "The AI provider associated with a container.",
+      "enum": [
+        "OpenAI"
+      ],
+      "x-ms-enum": {
+        "name": "AiProvider",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "OpenAI",
+            "value": "OpenAI",
+            "description": "OpenAI provider."
+          }
+        ]
+      }
+    },
+    "AllowedCopyScope": {
+      "type": "string",
+      "description": "Restrict copy to and from Storage Accounts within an AAD tenant or with Private Links to the same VNet.",
+      "enum": [
+        "PrivateLink",
+        "AAD",
+        "All"
+      ],
+      "x-ms-enum": {
+        "name": "AllowedCopyScope",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "PrivateLink",
+            "value": "PrivateLink"
+          },
+          {
+            "name": "AAD",
+            "value": "AAD"
+          },
+          {
+            "name": "All",
+            "value": "All"
+          }
+        ]
+      }
+    },
+    "AllowedMethods": {
+      "type": "string",
+      "enum": [
+        "DELETE",
+        "GET",
+        "HEAD",
+        "MERGE",
+        "POST",
+        "OPTIONS",
+        "PUT",
+        "PATCH",
+        "CONNECT",
+        "TRACE"
+      ],
+      "x-ms-enum": {
+        "name": "AllowedMethods",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "DELETE",
+            "value": "DELETE"
+          },
+          {
+            "name": "GET",
+            "value": "GET"
+          },
+          {
+            "name": "HEAD",
+            "value": "HEAD"
+          },
+          {
+            "name": "MERGE",
+            "value": "MERGE"
+          },
+          {
+            "name": "POST",
+            "value": "POST"
+          },
+          {
+            "name": "OPTIONS",
+            "value": "OPTIONS"
+          },
+          {
+            "name": "PUT",
+            "value": "PUT"
+          },
+          {
+            "name": "PATCH",
+            "value": "PATCH"
+          },
+          {
+            "name": "CONNECT",
+            "value": "CONNECT"
+          },
+          {
+            "name": "TRACE",
+            "value": "TRACE"
+          }
+        ]
+      }
+    },
+    "Azure.Core.uuid": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Universally Unique Identifier"
+    },
+    "Azure.ResourceManager.CommonTypes.CustomerManagedKeyEncryption": {
+      "type": "object",
+      "description": "Customer-managed key encryption properties for the resource.",
+      "properties": {
+        "keyEncryptionKeyIdentity": {
+          "$ref": "#/definitions/Azure.ResourceManager.CommonTypes.KeyEncryptionKeyIdentity",
+          "description": "All identity configuration for Customer-managed key settings defining which identity should be used to auth to Key Vault."
+        },
+        "keyEncryptionKeyUrl": {
+          "type": "string",
+          "description": "key encryption key Url, versioned or non-versioned. Ex: https://contosovault.vault.azure.net/keys/contosokek/562a4bb76b524a1493a6afe8e536ee78 or https://contosovault.vault.azure.net/keys/contosokek."
+        }
+      }
+    },
+    "Azure.ResourceManager.CommonTypes.Encryption": {
+      "type": "object",
+      "description": "(Optional) Discouraged to include in resource definition. Only needed where it is possible to disable platform (AKA infrastructure) encryption. Azure SQL TDE is an example of this. Values are enabled and disabled.",
+      "properties": {
+        "infrastructureEncryption": {
+          "$ref": "#/definitions/Azure.ResourceManager.CommonTypes.InfrastructureEncryption",
+          "description": "Values are enabled and disabled."
+        },
+        "customerManagedKeyEncryption": {
+          "$ref": "#/definitions/Azure.ResourceManager.CommonTypes.CustomerManagedKeyEncryption",
+          "description": "All Customer-managed key encryption properties for the resource."
+        }
+      }
+    },
+    "Azure.ResourceManager.CommonTypes.InfrastructureEncryption": {
+      "type": "string",
+      "description": "(Optional) Discouraged to include in resource definition. Only needed where it is possible to disable platform (AKA infrastructure) encryption. Azure SQL TDE is an example of this. Values are enabled and disabled.",
+      "enum": [
+        "enabled",
+        "disabled"
+      ],
+      "x-ms-enum": {
+        "name": "InfrastructureEncryption",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Enabled",
+            "value": "enabled",
+            "description": "Encryption is enabled"
+          },
+          {
+            "name": "Disabled",
+            "value": "disabled",
+            "description": "Encryption is disabled"
+          }
+        ]
+      }
+    },
+    "Azure.ResourceManager.CommonTypes.KeyEncryptionKeyIdentity": {
+      "type": "object",
+      "description": "All identity configuration for Customer-managed key settings defining which identity should be used to auth to Key Vault.",
+      "properties": {
+        "identityType": {
+          "$ref": "#/definitions/Azure.ResourceManager.CommonTypes.KeyEncryptionKeyIdentityType",
+          "description": "The type of identity to use. Values can be systemAssignedIdentity, userAssignedIdentity, or delegatedResourceIdentity."
+        },
+        "userAssignedIdentityResourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "User assigned identity to use for accessing key encryption key Url. Ex: /subscriptions/fa5fc227-a624-475e-b696-cdd604c735bc/resourceGroups/<resource group>/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myId. Mutually exclusive with identityType systemAssignedIdentity."
+        },
+        "federatedClientId": {
+          "$ref": "#/definitions/Azure.Core.uuid",
+          "description": "application client identity to use for accessing key encryption key Url in a different tenant. Ex: f83c6b1b-4d34-47e4-bb34-9d83df58b540"
+        },
+        "delegatedIdentityClientId": {
+          "$ref": "#/definitions/Azure.Core.uuid",
+          "description": "delegated identity to use for accessing key encryption key Url. Ex: /subscriptions/fa5fc227-a624-475e-b696-cdd604c735bc/resourceGroups/<resource group>/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myId. Mutually exclusive with identityType systemAssignedIdentity and userAssignedIdentity - internal use only."
+        }
+      }
+    },
+    "Azure.ResourceManager.CommonTypes.KeyEncryptionKeyIdentityType": {
+      "type": "string",
+      "description": "The type of identity to use.",
+      "enum": [
+        "systemAssignedIdentity",
+        "userAssignedIdentity",
+        "delegatedResourceIdentity"
+      ],
+      "x-ms-enum": {
+        "name": "KeyEncryptionKeyIdentityType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "SystemAssignedIdentity",
+            "value": "systemAssignedIdentity",
+            "description": "System assigned identity"
+          },
+          {
+            "name": "UserAssignedIdentity",
+            "value": "userAssignedIdentity",
+            "description": "User assigned identity"
+          },
+          {
+            "name": "DelegatedResourceIdentity",
+            "value": "delegatedResourceIdentity",
+            "description": "Delegated identity"
+          }
+        ]
+      }
+    },
+    "AzureEntityResource": {
+      "type": "object",
+      "title": "Entity Resource",
+      "description": "The resource model definition for an Azure Resource Manager resource with an etag.",
+      "properties": {
+        "etag": {
+          "type": "string",
+          "description": "Resource Etag.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/Resource"
+        }
+      ]
+    },
+    "AzureFilesIdentityBasedAuthentication": {
+      "type": "object",
+      "description": "Settings for Azure Files identity based authentication.",
+      "properties": {
+        "directoryServiceOptions": {
+          "$ref": "#/definitions/DirectoryServiceOptions",
+          "description": "Indicates the directory service used. Note that this enum may be extended in the future."
+        },
+        "activeDirectoryProperties": {
+          "$ref": "#/definitions/ActiveDirectoryProperties",
+          "description": "Additional information about the directory service. Required if directoryServiceOptions is AD (AD DS authentication). Optional for directoryServiceOptions AADDS (Entra DS authentication) and AADKERB (Entra authentication)."
+        },
+        "defaultSharePermission": {
+          "$ref": "#/definitions/DefaultSharePermission",
+          "description": "Default share permission for users using Kerberos authentication if RBAC role is not assigned."
+        },
+        "smbOAuthSettings": {
+          "$ref": "#/definitions/SmbOAuthSettings",
+          "description": "Required for Managed Identities access using OAuth over SMB."
+        }
+      },
+      "required": [
+        "directoryServiceOptions"
+      ]
+    },
+    "BlobContainer": {
+      "type": "object",
+      "description": "Properties of the blob container, including Id, resource name, resource type, Etag.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ContainerProperties",
+          "description": "Properties of the blob container.",
+          "x-ms-client-flatten": true,
+          "x-ms-client-name": "ContainerProperties"
+        },
+        "etag": {
+          "type": "string",
+          "description": "Resource Etag.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "BlobInventoryCreationTime": {
+      "type": "object",
+      "description": "This property defines the creation time based filtering condition. Blob Inventory schema parameter 'Creation-Time' is mandatory with this filter.",
+      "properties": {
+        "lastNDays": {
+          "type": "integer",
+          "format": "int32",
+          "description": "When set the policy filters the objects that are created in the last N days. Where N is an integer value between 1 to 36500.",
+          "minimum": 1,
+          "maximum": 36500
+        }
+      }
+    },
+    "BlobInventoryPolicy": {
+      "type": "object",
+      "description": "The storage account blob inventory policy.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/BlobInventoryPolicyProperties",
+          "description": "Returns the storage account blob inventory policy rules.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "BlobInventoryPolicyDefinition": {
+      "type": "object",
+      "description": "An object that defines the blob inventory rule.",
+      "properties": {
+        "filters": {
+          "$ref": "#/definitions/BlobInventoryPolicyFilter",
+          "description": "An object that defines the filter set."
+        },
+        "format": {
+          "$ref": "#/definitions/Format",
+          "description": "This is a required field, it specifies the format for the inventory files."
+        },
+        "schedule": {
+          "$ref": "#/definitions/Schedule",
+          "description": "This is a required field. This field is used to schedule an inventory formation."
+        },
+        "objectType": {
+          "$ref": "#/definitions/ObjectType",
+          "description": "This is a required field. This field specifies the scope of the inventory created either at the blob or container level."
+        },
+        "schemaFields": {
+          "type": "array",
+          "description": "This is a required field. This field specifies the fields and properties of the object to be included in the inventory. The Schema field value 'Name' is always required. The valid values for this field for the 'Blob' definition.objectType include 'Name, Creation-Time, Last-Modified, Content-Length, Content-MD5, BlobType, AccessTier, AccessTierChangeTime, AccessTierInferred, Tags, Expiry-Time, hdi_isfolder, Owner, Group, Permissions, Acl, Snapshot, VersionId, IsCurrentVersion, Metadata, LastAccessTime, Tags, Etag, ContentType, ContentEncoding, ContentLanguage, ContentCRC64, CacheControl, ContentDisposition, LeaseStatus, LeaseState, LeaseDuration, ServerEncrypted, Deleted, DeletionId, DeletedTime, RemainingRetentionDays, ImmutabilityPolicyUntilDate, ImmutabilityPolicyMode, LegalHold, CopyId, CopyStatus, CopySource, CopyProgress, CopyCompletionTime, CopyStatusDescription, CustomerProvidedKeySha256, RehydratePriority, ArchiveStatus, XmsBlobSequenceNumber, EncryptionScope, IncrementalCopy, TagCount'. For Blob object type schema field value 'DeletedTime' is applicable only for Hns enabled accounts. The valid values for 'Container' definition.objectType include 'Name, Last-Modified, Metadata, LeaseStatus, LeaseState, LeaseDuration, PublicAccess, HasImmutabilityPolicy, HasLegalHold, Etag, DefaultEncryptionScope, DenyEncryptionScopeOverride, ImmutableStorageWithVersioningEnabled, Deleted, Version, DeletedTime, RemainingRetentionDays'. Schema field values 'Expiry-Time, hdi_isfolder, Owner, Group, Permissions, Acl, DeletionId' are valid only for Hns enabled accounts.Schema field values 'Tags, TagCount' are only valid for Non-Hns accounts.",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "format",
+        "schedule",
+        "objectType",
+        "schemaFields"
+      ]
+    },
+    "BlobInventoryPolicyFilter": {
+      "type": "object",
+      "description": "An object that defines the blob inventory rule filter conditions. For 'Blob' definition.objectType all filter properties are applicable, 'blobTypes' is required and others are optional. For 'Container' definition.objectType only prefixMatch is applicable and is optional.",
+      "properties": {
+        "prefixMatch": {
+          "type": "array",
+          "description": "An array of strings with maximum 10 blob prefixes to be included in the inventory.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "excludePrefix": {
+          "type": "array",
+          "description": "An array of strings with maximum 10 blob prefixes to be excluded from the inventory.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "blobTypes": {
+          "type": "array",
+          "description": "An array of predefined enum values. Valid values include blockBlob, appendBlob, pageBlob. Hns accounts does not support pageBlobs. This field is required when definition.objectType property is set to 'Blob'.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "includeBlobVersions": {
+          "type": "boolean",
+          "description": "Includes blob versions in blob inventory when value is set to true. The definition.schemaFields values 'VersionId and IsCurrentVersion' are required if this property is set to true, else they must be excluded."
+        },
+        "includeSnapshots": {
+          "type": "boolean",
+          "description": "Includes blob snapshots in blob inventory when value is set to true. The definition.schemaFields value 'Snapshot' is required if this property is set to true, else it must be excluded."
+        },
+        "includeDeleted": {
+          "type": "boolean",
+          "description": "For 'Container' definition.objectType the definition.schemaFields must include 'Deleted, Version, DeletedTime and RemainingRetentionDays'. For 'Blob' definition.objectType and HNS enabled storage accounts the definition.schemaFields must include 'DeletionId, Deleted, DeletedTime and RemainingRetentionDays' and for Hns disabled accounts the definition.schemaFields must include 'Deleted and RemainingRetentionDays', else it must be excluded."
+        },
+        "creationTime": {
+          "$ref": "#/definitions/BlobInventoryCreationTime",
+          "description": "This property is used to filter objects based on the object creation time"
+        }
+      }
+    },
+    "BlobInventoryPolicyProperties": {
+      "type": "object",
+      "description": "The storage account blob inventory policy properties.",
+      "properties": {
+        "lastModifiedTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Returns the last modified date and time of the blob inventory policy.",
+          "readOnly": true
+        },
+        "policy": {
+          "$ref": "#/definitions/BlobInventoryPolicySchema",
+          "description": "The storage account blob inventory policy object. It is composed of policy rules."
+        }
+      },
+      "required": [
+        "policy"
+      ]
+    },
+    "BlobInventoryPolicyRule": {
+      "type": "object",
+      "description": "An object that wraps the blob inventory rule. Each rule is uniquely defined by name.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Rule is enabled when set to true."
+        },
+        "name": {
+          "type": "string",
+          "description": "A rule name can contain any combination of alpha numeric characters. Rule name is case-sensitive. It must be unique within a policy."
+        },
+        "destination": {
+          "type": "string",
+          "description": "Container name where blob inventory files are stored. Must be pre-created."
+        },
+        "definition": {
+          "$ref": "#/definitions/BlobInventoryPolicyDefinition",
+          "description": "An object that defines the blob inventory policy rule."
+        }
+      },
+      "required": [
+        "enabled",
+        "name",
+        "destination",
+        "definition"
+      ]
+    },
+    "BlobInventoryPolicySchema": {
+      "type": "object",
+      "description": "The storage account blob inventory policy rules.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Policy is enabled if set to true."
+        },
+        "destination": {
+          "type": "string",
+          "description": "Deprecated Property from API version 2021-04-01 onwards, the required destination container name must be specified at the rule level 'policy.rule.destination'",
+          "readOnly": true
+        },
+        "type": {
+          "$ref": "#/definitions/InventoryRuleType",
+          "description": "The valid value is Inventory"
+        },
+        "rules": {
+          "type": "array",
+          "description": "The storage account blob inventory policy rules. The rule is applied when it is enabled.",
+          "items": {
+            "$ref": "#/definitions/BlobInventoryPolicyRule"
+          }
+        }
+      },
+      "required": [
+        "enabled",
+        "type",
+        "rules"
+      ]
+    },
+    "BlobRestoreParameters": {
+      "type": "object",
+      "description": "Blob restore parameters",
+      "properties": {
+        "timeToRestore": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Restore blob to the specified time."
+        },
+        "blobRanges": {
+          "type": "array",
+          "description": "Blob ranges to restore.",
+          "items": {
+            "$ref": "#/definitions/BlobRestoreRange"
+          },
+          "x-ms-identifiers": []
+        }
+      },
+      "required": [
+        "timeToRestore",
+        "blobRanges"
+      ]
+    },
+    "BlobRestoreProgressStatus": {
+      "type": "string",
+      "description": "The status of blob restore progress. Possible values are: - InProgress: Indicates that blob restore is ongoing. - Complete: Indicates that blob restore has been completed successfully. - Failed: Indicates that blob restore is failed.",
+      "enum": [
+        "InProgress",
+        "Complete",
+        "Failed"
+      ],
+      "x-ms-enum": {
+        "name": "BlobRestoreProgressStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "InProgress",
+            "value": "InProgress"
+          },
+          {
+            "name": "Complete",
+            "value": "Complete"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed"
+          }
+        ]
+      }
+    },
+    "BlobRestoreRange": {
+      "type": "object",
+      "description": "Blob range",
+      "properties": {
+        "startRange": {
+          "type": "string",
+          "description": "Blob start range. This is inclusive. Empty means account start."
+        },
+        "endRange": {
+          "type": "string",
+          "description": "Blob end range. This is exclusive. Empty means account end."
+        }
+      },
+      "required": [
+        "startRange",
+        "endRange"
+      ]
+    },
+    "BlobRestoreStatus": {
+      "type": "object",
+      "description": "Blob restore status.",
+      "properties": {
+        "status": {
+          "$ref": "#/definitions/BlobRestoreProgressStatus",
+          "description": "The status of blob restore progress. Possible values are: - InProgress: Indicates that blob restore is ongoing. - Complete: Indicates that blob restore has been completed successfully. - Failed: Indicates that blob restore is failed.",
+          "readOnly": true
+        },
+        "failureReason": {
+          "type": "string",
+          "description": "Failure reason when blob restore is failed.",
+          "readOnly": true
+        },
+        "restoreId": {
+          "type": "string",
+          "description": "Id for tracking blob restore request.",
+          "readOnly": true
+        },
+        "parameters": {
+          "$ref": "#/definitions/BlobRestoreParameters",
+          "description": "Blob restore request parameters.",
+          "readOnly": true
+        }
+      }
+    },
+    "BlobServiceItems": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "List of blob services returned.",
+          "items": {
+            "$ref": "#/definitions/BlobServiceProperties"
+          },
+          "readOnly": true
+        },
+        "nextLink": {
+          "type": "string"
+        }
+      }
+    },
+    "BlobServiceProperties": {
+      "type": "object",
+      "description": "The properties of a storage account’s Blob service.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/BlobServicePropertiesProperties",
+          "description": "The properties of a storage account’s Blob service.",
+          "x-ms-client-flatten": true,
+          "x-ms-client-name": "BlobServiceProperties"
+        },
+        "sku": {
+          "$ref": "#/definitions/Sku",
+          "description": "Sku name and tier.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "BlobServicePropertiesProperties": {
+      "type": "object",
+      "description": "The properties of a storage account’s Blob service.",
+      "properties": {
+        "cors": {
+          "$ref": "#/definitions/CorsRules",
+          "description": "Specifies CORS rules for the Blob service. You can include up to five CorsRule elements in the request. If no CorsRule elements are included in the request body, all CORS rules will be deleted, and CORS will be disabled for the Blob service."
+        },
+        "defaultServiceVersion": {
+          "type": "string",
+          "description": "DefaultServiceVersion indicates the default version to use for requests to the Blob service if an incoming request’s version is not specified. Possible values include version 2008-10-27 and all more recent versions."
+        },
+        "deleteRetentionPolicy": {
+          "$ref": "#/definitions/DeleteRetentionPolicy",
+          "description": "The blob service properties for blob soft delete."
+        },
+        "staticWebsite": {
+          "$ref": "#/definitions/StaticWebsite",
+          "description": "The static website properties for blob storage."
+        },
+        "isVersioningEnabled": {
+          "type": "boolean",
+          "description": "Versioning is enabled if set to true."
+        },
+        "automaticSnapshotPolicyEnabled": {
+          "type": "boolean",
+          "description": "Deprecated in favor of isVersioningEnabled property."
+        },
+        "changeFeed": {
+          "$ref": "#/definitions/ChangeFeed",
+          "description": "The blob service properties for change feed events."
+        },
+        "restorePolicy": {
+          "$ref": "#/definitions/RestorePolicyProperties",
+          "description": "The blob service properties for blob restore policy."
+        },
+        "containerDeleteRetentionPolicy": {
+          "$ref": "#/definitions/DeleteRetentionPolicy",
+          "description": "The blob service properties for container soft delete."
+        },
+        "lastAccessTimeTrackingPolicy": {
+          "$ref": "#/definitions/LastAccessTimeTrackingPolicy",
+          "description": "The blob service property to configure last access time based tracking policy."
+        }
+      }
+    },
+    "BurstingConstants": {
+      "type": "object",
+      "description": "Constants used for calculating included burst IOPS and maximum burst credits for IOPS for a file share in the storage account.",
+      "properties": {
+        "burstFloorIOPS": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The guaranteed floor of burst IOPS for small file shares.",
+          "readOnly": true
+        },
+        "burstIOScalar": {
+          "type": "number",
+          "format": "double",
+          "description": "The scalar against provisioned IOPS in the file share included burst IOPS formula.",
+          "readOnly": true
+        },
+        "burstTimeframeSeconds": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The time frame for bursting in seconds in the file share maximum burst credits for IOPS formula.",
+          "readOnly": true
+        }
+      }
+    },
+    "ChangeFeed": {
+      "type": "object",
+      "description": "The blob service properties for change feed events.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Indicates whether change feed event logging is enabled for the Blob service."
+        },
+        "retentionInDays": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Indicates the duration of changeFeed retention in days. Minimum value is 1 day and maximum value is 146000 days (400 years). A null value indicates an infinite retention of the change feed.",
+          "minimum": 1,
+          "maximum": 146000
+        }
+      }
+    },
+    "CheckNameAvailabilityResult": {
+      "type": "object",
+      "description": "The CheckNameAvailability operation response.",
+      "properties": {
+        "nameAvailable": {
+          "type": "boolean",
+          "description": "Gets a boolean value that indicates whether the name is available for you to use. If true, the name is available. If false, the name has already been taken or is invalid and cannot be used.",
+          "readOnly": true
+        },
+        "reason": {
+          "$ref": "#/definitions/Reason",
+          "description": "Gets the reason that a storage account name could not be used. The Reason element is only returned if NameAvailable is false.",
+          "readOnly": true
+        },
+        "message": {
+          "type": "string",
+          "description": "Gets an error message explaining the Reason value in more detail.",
+          "readOnly": true
+        }
+      }
+    },
+    "CloudError": {
+      "type": "object",
+      "description": "An error response from the Storage service.",
+      "properties": {
+        "error": {
+          "$ref": "#/definitions/CloudErrorBody",
+          "description": "An error response from the Storage service."
+        }
+      },
+      "x-ms-external": true
+    },
+    "CloudErrorBody": {
+      "type": "object",
+      "description": "An error response from the Storage service.",
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "An identifier for the error. Codes are invariant and are intended to be consumed programmatically."
+        },
+        "message": {
+          "type": "string",
+          "description": "A message describing the error, intended to be suitable for display in a user interface."
+        },
+        "target": {
+          "type": "string",
+          "description": "The target of the particular error. For example, the name of the property in error."
+        },
+        "details": {
+          "type": "array",
+          "description": "A list of additional details about the error.",
+          "items": {
+            "$ref": "#/definitions/CloudErrorBody"
+          },
+          "x-ms-identifiers": []
+        }
+      },
+      "x-ms-external": true
+    },
+    "Connector": {
+      "type": "object",
+      "description": "A Connector is a tracked ARM resource modeled as a sub-resource of a Storage Account.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/StorageConnectorProperties",
+          "description": "The properties of the Storage Connector."
+        }
+      },
+      "required": [
+        "properties"
+      ],
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/TrackedResource"
+        }
+      ]
+    },
+    "ConnectorListResult": {
+      "type": "object",
+      "description": "The response of a Connector list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The Connector items on this page",
+          "items": {
+            "$ref": "#/definitions/Connector"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ConnectorUpdate": {
+      "type": "object",
+      "description": "A Connector is a tracked ARM resource modeled as a sub-resource of a Storage Account.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/StorageConnectorPropertiesUpdate",
+          "description": "The properties of the Storage Connector."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/TrackedResourceUpdate"
+        }
+      ]
+    },
+    "ContainerProperties": {
+      "type": "object",
+      "description": "The properties of a container.",
+      "properties": {
+        "version": {
+          "type": "string",
+          "description": "The version of the deleted blob container.",
+          "readOnly": true
+        },
+        "deleted": {
+          "type": "boolean",
+          "description": "Indicates whether the blob container was deleted.",
+          "readOnly": true
+        },
+        "deletedTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Blob container deletion time.",
+          "readOnly": true
+        },
+        "remainingRetentionDays": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Remaining retention days for soft deleted blob container.",
+          "readOnly": true
+        },
+        "defaultEncryptionScope": {
+          "type": "string",
+          "description": "Default the container to use specified encryption scope for all writes."
+        },
+        "denyEncryptionScopeOverride": {
+          "type": "boolean",
+          "description": "Block override of encryption scope from the container default."
+        },
+        "publicAccess": {
+          "$ref": "#/definitions/PublicAccess",
+          "description": "Specifies whether data in the container may be accessed publicly and the level of access."
+        },
+        "lastModifiedTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Returns the date and time the container was last modified.",
+          "readOnly": true
+        },
+        "leaseStatus": {
+          "$ref": "#/definitions/LeaseStatus",
+          "description": "The lease status of the container.",
+          "readOnly": true
+        },
+        "leaseState": {
+          "$ref": "#/definitions/LeaseState",
+          "description": "Lease state of the container.",
+          "readOnly": true
+        },
+        "leaseDuration": {
+          "$ref": "#/definitions/LeaseDuration",
+          "description": "Specifies whether the lease on a container is of infinite or fixed duration, only when the container is leased.",
+          "readOnly": true
+        },
+        "metadata": {
+          "type": "object",
+          "description": "A name-value pair to associate with the container as metadata.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "immutabilityPolicy": {
+          "$ref": "#/definitions/ImmutabilityPolicyProperties",
+          "description": "The ImmutabilityPolicy property of the container.",
+          "readOnly": true,
+          "x-ms-client-name": "ImmutabilityPolicy"
+        },
+        "legalHold": {
+          "$ref": "#/definitions/LegalHoldProperties",
+          "description": "The LegalHold property of the container.",
+          "readOnly": true
+        },
+        "hasLegalHold": {
+          "type": "boolean",
+          "description": "The hasLegalHold public property is set to true by SRP if there are at least one existing tag. The hasLegalHold public property is set to false by SRP if all existing legal hold tags are cleared out. There can be a maximum of 1000 blob containers with hasLegalHold=true for a given account.",
+          "readOnly": true
+        },
+        "hasImmutabilityPolicy": {
+          "type": "boolean",
+          "description": "The hasImmutabilityPolicy public property is set to true by SRP if ImmutabilityPolicy has been created for this container. The hasImmutabilityPolicy public property is set to false by SRP if ImmutabilityPolicy has not been created for this container.",
+          "readOnly": true
+        },
+        "immutableStorageWithVersioning": {
+          "$ref": "#/definitions/ImmutableStorageWithVersioning",
+          "description": "The object level immutability property of the container. The property is immutable and can only be set to true at the container creation time. Existing containers must undergo a migration process."
+        },
+        "enableNfsV3RootSquash": {
+          "type": "boolean",
+          "description": "Enable NFSv3 root squash on blob container."
+        },
+        "enableNfsV3AllSquash": {
+          "type": "boolean",
+          "description": "Enable NFSv3 all squash on blob container."
+        }
+      }
+    },
+    "ContextCache": {
+      "type": "object",
+      "description": "A Context Cache resource",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ContextCacheProperties",
+          "description": "The resource-specific properties for this resource."
+        },
+        "identity": {
+          "$ref": "../../../../../common-types/resource-management/v5/managedidentity.json#/definitions/SystemAssignedServiceIdentity",
+          "description": "The managed service identities assigned to this resource."
+        }
+      },
+      "required": [
+        "properties"
+      ],
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/TrackedResource"
+        }
+      ]
+    },
+    "ContextCacheAccountKind": {
+      "type": "string",
+      "description": "The kind of context cache account, determining storage topology.",
+      "enum": [
+        "Regional",
+        "DataZone",
+        "Global"
+      ],
+      "x-ms-enum": {
+        "name": "ContextCacheAccountKind",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Regional",
+            "value": "Regional",
+            "description": "Single-region storage account"
+          },
+          {
+            "name": "DataZone",
+            "value": "DataZone",
+            "description": "Multi-region within a data zone"
+          },
+          {
+            "name": "Global",
+            "value": "Global",
+            "description": "All regions with global distribution"
+          }
+        ]
+      }
+    },
+    "ContextCacheContainer": {
+      "type": "object",
+      "description": "A container resource within a Context Cache",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ContextCacheContainerProperties",
+          "description": "The resource-specific properties for this resource."
+        }
+      },
+      "required": [
+        "properties"
+      ],
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "ContextCacheContainerListResult": {
+      "type": "object",
+      "description": "The response of a ContextCacheContainer list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ContextCacheContainer items on this page",
+          "items": {
+            "$ref": "#/definitions/ContextCacheContainer"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ContextCacheContainerProperties": {
+      "type": "object",
+      "description": "Details of a container within a Context Cache.",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "Container description.",
+          "maxLength": 250
+        },
+        "modelName": {
+          "type": "string",
+          "description": "The model name associated with this container (e.g., gpt-4, claude-3).",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "provider": {
+          "$ref": "#/definitions/AiProvider",
+          "description": "The AI provider associated with this container.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "timeToLive": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The Time to Live (TTL) in days (1–30) for this container. Blobs in the container that have not been accessed within this number of days will be automatically deleted. If not specified at creation time, it defaults to 1 day.",
+          "minimum": 1,
+          "maximum": 30
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/ContextCacheProvisioningState",
+          "description": "The status of the last operation.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "modelName",
+        "provider"
+      ]
+    },
+    "ContextCacheContainerPropertiesUpdate": {
+      "type": "object",
+      "description": "Updatable properties of a container within a Context Cache.",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "Container description.",
+          "maxLength": 250
+        },
+        "timeToLive": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The Time to Live (TTL) in days (1–30) for this container. Blobs in the container that have not been accessed within this number of days will be automatically deleted.",
+          "minimum": 1,
+          "maximum": 30
+        }
+      }
+    },
+    "ContextCacheContainerUpdate": {
+      "type": "object",
+      "description": "The type used for update operations of the Context Cache Container.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ContextCacheContainerPropertiesUpdate",
+          "description": "The updatable properties of the Context Cache Container."
+        }
+      }
+    },
+    "ContextCacheListResult": {
+      "type": "object",
+      "description": "The response of a ContextCache list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ContextCache items on this page",
+          "items": {
+            "$ref": "#/definitions/ContextCache"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ContextCacheProperties": {
+      "type": "object",
+      "description": "Details of the Context Cache.",
+      "properties": {
+        "accountKind": {
+          "$ref": "#/definitions/ContextCacheAccountKind",
+          "description": "The kind of account determining storage topology.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "description": {
+          "type": "string",
+          "description": "Account description.",
+          "maxLength": 250
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/ContextCacheProvisioningState",
+          "description": "The status of the last operation.",
+          "readOnly": true
+        },
+        "encryption": {
+          "$ref": "#/definitions/Azure.ResourceManager.CommonTypes.Encryption",
+          "description": "Encryption settings for the account."
+        }
+      },
+      "required": [
+        "accountKind"
+      ]
+    },
+    "ContextCachePropertiesUpdate": {
+      "type": "object",
+      "description": "Updatable properties of the Context Cache.",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "Account description.",
+          "maxLength": 250
+        },
+        "encryption": {
+          "$ref": "#/definitions/Azure.ResourceManager.CommonTypes.Encryption",
+          "description": "Encryption settings for the account."
+        }
+      }
+    },
+    "ContextCacheProvisioningState": {
+      "type": "string",
+      "description": "The status of the current operation.",
+      "enum": [
+        "Succeeded",
+        "Failed",
+        "Canceled",
+        "Creating",
+        "Updating",
+        "Deleting",
+        "Accepted"
+      ],
+      "x-ms-enum": {
+        "name": "ContextCacheProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Resource has been created."
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Resource creation failed."
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Resource creation was canceled."
+          },
+          {
+            "name": "Creating",
+            "value": "Creating",
+            "description": "Initial provisioning in progress"
+          },
+          {
+            "name": "Updating",
+            "value": "Updating",
+            "description": "Update in progress"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "Deletion in progress"
+          },
+          {
+            "name": "Accepted",
+            "value": "Accepted",
+            "description": "Change accepted for processing"
+          }
+        ]
+      },
+      "readOnly": true
+    },
+    "ContextCacheUpdate": {
+      "type": "object",
+      "description": "The type used for update operations of the Context Cache.",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "identity": {
+          "$ref": "../../../../../common-types/resource-management/v5/managedidentity.json#/definitions/SystemAssignedServiceIdentity",
+          "description": "The managed service identity."
+        },
+        "properties": {
+          "$ref": "#/definitions/ContextCachePropertiesUpdate",
+          "description": "The updatable properties of the Context Cache."
+        }
+      }
+    },
+    "CorsRule": {
+      "type": "object",
+      "description": "Specifies a CORS rule for the Blob service.",
+      "properties": {
+        "allowedOrigins": {
+          "type": "array",
+          "description": "Required if CorsRule element is present. A list of origin domains that will be allowed via CORS, or \"*\" to allow all domains",
+          "items": {
+            "type": "string"
+          }
+        },
+        "allowedMethods": {
+          "type": "array",
+          "description": "Required if CorsRule element is present. A list of HTTP methods that are allowed to be executed by the origin.",
+          "items": {
+            "$ref": "#/definitions/AllowedMethods"
+          }
+        },
+        "maxAgeInSeconds": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Required if CorsRule element is present. The number of seconds that the client/browser should cache a preflight response."
+        },
+        "exposedHeaders": {
+          "type": "array",
+          "description": "Required if CorsRule element is present. A list of response headers to expose to CORS clients.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "allowedHeaders": {
+          "type": "array",
+          "description": "Required if CorsRule element is present. A list of headers allowed to be part of the cross-origin request.",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "allowedOrigins",
+        "allowedMethods",
+        "maxAgeInSeconds",
+        "exposedHeaders",
+        "allowedHeaders"
+      ]
+    },
+    "CorsRules": {
+      "type": "object",
+      "description": "Sets the CORS rules. You can include up to five CorsRule elements in the request.",
+      "properties": {
+        "corsRules": {
+          "type": "array",
+          "description": "The List of CORS rules. You can include up to five CorsRule elements in the request.",
+          "items": {
+            "$ref": "#/definitions/CorsRule"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "CustomDomain": {
+      "type": "object",
+      "description": "The custom domain assigned to this storage account. This can be set via Update.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Gets or sets the custom domain name assigned to the storage account. Name is the CNAME source."
+        },
+        "useSubDomainName": {
+          "type": "boolean",
+          "description": "Indicates whether indirect CName validation is enabled. Default value is false. This should only be set on updates."
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
+    "DataShare": {
+      "type": "object",
+      "description": "A DataShare is a tracked ARM resource modeled as a sub-resource of a Storage Account.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/StorageDataShareProperties",
+          "description": "The properties of the Storage DataShare."
+        }
+      },
+      "required": [
+        "properties"
+      ],
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/TrackedResource"
+        }
+      ]
+    },
+    "DataShareConnection": {
+      "type": "object",
+      "description": "The connection details for Data Share source",
+      "properties": {
+        "dataShareUri": {
+          "type": "string",
+          "description": "The URI of the backing DataShare. Must be in the format: azds://<region>:<DataShareName>:<DataShareIdentifier>",
+          "pattern": "^azds://[a-zA-Z0-9-]+:[a-zA-Z0-9-_]+:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+        }
+      },
+      "required": [
+        "dataShareUri"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/StorageConnectorConnection"
+        }
+      ],
+      "x-ms-discriminator-value": "DataShare"
+    },
+    "DataShareListResult": {
+      "type": "object",
+      "description": "The response of a DataShare list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The DataShare items on this page",
+          "items": {
+            "$ref": "#/definitions/DataShare"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "DataShareSource": {
+      "type": "object",
+      "description": "The properties of data share source",
+      "properties": {
+        "connection": {
+          "$ref": "#/definitions/StorageConnectorConnection",
+          "description": "Details for how to connect to the backing data store.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "authProperties": {
+          "$ref": "#/definitions/StorageConnectorAuthProperties",
+          "description": "Details for how to authenticate to the backing data store."
+        }
+      },
+      "required": [
+        "connection",
+        "authProperties"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/StorageConnectorSource"
+        }
+      ],
+      "x-ms-discriminator-value": "DataShare"
+    },
+    "DataShareSourceUpdate": {
+      "type": "object",
+      "description": "The properties of data share source",
+      "properties": {
+        "authProperties": {
+          "$ref": "#/definitions/StorageConnectorAuthPropertiesUpdate",
+          "description": "Details for how to authenticate to the backing data store."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/StorageConnectorSourceUpdate"
+        }
+      ],
+      "x-ms-discriminator-value": "DataShare"
+    },
+    "DataShareUpdate": {
+      "type": "object",
+      "description": "A DataShare is a tracked ARM resource modeled as a sub-resource of a Storage Account.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/StorageDataSharePropertiesUpdate",
+          "description": "The properties of the Storage DataShare."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/TrackedResourceUpdate"
+        }
+      ]
+    },
+    "DateAfterCreation": {
+      "type": "object",
+      "description": "Object to define snapshot and version action conditions.",
+      "properties": {
+        "daysAfterCreationGreaterThan": {
+          "type": "number",
+          "format": "float",
+          "description": "Value indicating the age in days after creation",
+          "minimum": 0
+        },
+        "daysAfterLastTierChangeGreaterThan": {
+          "type": "number",
+          "format": "float",
+          "description": "Value indicating the age in days after last blob tier change time. This property is only applicable for tierToArchive actions and requires daysAfterCreationGreaterThan to be set for snapshots and blob version based actions. The blob will be archived if both the conditions are satisfied.",
+          "minimum": 0
+        }
+      },
+      "required": [
+        "daysAfterCreationGreaterThan"
+      ]
+    },
+    "DateAfterModification": {
+      "type": "object",
+      "description": "Object to define the base blob action conditions. Properties daysAfterModificationGreaterThan, daysAfterLastAccessTimeGreaterThan and daysAfterCreationGreaterThan are mutually exclusive. The daysAfterLastTierChangeGreaterThan property is only applicable for tierToArchive actions which requires daysAfterModificationGreaterThan to be set, also it cannot be used in conjunction with daysAfterLastAccessTimeGreaterThan or daysAfterCreationGreaterThan.",
+      "properties": {
+        "daysAfterModificationGreaterThan": {
+          "type": "number",
+          "format": "float",
+          "description": "Value indicating the age in days after last modification",
+          "minimum": 0
+        },
+        "daysAfterLastAccessTimeGreaterThan": {
+          "type": "number",
+          "format": "float",
+          "description": "Value indicating the age in days after last blob access. This property can only be used in conjunction with last access time tracking policy",
+          "minimum": 0
+        },
+        "daysAfterLastTierChangeGreaterThan": {
+          "type": "number",
+          "format": "float",
+          "description": "Value indicating the age in days after last blob tier change time. This property is only applicable for tierToArchive actions and requires daysAfterModificationGreaterThan to be set for baseBlobs based actions. The blob will be archived if both the conditions are satisfied.",
+          "minimum": 0
+        },
+        "daysAfterCreationGreaterThan": {
+          "type": "number",
+          "format": "float",
+          "description": "Value indicating the age in days after blob creation.",
+          "minimum": 0
+        }
+      }
+    },
+    "DefaultSharePermission": {
+      "type": "string",
+      "description": "Default share permission for users using Kerberos authentication if RBAC role is not assigned.",
+      "enum": [
+        "None",
+        "StorageFileDataSmbShareReader",
+        "StorageFileDataSmbShareContributor",
+        "StorageFileDataSmbShareElevatedContributor"
+      ],
+      "x-ms-enum": {
+        "name": "DefaultSharePermission",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "None",
+            "value": "None"
+          },
+          {
+            "name": "StorageFileDataSmbShareReader",
+            "value": "StorageFileDataSmbShareReader"
+          },
+          {
+            "name": "StorageFileDataSmbShareContributor",
+            "value": "StorageFileDataSmbShareContributor"
+          },
+          {
+            "name": "StorageFileDataSmbShareElevatedContributor",
+            "value": "StorageFileDataSmbShareElevatedContributor"
+          }
+        ]
+      }
+    },
+    "DeleteRetentionPolicy": {
+      "type": "object",
+      "description": "The service properties for soft delete.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Indicates whether DeleteRetentionPolicy is enabled."
+        },
+        "days": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Indicates the number of days that the deleted item should be retained. The minimum specified value can be 1 and the maximum value can be 365.",
+          "minimum": 1,
+          "maximum": 365
+        },
+        "allowPermanentDelete": {
+          "type": "boolean",
+          "description": "This property when set to true allows deletion of the soft deleted blob versions and snapshots. This property cannot be used blob restore policy. This property only applies to blob service and does not apply to containers or file share."
+        }
+      }
+    },
+    "DeletedAccount": {
+      "type": "object",
+      "description": "Deleted storage account",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/DeletedAccountProperties",
+          "description": "Properties of the deleted account.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "DeletedAccountListResult": {
+      "type": "object",
+      "description": "The response of a DeletedAccount list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The DeletedAccount items on this page",
+          "items": {
+            "$ref": "#/definitions/DeletedAccount"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "DeletedAccountProperties": {
+      "type": "object",
+      "description": "Attributes of a deleted storage account.",
+      "properties": {
+        "storageAccountResourceId": {
+          "type": "string",
+          "description": "Full resource id of the original storage account.",
+          "readOnly": true
+        },
+        "location": {
+          "type": "string",
+          "description": "Location of the deleted account.",
+          "readOnly": true
+        },
+        "restoreReference": {
+          "type": "string",
+          "description": "Can be used to attempt recovering this deleted account via PutStorageAccount API.",
+          "readOnly": true
+        },
+        "creationTime": {
+          "type": "string",
+          "description": "Creation time of the deleted account.",
+          "readOnly": true
+        },
+        "deletionTime": {
+          "type": "string",
+          "description": "Deletion time of the deleted account.",
+          "readOnly": true
+        }
+      }
+    },
+    "DeletedShare": {
+      "type": "object",
+      "description": "The deleted share to be restored.",
+      "properties": {
+        "deletedShareName": {
+          "type": "string",
+          "description": "Required. Identify the name of the deleted share that will be restored."
+        },
+        "deletedShareVersion": {
+          "type": "string",
+          "description": "Required. Identify the version of the deleted share that will be restored."
+        }
+      },
+      "required": [
+        "deletedShareName",
+        "deletedShareVersion"
+      ]
+    },
+    "Dimension": {
+      "type": "object",
+      "description": "Dimension of blobs, possibly be blob type or access tier.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Display name of dimension."
+        },
+        "displayName": {
+          "type": "string",
+          "description": "Display name of dimension."
+        }
+      }
+    },
+    "DirectoryServiceOptions": {
+      "type": "string",
+      "description": "Indicates the directory service used. Note that this enum may be extended in the future.",
+      "enum": [
+        "None",
+        "AADDS",
+        "AD",
+        "AADKERB"
+      ],
+      "x-ms-enum": {
+        "name": "DirectoryServiceOptions",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "None",
+            "value": "None"
+          },
+          {
+            "name": "AADDS",
+            "value": "AADDS"
+          },
+          {
+            "name": "AD",
+            "value": "AD"
+          },
+          {
+            "name": "AADKERB",
+            "value": "AADKERB"
+          }
+        ]
+      }
+    },
+    "DnsEndpointType": {
+      "type": "string",
+      "description": "Allows you to specify the type of endpoint. Set this to AzureDNSZone to create a large number of accounts in a single subscription, which creates accounts in an Azure DNS Zone and the endpoint URL will have an alphanumeric DNS Zone identifier.",
+      "enum": [
+        "Standard",
+        "AzureDnsZone"
+      ],
+      "x-ms-enum": {
+        "name": "DnsEndpointType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Standard",
+            "value": "Standard"
+          },
+          {
+            "name": "AzureDnsZone",
+            "value": "AzureDnsZone"
+          }
+        ]
+      }
+    },
+    "DualStackEndpointPreference": {
+      "type": "object",
+      "description": "Dual-stack endpoint preference defines whether IPv6 endpoints are going to be published.",
+      "properties": {
+        "publishIpv6Endpoint": {
+          "type": "boolean",
+          "description": "A boolean flag which indicates whether IPv6 storage endpoints are to be published."
+        }
+      }
+    },
+    "EnabledProtocols": {
+      "type": "string",
+      "description": "The authentication protocol that is used for the file share. Can only be specified when creating a share.",
+      "enum": [
+        "SMB",
+        "NFS"
+      ],
+      "x-ms-enum": {
+        "name": "EnabledProtocols",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "SMB",
+            "value": "SMB"
+          },
+          {
+            "name": "NFS",
+            "value": "NFS"
+          }
+        ]
+      }
+    },
+    "Encryption": {
+      "type": "object",
+      "description": "The encryption settings on the storage account.",
+      "properties": {
+        "services": {
+          "$ref": "#/definitions/EncryptionServices",
+          "description": "List of services which support encryption."
+        },
+        "keySource": {
+          "type": "string",
+          "description": "The encryption keySource (provider). Possible values (case-insensitive):  Microsoft.Storage, Microsoft.Keyvault",
+          "default": "Microsoft.Storage",
+          "enum": [
+            "Microsoft.Storage",
+            "Microsoft.Keyvault"
+          ],
+          "x-ms-enum": {
+            "name": "KeySource",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "Microsoft.Storage",
+                "value": "Microsoft.Storage"
+              },
+              {
+                "name": "Microsoft.Keyvault",
+                "value": "Microsoft.Keyvault"
+              }
+            ]
+          }
+        },
+        "requireInfrastructureEncryption": {
+          "type": "boolean",
+          "description": "A boolean indicating whether or not the service applies a secondary layer of encryption with platform managed keys for data at rest.",
+          "x-ms-client-name": "RequireInfrastructureEncryption"
+        },
+        "keyvaultproperties": {
+          "$ref": "#/definitions/KeyVaultProperties",
+          "description": "Properties provided by key vault.",
+          "x-ms-client-name": "KeyVaultProperties"
+        },
+        "identity": {
+          "$ref": "#/definitions/EncryptionIdentity",
+          "description": "The identity to be used with service-side encryption at rest.",
+          "x-ms-client-name": "EncryptionIdentity"
+        }
+      }
+    },
+    "EncryptionIdentity": {
+      "type": "object",
+      "description": "Encryption identity for the storage account.",
+      "properties": {
+        "userAssignedIdentity": {
+          "type": "string",
+          "description": "Resource identifier of the UserAssigned identity to be associated with server-side encryption on the storage account.",
+          "x-ms-client-name": "EncryptionUserAssignedIdentity"
+        },
+        "federatedIdentityClientId": {
+          "type": "string",
+          "description": "ClientId of the multi-tenant application to be used in conjunction with the user-assigned identity for cross-tenant customer-managed-keys server-side encryption on the storage account.",
+          "x-ms-client-name": "EncryptionFederatedIdentityClientId"
+        }
+      }
+    },
+    "EncryptionInTransit": {
+      "type": "object",
+      "description": "Encryption in transit setting.",
+      "properties": {
+        "required": {
+          "type": "boolean",
+          "description": "Indicates whether encryption in transit is required"
+        }
+      }
+    },
+    "EncryptionScope": {
+      "type": "object",
+      "description": "The Encryption Scope resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/EncryptionScopeProperties",
+          "description": "Properties of the encryption scope.",
+          "x-ms-client-flatten": true,
+          "x-ms-client-name": "EncryptionScopeProperties"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "EncryptionScopeKeyVaultProperties": {
+      "type": "object",
+      "description": "The key vault properties for the encryption scope. This is a required field if encryption scope 'source' attribute is set to 'Microsoft.KeyVault'.",
+      "properties": {
+        "keyUri": {
+          "type": "string",
+          "description": "The object identifier for a key vault key object. When applied, the encryption scope will use the key referenced by the identifier to enable customer-managed key support on this encryption scope."
+        },
+        "currentVersionedKeyIdentifier": {
+          "type": "string",
+          "description": "The object identifier of the current versioned Key Vault Key in use.",
+          "readOnly": true
+        },
+        "lastKeyRotationTimestamp": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp of last rotation of the Key Vault Key.",
+          "readOnly": true
+        }
+      }
+    },
+    "EncryptionScopeListResult": {
+      "type": "object",
+      "description": "The response of a EncryptionScope list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The EncryptionScope items on this page",
+          "items": {
+            "$ref": "#/definitions/EncryptionScope"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "EncryptionScopeProperties": {
+      "type": "object",
+      "description": "Properties of the encryption scope.",
+      "properties": {
+        "source": {
+          "$ref": "#/definitions/EncryptionScopeSource",
+          "description": "The provider for the encryption scope. Possible values (case-insensitive):  Microsoft.Storage, Microsoft.KeyVault."
+        },
+        "state": {
+          "$ref": "#/definitions/EncryptionScopeState",
+          "description": "The state of the encryption scope. Possible values (case-insensitive):  Enabled, Disabled."
+        },
+        "creationTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Gets the creation date and time of the encryption scope in UTC.",
+          "readOnly": true
+        },
+        "lastModifiedTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Gets the last modification date and time of the encryption scope in UTC.",
+          "readOnly": true
+        },
+        "keyVaultProperties": {
+          "$ref": "#/definitions/EncryptionScopeKeyVaultProperties",
+          "description": "The key vault properties for the encryption scope. This is a required field if encryption scope 'source' attribute is set to 'Microsoft.KeyVault'."
+        },
+        "requireInfrastructureEncryption": {
+          "type": "boolean",
+          "description": "A boolean indicating whether or not the service applies a secondary layer of encryption with platform managed keys for data at rest."
+        }
+      }
+    },
+    "EncryptionScopeSource": {
+      "type": "string",
+      "description": "The provider for the encryption scope. Possible values (case-insensitive):  Microsoft.Storage, Microsoft.KeyVault.",
+      "enum": [
+        "Microsoft.Storage",
+        "Microsoft.KeyVault"
+      ],
+      "x-ms-enum": {
+        "name": "EncryptionScopeSource",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Microsoft.Storage",
+            "value": "Microsoft.Storage"
+          },
+          {
+            "name": "Microsoft.KeyVault",
+            "value": "Microsoft.KeyVault"
+          }
+        ]
+      }
+    },
+    "EncryptionScopeState": {
+      "type": "string",
+      "description": "The state of the encryption scope. Possible values (case-insensitive):  Enabled, Disabled.",
+      "enum": [
+        "Enabled",
+        "Disabled"
+      ],
+      "x-ms-enum": {
+        "name": "EncryptionScopeState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Enabled",
+            "value": "Enabled"
+          },
+          {
+            "name": "Disabled",
+            "value": "Disabled"
+          }
+        ]
+      }
+    },
+    "EncryptionService": {
+      "type": "object",
+      "description": "A service that allows server-side encryption to be used.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "A boolean indicating whether or not the service encrypts the data as it is stored. Encryption at rest is enabled by default today and cannot be disabled."
+        },
+        "lastEnabledTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Gets a rough estimate of the date/time when the encryption was last enabled by the user. Data is encrypted at rest by default today and cannot be disabled.",
+          "readOnly": true
+        },
+        "keyType": {
+          "$ref": "#/definitions/KeyType",
+          "description": "Encryption key type to be used for the encryption service. 'Account' key type implies that an account-scoped encryption key will be used. 'Service' key type implies that a default service key is used.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        }
+      }
+    },
+    "EncryptionServices": {
+      "type": "object",
+      "description": "A list of services that support encryption.",
+      "properties": {
+        "blob": {
+          "$ref": "#/definitions/EncryptionService",
+          "description": "The encryption function of the blob storage service."
+        },
+        "file": {
+          "$ref": "#/definitions/EncryptionService",
+          "description": "The encryption function of the file storage service."
+        },
+        "table": {
+          "$ref": "#/definitions/EncryptionService",
+          "description": "The encryption function of the table storage service."
+        },
+        "queue": {
+          "$ref": "#/definitions/EncryptionService",
+          "description": "The encryption function of the queue storage service."
+        }
+      }
+    },
+    "Endpoints": {
+      "type": "object",
+      "description": "The URIs that are used to perform a retrieval of a public blob, queue, table, web or dfs object.",
+      "properties": {
+        "blob": {
+          "type": "string",
+          "description": "Gets the blob endpoint.",
+          "readOnly": true
+        },
+        "queue": {
+          "type": "string",
+          "description": "Gets the queue endpoint.",
+          "readOnly": true
+        },
+        "table": {
+          "type": "string",
+          "description": "Gets the table endpoint.",
+          "readOnly": true
+        },
+        "file": {
+          "type": "string",
+          "description": "Gets the file endpoint.",
+          "readOnly": true
+        },
+        "web": {
+          "type": "string",
+          "description": "Gets the web endpoint.",
+          "readOnly": true
+        },
+        "dfs": {
+          "type": "string",
+          "description": "Gets the dfs endpoint.",
+          "readOnly": true
+        },
+        "microsoftEndpoints": {
+          "$ref": "#/definitions/StorageAccountMicrosoftEndpoints",
+          "description": "Gets the microsoft routing storage endpoints."
+        },
+        "internetEndpoints": {
+          "$ref": "#/definitions/StorageAccountInternetEndpoints",
+          "description": "Gets the internet routing storage endpoints"
+        },
+        "ipv6Endpoints": {
+          "$ref": "#/definitions/StorageAccountIpv6Endpoints",
+          "description": "Gets the IPv6 storage endpoints."
+        }
+      }
+    },
+    "ErrorResponse": {
+      "type": "object",
+      "description": "An error response from the storage resource provider.",
+      "properties": {
+        "error": {
+          "$ref": "#/definitions/ErrorResponseBody",
+          "description": "Azure Storage Resource Provider error response body."
+        }
+      }
+    },
+    "ErrorResponseBody": {
+      "type": "object",
+      "description": "Error response body contract.",
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "An identifier for the error. Codes are invariant and are intended to be consumed programmatically."
+        },
+        "message": {
+          "type": "string",
+          "description": "A message describing the error, intended to be suitable for display in a user interface."
+        }
+      }
+    },
+    "ExecutionTarget": {
+      "type": "object",
+      "description": "Target helps provide filter parameters for the objects in the storage account and forms the execution context for the storage task",
+      "properties": {
+        "prefix": {
+          "type": "array",
+          "description": "Required list of object prefixes to be included for task execution",
+          "items": {
+            "type": "string"
+          }
+        },
+        "excludePrefix": {
+          "type": "array",
+          "description": "List of object prefixes to be excluded from task execution. If there is a conflict between include and exclude prefixes, the exclude prefix will be the determining factor",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ExecutionTrigger": {
+      "type": "object",
+      "description": "Execution trigger for storage task assignment",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/TriggerType",
+          "description": "The trigger type of the storage task assignment execution"
+        },
+        "parameters": {
+          "$ref": "#/definitions/TriggerParameters",
+          "description": "The trigger parameters of the storage task assignment execution"
+        }
+      },
+      "required": [
+        "type",
+        "parameters"
+      ]
+    },
+    "ExecutionTriggerUpdate": {
+      "type": "object",
+      "description": "Execution trigger update for storage task assignment",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/TriggerType",
+          "description": "The trigger type of the storage task assignment execution"
+        },
+        "parameters": {
+          "$ref": "#/definitions/TriggerParametersUpdate",
+          "description": "The trigger parameters of the storage task assignment execution"
+        }
+      }
+    },
+    "ExtendedLocation": {
+      "type": "object",
+      "description": "The complex type of the extended location.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the extended location."
+        },
+        "type": {
+          "$ref": "#/definitions/ExtendedLocationTypes",
+          "description": "The type of the extended location."
+        }
+      }
+    },
+    "ExtendedLocationTypes": {
+      "type": "string",
+      "description": "The type of extendedLocation.",
+      "enum": [
+        "EdgeZone"
+      ],
+      "x-ms-enum": {
+        "name": "ExtendedLocationTypes",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "EdgeZone",
+            "value": "EdgeZone"
+          }
+        ]
+      }
+    },
+    "FileServiceItems": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "List of file services returned.",
+          "items": {
+            "$ref": "#/definitions/FileServiceProperties"
+          },
+          "readOnly": true
+        }
+      }
+    },
+    "FileServiceProperties": {
+      "type": "object",
+      "description": "The properties of File services in storage account.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/FileServicePropertiesProperties",
+          "description": "The properties of File services in storage account.",
+          "x-ms-client-flatten": true,
+          "x-ms-client-name": "FileServiceProperties"
+        },
+        "sku": {
+          "$ref": "#/definitions/Sku",
+          "description": "Sku name and tier.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "FileServicePropertiesProperties": {
+      "type": "object",
+      "description": "The properties of File services in storage account.",
+      "properties": {
+        "cors": {
+          "$ref": "#/definitions/CorsRules",
+          "description": "Specifies CORS rules for the File service. You can include up to five CorsRule elements in the request. If no CorsRule elements are included in the request body, all CORS rules will be deleted, and CORS will be disabled for the File service."
+        },
+        "shareDeleteRetentionPolicy": {
+          "$ref": "#/definitions/DeleteRetentionPolicy",
+          "description": "The file service properties for share soft delete."
+        },
+        "protocolSettings": {
+          "$ref": "#/definitions/ProtocolSettings",
+          "description": "Protocol settings for file service"
+        }
+      }
+    },
+    "FileServiceUsage": {
+      "type": "object",
+      "description": "The usage of file service in storage account.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/FileServiceUsageProperties",
+          "description": "File service usage in storage account including account limits, file share limits and constants used in recommendations and bursting formula."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "FileServiceUsageProperties": {
+      "type": "object",
+      "description": "File service usage in storage account including account limits, file share limits and constants used in recommendations and bursting formula.",
+      "properties": {
+        "storageAccountLimits": {
+          "$ref": "#/definitions/AccountLimits",
+          "description": "Maximum provisioned storage, IOPS, bandwidth and number of file shares limits for the storage account.",
+          "readOnly": true
+        },
+        "fileShareLimits": {
+          "$ref": "#/definitions/FileShareLimits",
+          "description": "Minimum and maximum provisioned storage, IOPS and bandwidth limits for a file share in the storage account.",
+          "readOnly": true
+        },
+        "fileShareRecommendations": {
+          "$ref": "#/definitions/FileShareRecommendations",
+          "description": "Constants used for calculating recommended provisioned IOPS and bandwidth for a file share in the storage account.",
+          "readOnly": true
+        },
+        "burstingConstants": {
+          "$ref": "#/definitions/BurstingConstants",
+          "description": "Constants used for calculating included burst IOPS and maximum burst credits for IOPS for a file share in the storage account.",
+          "readOnly": true
+        },
+        "storageAccountUsage": {
+          "$ref": "#/definitions/AccountUsage",
+          "description": "Usage of provisioned storage, IOPS, bandwidth and number of file shares across all live shares and soft-deleted shares in the account.",
+          "readOnly": true
+        }
+      }
+    },
+    "FileServiceUsages": {
+      "type": "object",
+      "description": "List file service usages schema.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The FileServiceUsage items on this page",
+          "items": {
+            "$ref": "#/definitions/FileServiceUsage"
+          },
+          "readOnly": true
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "FileShare": {
+      "type": "object",
+      "description": "Properties of the file share, including Id, resource name, resource type, Etag.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/FileShareProperties",
+          "description": "Properties of the file share.",
+          "x-ms-client-flatten": true,
+          "x-ms-client-name": "FileShareProperties"
+        },
+        "etag": {
+          "type": "string",
+          "description": "Resource Etag.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "FileShareItem": {
+      "type": "object",
+      "description": "The file share properties be listed out.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/FileShareProperties",
+          "description": "The file share properties be listed out.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/AzureEntityResource"
+        }
+      ]
+    },
+    "FileShareItems": {
+      "type": "object",
+      "description": "Response schema. Contains list of shares returned, and if paging is requested or required, a URL to next page of shares.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The FileShareItem items on this page",
+          "items": {
+            "$ref": "#/definitions/FileShareItem"
+          },
+          "readOnly": true
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "FileShareLimits": {
+      "type": "object",
+      "description": "Minimum and maximum provisioned storage, IOPS and bandwidth limits for a file share in the storage account.",
+      "properties": {
+        "minProvisionedStorageGiB": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The minimum provisioned storage quota limit in gibibytes for a file share in the storage account.",
+          "readOnly": true
+        },
+        "maxProvisionedStorageGiB": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The maximum provisioned storage quota limit in gibibytes for a file share in the storage account.",
+          "readOnly": true
+        },
+        "minProvisionedIOPS": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The minimum provisioned IOPS limit for a file share in the storage account.",
+          "readOnly": true
+        },
+        "maxProvisionedIOPS": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The maximum provisioned IOPS limit for a file share in the storage account.",
+          "readOnly": true
+        },
+        "minProvisionedBandwidthMiBPerSec": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The minimum provisioned bandwidth limit in mebibytes per second for a file share in the storage account.",
+          "readOnly": true
+        },
+        "maxProvisionedBandwidthMiBPerSec": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The maximum provisioned bandwidth limit in mebibytes per second for a file share in the storage account.",
+          "readOnly": true
+        },
+        "guardrailIOScalar": {
+          "type": "number",
+          "format": "double",
+          "description": "The IO scalar used for guardrail calculations for a file share in the storage account.",
+          "readOnly": true
+        },
+        "guardrailBandwidthScalar": {
+          "type": "number",
+          "format": "double",
+          "description": "The bandwidth scalar used for guardrail calculations for a file share in the storage account.",
+          "readOnly": true
+        }
+      }
+    },
+    "FileShareProperties": {
+      "type": "object",
+      "description": "The properties of the file share.",
+      "properties": {
+        "lastModifiedTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Returns the date and time the share was last modified.",
+          "readOnly": true
+        },
+        "metadata": {
+          "type": "object",
+          "description": "A name-value pair to associate with the share as metadata.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "shareQuota": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The provisioned size of the share, in gibibytes. Must be greater than 0, and less than or equal to 5TB (5120). For Large File Shares, the maximum size is 102400. For file shares created under Files Provisioned v2 account type, please refer to the GetFileServiceUsage API response for the minimum and maximum allowed provisioned storage size."
+        },
+        "provisionedIops": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The provisioned IOPS of the share. This property is only for file shares created under Files Provisioned v2 account type. Please refer to the GetFileServiceUsage API response for the minimum and maximum allowed value for provisioned IOPS."
+        },
+        "provisionedBandwidthMibps": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The provisioned bandwidth of the share, in mebibytes per second. This property is only for file shares created under Files Provisioned v2 account type. Please refer to the GetFileServiceUsage API response for the minimum and maximum allowed value for provisioned bandwidth."
+        },
+        "includedBurstIops": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The calculated burst IOPS of the share. This property is only for file shares created under Files Provisioned v2 account type.",
+          "readOnly": true
+        },
+        "maxBurstCreditsForIops": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The calculated maximum burst credits for the share. This property is only for file shares created under Files Provisioned v2 account type.",
+          "readOnly": true
+        },
+        "nextAllowedQuotaDowngradeTime": {
+          "type": "string",
+          "format": "date-time-rfc7231",
+          "description": "Returns the next allowed provisioned storage size downgrade time for the share. This property is only for file shares created under Files Provisioned v1 SSD and Files Provisioned v2 account type",
+          "readOnly": true
+        },
+        "nextAllowedProvisionedIopsDowngradeTime": {
+          "type": "string",
+          "format": "date-time-rfc7231",
+          "description": "Returns the next allowed provisioned IOPS downgrade time for the share. This property is only for file shares created under Files Provisioned v2 account type.",
+          "readOnly": true
+        },
+        "nextAllowedProvisionedBandwidthDowngradeTime": {
+          "type": "string",
+          "format": "date-time-rfc7231",
+          "description": "Returns the next allowed provisioned bandwidth downgrade time for the share. This property is only for file shares created under Files Provisioned v2 account type.",
+          "readOnly": true
+        },
+        "enabledProtocols": {
+          "$ref": "#/definitions/EnabledProtocols",
+          "description": "The authentication protocol that is used for the file share. Can only be specified when creating a share.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "rootSquash": {
+          "$ref": "#/definitions/RootSquashType",
+          "description": "The property is for NFS share only. The default is NoRootSquash."
+        },
+        "version": {
+          "type": "string",
+          "description": "The version of the share.",
+          "readOnly": true
+        },
+        "deleted": {
+          "type": "boolean",
+          "description": "Indicates whether the share was deleted.",
+          "readOnly": true
+        },
+        "deletedTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The deleted time if the share was deleted.",
+          "readOnly": true
+        },
+        "remainingRetentionDays": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Remaining retention days for share that was soft deleted.",
+          "readOnly": true
+        },
+        "accessTier": {
+          "$ref": "#/definitions/ShareAccessTier",
+          "description": "Access tier for specific share. GpV2 account can choose between TransactionOptimized (default), Hot, and Cool. FileStorage account can choose Premium."
+        },
+        "accessTierChangeTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Indicates the last modification time for share access tier.",
+          "readOnly": true
+        },
+        "accessTierStatus": {
+          "type": "string",
+          "description": "Indicates if there is a pending transition for access tier.",
+          "readOnly": true
+        },
+        "shareUsageBytes": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The approximate size of the data stored on the share. Note that this value may not include all recently created or recently resized files.",
+          "readOnly": true
+        },
+        "leaseStatus": {
+          "$ref": "#/definitions/LeaseStatus",
+          "description": "The lease status of the share.",
+          "readOnly": true
+        },
+        "leaseState": {
+          "$ref": "#/definitions/LeaseState",
+          "description": "Lease state of the share.",
+          "readOnly": true
+        },
+        "leaseDuration": {
+          "$ref": "#/definitions/LeaseDuration",
+          "description": "Specifies whether the lease on a share is of infinite or fixed duration, only when the share is leased.",
+          "readOnly": true
+        },
+        "signedIdentifiers": {
+          "type": "array",
+          "description": "List of stored access policies specified on the share.",
+          "items": {
+            "$ref": "#/definitions/SignedIdentifier"
+          }
+        },
+        "snapshotTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Creation time of share snapshot returned in the response of list shares with expand param \"snapshots\".",
+          "readOnly": true
+        },
+        "fileSharePaidBursting": {
+          "$ref": "#/definitions/FileSharePropertiesFileSharePaidBursting",
+          "description": "File Share Paid Bursting properties."
+        }
+      }
+    },
+    "FileSharePropertiesFileSharePaidBursting": {
+      "type": "object",
+      "description": "File Share Paid Bursting properties.",
+      "properties": {
+        "paidBurstingEnabled": {
+          "type": "boolean",
+          "description": "Indicates whether paid bursting is enabled for the share. This property is only for file shares created under Files Provisioned v1 SSD account type."
+        },
+        "paidBurstingMaxIops": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The maximum paid bursting IOPS for the share. This property is only for file shares created under Files Provisioned v1 SSD account type. The maximum allowed value is 102400 which is the maximum allowed IOPS for a share."
+        },
+        "paidBurstingMaxBandwidthMibps": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The maximum paid bursting bandwidth for the share, in mebibytes per second. This property is only for file shares created under Files Provisioned v1 SSD account type. The maximum allowed value is 10340 which is the maximum allowed bandwidth for a share."
+        }
+      }
+    },
+    "FileShareRecommendations": {
+      "type": "object",
+      "description": "Constants used for calculating recommended provisioned IOPS and bandwidth for a file share in the storage account.",
+      "properties": {
+        "baseIOPS": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The base IOPS in the file share provisioned IOPS recommendation formula.",
+          "readOnly": true
+        },
+        "ioScalar": {
+          "type": "number",
+          "format": "double",
+          "description": "The scalar for IO in the file share provisioned IOPS recommendation formula.",
+          "readOnly": true
+        },
+        "baseBandwidthMiBPerSec": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The base bandwidth in the file share provisioned bandwidth recommendation formula.",
+          "readOnly": true
+        },
+        "bandwidthScalar": {
+          "type": "number",
+          "format": "double",
+          "description": "The scalar for bandwidth in the file share provisioned bandwidth recommendation formula.",
+          "readOnly": true
+        }
+      }
+    },
+    "Format": {
+      "type": "string",
+      "description": "This is a required field, it specifies the format for the inventory files.",
+      "enum": [
+        "Csv",
+        "Parquet"
+      ],
+      "x-ms-enum": {
+        "name": "Format",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Csv",
+            "value": "Csv"
+          },
+          {
+            "name": "Parquet",
+            "value": "Parquet"
+          }
+        ]
+      }
+    },
+    "GeoPriorityReplicationStatus": {
+      "type": "object",
+      "description": "Geo Priority Replication enablement status for the storage account.",
+      "properties": {
+        "isBlobEnabled": {
+          "type": "boolean",
+          "description": "Indicates whether Blob Geo Priority Replication is enabled for the storage account."
+        }
+      }
+    },
+    "GeoReplicationStats": {
+      "type": "object",
+      "description": "Statistics related to replication for storage account's Blob, Table, Queue and File services. It is only available when geo-redundant replication is enabled for the storage account.",
+      "properties": {
+        "status": {
+          "$ref": "#/definitions/GeoReplicationStatus",
+          "description": "The status of the secondary location. Possible values are: - Live: Indicates that the secondary location is active and operational. - Bootstrap: Indicates initial synchronization from the primary location to the secondary location is in progress.This typically occurs when replication is first enabled. - Unavailable: Indicates that the secondary location is temporarily unavailable.",
+          "readOnly": true
+        },
+        "lastSyncTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "All primary writes preceding this UTC date/time value are guaranteed to be available for read operations. Primary writes following this point in time may or may not be available for reads. Element may be default value if value of LastSyncTime is not available, this can happen if secondary is offline or we are in bootstrap.",
+          "readOnly": true
+        },
+        "canFailover": {
+          "type": "boolean",
+          "description": "A boolean flag which indicates whether or not account failover is supported for the account.",
+          "readOnly": true
+        },
+        "canPlannedFailover": {
+          "type": "boolean",
+          "description": "A boolean flag which indicates whether or not planned account failover is supported for the account.",
+          "readOnly": true
+        },
+        "postFailoverRedundancy": {
+          "$ref": "#/definitions/PostFailoverRedundancy",
+          "description": "The redundancy type of the account after an account failover is performed.",
+          "readOnly": true
+        },
+        "postPlannedFailoverRedundancy": {
+          "$ref": "#/definitions/PostPlannedFailoverRedundancy",
+          "description": "The redundancy type of the account after a planned account failover is performed.",
+          "readOnly": true
+        }
+      }
+    },
+    "GeoReplicationStatus": {
+      "type": "string",
+      "description": "The status of the secondary location. Possible values are: - Live: Indicates that the secondary location is active and operational. - Bootstrap: Indicates initial synchronization from the primary location to the secondary location is in progress.This typically occurs when replication is first enabled. - Unavailable: Indicates that the secondary location is temporarily unavailable.",
+      "enum": [
+        "Live",
+        "Bootstrap",
+        "Unavailable"
+      ],
+      "x-ms-enum": {
+        "name": "GeoReplicationStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Live",
+            "value": "Live"
+          },
+          {
+            "name": "Bootstrap",
+            "value": "Bootstrap"
+          },
+          {
+            "name": "Unavailable",
+            "value": "Unavailable"
+          }
+        ]
+      }
+    },
+    "HttpProtocol": {
+      "type": "string",
+      "description": "The protocol permitted for a request made with the account SAS.",
+      "enum": [
+        "https,http",
+        "https"
+      ],
+      "x-ms-enum": {
+        "name": "HttpProtocol",
+        "modelAsString": false
+      }
+    },
+    "IPRule": {
+      "type": "object",
+      "description": "IP rule with specific IP or IP range in CIDR format.",
+      "properties": {
+        "value": {
+          "type": "string",
+          "description": "Specifies the IP or IP range in CIDR format.",
+          "x-ms-client-name": "IPAddressOrRange"
+        },
+        "action": {
+          "type": "string",
+          "description": "The action of IP ACL rule.",
+          "enum": [
+            "Allow"
+          ],
+          "x-ms-enum": {
+            "modelAsString": false
+          }
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "Identity": {
+      "type": "object",
+      "description": "Identity for the resource.",
+      "properties": {
+        "principalId": {
+          "type": "string",
+          "description": "The principal ID of resource identity.",
+          "readOnly": true
+        },
+        "tenantId": {
+          "type": "string",
+          "description": "The tenant ID of resource.",
+          "readOnly": true
+        },
+        "type": {
+          "$ref": "#/definitions/IdentityType",
+          "description": "The identity type."
+        },
+        "userAssignedIdentities": {
+          "type": "object",
+          "description": "Gets or sets a list of key value pairs that describe the set of User Assigned identities that will be used with this storage account. The key is the ARM resource identifier of the identity. Only 1 User Assigned identity is permitted here.",
+          "additionalProperties": {
+            "$ref": "#/definitions/UserAssignedIdentity"
+          }
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "IdentityType": {
+      "type": "string",
+      "description": "The identity type.",
+      "enum": [
+        "None",
+        "SystemAssigned",
+        "UserAssigned",
+        "SystemAssigned,UserAssigned"
+      ],
+      "x-ms-enum": {
+        "name": "IdentityType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "None",
+            "value": "None"
+          },
+          {
+            "name": "SystemAssigned",
+            "value": "SystemAssigned"
+          },
+          {
+            "name": "UserAssigned",
+            "value": "UserAssigned"
+          },
+          {
+            "name": "SystemAssigned,UserAssigned",
+            "value": "SystemAssigned,UserAssigned"
+          }
+        ]
+      }
+    },
+    "ImmutabilityPolicy": {
+      "type": "object",
+      "description": "The ImmutabilityPolicy property of a blob container, including Id, resource name, resource type, Etag.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ImmutabilityPolicyProperty",
+          "description": "The properties of an ImmutabilityPolicy of a blob container.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "Resource Etag.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "properties"
+      ],
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "ImmutabilityPolicyProperties": {
+      "type": "object",
+      "description": "The properties of an ImmutabilityPolicy of a blob container.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ImmutabilityPolicyProperty",
+          "description": "The properties of an ImmutabilityPolicy of a blob container.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "ImmutabilityPolicy Etag.",
+          "readOnly": true
+        },
+        "updateHistory": {
+          "type": "array",
+          "description": "The ImmutabilityPolicy update history of the blob container.",
+          "items": {
+            "$ref": "#/definitions/UpdateHistoryProperty"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "ImmutabilityPolicyProperty": {
+      "type": "object",
+      "description": "The properties of an ImmutabilityPolicy of a blob container.",
+      "properties": {
+        "immutabilityPeriodSinceCreationInDays": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The immutability period for the blobs in the container since the policy creation, in days."
+        },
+        "state": {
+          "$ref": "#/definitions/ImmutabilityPolicyState",
+          "description": "The ImmutabilityPolicy state of a blob container, possible values include: Locked and Unlocked.",
+          "readOnly": true
+        },
+        "allowProtectedAppendWrites": {
+          "type": "boolean",
+          "description": "This property can only be changed for unlocked time-based retention policies. When enabled, new blocks can be written to an append blob while maintaining immutability protection and compliance. Only new blocks can be added and any existing blocks cannot be modified or deleted. This property cannot be changed with ExtendImmutabilityPolicy API."
+        },
+        "allowProtectedAppendWritesAll": {
+          "type": "boolean",
+          "description": "This property can only be changed for unlocked time-based retention policies. When enabled, new blocks can be written to both 'Append and Bock Blobs' while maintaining immutability protection and compliance. Only new blocks can be added and any existing blocks cannot be modified or deleted. This property cannot be changed with ExtendImmutabilityPolicy API. The 'allowProtectedAppendWrites' and 'allowProtectedAppendWritesAll' properties are mutually exclusive."
+        }
+      }
+    },
+    "ImmutabilityPolicyState": {
+      "type": "string",
+      "description": "The ImmutabilityPolicy state of a blob container, possible values include: Locked and Unlocked.",
+      "enum": [
+        "Locked",
+        "Unlocked"
+      ],
+      "x-ms-enum": {
+        "name": "ImmutabilityPolicyState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Locked",
+            "value": "Locked"
+          },
+          {
+            "name": "Unlocked",
+            "value": "Unlocked"
+          }
+        ]
+      }
+    },
+    "ImmutabilityPolicyUpdateType": {
+      "type": "string",
+      "description": "The ImmutabilityPolicy update type of a blob container, possible values include: put, lock and extend.",
+      "enum": [
+        "put",
+        "lock",
+        "extend"
+      ],
+      "x-ms-enum": {
+        "name": "ImmutabilityPolicyUpdateType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "put",
+            "value": "put"
+          },
+          {
+            "name": "lock",
+            "value": "lock"
+          },
+          {
+            "name": "extend",
+            "value": "extend"
+          }
+        ]
+      }
+    },
+    "ImmutableStorageAccount": {
+      "type": "object",
+      "description": "This property enables and defines account-level immutability. Enabling the feature auto-enables Blob Versioning.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "A boolean flag which enables account-level immutability. All the containers under such an account have object-level immutability enabled by default."
+        },
+        "immutabilityPolicy": {
+          "$ref": "#/definitions/AccountImmutabilityPolicyProperties",
+          "description": "Specifies the default account-level immutability policy which is inherited and applied to objects that do not possess an explicit immutability policy at the object level. The object-level immutability policy has higher precedence than the container-level immutability policy, which has a higher precedence than the account-level immutability policy."
+        }
+      }
+    },
+    "ImmutableStorageWithVersioning": {
+      "type": "object",
+      "description": "Object level immutability properties of the container.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "This is an immutable property, when set to true it enables object level immutability at the container level."
+        },
+        "timeStamp": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Returns the date and time the object level immutability was enabled.",
+          "readOnly": true
+        },
+        "migrationState": {
+          "$ref": "#/definitions/MigrationState",
+          "description": "This property denotes the container level immutability to object level immutability migration state.",
+          "readOnly": true
+        }
+      }
+    },
+    "IntervalUnit": {
+      "type": "string",
+      "description": "Run interval unit of task execution. This is a required field when ExecutionTrigger.properties.type is 'OnSchedule'; this property should not be present when ExecutionTrigger.properties.type is 'RunOnce'",
+      "enum": [
+        "Days"
+      ],
+      "x-ms-enum": {
+        "name": "IntervalUnit",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "days",
+            "value": "Days"
+          }
+        ]
+      }
+    },
+    "InventoryRuleType": {
+      "type": "string",
+      "description": "The valid value is Inventory",
+      "enum": [
+        "Inventory"
+      ],
+      "x-ms-enum": {
+        "name": "InventoryRuleType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Inventory",
+            "value": "Inventory"
+          }
+        ]
+      }
+    },
+    "IssueType": {
+      "type": "string",
+      "description": "Type of issue",
+      "enum": [
+        "Unknown",
+        "ConfigurationPropagationFailure"
+      ],
+      "x-ms-enum": {
+        "name": "IssueType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Unknown",
+            "value": "Unknown"
+          },
+          {
+            "name": "ConfigurationPropagationFailure",
+            "value": "ConfigurationPropagationFailure"
+          }
+        ]
+      }
+    },
+    "KeyCreationTime": {
+      "type": "object",
+      "description": "Storage account keys creation time.",
+      "properties": {
+        "key1": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "key2": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "KeyPermission": {
+      "type": "string",
+      "description": "Permissions for the key -- read-only or full permissions.",
+      "enum": [
+        "Read",
+        "Full"
+      ],
+      "x-ms-enum": {
+        "name": "KeyPermission",
+        "modelAsString": false
+      }
+    },
+    "KeyPolicy": {
+      "type": "object",
+      "description": "KeyPolicy assigned to the storage account.",
+      "properties": {
+        "keyExpirationPeriodInDays": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The key expiration period in days."
+        }
+      },
+      "required": [
+        "keyExpirationPeriodInDays"
+      ]
+    },
+    "KeyType": {
+      "type": "string",
+      "description": "Encryption key type to be used for the encryption service. 'Account' key type implies that an account-scoped encryption key will be used. 'Service' key type implies that a default service key is used.",
+      "enum": [
+        "Service",
+        "Account"
+      ],
+      "x-ms-enum": {
+        "name": "KeyType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Service",
+            "value": "Service"
+          },
+          {
+            "name": "Account",
+            "value": "Account"
+          }
+        ]
+      }
+    },
+    "KeyVaultProperties": {
+      "type": "object",
+      "description": "Properties of key vault.",
+      "properties": {
+        "keyname": {
+          "type": "string",
+          "description": "The name of KeyVault key.",
+          "x-ms-client-name": "KeyName"
+        },
+        "keyversion": {
+          "type": "string",
+          "description": "The version of KeyVault key.",
+          "x-ms-client-name": "KeyVersion"
+        },
+        "keyvaulturi": {
+          "type": "string",
+          "description": "The Uri of KeyVault.",
+          "x-ms-client-name": "KeyVaultUri"
+        },
+        "currentVersionedKeyIdentifier": {
+          "type": "string",
+          "description": "The object identifier of the current versioned Key Vault Key in use.",
+          "readOnly": true,
+          "x-ms-client-name": "CurrentVersionedKeyIdentifier"
+        },
+        "lastKeyRotationTimestamp": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp of last rotation of the Key Vault Key.",
+          "readOnly": true,
+          "x-ms-client-name": "LastKeyRotationTimestamp"
+        },
+        "currentVersionedKeyExpirationTimestamp": {
+          "type": "string",
+          "format": "date-time",
+          "description": "This is a read only property that represents the expiration time of the current version of the customer managed key used for encryption.",
+          "readOnly": true,
+          "x-ms-client-name": "CurrentVersionedKeyExpirationTimestamp"
+        }
+      }
+    },
+    "Kind": {
+      "type": "string",
+      "description": "Indicates the type of storage account.",
+      "enum": [
+        "Storage",
+        "StorageV2",
+        "BlobStorage",
+        "FileStorage",
+        "BlockBlobStorage"
+      ],
+      "x-ms-enum": {
+        "name": "Kind",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Storage",
+            "value": "Storage"
+          },
+          {
+            "name": "StorageV2",
+            "value": "StorageV2"
+          },
+          {
+            "name": "BlobStorage",
+            "value": "BlobStorage"
+          },
+          {
+            "name": "FileStorage",
+            "value": "FileStorage"
+          },
+          {
+            "name": "BlockBlobStorage",
+            "value": "BlockBlobStorage"
+          }
+        ]
+      }
+    },
+    "LargeFileSharesState": {
+      "type": "string",
+      "description": "Allow large file shares if sets to Enabled. It cannot be disabled once it is enabled.",
+      "enum": [
+        "Disabled",
+        "Enabled"
+      ],
+      "x-ms-enum": {
+        "name": "LargeFileSharesState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Disabled",
+            "value": "Disabled"
+          },
+          {
+            "name": "Enabled",
+            "value": "Enabled"
+          }
+        ]
+      }
+    },
+    "LastAccessTimeTrackingPolicy": {
+      "type": "object",
+      "description": "The blob service properties for Last access time based tracking policy.",
+      "properties": {
+        "enable": {
+          "type": "boolean",
+          "description": "When set to true last access time based tracking is enabled."
+        },
+        "name": {
+          "$ref": "#/definitions/Name",
+          "description": "Name of the policy. The valid value is AccessTimeTracking. This field is currently read only"
+        },
+        "trackingGranularityInDays": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The field specifies blob object tracking granularity in days, typically how often the blob object should be tracked.This field is currently read only with value as 1"
+        },
+        "blobType": {
+          "type": "array",
+          "description": "An array of predefined supported blob types. Only blockBlob is the supported value. This field is currently read only",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "enable"
+      ]
+    },
+    "LeaseContainerRequest": {
+      "type": "object",
+      "description": "Lease Container request schema.",
+      "properties": {
+        "action": {
+          "$ref": "#/definitions/LeaseContainerRequestAction",
+          "description": "Specifies the lease action. Can be one of the available actions."
+        },
+        "leaseId": {
+          "type": "string",
+          "description": "Identifies the lease. Can be specified in any valid GUID string format."
+        },
+        "breakPeriod": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Optional. For a break action, proposed duration the lease should continue before it is broken, in seconds, between 0 and 60."
+        },
+        "leaseDuration": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Required for acquire. Specifies the duration of the lease, in seconds, or negative one (-1) for a lease that never expires."
+        },
+        "proposedLeaseId": {
+          "type": "string",
+          "description": "Optional for acquire, required for change. Proposed lease ID, in a GUID string format."
+        }
+      },
+      "required": [
+        "action"
+      ]
+    },
+    "LeaseContainerRequestAction": {
+      "type": "string",
+      "description": "Specifies the lease action. Can be one of the available actions.",
+      "enum": [
+        "Acquire",
+        "Renew",
+        "Change",
+        "Release",
+        "Break"
+      ],
+      "x-ms-enum": {
+        "name": "LeaseContainerRequestAction",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Acquire",
+            "value": "Acquire"
+          },
+          {
+            "name": "Renew",
+            "value": "Renew"
+          },
+          {
+            "name": "Change",
+            "value": "Change"
+          },
+          {
+            "name": "Release",
+            "value": "Release"
+          },
+          {
+            "name": "Break",
+            "value": "Break"
+          }
+        ]
+      }
+    },
+    "LeaseContainerResponse": {
+      "type": "object",
+      "description": "Lease Container response schema.",
+      "properties": {
+        "leaseId": {
+          "type": "string",
+          "description": "Returned unique lease ID that must be included with any request to delete the container, or to renew, change, or release the lease."
+        },
+        "leaseTimeSeconds": {
+          "type": "string",
+          "description": "Approximate time remaining in the lease period, in seconds."
+        }
+      }
+    },
+    "LeaseDuration": {
+      "type": "string",
+      "description": "Specifies whether the lease on a container is of infinite or fixed duration, only when the container is leased.",
+      "enum": [
+        "Infinite",
+        "Fixed"
+      ],
+      "x-ms-enum": {
+        "name": "LeaseDuration",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Infinite",
+            "value": "Infinite"
+          },
+          {
+            "name": "Fixed",
+            "value": "Fixed"
+          }
+        ]
+      }
+    },
+    "LeaseShareAction": {
+      "type": "string",
+      "description": "Specifies the lease action. Can be one of the available actions.",
+      "enum": [
+        "Acquire",
+        "Renew",
+        "Change",
+        "Release",
+        "Break"
+      ],
+      "x-ms-enum": {
+        "name": "LeaseShareAction",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Acquire",
+            "value": "Acquire"
+          },
+          {
+            "name": "Renew",
+            "value": "Renew"
+          },
+          {
+            "name": "Change",
+            "value": "Change"
+          },
+          {
+            "name": "Release",
+            "value": "Release"
+          },
+          {
+            "name": "Break",
+            "value": "Break"
+          }
+        ]
+      }
+    },
+    "LeaseShareRequest": {
+      "type": "object",
+      "description": "Lease Share request schema.",
+      "properties": {
+        "action": {
+          "$ref": "#/definitions/LeaseShareAction",
+          "description": "Specifies the lease action. Can be one of the available actions."
+        },
+        "leaseId": {
+          "type": "string",
+          "description": "Identifies the lease. Can be specified in any valid GUID string format."
+        },
+        "breakPeriod": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Optional. For a break action, proposed duration the lease should continue before it is broken, in seconds, between 0 and 60."
+        },
+        "leaseDuration": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Required for acquire. Specifies the duration of the lease, in seconds, or negative one (-1) for a lease that never expires."
+        },
+        "proposedLeaseId": {
+          "type": "string",
+          "description": "Optional for acquire, required for change. Proposed lease ID, in a GUID string format."
+        }
+      },
+      "required": [
+        "action"
+      ]
+    },
+    "LeaseShareResponse": {
+      "type": "object",
+      "description": "Lease Share response schema.",
+      "properties": {
+        "leaseId": {
+          "type": "string",
+          "description": "Returned unique lease ID that must be included with any request to delete the share, or to renew, change, or release the lease."
+        },
+        "leaseTimeSeconds": {
+          "type": "string",
+          "description": "Approximate time remaining in the lease period, in seconds."
+        }
+      }
+    },
+    "LeaseState": {
+      "type": "string",
+      "description": "Lease state of the container.",
+      "enum": [
+        "Available",
+        "Leased",
+        "Expired",
+        "Breaking",
+        "Broken"
+      ],
+      "x-ms-enum": {
+        "name": "LeaseState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Available",
+            "value": "Available"
+          },
+          {
+            "name": "Leased",
+            "value": "Leased"
+          },
+          {
+            "name": "Expired",
+            "value": "Expired"
+          },
+          {
+            "name": "Breaking",
+            "value": "Breaking"
+          },
+          {
+            "name": "Broken",
+            "value": "Broken"
+          }
+        ]
+      }
+    },
+    "LeaseStatus": {
+      "type": "string",
+      "description": "The lease status of the container.",
+      "enum": [
+        "Locked",
+        "Unlocked"
+      ],
+      "x-ms-enum": {
+        "name": "LeaseStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Locked",
+            "value": "Locked"
+          },
+          {
+            "name": "Unlocked",
+            "value": "Unlocked"
+          }
+        ]
+      }
+    },
+    "LegalHold": {
+      "type": "object",
+      "description": "The LegalHold property of a blob container.",
+      "properties": {
+        "hasLegalHold": {
+          "type": "boolean",
+          "description": "The hasLegalHold public property is set to true by SRP if there are at least one existing tag. The hasLegalHold public property is set to false by SRP if all existing legal hold tags are cleared out. There can be a maximum of 1000 blob containers with hasLegalHold=true for a given account.",
+          "readOnly": true
+        },
+        "tags": {
+          "type": "array",
+          "description": "Each tag should be 3 to 23 alphanumeric characters and is normalized to lower case at SRP.",
+          "items": {
+            "$ref": "#/definitions/LimitedString"
+          }
+        },
+        "allowProtectedAppendWritesAll": {
+          "type": "boolean",
+          "description": "When enabled, new blocks can be written to both 'Append and Bock Blobs' while maintaining legal hold protection and compliance. Only new blocks can be added and any existing blocks cannot be modified or deleted."
+        }
+      },
+      "required": [
+        "tags"
+      ]
+    },
+    "LegalHoldProperties": {
+      "type": "object",
+      "description": "The LegalHold property of a blob container.",
+      "properties": {
+        "hasLegalHold": {
+          "type": "boolean",
+          "description": "The hasLegalHold public property is set to true by SRP if there are at least one existing tag. The hasLegalHold public property is set to false by SRP if all existing legal hold tags are cleared out. There can be a maximum of 1000 blob containers with hasLegalHold=true for a given account.",
+          "readOnly": true
+        },
+        "tags": {
+          "type": "array",
+          "description": "The list of LegalHold tags of a blob container.",
+          "items": {
+            "$ref": "#/definitions/TagProperty"
+          },
+          "x-ms-identifiers": []
+        },
+        "protectedAppendWritesHistory": {
+          "$ref": "#/definitions/ProtectedAppendWritesHistory",
+          "description": "Protected append blob writes history."
+        }
+      }
+    },
+    "LimitedString": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 23
+    },
+    "ListAccountSasResponse": {
+      "type": "object",
+      "description": "The List SAS credentials operation response.",
+      "properties": {
+        "accountSasToken": {
+          "type": "string",
+          "description": "List SAS credentials of storage account.",
+          "readOnly": true
+        }
+      }
+    },
+    "ListBlobInventoryPolicy": {
+      "type": "object",
+      "description": "List of blob inventory policies returned.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "List of blob inventory policies.",
+          "items": {
+            "$ref": "#/definitions/BlobInventoryPolicy"
+          },
+          "readOnly": true
+        },
+        "nextLink": {
+          "type": "string"
+        }
+      }
+    },
+    "ListContainerItem": {
+      "type": "object",
+      "description": "The blob container properties be listed out.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ContainerProperties",
+          "description": "The blob container properties be listed out.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/AzureEntityResource"
+        }
+      ]
+    },
+    "ListContainerItems": {
+      "type": "object",
+      "description": "Response schema. Contains list of blobs returned, and if paging is requested or required, a URL to next page of containers.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ListContainerItem items on this page",
+          "items": {
+            "$ref": "#/definitions/ListContainerItem"
+          },
+          "readOnly": true
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ListQueue": {
+      "type": "object",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ListQueueProperties",
+          "description": "List Queue resource properties.",
+          "x-ms-client-flatten": true,
+          "x-ms-client-name": "QueueProperties"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/Resource"
+        }
+      ]
+    },
+    "ListQueueProperties": {
+      "type": "object",
+      "properties": {
+        "metadata": {
+          "type": "object",
+          "description": "A name-value pair that represents queue metadata.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ListQueueResource": {
+      "type": "object",
+      "description": "Response schema. Contains list of queues returned",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ListQueue items on this page",
+          "items": {
+            "$ref": "#/definitions/ListQueue"
+          },
+          "readOnly": true
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ListQueueServices": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "List of queue services returned.",
+          "items": {
+            "$ref": "#/definitions/QueueServiceProperties"
+          },
+          "readOnly": true
+        }
+      }
+    },
+    "ListServiceSasResponse": {
+      "type": "object",
+      "description": "The List service SAS credentials operation response.",
+      "properties": {
+        "serviceSasToken": {
+          "type": "string",
+          "description": "List service SAS credentials of specific resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "ListTableResource": {
+      "type": "object",
+      "description": "Response schema. Contains list of tables returned",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The Table items on this page",
+          "items": {
+            "$ref": "#/definitions/Table"
+          },
+          "readOnly": true
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ListTableServices": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "List of table services returned.",
+          "items": {
+            "$ref": "#/definitions/TableServiceProperties"
+          },
+          "readOnly": true
+        }
+      }
+    },
+    "LocalUser": {
+      "type": "object",
+      "description": "The local user associated with the storage accounts.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/LocalUserProperties",
+          "description": "Storage account local user properties.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "LocalUserKeys": {
+      "type": "object",
+      "description": "The Storage Account Local User keys.",
+      "properties": {
+        "sshAuthorizedKeys": {
+          "type": "array",
+          "description": "Optional, local user ssh authorized keys for SFTP.",
+          "items": {
+            "$ref": "#/definitions/SshPublicKey"
+          },
+          "x-ms-identifiers": []
+        },
+        "sharedKey": {
+          "type": "string",
+          "format": "password",
+          "description": "Auto generated by the server for SMB authentication.",
+          "readOnly": true,
+          "x-ms-secret": true
+        }
+      }
+    },
+    "LocalUserProperties": {
+      "type": "object",
+      "description": "The Storage Account Local User properties.",
+      "properties": {
+        "permissionScopes": {
+          "type": "array",
+          "description": "The permission scopes of the local user.",
+          "items": {
+            "$ref": "#/definitions/PermissionScope"
+          },
+          "x-ms-identifiers": []
+        },
+        "homeDirectory": {
+          "type": "string",
+          "description": "Optional, local user home directory."
+        },
+        "sshAuthorizedKeys": {
+          "type": "array",
+          "description": "Optional, local user ssh authorized keys for SFTP.",
+          "items": {
+            "$ref": "#/definitions/SshPublicKey"
+          },
+          "x-ms-identifiers": []
+        },
+        "sid": {
+          "type": "string",
+          "description": "A unique Security Identifier that is generated by the server.",
+          "readOnly": true
+        },
+        "hasSharedKey": {
+          "type": "boolean",
+          "description": "Indicates whether shared key exists. Set it to false to remove existing shared key."
+        },
+        "hasSshKey": {
+          "type": "boolean",
+          "description": "Indicates whether ssh key exists. Set it to false to remove existing SSH key."
+        },
+        "hasSshPassword": {
+          "type": "boolean",
+          "description": "Indicates whether ssh password exists. Set it to false to remove existing SSH password."
+        },
+        "userId": {
+          "type": "integer",
+          "format": "int32",
+          "description": "A unique Identifier that is generated by the server.",
+          "readOnly": true
+        },
+        "groupId": {
+          "type": "integer",
+          "format": "int32",
+          "description": "An identifier for associating a group of users."
+        },
+        "allowAclAuthorization": {
+          "type": "boolean",
+          "description": "Indicates whether ACL authorization is allowed for this user. Set it to false to disallow using ACL authorization."
+        },
+        "extendedGroups": {
+          "type": "array",
+          "description": "Supplementary group membership. Only applicable for local users enabled for NFSv3 access.",
+          "items": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "isNFSv3Enabled": {
+          "type": "boolean",
+          "description": "Indicates if the local user is enabled for access with NFSv3 protocol."
+        }
+      }
+    },
+    "LocalUserRegeneratePasswordResult": {
+      "type": "object",
+      "description": "The secrets of Storage Account Local User.",
+      "properties": {
+        "sshPassword": {
+          "type": "string",
+          "format": "password",
+          "description": "Auto generated password by the server for SSH authentication if hasSshPassword is set to true on the creation of local user.",
+          "readOnly": true,
+          "x-ms-secret": true
+        }
+      }
+    },
+    "LocalUsers": {
+      "type": "object",
+      "description": "List of local users requested, and if paging is required, a URL to the next page of local users.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The LocalUser items on this page",
+          "items": {
+            "$ref": "#/definitions/LocalUser"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ManagedIdentityAuthProperties": {
+      "type": "object",
+      "description": "The managed identity auth properties for dataShare connection.",
+      "properties": {
+        "identityResourceId": {
+          "type": "string",
+          "description": "ARM ResourceId of the managed identity that should be used to authenticate to the backing data source."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/StorageConnectorAuthProperties"
+        }
+      ],
+      "x-ms-discriminator-value": "ManagedIdentity"
+    },
+    "ManagedIdentityAuthPropertiesUpdate": {
+      "type": "object",
+      "description": "The managed identity auth properties for dataShare connection.",
+      "properties": {
+        "identityResourceId": {
+          "type": "string",
+          "description": "ARM ResourceId of the managed identity that should be used to authenticate to the backing data source."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/StorageConnectorAuthPropertiesUpdate"
+        }
+      ],
+      "x-ms-discriminator-value": "ManagedIdentity"
+    },
+    "ManagementPolicy": {
+      "type": "object",
+      "description": "The Get Storage Account ManagementPolicies operation response.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ManagementPolicyProperties",
+          "description": "Returns the Storage Account Data Policies Rules.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "ManagementPolicyAction": {
+      "type": "object",
+      "description": "Actions are applied to the filtered blobs when the execution condition is met.",
+      "properties": {
+        "baseBlob": {
+          "$ref": "#/definitions/ManagementPolicyBaseBlob",
+          "description": "The management policy action for base blob"
+        },
+        "snapshot": {
+          "$ref": "#/definitions/ManagementPolicySnapShot",
+          "description": "The management policy action for snapshot"
+        },
+        "version": {
+          "$ref": "#/definitions/ManagementPolicyVersion",
+          "description": "The management policy action for version"
+        }
+      }
+    },
+    "ManagementPolicyBaseBlob": {
+      "type": "object",
+      "description": "Management policy action for base blob.",
+      "properties": {
+        "tierToCool": {
+          "$ref": "#/definitions/DateAfterModification",
+          "description": "The function to tier blobs to cool storage."
+        },
+        "tierToArchive": {
+          "$ref": "#/definitions/DateAfterModification",
+          "description": "The function to tier blobs to archive storage."
+        },
+        "tierToCold": {
+          "$ref": "#/definitions/DateAfterModification",
+          "description": "The function to tier blobs to cold storage."
+        },
+        "tierToHot": {
+          "$ref": "#/definitions/DateAfterModification",
+          "description": "The function to tier blobs to hot storage. This action can only be used with Premium Block Blob Storage Accounts"
+        },
+        "delete": {
+          "$ref": "#/definitions/DateAfterModification",
+          "description": "The function to delete the blob"
+        },
+        "enableAutoTierToHotFromCool": {
+          "type": "boolean",
+          "description": "This property enables auto tiering of a blob from cool to hot on a blob access. This property requires tierToCool.daysAfterLastAccessTimeGreaterThan."
+        }
+      }
+    },
+    "ManagementPolicyDefinition": {
+      "type": "object",
+      "description": "An object that defines the Lifecycle rule. Each definition is made up with a filters set and an actions set.",
+      "properties": {
+        "actions": {
+          "$ref": "#/definitions/ManagementPolicyAction",
+          "description": "An object that defines the action set."
+        },
+        "filters": {
+          "$ref": "#/definitions/ManagementPolicyFilter",
+          "description": "An object that defines the filter set."
+        }
+      },
+      "required": [
+        "actions"
+      ]
+    },
+    "ManagementPolicyFilter": {
+      "type": "object",
+      "description": "Filters limit rule actions to a subset of blobs within the storage account. If multiple filters are defined, a logical AND is performed on all filters.",
+      "properties": {
+        "prefixMatch": {
+          "type": "array",
+          "description": "An array of strings for prefixes to be match.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "blobTypes": {
+          "type": "array",
+          "description": "An array of predefined enum values. Currently blockBlob supports all tiering and delete actions. Only delete actions are supported for appendBlob.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "blobIndexMatch": {
+          "type": "array",
+          "description": "An array of blob index tag based filters, there can be at most 10 tag filters",
+          "items": {
+            "$ref": "#/definitions/TagFilter"
+          }
+        }
+      },
+      "required": [
+        "blobTypes"
+      ]
+    },
+    "ManagementPolicyProperties": {
+      "type": "object",
+      "description": "The Storage Account ManagementPolicy properties.",
+      "properties": {
+        "lastModifiedTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Returns the date and time the ManagementPolicies was last modified.",
+          "readOnly": true
+        },
+        "policy": {
+          "$ref": "#/definitions/ManagementPolicySchema",
+          "description": "The Storage Account ManagementPolicy, in JSON format. See more details in: https://learn.microsoft.com/azure/storage/blobs/lifecycle-management-overview."
+        }
+      },
+      "required": [
+        "policy"
+      ]
+    },
+    "ManagementPolicyRule": {
+      "type": "object",
+      "description": "An object that wraps the Lifecycle rule. Each rule is uniquely defined by name.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Rule is enabled if set to true."
+        },
+        "name": {
+          "type": "string",
+          "description": "A rule name can contain any combination of alpha numeric characters. Rule name is case-sensitive. It must be unique within a policy."
+        },
+        "type": {
+          "$ref": "#/definitions/RuleType",
+          "description": "The valid value is Lifecycle"
+        },
+        "definition": {
+          "$ref": "#/definitions/ManagementPolicyDefinition",
+          "description": "An object that defines the Lifecycle rule."
+        }
+      },
+      "required": [
+        "name",
+        "type",
+        "definition"
+      ]
+    },
+    "ManagementPolicySchema": {
+      "type": "object",
+      "description": "The Storage Account ManagementPolicies Rules. See more details in: https://learn.microsoft.com/azure/storage/blobs/lifecycle-management-overview.",
+      "properties": {
+        "rules": {
+          "type": "array",
+          "description": "The Storage Account ManagementPolicies Rules. See more details in: https://learn.microsoft.com/azure/storage/blobs/lifecycle-management-overview.",
+          "items": {
+            "$ref": "#/definitions/ManagementPolicyRule"
+          }
+        }
+      },
+      "required": [
+        "rules"
+      ]
+    },
+    "ManagementPolicySnapShot": {
+      "type": "object",
+      "description": "Management policy action for snapshot.",
+      "properties": {
+        "tierToCool": {
+          "$ref": "#/definitions/DateAfterCreation",
+          "description": "The function to tier blob snapshot to cool storage."
+        },
+        "tierToArchive": {
+          "$ref": "#/definitions/DateAfterCreation",
+          "description": "The function to tier blob snapshot to archive storage."
+        },
+        "tierToCold": {
+          "$ref": "#/definitions/DateAfterCreation",
+          "description": "The function to tier blobs to cold storage."
+        },
+        "tierToHot": {
+          "$ref": "#/definitions/DateAfterCreation",
+          "description": "The function to tier blobs to hot storage. This action can only be used with Premium Block Blob Storage Accounts"
+        },
+        "delete": {
+          "$ref": "#/definitions/DateAfterCreation",
+          "description": "The function to delete the blob snapshot"
+        }
+      }
+    },
+    "ManagementPolicyVersion": {
+      "type": "object",
+      "description": "Management policy action for blob version.",
+      "properties": {
+        "tierToCool": {
+          "$ref": "#/definitions/DateAfterCreation",
+          "description": "The function to tier blob version to cool storage."
+        },
+        "tierToArchive": {
+          "$ref": "#/definitions/DateAfterCreation",
+          "description": "The function to tier blob version to archive storage."
+        },
+        "tierToCold": {
+          "$ref": "#/definitions/DateAfterCreation",
+          "description": "The function to tier blobs to cold storage."
+        },
+        "tierToHot": {
+          "$ref": "#/definitions/DateAfterCreation",
+          "description": "The function to tier blobs to hot storage. This action can only be used with Premium Block Blob Storage Accounts"
+        },
+        "delete": {
+          "$ref": "#/definitions/DateAfterCreation",
+          "description": "The function to delete the blob version"
+        }
+      }
+    },
+    "MetricSpecification": {
+      "type": "object",
+      "description": "Metric specification of operation.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of metric specification."
+        },
+        "displayName": {
+          "type": "string",
+          "description": "Display name of metric specification."
+        },
+        "displayDescription": {
+          "type": "string",
+          "description": "Display description of metric specification."
+        },
+        "unit": {
+          "type": "string",
+          "description": "Unit could be Bytes or Count."
+        },
+        "dimensions": {
+          "type": "array",
+          "description": "Dimensions of blobs, including blob type and access tier.",
+          "items": {
+            "$ref": "#/definitions/Dimension"
+          }
+        },
+        "aggregationType": {
+          "type": "string",
+          "description": "Aggregation type could be Average."
+        },
+        "fillGapWithZero": {
+          "type": "boolean",
+          "description": "The property to decide fill gap with zero or not."
+        },
+        "category": {
+          "type": "string",
+          "description": "The category this metric specification belong to, could be Capacity."
+        },
+        "resourceIdDimensionNameOverride": {
+          "type": "string",
+          "description": "Account Resource Id."
+        }
+      }
+    },
+    "MetricsEmitted": {
+      "type": "string",
+      "description": "The metrics emitted by the advanced platform metrics rule.",
+      "enum": [
+        "ContainerBlobCount",
+        "ContainerUsedSize"
+      ],
+      "x-ms-enum": {
+        "name": "MetricsEmitted",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "ContainerBlobCount",
+            "value": "ContainerBlobCount",
+            "description": "Container blob count metric"
+          },
+          {
+            "name": "ContainerUsedSize",
+            "value": "ContainerUsedSize",
+            "description": "Container used size metric"
+          }
+        ]
+      }
+    },
+    "MigrationState": {
+      "type": "string",
+      "description": "This property denotes the container level immutability to object level immutability migration state.",
+      "enum": [
+        "InProgress",
+        "Completed"
+      ],
+      "x-ms-enum": {
+        "name": "MigrationState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "InProgress",
+            "value": "InProgress"
+          },
+          {
+            "name": "Completed",
+            "value": "Completed"
+          }
+        ]
+      }
+    },
+    "MinimumTlsVersion": {
+      "type": "string",
+      "description": "Set the minimum TLS version to be permitted on requests to storage. The default interpretation is TLS 1.0 for this property. Minimum TLS version 1.3 version is not supported.",
+      "enum": [
+        "TLS1_0",
+        "TLS1_1",
+        "TLS1_2",
+        "TLS1_3"
+      ],
+      "x-ms-enum": {
+        "name": "MinimumTlsVersion",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "TLS1_0",
+            "value": "TLS1_0"
+          },
+          {
+            "name": "TLS1_1",
+            "value": "TLS1_1"
+          },
+          {
+            "name": "TLS1_2",
+            "value": "TLS1_2"
+          },
+          {
+            "name": "TLS1_3",
+            "value": "TLS1_3"
+          }
+        ]
+      }
+    },
+    "Multichannel": {
+      "type": "object",
+      "description": "Multichannel setting. Applies to Premium FileStorage only.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Indicates whether multichannel is enabled"
+        }
+      }
+    },
+    "Name": {
+      "type": "string",
+      "description": "Name of the policy. The valid value is AccessTimeTracking. This field is currently read only",
+      "enum": [
+        "AccessTimeTracking"
+      ],
+      "x-ms-enum": {
+        "name": "Name",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "AccessTimeTracking",
+            "value": "AccessTimeTracking"
+          }
+        ]
+      }
+    },
+    "NativeDataSharingProvisioningState": {
+      "type": "string",
+      "description": "Provisioning state of the resource at the time the operation was called.",
+      "enum": [
+        "Accepted",
+        "Creating",
+        "Succeeded",
+        "Deleting",
+        "Canceled",
+        "Failed"
+      ],
+      "x-ms-enum": {
+        "name": "NativeDataSharingProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Accepted",
+            "value": "Accepted",
+            "description": "The request has been accepted for processing."
+          },
+          {
+            "name": "Creating",
+            "value": "Creating",
+            "description": "The resource is being created."
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "The resource has been successfully created."
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "The resource is being deleted."
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "The request has been canceled."
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "The resource creation or deletion has failed."
+          }
+        ]
+      },
+      "readOnly": true
+    },
+    "NetworkRuleSet": {
+      "type": "object",
+      "description": "Network rule set",
+      "properties": {
+        "bypass": {
+          "type": "string",
+          "description": "Specifies whether traffic is bypassed for Logging/Metrics/AzureServices. Possible values are any combination of Logging|Metrics|AzureServices (For example, \"Logging, Metrics\"), or None to bypass none of those traffics.",
+          "default": "AzureServices",
+          "enum": [
+            "None",
+            "Logging",
+            "Metrics",
+            "AzureServices"
+          ],
+          "x-ms-enum": {
+            "name": "Bypass",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "None",
+                "value": "None"
+              },
+              {
+                "name": "Logging",
+                "value": "Logging"
+              },
+              {
+                "name": "Metrics",
+                "value": "Metrics"
+              },
+              {
+                "name": "AzureServices",
+                "value": "AzureServices"
+              }
+            ]
+          },
+          "x-ms-client-name": "Bypass"
+        },
+        "resourceAccessRules": {
+          "type": "array",
+          "description": "Sets the resource access rules",
+          "items": {
+            "$ref": "#/definitions/ResourceAccessRule"
+          },
+          "x-ms-identifiers": []
+        },
+        "virtualNetworkRules": {
+          "type": "array",
+          "description": "Sets the virtual network rules",
+          "items": {
+            "$ref": "#/definitions/VirtualNetworkRule"
+          }
+        },
+        "ipRules": {
+          "type": "array",
+          "description": "Sets the IP ACL rules",
+          "items": {
+            "$ref": "#/definitions/IPRule"
+          },
+          "x-ms-identifiers": []
+        },
+        "ipv6Rules": {
+          "type": "array",
+          "description": "Sets the IPv6 ACL rules.",
+          "items": {
+            "$ref": "#/definitions/IPRule"
+          },
+          "x-ms-identifiers": []
+        },
+        "defaultAction": {
+          "type": "string",
+          "description": "Specifies the default action of allow or deny when no other rules match.",
+          "default": "Allow",
+          "enum": [
+            "Allow",
+            "Deny"
+          ],
+          "x-ms-enum": {
+            "name": "DefaultAction",
+            "modelAsString": false
+          }
+        }
+      },
+      "required": [
+        "defaultAction"
+      ]
+    },
+    "NetworkSecurityPerimeter": {
+      "type": "object",
+      "description": "NetworkSecurityPerimeter related information",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The ARM identifier of the resource"
+        },
+        "perimeterGuid": {
+          "type": "string",
+          "description": "Guid of the resource"
+        },
+        "location": {
+          "type": "string",
+          "description": "Location of the resource",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        }
+      }
+    },
+    "NetworkSecurityPerimeterConfiguration": {
+      "type": "object",
+      "description": "The Network Security Perimeter configuration resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/NetworkSecurityPerimeterConfigurationProperties",
+          "description": "Properties of the Network Security Perimeter Configuration",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "NetworkSecurityPerimeterConfigurationList": {
+      "type": "object",
+      "description": "Result of the List Network Security Perimeter configuration operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The NetworkSecurityPerimeterConfiguration items on this page",
+          "items": {
+            "$ref": "#/definitions/NetworkSecurityPerimeterConfiguration"
+          },
+          "readOnly": true
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "NetworkSecurityPerimeterConfigurationProperties": {
+      "type": "object",
+      "description": "Properties of the Network Security Perimeter Configuration",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/NetworkSecurityPerimeterConfigurationProvisioningState",
+          "description": "Provisioning state of Network Security Perimeter configuration propagation",
+          "readOnly": true
+        },
+        "provisioningIssues": {
+          "type": "array",
+          "description": "List of Provisioning Issues if any",
+          "items": {
+            "$ref": "#/definitions/ProvisioningIssue"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": [
+            "name"
+          ]
+        },
+        "networkSecurityPerimeter": {
+          "$ref": "#/definitions/NetworkSecurityPerimeter",
+          "description": "NetworkSecurityPerimeter related information",
+          "readOnly": true
+        },
+        "resourceAssociation": {
+          "$ref": "#/definitions/NetworkSecurityPerimeterConfigurationPropertiesResourceAssociation",
+          "description": "Information about resource association",
+          "readOnly": true
+        },
+        "profile": {
+          "$ref": "#/definitions/NetworkSecurityPerimeterConfigurationPropertiesProfile",
+          "description": "Network Security Perimeter profile",
+          "readOnly": true
+        }
+      }
+    },
+    "NetworkSecurityPerimeterConfigurationPropertiesProfile": {
+      "type": "object",
+      "description": "Network Security Perimeter profile",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the resource"
+        },
+        "accessRulesVersion": {
+          "type": "number",
+          "format": "float",
+          "description": "Current access rules version"
+        },
+        "accessRules": {
+          "type": "array",
+          "description": "List of Access Rules",
+          "items": {
+            "$ref": "#/definitions/NspAccessRule"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        },
+        "diagnosticSettingsVersion": {
+          "type": "number",
+          "format": "float",
+          "description": "Diagnostic settings version"
+        },
+        "enabledLogCategories": {
+          "type": "array",
+          "description": "Enabled logging categories",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "NetworkSecurityPerimeterConfigurationPropertiesResourceAssociation": {
+      "type": "object",
+      "description": "Information about resource association",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the resource association"
+        },
+        "accessMode": {
+          "$ref": "#/definitions/ResourceAssociationAccessMode",
+          "description": "Access Mode of the resource association"
+        }
+      }
+    },
+    "NetworkSecurityPerimeterConfigurationProvisioningState": {
+      "type": "string",
+      "description": "Provisioning state of Network Security Perimeter configuration propagation",
+      "enum": [
+        "Accepted",
+        "Succeeded",
+        "Failed",
+        "Deleting",
+        "Canceled"
+      ],
+      "x-ms-enum": {
+        "name": "NetworkSecurityPerimeterConfigurationProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Accepted",
+            "value": "Accepted"
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting"
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled"
+          }
+        ]
+      },
+      "readOnly": true
+    },
+    "NfsSetting": {
+      "type": "object",
+      "description": "Setting for NFS protocol",
+      "properties": {
+        "encryptionInTransit": {
+          "$ref": "#/definitions/EncryptionInTransit",
+          "description": "Encryption in transit setting."
+        }
+      }
+    },
+    "NspAccessRule": {
+      "type": "object",
+      "description": "Information of Access Rule in Network Security Perimeter profile",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the resource"
+        },
+        "properties": {
+          "$ref": "#/definitions/NspAccessRuleProperties",
+          "description": "Properties of Access Rule",
+          "readOnly": true
+        }
+      }
+    },
+    "NspAccessRuleDirection": {
+      "type": "string",
+      "description": "Direction of Access Rule",
+      "enum": [
+        "Inbound",
+        "Outbound"
+      ],
+      "x-ms-enum": {
+        "name": "NspAccessRuleDirection",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Inbound",
+            "value": "Inbound"
+          },
+          {
+            "name": "Outbound",
+            "value": "Outbound"
+          }
+        ]
+      }
+    },
+    "NspAccessRuleProperties": {
+      "type": "object",
+      "description": "Properties of Access Rule",
+      "properties": {
+        "direction": {
+          "$ref": "#/definitions/NspAccessRuleDirection",
+          "description": "Direction of Access Rule"
+        },
+        "addressPrefixes": {
+          "type": "array",
+          "description": "Address prefixes in the CIDR format for inbound rules",
+          "items": {
+            "type": "string"
+          }
+        },
+        "subscriptions": {
+          "type": "array",
+          "description": "Subscriptions for inbound rules",
+          "items": {
+            "$ref": "#/definitions/NspAccessRulePropertiesSubscriptionsItem"
+          }
+        },
+        "networkSecurityPerimeters": {
+          "type": "array",
+          "description": "NetworkSecurityPerimeters for inbound rules",
+          "items": {
+            "$ref": "#/definitions/NetworkSecurityPerimeter"
+          },
+          "readOnly": true
+        },
+        "fullyQualifiedDomainNames": {
+          "type": "array",
+          "description": "FQDN for outbound rules",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        }
+      }
+    },
+    "NspAccessRulePropertiesSubscriptionsItem": {
+      "type": "object",
+      "description": "Subscription for inbound rule",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The ARM identifier of subscription"
+        }
+      }
+    },
+    "ObjectReplicationPolicies": {
+      "type": "object",
+      "description": "List storage account object replication policies.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The replication policy between two storage accounts.",
+          "items": {
+            "$ref": "#/definitions/ObjectReplicationPolicy"
+          }
+        },
+        "nextLink": {
+          "type": "string"
+        }
+      }
+    },
+    "ObjectReplicationPolicy": {
+      "type": "object",
+      "description": "The replication policy between two storage accounts. Multiple rules can be defined in one policy.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ObjectReplicationPolicyProperties",
+          "description": "Returns the Storage Account Object Replication Policy.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "ObjectReplicationPolicyFilter": {
+      "type": "object",
+      "description": "Filters limit replication to a subset of blobs within the storage account. A logical OR is performed on values in the filter. If multiple filters are defined, a logical AND is performed on all filters.",
+      "properties": {
+        "prefixMatch": {
+          "type": "array",
+          "description": "Optional. Filters the results to replicate only blobs whose names begin with the specified prefix.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "minCreationTime": {
+          "type": "string",
+          "description": "Blobs created after the time will be replicated to the destination. It must be in datetime format 'yyyy-MM-ddTHH:mm:ssZ'. Example: 2020-02-19T16:05:00Z"
+        }
+      }
+    },
+    "ObjectReplicationPolicyProperties": {
+      "type": "object",
+      "description": "The Storage Account ObjectReplicationPolicy properties.",
+      "properties": {
+        "policyId": {
+          "type": "string",
+          "description": "A unique id for object replication policy.",
+          "readOnly": true
+        },
+        "enabledTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Indicates when the policy is enabled on the source account.",
+          "readOnly": true
+        },
+        "sourceAccount": {
+          "type": "string",
+          "description": "Required. Source account name. It should be full resource id if allowCrossTenantReplication set to false."
+        },
+        "destinationAccount": {
+          "type": "string",
+          "description": "Required. Destination account name. It should be full resource id if allowCrossTenantReplication set to false."
+        },
+        "rules": {
+          "type": "array",
+          "description": "The storage account object replication rules.",
+          "items": {
+            "$ref": "#/definitions/ObjectReplicationPolicyRule"
+          },
+          "x-ms-identifiers": []
+        },
+        "metrics": {
+          "$ref": "#/definitions/ObjectReplicationPolicyPropertiesMetrics",
+          "description": "Optional. The object replication policy metrics feature options."
+        },
+        "priorityReplication": {
+          "$ref": "#/definitions/ObjectReplicationPolicyPropertiesPriorityReplication",
+          "description": "Optional. The object replication policy priority replication feature options."
+        },
+        "tagsReplication": {
+          "$ref": "#/definitions/ObjectReplicationPolicyPropertiesTagsReplication",
+          "description": "Optional. The object replication policy tags replication feature options."
+        }
+      },
+      "required": [
+        "sourceAccount",
+        "destinationAccount"
+      ]
+    },
+    "ObjectReplicationPolicyPropertiesMetrics": {
+      "type": "object",
+      "description": "Optional. The object replication policy metrics feature options.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Indicates whether object replication metrics feature is enabled for the policy."
+        }
+      }
+    },
+    "ObjectReplicationPolicyPropertiesPriorityReplication": {
+      "type": "object",
+      "description": "Optional. The object replication policy priority replication feature options.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Indicates whether object replication priority replication feature is enabled for the policy."
+        }
+      }
+    },
+    "ObjectReplicationPolicyPropertiesTagsReplication": {
+      "type": "object",
+      "description": "Optional. The object replication policy tags replication feature options.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Indicates whether object replication tags replication feature is enabled for the policy."
+        }
+      }
+    },
+    "ObjectReplicationPolicyRule": {
+      "type": "object",
+      "description": "The replication policy rule between two containers.",
+      "properties": {
+        "ruleId": {
+          "type": "string",
+          "description": "Rule Id is auto-generated for each new rule on destination account. It is required for put policy on source account."
+        },
+        "sourceContainer": {
+          "type": "string",
+          "description": "Required. Source container name."
+        },
+        "destinationContainer": {
+          "type": "string",
+          "description": "Required. Destination container name."
+        },
+        "filters": {
+          "$ref": "#/definitions/ObjectReplicationPolicyFilter",
+          "description": "Optional. An object that defines the filter set."
+        }
+      },
+      "required": [
+        "sourceContainer",
+        "destinationContainer"
+      ]
+    },
+    "ObjectType": {
+      "type": "string",
+      "description": "This is a required field. This field specifies the scope of the inventory created either at the blob or container level.",
+      "enum": [
+        "Blob",
+        "Container"
+      ],
+      "x-ms-enum": {
+        "name": "ObjectType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Blob",
+            "value": "Blob"
+          },
+          {
+            "name": "Container",
+            "value": "Container"
+          }
+        ]
+      }
+    },
+    "Operation": {
+      "type": "object",
+      "description": "Storage REST API operation definition.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Operation name: {provider}/{resource}/{operation}"
+        },
+        "display": {
+          "$ref": "#/definitions/OperationDisplay",
+          "description": "Display metadata associated with the operation."
+        },
+        "origin": {
+          "type": "string",
+          "description": "The origin of operations."
+        },
+        "properties": {
+          "$ref": "#/definitions/OperationProperties",
+          "description": "Properties of operation, include metric specifications.",
+          "x-ms-client-flatten": true,
+          "x-ms-client-name": "operationProperties"
+        }
+      }
+    },
+    "OperationDisplay": {
+      "type": "object",
+      "description": "Display metadata associated with the operation.",
+      "properties": {
+        "provider": {
+          "type": "string",
+          "description": "Service provider: Microsoft Storage."
+        },
+        "resource": {
+          "type": "string",
+          "description": "Resource on which the operation is performed etc."
+        },
+        "operation": {
+          "type": "string",
+          "description": "Type of operation: get, read, delete, etc."
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of the operation."
+        }
+      }
+    },
+    "OperationListResult": {
+      "type": "object",
+      "description": "The list of available operations.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "List of operations supported by the resource provider.",
+          "items": {
+            "$ref": "#/definitions/Operation"
+          }
+        },
+        "nextLink": {
+          "type": "string"
+        }
+      }
+    },
+    "OperationProperties": {
+      "type": "object",
+      "description": "Properties of operation, include metric specifications.",
+      "properties": {
+        "serviceSpecification": {
+          "$ref": "#/definitions/ServiceSpecification",
+          "description": "One property of operation, include metric specifications."
+        }
+      }
+    },
+    "PermissionScope": {
+      "type": "object",
+      "properties": {
+        "permissions": {
+          "type": "string",
+          "description": "The permissions for the local user. Possible values include: Read (r), Write (w), Delete (d), List (l), Create (c), Modify Ownership (o), and Modify Permissions (p)."
+        },
+        "service": {
+          "type": "string",
+          "description": "The service used by the local user, e.g. blob, file."
+        },
+        "resourceName": {
+          "type": "string",
+          "description": "The name of resource, normally the container name or the file share name, used by the local user."
+        }
+      },
+      "required": [
+        "permissions",
+        "service",
+        "resourceName"
+      ]
+    },
+    "Permissions": {
+      "type": "string",
+      "description": "The signed permissions for the account SAS. Possible values include: Read (r), Write (w), Delete (d), List (l), Add (a), Create (c), Update (u) and Process (p).",
+      "enum": [
+        "r",
+        "d",
+        "w",
+        "l",
+        "a",
+        "c",
+        "u",
+        "p"
+      ],
+      "x-ms-enum": {
+        "name": "Permissions",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "r",
+            "value": "r"
+          },
+          {
+            "name": "d",
+            "value": "d"
+          },
+          {
+            "name": "w",
+            "value": "w"
+          },
+          {
+            "name": "l",
+            "value": "l"
+          },
+          {
+            "name": "a",
+            "value": "a"
+          },
+          {
+            "name": "c",
+            "value": "c"
+          },
+          {
+            "name": "u",
+            "value": "u"
+          },
+          {
+            "name": "p",
+            "value": "p"
+          }
+        ]
+      }
+    },
+    "Placement": {
+      "type": "object",
+      "description": "The complex type of the zonal placement details.",
+      "properties": {
+        "zonePlacementPolicy": {
+          "$ref": "#/definitions/ZonePlacementPolicy",
+          "description": "The availability zone pinning policy for the storage account."
+        }
+      }
+    },
+    "PolicyViolationAction": {
+      "type": "string",
+      "description": "The action to perform when a user delegation SAS (shared access signature) policy requirement is violated.",
+      "enum": [
+        "None",
+        "Log",
+        "Block"
+      ],
+      "x-ms-enum": {
+        "name": "PolicyViolationAction",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "None",
+            "value": "None",
+            "description": "No action is taken when the policy requirement is violated."
+          },
+          {
+            "name": "Log",
+            "value": "Log",
+            "description": "The policy violation is logged for audit purposes."
+          },
+          {
+            "name": "Block",
+            "value": "Block",
+            "description": "The request is blocked and denied when the policy requirement is violated."
+          }
+        ]
+      }
+    },
+    "PostFailoverRedundancy": {
+      "type": "string",
+      "description": "The redundancy type of the account after an account failover is performed.",
+      "enum": [
+        "Standard_LRS",
+        "Standard_ZRS"
+      ],
+      "x-ms-enum": {
+        "name": "PostFailoverRedundancy",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Standard_LRS",
+            "value": "Standard_LRS"
+          },
+          {
+            "name": "Standard_ZRS",
+            "value": "Standard_ZRS"
+          }
+        ]
+      }
+    },
+    "PostPlannedFailoverRedundancy": {
+      "type": "string",
+      "description": "The redundancy type of the account after a planned account failover is performed.",
+      "enum": [
+        "Standard_GRS",
+        "Standard_GZRS",
+        "Standard_RAGRS",
+        "Standard_RAGZRS"
+      ],
+      "x-ms-enum": {
+        "name": "PostPlannedFailoverRedundancy",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Standard_GRS",
+            "value": "Standard_GRS"
+          },
+          {
+            "name": "Standard_GZRS",
+            "value": "Standard_GZRS"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "value": "Standard_RAGRS"
+          },
+          {
+            "name": "Standard_RAGZRS",
+            "value": "Standard_RAGZRS"
+          }
+        ]
+      }
+    },
+    "PrivateEndpoint": {
+      "type": "object",
+      "description": "The Private Endpoint resource.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The ARM identifier for Private Endpoint",
+          "readOnly": true
+        }
+      }
+    },
+    "PrivateEndpointConnection": {
+      "type": "object",
+      "description": "The Private Endpoint Connection resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/PrivateEndpointConnectionProperties",
+          "description": "Resource properties.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "PrivateEndpointConnectionListResult": {
+      "type": "object",
+      "description": "List of private endpoint connection associated with the specified storage account",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "Array of private endpoint connections",
+          "items": {
+            "$ref": "#/definitions/PrivateEndpointConnection"
+          }
+        },
+        "nextLink": {
+          "type": "string"
+        }
+      }
+    },
+    "PrivateEndpointConnectionProperties": {
+      "type": "object",
+      "description": "Properties of the PrivateEndpointConnectProperties.",
+      "properties": {
+        "privateEndpoint": {
+          "$ref": "#/definitions/PrivateEndpoint",
+          "description": "The resource of private end point."
+        },
+        "privateLinkServiceConnectionState": {
+          "$ref": "#/definitions/PrivateLinkServiceConnectionState",
+          "description": "A collection of information about the state of the connection between service consumer and provider."
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/PrivateEndpointConnectionProvisioningState",
+          "description": "The provisioning state of the private endpoint connection resource.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "privateLinkServiceConnectionState"
+      ]
+    },
+    "PrivateEndpointConnectionProvisioningState": {
+      "type": "string",
+      "description": "The current provisioning state.",
+      "enum": [
+        "Succeeded",
+        "Creating",
+        "Deleting",
+        "Failed"
+      ],
+      "x-ms-enum": {
+        "name": "PrivateEndpointConnectionProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Succeeded",
+            "value": "Succeeded"
+          },
+          {
+            "name": "Creating",
+            "value": "Creating"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed"
+          }
+        ]
+      },
+      "readOnly": true
+    },
+    "PrivateEndpointServiceConnectionStatus": {
+      "type": "string",
+      "description": "The private endpoint connection status.",
+      "enum": [
+        "Pending",
+        "Approved",
+        "Rejected"
+      ],
+      "x-ms-enum": {
+        "name": "PrivateEndpointServiceConnectionStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Pending",
+            "value": "Pending"
+          },
+          {
+            "name": "Approved",
+            "value": "Approved"
+          },
+          {
+            "name": "Rejected",
+            "value": "Rejected"
+          }
+        ]
+      }
+    },
+    "PrivateLinkResource": {
+      "type": "object",
+      "description": "A private link resource",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/PrivateLinkResourceProperties",
+          "description": "Resource properties.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/Resource"
+        }
+      ]
+    },
+    "PrivateLinkResourceListResult": {
+      "type": "object",
+      "description": "A list of private link resources",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "Array of private link resources",
+          "items": {
+            "$ref": "#/definitions/PrivateLinkResource"
+          }
+        }
+      }
+    },
+    "PrivateLinkResourceProperties": {
+      "type": "object",
+      "description": "Properties of a private link resource.",
+      "properties": {
+        "groupId": {
+          "type": "string",
+          "description": "The private link resource group id.",
+          "readOnly": true
+        },
+        "requiredMembers": {
+          "type": "array",
+          "description": "The private link resource required member names.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "requiredZoneNames": {
+          "type": "array",
+          "description": "The private link resource Private link DNS zone name.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "PrivateLinkServiceConnectionState": {
+      "type": "object",
+      "description": "A collection of information about the state of the connection between service consumer and provider.",
+      "properties": {
+        "status": {
+          "$ref": "#/definitions/PrivateEndpointServiceConnectionStatus",
+          "description": "Indicates whether the connection has been Approved/Rejected/Removed by the owner of the service."
+        },
+        "description": {
+          "type": "string",
+          "description": "The reason for approval/rejection of the connection."
+        },
+        "actionRequired": {
+          "type": "string",
+          "description": "A message indicating if changes on the service provider require any updates on the consumer."
+        }
+      }
+    },
+    "ProtectedAppendWritesHistory": {
+      "type": "object",
+      "description": "Protected append writes history setting for the blob container with Legal holds.",
+      "properties": {
+        "allowProtectedAppendWritesAll": {
+          "type": "boolean",
+          "description": "When enabled, new blocks can be written to both 'Append and Bock Blobs' while maintaining legal hold protection and compliance. Only new blocks can be added and any existing blocks cannot be modified or deleted."
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Returns the date and time the tag was added.",
+          "readOnly": true
+        }
+      }
+    },
+    "ProtocolSettings": {
+      "type": "object",
+      "description": "Protocol settings for file service",
+      "properties": {
+        "smb": {
+          "$ref": "#/definitions/SmbSetting",
+          "description": "Setting for SMB protocol"
+        },
+        "nfs": {
+          "$ref": "#/definitions/NfsSetting",
+          "description": "Setting for NFS protocol"
+        }
+      }
+    },
+    "ProvisioningIssue": {
+      "type": "object",
+      "description": "Describes provisioning issue for given NetworkSecurityPerimeterConfiguration",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the issue"
+        },
+        "properties": {
+          "$ref": "#/definitions/ProvisioningIssueProperties",
+          "description": "Properties of provisioning issue",
+          "readOnly": true
+        }
+      }
+    },
+    "ProvisioningIssueProperties": {
+      "type": "object",
+      "description": "Properties of provisioning issue",
+      "properties": {
+        "issueType": {
+          "$ref": "#/definitions/IssueType",
+          "description": "Type of issue"
+        },
+        "severity": {
+          "$ref": "#/definitions/Severity",
+          "description": "Severity of the issue."
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of the issue"
+        }
+      }
+    },
+    "ProvisioningState": {
+      "type": "string",
+      "description": "Gets the status of the storage account at the time the operation was called.",
+      "enum": [
+        "Creating",
+        "ResolvingDNS",
+        "Succeeded"
+      ],
+      "x-ms-enum": {
+        "name": "ProvisioningState",
+        "modelAsString": false,
+        "values": [
+          {
+            "name": "Creating",
+            "value": "Creating"
+          },
+          {
+            "name": "ResolvingDNS",
+            "value": "ResolvingDNS"
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded"
+          }
+        ]
+      }
+    },
+    "PublicAccess": {
+      "type": "string",
+      "description": "Specifies whether data in the container may be accessed publicly and the level of access.",
+      "enum": [
+        "Container",
+        "Blob",
+        "None"
+      ],
+      "x-ms-enum": {
+        "name": "PublicAccess",
+        "modelAsString": false
+      }
+    },
+    "PublicNetworkAccess": {
+      "type": "string",
+      "description": "Allow, disallow, or let Network Security Perimeter configuration to evaluate public network access to Storage Account. Value is optional but if passed in, must be 'Enabled', 'Disabled' or 'SecuredByPerimeter'.",
+      "enum": [
+        "Enabled",
+        "Disabled",
+        "SecuredByPerimeter"
+      ],
+      "x-ms-enum": {
+        "name": "PublicNetworkAccess",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Enabled",
+            "value": "Enabled"
+          },
+          {
+            "name": "Disabled",
+            "value": "Disabled"
+          },
+          {
+            "name": "SecuredByPerimeter",
+            "value": "SecuredByPerimeter"
+          }
+        ]
+      }
+    },
+    "QueueProperties": {
+      "type": "object",
+      "properties": {
+        "metadata": {
+          "type": "object",
+          "description": "A name-value pair that represents queue metadata.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "approximateMessageCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Integer indicating an approximate number of messages in the queue. This number is not lower than the actual number of messages in the queue, but could be higher.",
+          "readOnly": true
+        }
+      }
+    },
+    "QueueServiceProperties": {
+      "type": "object",
+      "description": "The properties of a storage account’s Queue service.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/QueueServicePropertiesProperties",
+          "description": "The properties of a storage account’s Queue service.",
+          "x-ms-client-flatten": true,
+          "x-ms-client-name": "QueueServiceProperties"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "QueueServicePropertiesProperties": {
+      "type": "object",
+      "description": "The properties of a storage account’s Queue service.",
+      "properties": {
+        "cors": {
+          "$ref": "#/definitions/CorsRules",
+          "description": "Specifies CORS rules for the Queue service. You can include up to five CorsRule elements in the request. If no CorsRule elements are included in the request body, all CORS rules will be deleted, and CORS will be disabled for the Queue service."
+        }
+      }
+    },
+    "Reason": {
+      "type": "string",
+      "description": "Gets the reason that a storage account name could not be used. The Reason element is only returned if NameAvailable is false.",
+      "enum": [
+        "AccountNameInvalid",
+        "AlreadyExists"
+      ],
+      "x-ms-enum": {
+        "name": "Reason",
+        "modelAsString": false
+      }
+    },
+    "ReasonCode": {
+      "type": "string",
+      "description": "The reason for the restriction. As of now this can be \"QuotaId\" or \"NotAvailableForSubscription\". Quota Id is set when the SKU has requiredQuotas parameter as the subscription does not belong to that quota. The \"NotAvailableForSubscription\" is related to capacity at DC.",
+      "enum": [
+        "QuotaId",
+        "NotAvailableForSubscription"
+      ],
+      "x-ms-enum": {
+        "name": "ReasonCode",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "QuotaId",
+            "value": "QuotaId"
+          },
+          {
+            "name": "NotAvailableForSubscription",
+            "value": "NotAvailableForSubscription"
+          }
+        ]
+      }
+    },
+    "ResourceAccessRule": {
+      "type": "object",
+      "description": "Resource Access Rule.",
+      "properties": {
+        "tenantId": {
+          "type": "string",
+          "description": "Tenant Id"
+        },
+        "resourceId": {
+          "type": "string",
+          "description": "Resource Id"
+        }
+      }
+    },
+    "ResourceAssociationAccessMode": {
+      "type": "string",
+      "description": "Access Mode of the resource association",
+      "enum": [
+        "Enforced",
+        "Learning",
+        "Audit"
+      ],
+      "x-ms-enum": {
+        "name": "ResourceAssociationAccessMode",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Enforced",
+            "value": "Enforced"
+          },
+          {
+            "name": "Learning",
+            "value": "Learning"
+          },
+          {
+            "name": "Audit",
+            "value": "Audit"
+          }
+        ]
+      }
+    },
+    "RestorePolicyProperties": {
+      "type": "object",
+      "description": "The blob service properties for blob restore policy",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Blob restore is enabled if set to true."
+        },
+        "days": {
+          "type": "integer",
+          "format": "int32",
+          "description": "how long this blob can be restored. It should be great than zero and less than DeleteRetentionPolicy.days.",
+          "minimum": 1,
+          "maximum": 365
+        },
+        "lastEnabledTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Deprecated in favor of minRestoreTime property.",
+          "readOnly": true
+        },
+        "minRestoreTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Returns the minimum date and time that the restore can be started.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "enabled"
+      ]
+    },
+    "Restriction": {
+      "type": "object",
+      "description": "The restriction because of which SKU cannot be used.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The type of restrictions. As of now only possible value for this is location.",
+          "readOnly": true
+        },
+        "values": {
+          "type": "array",
+          "description": "The value of restrictions. If the restriction type is set to location. This would be different locations where the SKU is restricted.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "reasonCode": {
+          "$ref": "#/definitions/ReasonCode",
+          "description": "The reason for the restriction. As of now this can be \"QuotaId\" or \"NotAvailableForSubscription\". Quota Id is set when the SKU has requiredQuotas parameter as the subscription does not belong to that quota. The \"NotAvailableForSubscription\" is related to capacity at DC."
+        }
+      }
+    },
+    "RootSquashType": {
+      "type": "string",
+      "description": "The property is for NFS share only. The default is NoRootSquash.",
+      "enum": [
+        "NoRootSquash",
+        "RootSquash",
+        "AllSquash"
+      ],
+      "x-ms-enum": {
+        "name": "RootSquashType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "NoRootSquash",
+            "value": "NoRootSquash"
+          },
+          {
+            "name": "RootSquash",
+            "value": "RootSquash"
+          },
+          {
+            "name": "AllSquash",
+            "value": "AllSquash"
+          }
+        ]
+      }
+    },
+    "RoutingChoice": {
+      "type": "string",
+      "description": "Routing Choice defines the kind of network routing opted by the user.",
+      "enum": [
+        "MicrosoftRouting",
+        "InternetRouting"
+      ],
+      "x-ms-enum": {
+        "name": "RoutingChoice",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "MicrosoftRouting",
+            "value": "MicrosoftRouting"
+          },
+          {
+            "name": "InternetRouting",
+            "value": "InternetRouting"
+          }
+        ]
+      }
+    },
+    "RoutingPreference": {
+      "type": "object",
+      "description": "Routing preference defines the type of network, either microsoft or internet routing to be used to deliver the user data, the default option is microsoft routing",
+      "properties": {
+        "routingChoice": {
+          "$ref": "#/definitions/RoutingChoice",
+          "description": "Routing Choice defines the kind of network routing opted by the user."
+        },
+        "publishMicrosoftEndpoints": {
+          "type": "boolean",
+          "description": "A boolean flag which indicates whether microsoft routing storage endpoints are to be published"
+        },
+        "publishInternetEndpoints": {
+          "type": "boolean",
+          "description": "A boolean flag which indicates whether internet routing storage endpoints are to be published"
+        }
+      }
+    },
+    "RuleType": {
+      "type": "string",
+      "description": "The valid value is Lifecycle",
+      "enum": [
+        "Lifecycle"
+      ],
+      "x-ms-enum": {
+        "name": "RuleType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Lifecycle",
+            "value": "Lifecycle"
+          }
+        ]
+      }
+    },
+    "RunResult": {
+      "type": "string",
+      "description": "Represents the overall result of the execution for the run instance",
+      "enum": [
+        "Succeeded",
+        "Failed"
+      ],
+      "x-ms-enum": {
+        "name": "RunResult",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Succeeded",
+            "value": "Succeeded"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed"
+          }
+        ]
+      },
+      "readOnly": true
+    },
+    "RunStatusEnum": {
+      "type": "string",
+      "description": "Represents the status of the execution.",
+      "enum": [
+        "InProgress",
+        "Finished"
+      ],
+      "x-ms-enum": {
+        "name": "RunStatusEnum",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "InProgress",
+            "value": "InProgress"
+          },
+          {
+            "name": "Finished",
+            "value": "Finished"
+          }
+        ]
+      }
+    },
+    "SKUCapability": {
+      "type": "object",
+      "description": "The capability information in the specified SKU, including file encryption, network ACLs, change notification, etc.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of capability, The capability information in the specified SKU, including file encryption, network ACLs, change notification, etc.",
+          "readOnly": true
+        },
+        "value": {
+          "type": "string",
+          "description": "A string value to indicate states of given capability. Possibly 'true' or 'false'.",
+          "readOnly": true
+        }
+      }
+    },
+    "SasPolicy": {
+      "type": "object",
+      "description": "SasPolicy assigned to the storage account.",
+      "properties": {
+        "sasExpirationPeriod": {
+          "type": "string",
+          "description": "The SAS expiration period, DD.HH:MM:SS."
+        },
+        "expirationAction": {
+          "type": "string",
+          "description": "The SAS Expiration Action defines the action to be performed when sasPolicy.sasExpirationPeriod is violated. The 'Log' action can be used for audit purposes and the 'Block' action can be used to block and deny the usage of SAS tokens that do not adhere to the sas policy expiration period.",
+          "default": "Log",
+          "enum": [
+            "Log",
+            "Block"
+          ],
+          "x-ms-enum": {
+            "name": "ExpirationAction",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "Log",
+                "value": "Log"
+              },
+              {
+                "name": "Block",
+                "value": "Block"
+              }
+            ]
+          }
+        },
+        "requireUserBoundUserDelegationSas": {
+          "type": "boolean",
+          "description": "Indicates whether user delegation SAS (shared access signature) tokens are required to be bound to a specific user. The default interpretation is false for this property."
+        },
+        "requireUserBoundUserDelegationSasAction": {
+          "$ref": "#/definitions/PolicyViolationAction",
+          "description": "The action to perform when a user delegation SAS (shared access signature) token is not bound to a user as required by requireUserBoundUserDelegationSas."
+        }
+      },
+      "required": [
+        "sasExpirationPeriod",
+        "expirationAction"
+      ]
+    },
+    "Schedule": {
+      "type": "string",
+      "description": "This is a required field. This field is used to schedule an inventory formation.",
+      "enum": [
+        "Daily",
+        "Weekly"
+      ],
+      "x-ms-enum": {
+        "name": "Schedule",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Daily",
+            "value": "Daily"
+          },
+          {
+            "name": "Weekly",
+            "value": "Weekly"
+          }
+        ]
+      }
+    },
+    "ServiceSasParameters": {
+      "type": "object",
+      "description": "The parameters to list service SAS credentials of a specific resource.",
+      "properties": {
+        "canonicalizedResource": {
+          "type": "string",
+          "description": "The canonical path to the signed resource."
+        },
+        "signedResource": {
+          "$ref": "#/definitions/SignedResource",
+          "description": "The signed services accessible with the service SAS. Possible values include: Blob (b), Container (c), File (f), Share (s).",
+          "x-ms-client-name": "Resource"
+        },
+        "signedPermission": {
+          "$ref": "#/definitions/Permissions",
+          "description": "The signed permissions for the service SAS. Possible values include: Read (r), Write (w), Delete (d), List (l), Add (a), Create (c), Update (u) and Process (p).",
+          "x-ms-client-name": "Permissions"
+        },
+        "signedIp": {
+          "type": "string",
+          "description": "An IP address or a range of IP addresses from which to accept requests.",
+          "x-ms-client-name": "IPAddressOrRange"
+        },
+        "signedProtocol": {
+          "$ref": "#/definitions/HttpProtocol",
+          "description": "The protocol permitted for a request made with the account SAS.",
+          "x-ms-client-name": "Protocols"
+        },
+        "signedStart": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The time at which the SAS becomes valid.",
+          "x-ms-client-name": "SharedAccessStartTime"
+        },
+        "signedExpiry": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The time at which the shared access signature becomes invalid.",
+          "x-ms-client-name": "SharedAccessExpiryTime"
+        },
+        "signedIdentifier": {
+          "type": "string",
+          "description": "A unique value up to 64 characters in length that correlates to an access policy specified for the container, queue, or table.",
+          "maxLength": 64,
+          "x-ms-client-name": "Identifier"
+        },
+        "startPk": {
+          "type": "string",
+          "description": "The start of partition key.",
+          "x-ms-client-name": "PartitionKeyStart"
+        },
+        "endPk": {
+          "type": "string",
+          "description": "The end of partition key.",
+          "x-ms-client-name": "PartitionKeyEnd"
+        },
+        "startRk": {
+          "type": "string",
+          "description": "The start of row key.",
+          "x-ms-client-name": "RowKeyStart"
+        },
+        "endRk": {
+          "type": "string",
+          "description": "The end of row key.",
+          "x-ms-client-name": "RowKeyEnd"
+        },
+        "keyToSign": {
+          "type": "string",
+          "description": "The key to sign the account SAS token with."
+        },
+        "rscc": {
+          "type": "string",
+          "description": "The response header override for cache control.",
+          "x-ms-client-name": "CacheControl"
+        },
+        "rscd": {
+          "type": "string",
+          "description": "The response header override for content disposition.",
+          "x-ms-client-name": "ContentDisposition"
+        },
+        "rsce": {
+          "type": "string",
+          "description": "The response header override for content encoding.",
+          "x-ms-client-name": "ContentEncoding"
+        },
+        "rscl": {
+          "type": "string",
+          "description": "The response header override for content language.",
+          "x-ms-client-name": "ContentLanguage"
+        },
+        "rsct": {
+          "type": "string",
+          "description": "The response header override for content type.",
+          "x-ms-client-name": "ContentType"
+        }
+      },
+      "required": [
+        "canonicalizedResource"
+      ]
+    },
+    "ServiceSharedKeyAccessProperties": {
+      "type": "object",
+      "description": "Defines shared key access settings for an individual storage service.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Indicates whether shared key access is enabled for the service."
+        }
+      }
+    },
+    "ServiceSpecification": {
+      "type": "object",
+      "description": "One property of operation, include metric specifications.",
+      "properties": {
+        "metricSpecifications": {
+          "type": "array",
+          "description": "Metric specifications of operation.",
+          "items": {
+            "$ref": "#/definitions/MetricSpecification"
+          }
+        }
+      }
+    },
+    "Services": {
+      "type": "string",
+      "description": "The signed services accessible with the account SAS. Possible values include: Blob (b), Queue (q), Table (t), File (f).",
+      "enum": [
+        "b",
+        "q",
+        "t",
+        "f"
+      ],
+      "x-ms-enum": {
+        "name": "Services",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "b",
+            "value": "b"
+          },
+          {
+            "name": "q",
+            "value": "q"
+          },
+          {
+            "name": "t",
+            "value": "t"
+          },
+          {
+            "name": "f",
+            "value": "f"
+          }
+        ]
+      }
+    },
+    "Severity": {
+      "type": "string",
+      "description": "Severity of the issue.",
+      "enum": [
+        "Warning",
+        "Error"
+      ],
+      "x-ms-enum": {
+        "name": "Severity",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Warning",
+            "value": "Warning"
+          },
+          {
+            "name": "Error",
+            "value": "Error"
+          }
+        ]
+      }
+    },
+    "ShareAccessTier": {
+      "type": "string",
+      "description": "Access tier for specific share. GpV2 account can choose between TransactionOptimized (default), Hot, and Cool. FileStorage account can choose Premium.",
+      "enum": [
+        "TransactionOptimized",
+        "Hot",
+        "Cool",
+        "Premium"
+      ],
+      "x-ms-enum": {
+        "name": "ShareAccessTier",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "TransactionOptimized",
+            "value": "TransactionOptimized"
+          },
+          {
+            "name": "Hot",
+            "value": "Hot"
+          },
+          {
+            "name": "Cool",
+            "value": "Cool"
+          },
+          {
+            "name": "Premium",
+            "value": "Premium"
+          }
+        ]
+      }
+    },
+    "SignedIdentifier": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "An unique identifier of the stored access policy."
+        },
+        "accessPolicy": {
+          "$ref": "#/definitions/AccessPolicy",
+          "description": "Access policy"
+        }
+      }
+    },
+    "SignedResource": {
+      "type": "string",
+      "description": "The signed services accessible with the service SAS. Possible values include: Blob (b), Container (c), File (f), Share (s).",
+      "enum": [
+        "b",
+        "c",
+        "f",
+        "s"
+      ],
+      "x-ms-enum": {
+        "name": "SignedResource",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "b",
+            "value": "b"
+          },
+          {
+            "name": "c",
+            "value": "c"
+          },
+          {
+            "name": "f",
+            "value": "f"
+          },
+          {
+            "name": "s",
+            "value": "s"
+          }
+        ]
+      }
+    },
+    "SignedResourceTypes": {
+      "type": "string",
+      "description": "The signed resource types that are accessible with the account SAS. Service (s): Access to service-level APIs; Container (c): Access to container-level APIs; Object (o): Access to object-level APIs for blobs, queue messages, table entities, and files.",
+      "enum": [
+        "s",
+        "c",
+        "o"
+      ],
+      "x-ms-enum": {
+        "name": "SignedResourceTypes",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "s",
+            "value": "s"
+          },
+          {
+            "name": "c",
+            "value": "c"
+          },
+          {
+            "name": "o",
+            "value": "o"
+          }
+        ]
+      }
+    },
+    "Sku": {
+      "type": "object",
+      "description": "The SKU of the storage account.",
+      "properties": {
+        "name": {
+          "$ref": "#/definitions/SkuName",
+          "description": "The SKU name. Required for account creation; optional for update. Note that in older versions, SKU name was called accountType."
+        },
+        "tier": {
+          "$ref": "#/definitions/SkuTier",
+          "description": "The SKU tier. This is based on the SKU name.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
+    "SkuConversionStatus": {
+      "type": "string",
+      "description": "This property indicates the current sku conversion status.",
+      "enum": [
+        "InProgress",
+        "Succeeded",
+        "Failed"
+      ],
+      "x-ms-enum": {
+        "name": "SkuConversionStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "InProgress",
+            "value": "InProgress"
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed"
+          }
+        ]
+      },
+      "readOnly": true
+    },
+    "SkuInformation": {
+      "type": "object",
+      "description": "Storage SKU and its properties",
+      "properties": {
+        "name": {
+          "$ref": "#/definitions/SkuName",
+          "description": "The SKU name. Required for account creation; optional for update. Note that in older versions, SKU name was called accountType."
+        },
+        "tier": {
+          "$ref": "#/definitions/SkuTier",
+          "description": "The SKU tier. This is based on the SKU name.",
+          "readOnly": true
+        },
+        "resourceType": {
+          "type": "string",
+          "description": "The type of the resource, usually it is 'storageAccounts'.",
+          "readOnly": true
+        },
+        "kind": {
+          "$ref": "#/definitions/Kind",
+          "description": "Indicates the type of storage account.",
+          "readOnly": true
+        },
+        "locations": {
+          "type": "array",
+          "description": "The set of locations that the SKU is available. This will be supported and registered Azure Geo Regions (e.g. West US, East US, Southeast Asia, etc.).",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "locationInfo": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SkuInformationLocationInfoItem"
+          },
+          "x-ms-identifiers": []
+        },
+        "capabilities": {
+          "type": "array",
+          "description": "The capability information in the specified SKU, including file encryption, network ACLs, change notification, etc.",
+          "items": {
+            "$ref": "#/definitions/SKUCapability"
+          },
+          "readOnly": true
+        },
+        "restrictions": {
+          "type": "array",
+          "description": "The restrictions because of which SKU cannot be used. This is empty if there are no restrictions.",
+          "items": {
+            "$ref": "#/definitions/Restriction"
+          },
+          "x-ms-identifiers": []
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
+    "SkuInformationLocationInfoItem": {
+      "type": "object",
+      "properties": {
+        "location": {
+          "type": "string",
+          "description": "Describes the location for the product where storage account resource can be created.",
+          "readOnly": true
+        },
+        "zones": {
+          "type": "array",
+          "description": "Describes the available zones for the product where storage account resource can be created.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        }
+      }
+    },
+    "SkuName": {
+      "type": "string",
+      "description": "The SKU name. Required for account creation; optional for update. Note that in older versions, SKU name was called accountType.",
+      "enum": [
+        "Standard_LRS",
+        "Standard_GRS",
+        "Standard_RAGRS",
+        "Standard_ZRS",
+        "Premium_LRS",
+        "Premium_ZRS",
+        "Standard_GZRS",
+        "Standard_RAGZRS",
+        "StandardV2_LRS",
+        "StandardV2_GRS",
+        "StandardV2_ZRS",
+        "StandardV2_GZRS",
+        "PremiumV2_LRS",
+        "PremiumV2_ZRS"
+      ],
+      "x-ms-enum": {
+        "name": "SkuName",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Standard_LRS",
+            "value": "Standard_LRS"
+          },
+          {
+            "name": "Standard_GRS",
+            "value": "Standard_GRS"
+          },
+          {
+            "name": "Standard_RAGRS",
+            "value": "Standard_RAGRS"
+          },
+          {
+            "name": "Standard_ZRS",
+            "value": "Standard_ZRS"
+          },
+          {
+            "name": "Premium_LRS",
+            "value": "Premium_LRS"
+          },
+          {
+            "name": "Premium_ZRS",
+            "value": "Premium_ZRS"
+          },
+          {
+            "name": "Standard_GZRS",
+            "value": "Standard_GZRS"
+          },
+          {
+            "name": "Standard_RAGZRS",
+            "value": "Standard_RAGZRS"
+          },
+          {
+            "name": "StandardV2_LRS",
+            "value": "StandardV2_LRS"
+          },
+          {
+            "name": "StandardV2_GRS",
+            "value": "StandardV2_GRS"
+          },
+          {
+            "name": "StandardV2_ZRS",
+            "value": "StandardV2_ZRS"
+          },
+          {
+            "name": "StandardV2_GZRS",
+            "value": "StandardV2_GZRS"
+          },
+          {
+            "name": "PremiumV2_LRS",
+            "value": "PremiumV2_LRS"
+          },
+          {
+            "name": "PremiumV2_ZRS",
+            "value": "PremiumV2_ZRS"
+          }
+        ]
+      }
+    },
+    "SkuTier": {
+      "type": "string",
+      "description": "The SKU tier. This is based on the SKU name.",
+      "enum": [
+        "Standard",
+        "Premium"
+      ],
+      "x-ms-enum": {
+        "name": "SkuTier",
+        "modelAsString": false
+      }
+    },
+    "SmbOAuthSettings": {
+      "type": "object",
+      "description": "Setting property for Managed Identity access over SMB using OAuth",
+      "properties": {
+        "isSmbOAuthEnabled": {
+          "type": "boolean",
+          "description": "Specifies if managed identities can access SMB shares using OAuth. The default interpretation is false for this property."
+        }
+      }
+    },
+    "SmbSetting": {
+      "type": "object",
+      "description": "Setting for SMB protocol",
+      "properties": {
+        "multichannel": {
+          "$ref": "#/definitions/Multichannel",
+          "description": "Multichannel setting. Applies to Premium FileStorage only."
+        },
+        "versions": {
+          "type": "string",
+          "description": "SMB protocol versions supported by server. Valid values are SMB2.1, SMB3.0, SMB3.1.1. Should be passed as a string with delimiter ';'."
+        },
+        "authenticationMethods": {
+          "type": "string",
+          "description": "SMB authentication methods supported by server. Valid values are NTLMv2, Kerberos. Should be passed as a string with delimiter ';'."
+        },
+        "kerberosTicketEncryption": {
+          "type": "string",
+          "description": "Kerberos ticket encryption supported by server. Valid values are RC4-HMAC, AES-256. Should be passed as a string with delimiter ';'"
+        },
+        "channelEncryption": {
+          "type": "string",
+          "description": "SMB channel encryption supported by server. Valid values are AES-128-CCM, AES-128-GCM, AES-256-GCM. Should be passed as a string with delimiter ';'."
+        },
+        "encryptionInTransit": {
+          "$ref": "#/definitions/EncryptionInTransit",
+          "description": "Encryption in transit setting."
+        }
+      }
+    },
+    "SshPublicKey": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "Optional. It is used to store the function/usage of the key"
+        },
+        "key": {
+          "type": "string",
+          "description": "Ssh public key base64 encoded. The format should be: '<keyType> <keyData>', e.g. ssh-rsa AAAABBBB"
+        }
+      }
+    },
+    "State": {
+      "type": "string",
+      "description": "Gets the state of virtual network rule.",
+      "enum": [
+        "Provisioning",
+        "Deprovisioning",
+        "Succeeded",
+        "Failed",
+        "NetworkSourceDeleted"
+      ],
+      "x-ms-enum": {
+        "name": "State",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Provisioning",
+            "value": "Provisioning"
+          },
+          {
+            "name": "Deprovisioning",
+            "value": "Deprovisioning"
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed"
+          },
+          {
+            "name": "NetworkSourceDeleted",
+            "value": "NetworkSourceDeleted"
+          }
+        ]
+      },
+      "readOnly": true
+    },
+    "StaticWebsite": {
+      "type": "object",
+      "description": "The static website properties for blob storage.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Indicates whether static website support is enabled for the specified account."
+        },
+        "indexDocument": {
+          "type": "string",
+          "description": "The webpage that Azure Storage serves for requests to the root of a website or any subfolder (for example, index.html). The value is case-sensitive."
+        },
+        "defaultIndexDocumentPath": {
+          "type": "string",
+          "description": "The absolute path where the default index file is present. This absolute path is mutually exclusive to \"indexDocument\" and it is case-sensitive."
+        },
+        "errorDocument404Path": {
+          "type": "string",
+          "description": "The absolute path to a webpage that Azure Storage serves for requests that don't correspond to an existing file. The contents of the page are returned with HTTP 404 Not Found. Only a single custom 404 page is supported in each static website."
+        }
+      },
+      "required": [
+        "enabled"
+      ]
+    },
+    "StorageAccount": {
+      "type": "object",
+      "description": "The storage account.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/StorageAccountProperties",
+          "description": "Properties of the storage account.",
+          "x-ms-client-flatten": true
+        },
+        "sku": {
+          "$ref": "#/definitions/Sku",
+          "description": "Gets the SKU.",
+          "readOnly": true
+        },
+        "kind": {
+          "$ref": "#/definitions/Kind",
+          "description": "Gets the Kind.",
+          "readOnly": true
+        },
+        "identity": {
+          "$ref": "#/definitions/Identity",
+          "description": "The identity of the resource."
+        },
+        "extendedLocation": {
+          "$ref": "#/definitions/ExtendedLocation",
+          "description": "The extendedLocation of the resource."
+        },
+        "zones": {
+          "type": "array",
+          "description": "The availability zones.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "placement": {
+          "$ref": "#/definitions/Placement",
+          "description": "Optional. Gets or sets the zonal placement details for the storage account."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/TrackedResource"
+        }
+      ]
+    },
+    "StorageAccountCheckNameAvailabilityParameters": {
+      "type": "object",
+      "description": "The parameters used to check the availability of the storage account name.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The storage account name."
+        },
+        "type": {
+          "type": "string",
+          "description": "The type of resource, Microsoft.Storage/storageAccounts",
+          "enum": [
+            "Microsoft.Storage/storageAccounts"
+          ],
+          "x-ms-enum": {
+            "modelAsString": false
+          }
+        }
+      },
+      "required": [
+        "name",
+        "type"
+      ]
+    },
+    "StorageAccountCreateParameters": {
+      "type": "object",
+      "description": "The parameters used when creating a storage account.",
+      "properties": {
+        "sku": {
+          "$ref": "#/definitions/Sku",
+          "description": "Required. Gets or sets the SKU name."
+        },
+        "kind": {
+          "$ref": "#/definitions/Kind",
+          "description": "Required. Indicates the type of storage account."
+        },
+        "location": {
+          "type": "string",
+          "description": "Required. Gets or sets the location of the resource. This will be one of the supported and registered Azure Geo Regions (e.g. West US, East US, Southeast Asia, etc.). The geo region of a resource cannot be changed once it is created, but if an identical geo region is specified on update, the request will succeed."
+        },
+        "extendedLocation": {
+          "$ref": "#/definitions/ExtendedLocation",
+          "description": "Optional. Set the extended location of the resource. If not set, the storage account will be created in Azure main region. Otherwise it will be created in the specified extended location"
+        },
+        "zones": {
+          "type": "array",
+          "description": "Optional. Gets or sets the pinned logical availability zone for the storage account.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "placement": {
+          "$ref": "#/definitions/Placement",
+          "description": "Optional. Gets or sets the zonal placement details for the storage account."
+        },
+        "tags": {
+          "type": "object",
+          "description": "Gets or sets a list of key value pairs that describe the resource. These tags can be used for viewing and grouping this resource (across resource groups). A maximum of 15 tags can be provided for a resource. Each tag must have a key with a length no greater than 128 characters and a value with a length no greater than 256 characters.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "identity": {
+          "$ref": "#/definitions/Identity",
+          "description": "The identity of the resource."
+        },
+        "properties": {
+          "$ref": "#/definitions/StorageAccountPropertiesCreateParameters",
+          "description": "The parameters used to create the storage account.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "required": [
+        "sku",
+        "kind",
+        "location"
+      ]
+    },
+    "StorageAccountInternetEndpoints": {
+      "type": "object",
+      "description": "The URIs that are used to perform a retrieval of a public blob, file, web or dfs object via a internet routing endpoint.",
+      "properties": {
+        "blob": {
+          "type": "string",
+          "description": "Gets the blob endpoint.",
+          "readOnly": true
+        },
+        "file": {
+          "type": "string",
+          "description": "Gets the file endpoint.",
+          "readOnly": true
+        },
+        "web": {
+          "type": "string",
+          "description": "Gets the web endpoint.",
+          "readOnly": true
+        },
+        "dfs": {
+          "type": "string",
+          "description": "Gets the dfs endpoint.",
+          "readOnly": true
+        }
+      }
+    },
+    "StorageAccountIpv6Endpoints": {
+      "type": "object",
+      "description": "The URIs that are used to perform a retrieval of a public blob, queue, table, web or dfs object via an IPv6 endpoint.",
+      "properties": {
+        "blob": {
+          "type": "string",
+          "description": "Gets the blob endpoint.",
+          "readOnly": true
+        },
+        "queue": {
+          "type": "string",
+          "description": "Gets the queue endpoint.",
+          "readOnly": true
+        },
+        "table": {
+          "type": "string",
+          "description": "Gets the table endpoint.",
+          "readOnly": true
+        },
+        "file": {
+          "type": "string",
+          "description": "Gets the file endpoint.",
+          "readOnly": true
+        },
+        "web": {
+          "type": "string",
+          "description": "Gets the web endpoint.",
+          "readOnly": true
+        },
+        "dfs": {
+          "type": "string",
+          "description": "Gets the dfs endpoint.",
+          "readOnly": true
+        },
+        "microsoftEndpoints": {
+          "$ref": "#/definitions/StorageAccountMicrosoftEndpoints",
+          "description": "Gets the microsoft routing storage endpoints."
+        },
+        "internetEndpoints": {
+          "$ref": "#/definitions/StorageAccountInternetEndpoints",
+          "description": "Gets the internet routing storage endpoints"
+        }
+      }
+    },
+    "StorageAccountKey": {
+      "type": "object",
+      "description": "An access key for the storage account.",
+      "properties": {
+        "keyName": {
+          "type": "string",
+          "description": "Name of the key.",
+          "readOnly": true
+        },
+        "value": {
+          "type": "string",
+          "description": "Base 64-encoded value of the key.",
+          "readOnly": true
+        },
+        "permissions": {
+          "$ref": "#/definitions/KeyPermission",
+          "description": "Permissions for the key -- read-only or full permissions.",
+          "readOnly": true
+        },
+        "creationTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Creation time of the key, in round trip date format.",
+          "readOnly": true
+        }
+      }
+    },
+    "StorageAccountListKeysResult": {
+      "type": "object",
+      "description": "The response from the ListKeys operation.",
+      "properties": {
+        "keys": {
+          "type": "array",
+          "description": "Gets the list of storage account keys and their properties for the specified storage account.",
+          "items": {
+            "$ref": "#/definitions/StorageAccountKey"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "StorageAccountListResult": {
+      "type": "object",
+      "description": "The response of a StorageAccount list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The StorageAccount items on this page",
+          "items": {
+            "$ref": "#/definitions/StorageAccount"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "StorageAccountMicrosoftEndpoints": {
+      "type": "object",
+      "description": "The URIs that are used to perform a retrieval of a public blob, queue, table, web or dfs object via a microsoft routing endpoint.",
+      "properties": {
+        "blob": {
+          "type": "string",
+          "description": "Gets the blob endpoint.",
+          "readOnly": true
+        },
+        "queue": {
+          "type": "string",
+          "description": "Gets the queue endpoint.",
+          "readOnly": true
+        },
+        "table": {
+          "type": "string",
+          "description": "Gets the table endpoint.",
+          "readOnly": true
+        },
+        "file": {
+          "type": "string",
+          "description": "Gets the file endpoint.",
+          "readOnly": true
+        },
+        "web": {
+          "type": "string",
+          "description": "Gets the web endpoint.",
+          "readOnly": true
+        },
+        "dfs": {
+          "type": "string",
+          "description": "Gets the dfs endpoint.",
+          "readOnly": true
+        }
+      }
+    },
+    "StorageAccountMigration": {
+      "type": "object",
+      "description": "The parameters or status associated with an ongoing or enqueued storage account migration in order to update its current SKU or region.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/StorageAccountMigrationProperties",
+          "description": "The properties of a storage account’s ongoing or enqueued migration.",
+          "x-ms-client-flatten": true,
+          "x-ms-client-name": "StorageAccountMigrationDetails"
+        }
+      },
+      "required": [
+        "properties"
+      ],
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "StorageAccountMigrationProperties": {
+      "type": "object",
+      "description": "The properties of a storage account's ongoing or enqueued migration.",
+      "properties": {
+        "targetSkuName": {
+          "$ref": "#/definitions/SkuName",
+          "description": "Target sku name for the account"
+        },
+        "migrationStatus": {
+          "$ref": "#/definitions/migrationStatus",
+          "description": "Current status of migration",
+          "readOnly": true
+        },
+        "migrationFailedReason": {
+          "type": "string",
+          "description": "Error code for migration failure",
+          "readOnly": true
+        },
+        "migrationFailedDetailedReason": {
+          "type": "string",
+          "description": "Reason for migration failure",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "targetSkuName"
+      ]
+    },
+    "StorageAccountProperties": {
+      "type": "object",
+      "description": "Properties of the storage account.",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningState",
+          "description": "Gets the status of the storage account at the time the operation was called.",
+          "readOnly": true
+        },
+        "primaryEndpoints": {
+          "$ref": "#/definitions/Endpoints",
+          "description": "Gets the URLs that are used to perform a retrieval of a public blob, queue, or table object. Note that Standard_ZRS and Premium_LRS accounts only return the blob endpoint.",
+          "readOnly": true
+        },
+        "primaryLocation": {
+          "type": "string",
+          "description": "Gets the location of the primary data center for the storage account.",
+          "readOnly": true
+        },
+        "statusOfPrimary": {
+          "$ref": "#/definitions/AccountStatus",
+          "description": "Gets the status indicating whether the primary location of the storage account is available or unavailable.",
+          "readOnly": true
+        },
+        "lastGeoFailoverTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Gets the timestamp of the most recent instance of a failover to the secondary location. Only the most recent timestamp is retained. This element is not returned if there has never been a failover instance. Only available if the accountType is Standard_GRS or Standard_RAGRS.",
+          "readOnly": true
+        },
+        "secondaryLocation": {
+          "type": "string",
+          "description": "Gets the location of the geo-replicated secondary for the storage account. Only available if the accountType is Standard_GRS or Standard_RAGRS.",
+          "readOnly": true
+        },
+        "statusOfSecondary": {
+          "$ref": "#/definitions/AccountStatus",
+          "description": "Gets the status indicating whether the secondary location of the storage account is available or unavailable. Only available if the SKU name is Standard_GRS or Standard_RAGRS.",
+          "readOnly": true
+        },
+        "creationTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Gets the creation date and time of the storage account in UTC.",
+          "readOnly": true
+        },
+        "customDomain": {
+          "$ref": "#/definitions/CustomDomain",
+          "description": "Gets the custom domain the user assigned to this storage account.",
+          "readOnly": true
+        },
+        "sasPolicy": {
+          "$ref": "#/definitions/SasPolicy",
+          "description": "SasPolicy assigned to the storage account.",
+          "readOnly": true
+        },
+        "keyPolicy": {
+          "$ref": "#/definitions/KeyPolicy",
+          "description": "KeyPolicy assigned to the storage account.",
+          "readOnly": true
+        },
+        "keyCreationTime": {
+          "$ref": "#/definitions/KeyCreationTime",
+          "description": "Storage account keys creation time.",
+          "readOnly": true
+        },
+        "secondaryEndpoints": {
+          "$ref": "#/definitions/Endpoints",
+          "description": "Gets the URLs that are used to perform a retrieval of a public blob, queue, or table object from the secondary location of the storage account. Only available if the SKU name is Standard_RAGRS.",
+          "readOnly": true
+        },
+        "encryption": {
+          "$ref": "#/definitions/Encryption",
+          "description": "Encryption settings to be used for server-side encryption for the storage account.",
+          "readOnly": true
+        },
+        "accessTier": {
+          "$ref": "#/definitions/AccessTier",
+          "description": "Required for storage accounts where kind = BlobStorage. The access tier is used for billing. The 'Premium' access tier is the default value for premium block blobs storage account type and it cannot be changed for the premium block blobs storage account type.",
+          "readOnly": true
+        },
+        "azureFilesIdentityBasedAuthentication": {
+          "$ref": "#/definitions/AzureFilesIdentityBasedAuthentication",
+          "description": "Provides the identity based authentication settings for Azure Files."
+        },
+        "supportsHttpsTrafficOnly": {
+          "type": "boolean",
+          "description": "Allows https traffic only to storage service if sets to true.",
+          "x-ms-client-name": "EnableHttpsTrafficOnly"
+        },
+        "networkAcls": {
+          "$ref": "#/definitions/NetworkRuleSet",
+          "description": "Network rule set",
+          "readOnly": true,
+          "x-ms-client-name": "NetworkRuleSet"
+        },
+        "isSftpEnabled": {
+          "type": "boolean",
+          "description": "Enables Secure File Transfer Protocol, if set to true",
+          "x-ms-client-name": "IsSftpEnabled"
+        },
+        "isLocalUserEnabled": {
+          "type": "boolean",
+          "description": "Enables local users feature, if set to true",
+          "x-ms-client-name": "IsLocalUserEnabled"
+        },
+        "enableExtendedGroups": {
+          "type": "boolean",
+          "description": "Enables extended group support with local users feature, if set to true",
+          "x-ms-client-name": "EnableExtendedGroups"
+        },
+        "isHnsEnabled": {
+          "type": "boolean",
+          "description": "Account HierarchicalNamespace enabled if sets to true.",
+          "x-ms-client-name": "IsHnsEnabled"
+        },
+        "geoReplicationStats": {
+          "$ref": "#/definitions/GeoReplicationStats",
+          "description": "Geo Replication Stats",
+          "readOnly": true,
+          "x-ms-client-name": "GeoReplicationStats"
+        },
+        "failoverInProgress": {
+          "type": "boolean",
+          "description": "If the failover is in progress, the value will be true, otherwise, it will be null.",
+          "readOnly": true,
+          "x-ms-client-name": "FailoverInProgress"
+        },
+        "largeFileSharesState": {
+          "$ref": "#/definitions/LargeFileSharesState",
+          "description": "Allow large file shares if sets to Enabled. It cannot be disabled once it is enabled."
+        },
+        "privateEndpointConnections": {
+          "type": "array",
+          "description": "List of private endpoint connection associated with the specified storage account",
+          "items": {
+            "$ref": "#/definitions/PrivateEndpointConnection"
+          },
+          "readOnly": true
+        },
+        "routingPreference": {
+          "$ref": "#/definitions/RoutingPreference",
+          "description": "Maintains information about the network routing choice opted by the user for data transfer",
+          "x-ms-client-name": "RoutingPreference"
+        },
+        "dualStackEndpointPreference": {
+          "$ref": "#/definitions/DualStackEndpointPreference",
+          "description": "Maintains information about the Internet protocol opted by the user."
+        },
+        "blobRestoreStatus": {
+          "$ref": "#/definitions/BlobRestoreStatus",
+          "description": "Blob restore status",
+          "readOnly": true,
+          "x-ms-client-name": "BlobRestoreStatus"
+        },
+        "allowBlobPublicAccess": {
+          "type": "boolean",
+          "description": "Allow or disallow public access to all blobs or containers in the storage account. The default interpretation is false for this property.",
+          "x-ms-client-name": "AllowBlobPublicAccess"
+        },
+        "minimumTlsVersion": {
+          "$ref": "#/definitions/MinimumTlsVersion",
+          "description": "Set the minimum TLS version to be permitted on requests to storage. The default interpretation is TLS 1.0 for this property. Minimum TLS version 1.3 version is not supported."
+        },
+        "allowSharedKeyAccess": {
+          "type": "boolean",
+          "description": "Indicates whether the storage account permits requests to be authorized with the account access key via Shared Key. If false, then all requests, including shared access signatures, must be authorized with Azure Active Directory (Azure AD). The default value is null, which is equivalent to true."
+        },
+        "isNfsV3Enabled": {
+          "type": "boolean",
+          "description": "NFS 3.0 protocol support enabled if set to true.",
+          "x-ms-client-name": "EnableNfsV3"
+        },
+        "allowCrossTenantReplication": {
+          "type": "boolean",
+          "description": "Allow or disallow cross AAD tenant object replication. Set this property to true for new or existing accounts only if object replication policies will involve storage accounts in different AAD tenants. The default interpretation is false for new accounts to follow best security practices by default."
+        },
+        "defaultToOAuthAuthentication": {
+          "type": "boolean",
+          "description": "A boolean flag which indicates whether the default authentication is OAuth or not. The default interpretation is false for this property."
+        },
+        "publicNetworkAccess": {
+          "$ref": "#/definitions/PublicNetworkAccess",
+          "description": "Allow, disallow, or let Network Security Perimeter configuration to evaluate public network access to Storage Account."
+        },
+        "immutableStorageWithVersioning": {
+          "$ref": "#/definitions/ImmutableStorageAccount",
+          "description": "The property is immutable and can only be set to true at the account creation time. When set to true, it enables object level immutability for all the containers in the account by default.",
+          "x-ms-client-name": "ImmutableStorageWithVersioning"
+        },
+        "allowedCopyScope": {
+          "$ref": "#/definitions/AllowedCopyScope",
+          "description": "Restrict copy to and from Storage Accounts within an AAD tenant or with Private Links to the same VNet."
+        },
+        "storageAccountSkuConversionStatus": {
+          "$ref": "#/definitions/StorageAccountSkuConversionStatus",
+          "description": "This property is readOnly and is set by server during asynchronous storage account sku conversion operations.",
+          "x-ms-client-name": "StorageAccountSkuConversionStatus"
+        },
+        "dnsEndpointType": {
+          "$ref": "#/definitions/DnsEndpointType",
+          "description": "Allows you to specify the type of endpoint. Set this to AzureDNSZone to create a large number of accounts in a single subscription, which creates accounts in an Azure DNS Zone and the endpoint URL will have an alphanumeric DNS Zone identifier."
+        },
+        "isSkuConversionBlocked": {
+          "type": "boolean",
+          "description": "This property will be set to true or false on an event of ongoing migration. Default value is null.",
+          "readOnly": true,
+          "x-ms-client-name": "IsSkuConversionBlocked"
+        },
+        "accountMigrationInProgress": {
+          "type": "boolean",
+          "description": "If customer initiated account migration is in progress, the value will be true else it will be null.",
+          "readOnly": true,
+          "x-ms-client-name": "AccountMigrationInProgress"
+        },
+        "geoPriorityReplicationStatus": {
+          "$ref": "#/definitions/GeoPriorityReplicationStatus",
+          "description": "Status indicating whether Geo Priority Replication is enabled for the account."
+        },
+        "allowSharedKeyAccessForServices": {
+          "$ref": "#/definitions/StorageAccountSharedKeyAccessProperties",
+          "description": "Indicate shared key access properties at service level"
+        },
+        "dataCollaborationPolicyProperties": {
+          "$ref": "#/definitions/StorageDataCollaborationPolicyProperties",
+          "description": "Data Collaboration policy for the storage account."
+        },
+        "allowCrossTenantDelegationSas": {
+          "type": "boolean",
+          "description": "Allow or disallow cross AAD tenant user delegation SAS (shared access signature). The default interpretation is false for this property."
+        }
+      }
+    },
+    "StorageAccountPropertiesCreateParameters": {
+      "type": "object",
+      "description": "The parameters used to create the storage account.",
+      "properties": {
+        "allowedCopyScope": {
+          "$ref": "#/definitions/AllowedCopyScope",
+          "description": "Restrict copy to and from Storage Accounts within an AAD tenant or with Private Links to the same VNet."
+        },
+        "publicNetworkAccess": {
+          "$ref": "#/definitions/PublicNetworkAccess",
+          "description": "Allow, disallow, or let Network Security Perimeter configuration to evaluate public network access to Storage Account. Value is optional but if passed in, must be 'Enabled', 'Disabled' or 'SecuredByPerimeter'."
+        },
+        "sasPolicy": {
+          "$ref": "#/definitions/SasPolicy",
+          "description": "SasPolicy assigned to the storage account."
+        },
+        "keyPolicy": {
+          "$ref": "#/definitions/KeyPolicy",
+          "description": "KeyPolicy assigned to the storage account."
+        },
+        "customDomain": {
+          "$ref": "#/definitions/CustomDomain",
+          "description": "User domain assigned to the storage account. Name is the CNAME source. Only one custom domain is supported per storage account at this time. To clear the existing custom domain, use an empty string for the custom domain name property."
+        },
+        "encryption": {
+          "$ref": "#/definitions/Encryption",
+          "description": "Encryption settings to be used for server-side encryption for the storage account."
+        },
+        "networkAcls": {
+          "$ref": "#/definitions/NetworkRuleSet",
+          "description": "Network rule set",
+          "x-ms-client-name": "NetworkRuleSet"
+        },
+        "accessTier": {
+          "$ref": "#/definitions/AccessTier",
+          "description": "Required for storage accounts where kind = BlobStorage. The access tier is used for billing. The 'Premium' access tier is the default value for premium block blobs storage account type and it cannot be changed for the premium block blobs storage account type."
+        },
+        "azureFilesIdentityBasedAuthentication": {
+          "$ref": "#/definitions/AzureFilesIdentityBasedAuthentication",
+          "description": "Provides the identity based authentication settings for Azure Files."
+        },
+        "supportsHttpsTrafficOnly": {
+          "type": "boolean",
+          "description": "Allows https traffic only to storage service if sets to true. The default value is true since API version 2019-04-01.",
+          "x-ms-client-name": "EnableHttpsTrafficOnly"
+        },
+        "isSftpEnabled": {
+          "type": "boolean",
+          "description": "Enables Secure File Transfer Protocol, if set to true",
+          "x-ms-client-name": "IsSftpEnabled"
+        },
+        "isLocalUserEnabled": {
+          "type": "boolean",
+          "description": "Enables local users feature, if set to true",
+          "x-ms-client-name": "IsLocalUserEnabled"
+        },
+        "enableExtendedGroups": {
+          "type": "boolean",
+          "description": "Enables extended group support with local users feature, if set to true",
+          "x-ms-client-name": "EnableExtendedGroups"
+        },
+        "isHnsEnabled": {
+          "type": "boolean",
+          "description": "Account HierarchicalNamespace enabled if sets to true.",
+          "x-ms-client-name": "IsHnsEnabled"
+        },
+        "largeFileSharesState": {
+          "$ref": "#/definitions/LargeFileSharesState",
+          "description": "Allow large file shares if sets to Enabled. It cannot be disabled once it is enabled."
+        },
+        "routingPreference": {
+          "$ref": "#/definitions/RoutingPreference",
+          "description": "Maintains information about the network routing choice opted by the user for data transfer",
+          "x-ms-client-name": "RoutingPreference"
+        },
+        "dualStackEndpointPreference": {
+          "$ref": "#/definitions/DualStackEndpointPreference",
+          "description": "Maintains information about the Internet protocol opted by the user."
+        },
+        "allowBlobPublicAccess": {
+          "type": "boolean",
+          "description": "Allow or disallow public access to all blobs or containers in the storage account. The default interpretation is false for this property.",
+          "x-ms-client-name": "AllowBlobPublicAccess"
+        },
+        "minimumTlsVersion": {
+          "$ref": "#/definitions/MinimumTlsVersion",
+          "description": "Set the minimum TLS version to be permitted on requests to storage. The default interpretation is TLS 1.0 for this property. Minimum TLS version 1.3 version is not supported."
+        },
+        "allowSharedKeyAccess": {
+          "type": "boolean",
+          "description": "Indicates whether the storage account permits requests to be authorized with the account access key via Shared Key. If false, then all requests, including shared access signatures, must be authorized with Azure Active Directory (Azure AD). The default value is null, which is equivalent to true."
+        },
+        "isNfsV3Enabled": {
+          "type": "boolean",
+          "description": "NFS 3.0 protocol support enabled if set to true.",
+          "x-ms-client-name": "EnableNfsV3"
+        },
+        "allowCrossTenantReplication": {
+          "type": "boolean",
+          "description": "Allow or disallow cross AAD tenant object replication. Set this property to true for new or existing accounts only if object replication policies will involve storage accounts in different AAD tenants. The default interpretation is false for new accounts to follow best security practices by default."
+        },
+        "defaultToOAuthAuthentication": {
+          "type": "boolean",
+          "description": "A boolean flag which indicates whether the default authentication is OAuth or not. The default interpretation is false for this property."
+        },
+        "immutableStorageWithVersioning": {
+          "$ref": "#/definitions/ImmutableStorageAccount",
+          "description": "The property is immutable and can only be set to true at the account creation time. When set to true, it enables object level immutability for all the new containers in the account by default.",
+          "x-ms-client-name": "ImmutableStorageWithVersioning"
+        },
+        "dnsEndpointType": {
+          "$ref": "#/definitions/DnsEndpointType",
+          "description": "Allows you to specify the type of endpoint. Set this to AzureDNSZone to create a large number of accounts in a single subscription, which creates accounts in an Azure DNS Zone and the endpoint URL will have an alphanumeric DNS Zone identifier."
+        },
+        "geoPriorityReplicationStatus": {
+          "$ref": "#/definitions/GeoPriorityReplicationStatus",
+          "description": "Status indicating whether Geo Priority Replication is enabled for the account."
+        },
+        "allowSharedKeyAccessForServices": {
+          "$ref": "#/definitions/StorageAccountSharedKeyAccessProperties",
+          "description": "Indicate shared key access properties at service level"
+        },
+        "dataCollaborationPolicyProperties": {
+          "$ref": "#/definitions/StorageDataCollaborationPolicyProperties",
+          "description": "Data Collaboration policy for the storage account."
+        },
+        "allowCrossTenantDelegationSas": {
+          "type": "boolean",
+          "description": "Allow or disallow cross AAD tenant user delegation SAS (shared access signature). The default interpretation is false for this property."
+        }
+      }
+    },
+    "StorageAccountPropertiesUpdateParameters": {
+      "type": "object",
+      "description": "The parameters used when updating a storage account.",
+      "properties": {
+        "customDomain": {
+          "$ref": "#/definitions/CustomDomain",
+          "description": "Custom domain assigned to the storage account by the user. Name is the CNAME source. Only one custom domain is supported per storage account at this time. To clear the existing custom domain, use an empty string for the custom domain name property."
+        },
+        "encryption": {
+          "$ref": "#/definitions/Encryption",
+          "description": "Not applicable. Azure Storage encryption at rest is enabled by default for all storage accounts and cannot be disabled."
+        },
+        "sasPolicy": {
+          "$ref": "#/definitions/SasPolicy",
+          "description": "SasPolicy assigned to the storage account."
+        },
+        "keyPolicy": {
+          "$ref": "#/definitions/KeyPolicy",
+          "description": "KeyPolicy assigned to the storage account."
+        },
+        "accessTier": {
+          "$ref": "#/definitions/AccessTier",
+          "description": "Required for storage accounts where kind = BlobStorage. The access tier is used for billing. The 'Premium' access tier is the default value for premium block blobs storage account type and it cannot be changed for the premium block blobs storage account type."
+        },
+        "azureFilesIdentityBasedAuthentication": {
+          "$ref": "#/definitions/AzureFilesIdentityBasedAuthentication",
+          "description": "Provides the identity based authentication settings for Azure Files."
+        },
+        "supportsHttpsTrafficOnly": {
+          "type": "boolean",
+          "description": "Allows https traffic only to storage service if sets to true.",
+          "x-ms-client-name": "EnableHttpsTrafficOnly"
+        },
+        "isSftpEnabled": {
+          "type": "boolean",
+          "description": "Enables Secure File Transfer Protocol, if set to true",
+          "x-ms-client-name": "IsSftpEnabled"
+        },
+        "isLocalUserEnabled": {
+          "type": "boolean",
+          "description": "Enables local users feature, if set to true",
+          "x-ms-client-name": "IsLocalUserEnabled"
+        },
+        "enableExtendedGroups": {
+          "type": "boolean",
+          "description": "Enables extended group support with local users feature, if set to true",
+          "x-ms-client-name": "EnableExtendedGroups"
+        },
+        "networkAcls": {
+          "$ref": "#/definitions/NetworkRuleSet",
+          "description": "Network rule set",
+          "x-ms-client-name": "NetworkRuleSet"
+        },
+        "largeFileSharesState": {
+          "$ref": "#/definitions/LargeFileSharesState",
+          "description": "Allow large file shares if sets to Enabled. It cannot be disabled once it is enabled."
+        },
+        "routingPreference": {
+          "$ref": "#/definitions/RoutingPreference",
+          "description": "Maintains information about the network routing choice opted by the user for data transfer",
+          "x-ms-client-name": "RoutingPreference"
+        },
+        "dualStackEndpointPreference": {
+          "$ref": "#/definitions/DualStackEndpointPreference",
+          "description": "Maintains information about the Internet protocol opted by the user."
+        },
+        "allowBlobPublicAccess": {
+          "type": "boolean",
+          "description": "Allow or disallow public access to all blobs or containers in the storage account. The default interpretation is false for this property.",
+          "x-ms-client-name": "AllowBlobPublicAccess"
+        },
+        "minimumTlsVersion": {
+          "$ref": "#/definitions/MinimumTlsVersion",
+          "description": "Set the minimum TLS version to be permitted on requests to storage. The default interpretation is TLS 1.0 for this property. Minimum TLS version 1.3 version is not supported."
+        },
+        "allowSharedKeyAccess": {
+          "type": "boolean",
+          "description": "Indicates whether the storage account permits requests to be authorized with the account access key via Shared Key. If false, then all requests, including shared access signatures, must be authorized with Azure Active Directory (Azure AD). The default value is null, which is equivalent to true."
+        },
+        "allowCrossTenantReplication": {
+          "type": "boolean",
+          "description": "Allow or disallow cross AAD tenant object replication. Set this property to true for new or existing accounts only if object replication policies will involve storage accounts in different AAD tenants. The default interpretation is false for new accounts to follow best security practices by default."
+        },
+        "defaultToOAuthAuthentication": {
+          "type": "boolean",
+          "description": "A boolean flag which indicates whether the default authentication is OAuth or not. The default interpretation is false for this property."
+        },
+        "publicNetworkAccess": {
+          "$ref": "#/definitions/PublicNetworkAccess",
+          "description": "Allow, disallow, or let Network Security Perimeter configuration to evaluate public network access to Storage Account. Value is optional but if passed in, must be 'Enabled', 'Disabled' or 'SecuredByPerimeter'."
+        },
+        "immutableStorageWithVersioning": {
+          "$ref": "#/definitions/ImmutableStorageAccount",
+          "description": "The property is immutable and can only be set to true at the account creation time. When set to true, it enables object level immutability for all the containers in the account by default.",
+          "x-ms-client-name": "ImmutableStorageWithVersioning"
+        },
+        "allowedCopyScope": {
+          "$ref": "#/definitions/AllowedCopyScope",
+          "description": "Restrict copy to and from Storage Accounts within an AAD tenant or with Private Links to the same VNet."
+        },
+        "dnsEndpointType": {
+          "$ref": "#/definitions/DnsEndpointType",
+          "description": "Allows you to specify the type of endpoint. Set this to AzureDNSZone to create a large number of accounts in a single subscription, which creates accounts in an Azure DNS Zone and the endpoint URL will have an alphanumeric DNS Zone identifier."
+        },
+        "geoPriorityReplicationStatus": {
+          "$ref": "#/definitions/GeoPriorityReplicationStatus",
+          "description": "Status indicating whether Geo Priority Replication is enabled for the account."
+        },
+        "allowSharedKeyAccessForServices": {
+          "$ref": "#/definitions/StorageAccountSharedKeyAccessProperties",
+          "description": "Indicate shared key access properties at service level"
+        },
+        "dataCollaborationPolicyProperties": {
+          "$ref": "#/definitions/StorageDataCollaborationPolicyProperties",
+          "description": "Data Collaboration policy for the storage account."
+        },
+        "allowCrossTenantDelegationSas": {
+          "type": "boolean",
+          "description": "Allow or disallow cross AAD tenant user delegation SAS (shared access signature). The default interpretation is false for this property."
+        }
+      }
+    },
+    "StorageAccountRegenerateKeyParameters": {
+      "type": "object",
+      "description": "The parameters used to regenerate the storage account key.",
+      "properties": {
+        "keyName": {
+          "type": "string",
+          "description": "The name of storage keys that want to be regenerated, possible values are key1, key2, kerb1, kerb2."
+        }
+      },
+      "required": [
+        "keyName"
+      ]
+    },
+    "StorageAccountSharedKeyAccessProperties": {
+      "type": "object",
+      "description": "Defines shared key access properties for a storage account.",
+      "properties": {
+        "blob": {
+          "$ref": "#/definitions/ServiceSharedKeyAccessProperties",
+          "description": "Shared key access settings for Blob service."
+        },
+        "file": {
+          "$ref": "#/definitions/ServiceSharedKeyAccessProperties",
+          "description": "Shared key access settings for File service."
+        },
+        "table": {
+          "$ref": "#/definitions/ServiceSharedKeyAccessProperties",
+          "description": "Shared key access settings for Table service."
+        },
+        "queue": {
+          "$ref": "#/definitions/ServiceSharedKeyAccessProperties",
+          "description": "Shared key access settings for Queue service."
+        }
+      }
+    },
+    "StorageAccountSkuConversionStatus": {
+      "type": "object",
+      "description": "This defines the sku conversion status object for asynchronous sku conversions.",
+      "properties": {
+        "skuConversionStatus": {
+          "$ref": "#/definitions/SkuConversionStatus",
+          "description": "This property indicates the current sku conversion status.",
+          "readOnly": true
+        },
+        "targetSkuName": {
+          "$ref": "#/definitions/SkuName",
+          "description": "This property represents the target sku name to which the account sku is being converted asynchronously."
+        },
+        "startTime": {
+          "type": "string",
+          "description": "This property represents the sku conversion start time.",
+          "readOnly": true
+        },
+        "endTime": {
+          "type": "string",
+          "description": "This property represents the sku conversion end time.",
+          "readOnly": true
+        }
+      }
+    },
+    "StorageAccountUpdateParameters": {
+      "type": "object",
+      "description": "The parameters that can be provided when updating the storage account properties.",
+      "properties": {
+        "sku": {
+          "$ref": "#/definitions/Sku",
+          "description": "Gets or sets the SKU name. Note that the SKU name cannot be updated to Standard_ZRS, Premium_LRS or Premium_ZRS, nor can accounts of those SKU names be updated to any other value."
+        },
+        "tags": {
+          "type": "object",
+          "description": "Gets or sets a list of key value pairs that describe the resource. These tags can be used in viewing and grouping this resource (across resource groups). A maximum of 15 tags can be provided for a resource. Each tag must have a key no greater in length than 128 characters and a value no greater in length than 256 characters.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "identity": {
+          "$ref": "#/definitions/Identity",
+          "description": "The identity of the resource."
+        },
+        "properties": {
+          "$ref": "#/definitions/StorageAccountPropertiesUpdateParameters",
+          "description": "The parameters used when updating a storage account.",
+          "x-ms-client-flatten": true
+        },
+        "kind": {
+          "$ref": "#/definitions/Kind",
+          "description": "Optional. Indicates the type of storage account. Currently only StorageV2 value supported by server."
+        },
+        "zones": {
+          "type": "array",
+          "description": "Optional. Gets or sets the pinned logical availability zone for the storage account.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "placement": {
+          "$ref": "#/definitions/Placement",
+          "description": "Optional. Gets or sets the zonal placement details for the storage account."
+        }
+      }
+    },
+    "StorageConnectorAuthProperties": {
+      "type": "object",
+      "description": "The authentication properties of the backing data source",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/StorageConnectorAuthType",
+          "description": "Type of the authentication properties. Controls the type of the authProperties object"
+        }
+      },
+      "discriminator": "type",
+      "required": [
+        "type"
+      ]
+    },
+    "StorageConnectorAuthPropertiesUpdate": {
+      "type": "object",
+      "description": "The authentication properties of the backing data source",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/StorageConnectorAuthType",
+          "description": "Type of the authentication properties. Controls the type of the authProperties object"
+        }
+      },
+      "discriminator": "type",
+      "required": [
+        "type"
+      ]
+    },
+    "StorageConnectorAuthType": {
+      "type": "string",
+      "description": "The auth type supported for bucket connection in storage connector.",
+      "enum": [
+        "ManagedIdentity"
+      ],
+      "x-ms-enum": {
+        "name": "StorageConnectorAuthType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "ManagedIdentity",
+            "value": "ManagedIdentity",
+            "description": "Managed Identity auth type"
+          }
+        ]
+      }
+    },
+    "StorageConnectorConnection": {
+      "type": "object",
+      "description": "The connection properties of the backing data source",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/StorageConnectorConnectionType",
+          "description": "Type of the connection. Controls the type of the connection object. Not mutable once the Storage Connector is created."
+        }
+      },
+      "discriminator": "type",
+      "required": [
+        "type"
+      ]
+    },
+    "StorageConnectorConnectionType": {
+      "type": "string",
+      "description": "The connection type for bucket connection in storage connector.",
+      "enum": [
+        "DataShare"
+      ],
+      "x-ms-enum": {
+        "name": "StorageConnectorConnectionType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "DataShare",
+            "value": "DataShare",
+            "description": "DataShare connection type"
+          }
+        ]
+      }
+    },
+    "StorageConnectorDataSourceType": {
+      "type": "string",
+      "description": "The type of the backing data source for storage connector",
+      "enum": [
+        "Azure_DataShare"
+      ],
+      "x-ms-enum": {
+        "name": "StorageConnectorDataSourceType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Azure_DataShare",
+            "value": "Azure_DataShare",
+            "description": "Azure DataShare data source type."
+          }
+        ]
+      }
+    },
+    "StorageConnectorProperties": {
+      "type": "object",
+      "description": "The storage connector properties",
+      "properties": {
+        "uniqueId": {
+          "type": "string",
+          "description": "System-generated GUID identifier for the Storage Connector. Not a valid input parameter when creating.",
+          "readOnly": true
+        },
+        "state": {
+          "type": "string",
+          "description": "State - Active or Inactive. Whether or not the Storage Connector should start as active (default: Active)\n(While set to false on the Storage Connector, all data plane requests using this Storage Connector fail, and this Storage Connector is not billed if it would be otherwise.",
+          "default": "Active",
+          "enum": [
+            "Active",
+            "Inactive"
+          ],
+          "x-ms-enum": {
+            "name": "StorageConnectorState",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "Active",
+                "value": "Active",
+                "description": "Whether the connector is active"
+              },
+              {
+                "name": "Inactive",
+                "value": "Inactive",
+                "description": "Whether the connector is inactive"
+              }
+            ]
+          }
+        },
+        "creationTime": {
+          "type": "string",
+          "description": "System-generated creation time of the Storage Connector in ISO 8601 date-time format (YYYY-MM-DDTHH:mm:ssZ).\nNot a valid input parameter during creating.",
+          "readOnly": true
+        },
+        "description": {
+          "type": "string",
+          "description": "Arbitrary description of this Storage Connector. Max 250 characters.",
+          "maxLength": 250
+        },
+        "testConnection": {
+          "type": "boolean",
+          "description": "Test connection to backing data source before creating the storage connector.",
+          "default": false,
+          "x-ms-mutability": [
+            "update",
+            "create"
+          ]
+        },
+        "dataSourceType": {
+          "$ref": "#/definitions/StorageConnectorDataSourceType",
+          "description": "The type of backing data source for this Storage Connector.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "source": {
+          "$ref": "#/definitions/StorageConnectorSource",
+          "description": "Information about how to communicate with and authenticate to the backing data store."
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/NativeDataSharingProvisioningState",
+          "description": "Represents the provisioning state of the storage connector.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "dataSourceType",
+        "source"
+      ]
+    },
+    "StorageConnectorPropertiesUpdate": {
+      "type": "object",
+      "description": "The storage connector properties",
+      "properties": {
+        "state": {
+          "type": "string",
+          "description": "State - Active or Inactive. Whether or not the Storage Connector should start as active (default: Active)\n(While set to false on the Storage Connector, all data plane requests using this Storage Connector fail, and this Storage Connector is not billed if it would be otherwise.",
+          "default": "Active",
+          "enum": [
+            "Active",
+            "Inactive"
+          ],
+          "x-ms-enum": {
+            "name": "StorageConnectorState",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "Active",
+                "value": "Active",
+                "description": "Whether the connector is active"
+              },
+              {
+                "name": "Inactive",
+                "value": "Inactive",
+                "description": "Whether the connector is inactive"
+              }
+            ]
+          }
+        },
+        "description": {
+          "type": "string",
+          "description": "Arbitrary description of this Storage Connector. Max 250 characters.",
+          "maxLength": 250
+        },
+        "testConnection": {
+          "type": "boolean",
+          "description": "Test connection to backing data source before creating the storage connector.",
+          "default": false,
+          "x-ms-mutability": [
+            "update",
+            "create"
+          ]
+        },
+        "source": {
+          "$ref": "#/definitions/StorageConnectorSourceUpdate",
+          "description": "Information about how to communicate with and authenticate to the backing data store."
+        }
+      }
+    },
+    "StorageConnectorSource": {
+      "type": "object",
+      "description": "The storage connector backing data source information",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/StorageConnectorSourceType",
+          "description": "Type of the Storage Connector. Not mutable once the Storage Connector is created.\""
+        }
+      },
+      "discriminator": "type",
+      "required": [
+        "type"
+      ]
+    },
+    "StorageConnectorSourceType": {
+      "type": "string",
+      "description": "The type of the backing data source for storage connector",
+      "enum": [
+        "DataShare"
+      ],
+      "x-ms-enum": {
+        "name": "StorageConnectorSourceType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "DataShare",
+            "value": "DataShare",
+            "description": "Source type - DataShare"
+          }
+        ]
+      }
+    },
+    "StorageConnectorSourceUpdate": {
+      "type": "object",
+      "description": "The storage connector backing data source information",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/StorageConnectorSourceType",
+          "description": "Type of the Storage Connector. Not mutable once the Storage Connector is created.\""
+        }
+      },
+      "discriminator": "type",
+      "required": [
+        "type"
+      ]
+    },
+    "StorageDataCollaborationPolicyProperties": {
+      "type": "object",
+      "description": "Defines Data Collaboration Policy for a storage account.",
+      "properties": {
+        "allowStorageConnectors": {
+          "type": "boolean",
+          "description": "Indicates whether storage connectors are allowed to created or managed on the storage account."
+        },
+        "allowStorageDataShares": {
+          "type": "boolean",
+          "description": "Indicates whether data shares are allowed to be created or managed on the storage account."
+        },
+        "allowCrossTenantDataSharing": {
+          "type": "boolean",
+          "description": "Indicates whether cross-entra tenant data sharing is allowed on the storage account."
+        }
+      }
+    },
+    "StorageDataShareAccessPolicy": {
+      "type": "object",
+      "description": "Policy that specify the permission allowed to a managed identity",
+      "properties": {
+        "principalId": {
+          "type": "string",
+          "description": "The AAD principal ID of the Managed Identity.",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+        },
+        "tenantId": {
+          "type": "string",
+          "description": "The AAD tenant ID of the Managed Identity.",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+        },
+        "permission": {
+          "$ref": "#/definitions/StorageDataShareAccessPolicyPermission",
+          "description": "Allowed permissions. Currently, only supported value is Read."
+        }
+      },
+      "required": [
+        "principalId",
+        "tenantId",
+        "permission"
+      ]
+    },
+    "StorageDataShareAccessPolicyPermission": {
+      "type": "string",
+      "description": "The permissions supported in access policies for storage data share",
+      "enum": [
+        "None",
+        "Read"
+      ],
+      "x-ms-enum": {
+        "name": "StorageDataShareAccessPolicyPermission",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "None",
+            "value": "None",
+            "description": "No permission"
+          },
+          {
+            "name": "Read",
+            "value": "Read",
+            "description": "Read permission"
+          }
+        ]
+      }
+    },
+    "StorageDataShareAsset": {
+      "type": "object",
+      "description": "Properties of a shared resource.",
+      "properties": {
+        "assetPath": {
+          "type": "string",
+          "description": "Source Path to be shared. It can be a folder or a blob.\nThe asset path should contain container name followed by path within the container, e.g. /container1/logs/external."
+        },
+        "displayName": {
+          "type": "string",
+          "description": "Consumer visible name of the original path."
+        }
+      },
+      "required": [
+        "assetPath",
+        "displayName"
+      ]
+    },
+    "StorageDataShareProperties": {
+      "type": "object",
+      "description": "The storage datashare properties",
+      "properties": {
+        "dataShareIdentifier": {
+          "type": "string",
+          "description": "System-generated GUID identifier for the Storage DataShare. Not a valid input parameter when creating.",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+          "readOnly": true
+        },
+        "description": {
+          "type": "string",
+          "description": "Arbitrary description of this Data Share. Max 250 characters.",
+          "maxLength": 250
+        },
+        "dataShareUri": {
+          "type": "string",
+          "description": "The DataShare URI to be shared with the consumer.\nURI Format - 'azds://<location>:<dataShareName>:<dataShareIdentifier>'.",
+          "pattern": "^azds://[a-zA-Z0-9-]+:[a-zA-Z0-9-_]+:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+          "readOnly": true
+        },
+        "accessPolicies": {
+          "type": "array",
+          "description": "List of access policies that specify the permission allowed to a managed identity.\nFor Create - This property is required and cannot be null. If no access policies are provided at creation time, specify an empty array.\nFor Update - This property is optional. If set to null or not passed, the existing access policies are left unchanged.\nIf provided with a non-null value, the existing access policies are replaced with the specified list.",
+          "items": {
+            "$ref": "#/definitions/StorageDataShareAccessPolicy"
+          },
+          "x-ms-identifiers": []
+        },
+        "assets": {
+          "type": "array",
+          "description": "List of assets that specify the properties of the shared resources.\nFor Create - This property is required and cannot be null. If no assets are provided at creation time, specify an empty array.\nFor Update - This property is optional. If set to null or not passed, the existing assets are left unchanged.\nIf provided with a non-null value, the existing assets are replaced with the specified list.",
+          "items": {
+            "$ref": "#/definitions/StorageDataShareAsset"
+          },
+          "x-ms-identifiers": []
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/NativeDataSharingProvisioningState",
+          "description": "Represents the provisioning state of the storage datashare.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "accessPolicies",
+        "assets"
+      ]
+    },
+    "StorageDataSharePropertiesUpdate": {
+      "type": "object",
+      "description": "The storage datashare properties",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "Arbitrary description of this Data Share. Max 250 characters.",
+          "maxLength": 250
+        },
+        "accessPolicies": {
+          "type": "array",
+          "description": "List of access policies that specify the permission allowed to a managed identity.\nFor Create - This property is required and cannot be null. If no access policies are provided at creation time, specify an empty array.\nFor Update - This property is optional. If set to null or not passed, the existing access policies are left unchanged.\nIf provided with a non-null value, the existing access policies are replaced with the specified list.",
+          "items": {
+            "$ref": "#/definitions/StorageDataShareAccessPolicy"
+          },
+          "x-ms-identifiers": []
+        },
+        "assets": {
+          "type": "array",
+          "description": "List of assets that specify the properties of the shared resources.\nFor Create - This property is required and cannot be null. If no assets are provided at creation time, specify an empty array.\nFor Update - This property is optional. If set to null or not passed, the existing assets are left unchanged.\nIf provided with a non-null value, the existing assets are replaced with the specified list.",
+          "items": {
+            "$ref": "#/definitions/StorageDataShareAsset"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "StorageQueue": {
+      "type": "object",
+      "description": "Concrete proxy resource types can be created by aliasing this type using a specific property type.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/QueueProperties",
+          "description": "Queue resource properties.",
+          "x-ms-client-flatten": true,
+          "x-ms-client-name": "QueueProperties"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "StorageSkuListResult": {
+      "type": "object",
+      "description": "The response from the List Storage SKUs operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "Get the list result of storage SKUs and their properties.",
+          "items": {
+            "$ref": "#/definitions/SkuInformation"
+          },
+          "readOnly": true
+        },
+        "nextLink": {
+          "type": "string"
+        }
+      }
+    },
+    "StorageTaskAssignment": {
+      "type": "object",
+      "description": "The storage task assignment.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/StorageTaskAssignmentProperties",
+          "description": "Properties of the storage task assignment."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "StorageTaskAssignmentExecutionContext": {
+      "type": "object",
+      "description": "Execution context of the storage task assignment.",
+      "properties": {
+        "target": {
+          "$ref": "#/definitions/ExecutionTarget",
+          "description": "Execution target of the storage task assignment"
+        },
+        "trigger": {
+          "$ref": "#/definitions/ExecutionTrigger",
+          "description": "Execution trigger of the storage task assignment"
+        }
+      },
+      "required": [
+        "trigger"
+      ]
+    },
+    "StorageTaskAssignmentProperties": {
+      "type": "object",
+      "description": "Properties of the storage task assignment.",
+      "properties": {
+        "taskId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Id of the corresponding storage task"
+        },
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether the storage task assignment is enabled or not"
+        },
+        "description": {
+          "type": "string",
+          "description": "Text that describes the purpose of the storage task assignment"
+        },
+        "executionContext": {
+          "$ref": "#/definitions/StorageTaskAssignmentExecutionContext",
+          "description": "The storage task assignment execution context"
+        },
+        "report": {
+          "$ref": "#/definitions/StorageTaskAssignmentReport",
+          "description": "The storage task assignment report"
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/StorageTaskAssignmentProvisioningState",
+          "description": "Represents the provisioning state of the storage task assignment.",
+          "readOnly": true
+        },
+        "runStatus": {
+          "$ref": "#/definitions/StorageTaskReportProperties",
+          "description": "Run status of storage task assignment"
+        }
+      },
+      "required": [
+        "taskId",
+        "enabled",
+        "description",
+        "executionContext",
+        "report"
+      ]
+    },
+    "StorageTaskAssignmentProvisioningState": {
+      "type": "string",
+      "description": "Gets the status of the storage account at the time the operation was called.",
+      "enum": [
+        "ValidateSubscriptionQuotaBegin",
+        "ValidateSubscriptionQuotaEnd",
+        "Accepted",
+        "Creating",
+        "Succeeded",
+        "Deleting",
+        "Canceled",
+        "Failed"
+      ],
+      "x-ms-enum": {
+        "name": "StorageTaskAssignmentProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "ValidateSubscriptionQuotaBegin",
+            "value": "ValidateSubscriptionQuotaBegin"
+          },
+          {
+            "name": "ValidateSubscriptionQuotaEnd",
+            "value": "ValidateSubscriptionQuotaEnd"
+          },
+          {
+            "name": "Accepted",
+            "value": "Accepted"
+          },
+          {
+            "name": "Creating",
+            "value": "Creating"
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting"
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed"
+          }
+        ]
+      },
+      "readOnly": true
+    },
+    "StorageTaskAssignmentReport": {
+      "type": "object",
+      "description": "The storage task assignment report",
+      "properties": {
+        "prefix": {
+          "type": "string",
+          "description": "The container prefix for the location of storage task assignment report"
+        }
+      },
+      "required": [
+        "prefix"
+      ]
+    },
+    "StorageTaskAssignmentUpdateExecutionContext": {
+      "type": "object",
+      "description": "Execution context of the storage task assignment update.",
+      "properties": {
+        "target": {
+          "$ref": "#/definitions/ExecutionTarget",
+          "description": "Execution target of the storage task assignment"
+        },
+        "trigger": {
+          "$ref": "#/definitions/ExecutionTriggerUpdate",
+          "description": "Execution trigger of the storage task assignment"
+        }
+      }
+    },
+    "StorageTaskAssignmentUpdateParameters": {
+      "type": "object",
+      "description": "Parameters of the storage task assignment update request",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/StorageTaskAssignmentUpdateProperties",
+          "description": "Properties of the storage task assignment."
+        }
+      }
+    },
+    "StorageTaskAssignmentUpdateProperties": {
+      "type": "object",
+      "description": "Properties of the storage task update assignment.",
+      "properties": {
+        "taskId": {
+          "type": "string",
+          "description": "Id of the corresponding storage task",
+          "readOnly": true
+        },
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether the storage task assignment is enabled or not"
+        },
+        "description": {
+          "type": "string",
+          "description": "Text that describes the purpose of the storage task assignment"
+        },
+        "executionContext": {
+          "$ref": "#/definitions/StorageTaskAssignmentUpdateExecutionContext",
+          "description": "The storage task assignment execution context"
+        },
+        "report": {
+          "$ref": "#/definitions/StorageTaskAssignmentUpdateReport",
+          "description": "The storage task assignment report"
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/StorageTaskAssignmentProvisioningState",
+          "description": "Represents the provisioning state of the storage task assignment.",
+          "readOnly": true
+        },
+        "runStatus": {
+          "$ref": "#/definitions/StorageTaskReportProperties",
+          "description": "Run status of storage task assignment"
+        }
+      }
+    },
+    "StorageTaskAssignmentUpdateReport": {
+      "type": "object",
+      "description": "The storage task assignment report",
+      "properties": {
+        "prefix": {
+          "type": "string",
+          "description": "The prefix of the storage task assignment report"
+        }
+      }
+    },
+    "StorageTaskAssignmentsList": {
+      "type": "object",
+      "description": "List of storage task assignments for the storage account",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The StorageTaskAssignment items on this page",
+          "items": {
+            "$ref": "#/definitions/StorageTaskAssignment"
+          },
+          "readOnly": true
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "StorageTaskReportInstance": {
+      "type": "object",
+      "description": "Storage Tasks run report instance",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/StorageTaskReportProperties",
+          "description": "Storage task execution report for a run instance."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "StorageTaskReportProperties": {
+      "type": "object",
+      "description": "Storage task execution report for a run instance.",
+      "properties": {
+        "taskAssignmentId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Represents the Storage Task Assignment Id associated with the storage task that provided an execution context.",
+          "readOnly": true,
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Storage/storageAccounts/storageTaskAssignments"
+              }
+            ]
+          }
+        },
+        "storageAccountId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Represents the Storage Account Id where the storage task definition was applied and executed.",
+          "readOnly": true,
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Storage/storageAccounts"
+              }
+            ]
+          }
+        },
+        "startTime": {
+          "type": "string",
+          "description": "Start time of the run instance. Filter options such as startTime gt '2023-06-26T20:51:24.4494016Z' and other comparison operators can be used as described for DateTime properties in https://learn.microsoft.com/rest/api/storageservices/querying-tables-and-entities#supported-comparison-operators",
+          "readOnly": true
+        },
+        "finishTime": {
+          "type": "string",
+          "description": "End time of the run instance. Filter options such as startTime gt '2023-06-26T20:51:24.4494016Z' and other comparison operators can be used as described for DateTime properties in https://learn.microsoft.com/rest/api/storageservices/querying-tables-and-entities#supported-comparison-operators",
+          "readOnly": true
+        },
+        "objectsTargetedCount": {
+          "type": "string",
+          "description": "Total number of objects that meet the condition as defined in the storage task assignment execution context. Filter options such as objectsTargetedCount gt 50 and other comparison operators can be used as described for Numerical properties in https://learn.microsoft.com/rest/api/storageservices/querying-tables-and-entities#supported-comparison-operators",
+          "readOnly": true
+        },
+        "objectsOperatedOnCount": {
+          "type": "string",
+          "description": "Total number of objects that meet the storage tasks condition and were operated upon. Filter options such as objectsOperatedOnCount ge 100 and other comparison operators can be used as described for Numerical properties in https://learn.microsoft.com/rest/api/storageservices/querying-tables-and-entities#supported-comparison-operators",
+          "readOnly": true
+        },
+        "objectFailedCount": {
+          "type": "string",
+          "description": "Total number of objects where task operation failed when was attempted. Filter options such as objectFailedCount eq 0 and other comparison operators can be used as described for Numerical properties in https://learn.microsoft.com/rest/api/storageservices/querying-tables-and-entities#supported-comparison-operators",
+          "readOnly": true
+        },
+        "objectsSucceededCount": {
+          "type": "string",
+          "description": "Total number of objects where task operation succeeded when was attempted.Filter options such as objectsSucceededCount gt 150 and other comparison operators can be used as described for Numerical properties in https://learn.microsoft.com/rest/api/storageservices/querying-tables-and-entities#supported-comparison-operators",
+          "readOnly": true
+        },
+        "runStatusError": {
+          "type": "string",
+          "description": "Well known Azure Storage error code that represents the error encountered during execution of the run instance.",
+          "readOnly": true
+        },
+        "runStatusEnum": {
+          "$ref": "#/definitions/RunStatusEnum",
+          "description": "Represents the status of the execution.",
+          "readOnly": true
+        },
+        "summaryReportPath": {
+          "type": "string",
+          "description": "Full path to the verbose report stored in the reporting container as specified in the assignment execution context for the storage account.",
+          "readOnly": true
+        },
+        "taskId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Storage Task Arm Id.",
+          "readOnly": true,
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.StorageActions/storageTasks"
+              }
+            ]
+          }
+        },
+        "taskVersion": {
+          "type": "string",
+          "description": "Storage Task Version",
+          "readOnly": true
+        },
+        "runResult": {
+          "$ref": "#/definitions/RunResult",
+          "description": "Represents the overall result of the execution for the run instance",
+          "readOnly": true
+        }
+      }
+    },
+    "StorageTaskReportSummary": {
+      "type": "object",
+      "description": "Fetch Storage Tasks Run Summary.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The StorageTaskReportInstance items on this page",
+          "items": {
+            "$ref": "#/definitions/StorageTaskReportInstance"
+          },
+          "readOnly": true
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "Table": {
+      "type": "object",
+      "description": "Properties of the table, including Id, resource name, resource type.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/TableProperties",
+          "description": "Table resource properties.",
+          "x-ms-client-flatten": true,
+          "x-ms-client-name": "TableProperties"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "TableAccessPolicy": {
+      "type": "object",
+      "description": "Table Access Policy Properties Object.",
+      "properties": {
+        "startTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Start time of the access policy"
+        },
+        "expiryTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expiry time of the access policy"
+        },
+        "permission": {
+          "type": "string",
+          "description": "Required. List of abbreviated permissions. Supported permission values include 'r','a','u','d'"
+        }
+      },
+      "required": [
+        "permission"
+      ]
+    },
+    "TableProperties": {
+      "type": "object",
+      "properties": {
+        "tableName": {
+          "type": "string",
+          "description": "Table name under the specified account",
+          "readOnly": true
+        },
+        "signedIdentifiers": {
+          "type": "array",
+          "description": "List of stored access policies specified on the table.",
+          "items": {
+            "$ref": "#/definitions/TableSignedIdentifier"
+          }
+        }
+      }
+    },
+    "TableServiceProperties": {
+      "type": "object",
+      "description": "The properties of a storage account’s Table service.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/TableServicePropertiesProperties",
+          "description": "The properties of a storage account’s Table service.",
+          "x-ms-client-flatten": true,
+          "x-ms-client-name": "TableServiceProperties"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "TableServicePropertiesProperties": {
+      "type": "object",
+      "description": "The properties of a storage account’s Table service.",
+      "properties": {
+        "cors": {
+          "$ref": "#/definitions/CorsRules",
+          "description": "Specifies CORS rules for the Table service. You can include up to five CorsRule elements in the request. If no CorsRule elements are included in the request body, all CORS rules will be deleted, and CORS will be disabled for the Table service."
+        }
+      }
+    },
+    "TableSignedIdentifier": {
+      "type": "object",
+      "description": "Object to set Table Access Policy.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "unique-64-character-value of the stored access policy."
+        },
+        "accessPolicy": {
+          "$ref": "#/definitions/TableAccessPolicy",
+          "description": "Access policy"
+        }
+      },
+      "required": [
+        "id"
+      ]
+    },
+    "TagFilter": {
+      "type": "object",
+      "description": "Blob index tag based filtering for blob objects",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "This is the filter tag name, it can have 1 - 128 characters",
+          "minLength": 1,
+          "maxLength": 128
+        },
+        "op": {
+          "type": "string",
+          "description": "This is the comparison operator which is used for object comparison and filtering. Only == (equality operator) is currently supported"
+        },
+        "value": {
+          "type": "string",
+          "description": "This is the filter tag value field used for tag based filtering, it can have 0 - 256 characters",
+          "minLength": 0,
+          "maxLength": 256
+        }
+      },
+      "required": [
+        "name",
+        "op",
+        "value"
+      ]
+    },
+    "TagProperty": {
+      "type": "object",
+      "description": "A tag of the LegalHold of a blob container.",
+      "properties": {
+        "tag": {
+          "type": "string",
+          "description": "The tag value.",
+          "readOnly": true
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Returns the date and time the tag was added.",
+          "readOnly": true
+        },
+        "objectIdentifier": {
+          "type": "string",
+          "description": "Returns the Object ID of the user who added the tag.",
+          "readOnly": true
+        },
+        "tenantId": {
+          "type": "string",
+          "description": "Returns the Tenant ID that issued the token for the user who added the tag.",
+          "readOnly": true
+        },
+        "upn": {
+          "type": "string",
+          "description": "Returns the User Principal Name of the user who added the tag.",
+          "readOnly": true
+        }
+      }
+    },
+    "TestConnectionResponse": {
+      "type": "object",
+      "description": "Test connection response properties",
+      "properties": {
+        "storageConnectorMethodName": {
+          "type": "string",
+          "description": "Indicates the method used to validate the connection to the backing data store.\nValid values are `GetBlob` and `ListBlobs` for failure, and `TestExistingConnection` for success.",
+          "minLength": 1
+        },
+        "storageConnectorErrorMessage": {
+          "type": "string",
+          "description": "A string representing the error received from the backing data store.\nFormat will vary depending on the data store type and will be capped at 1 MB in size.\nThe error message will be empty if the connection was successful."
+        },
+        "storageConnectorRequestId": {
+          "type": "string",
+          "description": "The request Id associated with the request sent to the backing data store for validation.",
+          "minLength": 1
+        }
+      },
+      "required": [
+        "storageConnectorMethodName",
+        "storageConnectorRequestId"
+      ]
+    },
+    "TestExistingConnectionRequest": {
+      "type": "object",
+      "description": "Test existing connection request properties",
+      "properties": {
+        "uniqueId": {
+          "type": "string",
+          "description": "The uniqueId of the storage connector as returned by the server."
+        }
+      },
+      "required": [
+        "uniqueId"
+      ]
+    },
+    "TrackedResourceUpdate": {
+      "type": "object",
+      "description": "The resource model definition for an Azure Resource Manager tracked top level resource which has 'tags' and a 'location'",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/Resource"
+        }
+      ]
+    },
+    "TriggerParameters": {
+      "type": "object",
+      "description": "The trigger parameters update for the storage task assignment execution",
+      "properties": {
+        "startFrom": {
+          "type": "string",
+          "format": "date-time",
+          "description": "When to start task execution. This is a required field when ExecutionTrigger.properties.type is 'OnSchedule'; this property should not be present when ExecutionTrigger.properties.type is 'RunOnce'"
+        },
+        "interval": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Run interval of task execution. This is a required field when ExecutionTrigger.properties.type is 'OnSchedule'; this property should not be present when ExecutionTrigger.properties.type is 'RunOnce'",
+          "minimum": 1
+        },
+        "intervalUnit": {
+          "$ref": "#/definitions/IntervalUnit",
+          "description": "Run interval unit of task execution. This is a required field when ExecutionTrigger.properties.type is 'OnSchedule'; this property should not be present when ExecutionTrigger.properties.type is 'RunOnce'"
+        },
+        "endBy": {
+          "type": "string",
+          "format": "date-time",
+          "description": "When to end task execution. This is a required field when ExecutionTrigger.properties.type is 'OnSchedule'; this property should not be present when ExecutionTrigger.properties.type is 'RunOnce'"
+        },
+        "startOn": {
+          "type": "string",
+          "format": "date-time",
+          "description": "When to start task execution. This is a required field when ExecutionTrigger.properties.type is 'RunOnce'; this property should not be present when ExecutionTrigger.properties.type is 'OnSchedule'"
+        }
+      }
+    },
+    "TriggerParametersUpdate": {
+      "type": "object",
+      "description": "The trigger parameters update for the storage task assignment execution",
+      "properties": {
+        "startFrom": {
+          "type": "string",
+          "format": "date-time",
+          "description": "When to start task execution. This is a mutable field when ExecutionTrigger.properties.type is 'OnSchedule'; this property should not be present when ExecutionTrigger.properties.type is 'RunOnce'"
+        },
+        "interval": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Run interval of task execution. This is a mutable field when ExecutionTrigger.properties.type is 'OnSchedule'; this property should not be present when ExecutionTrigger.properties.type is 'RunOnce'",
+          "minimum": 1
+        },
+        "intervalUnit": {
+          "$ref": "#/definitions/IntervalUnit",
+          "description": "Run interval unit of task execution. This is a mutable field when ExecutionTrigger.properties.type is 'OnSchedule'; this property should not be present when ExecutionTrigger.properties.type is 'RunOnce'"
+        },
+        "endBy": {
+          "type": "string",
+          "format": "date-time",
+          "description": "When to end task execution. This is a mutable field when ExecutionTrigger.properties.type is 'OnSchedule'; this property should not be present when ExecutionTrigger.properties.type is 'RunOnce'"
+        },
+        "startOn": {
+          "type": "string",
+          "format": "date-time",
+          "description": "When to start task execution. This is a mutable field when ExecutionTrigger.properties.type is 'RunOnce'; this property should not be present when ExecutionTrigger.properties.type is 'OnSchedule'"
+        }
+      }
+    },
+    "TriggerType": {
+      "type": "string",
+      "description": "The trigger type of the storage task assignment execution",
+      "enum": [
+        "RunOnce",
+        "OnSchedule",
+        "MockRun"
+      ],
+      "x-ms-enum": {
+        "name": "TriggerType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "RunOnce",
+            "value": "RunOnce"
+          },
+          {
+            "name": "OnSchedule",
+            "value": "OnSchedule"
+          },
+          {
+            "name": "MockRun",
+            "value": "MockRun",
+            "description": "Run the task as a mock for testing"
+          }
+        ]
+      }
+    },
+    "UpdateHistoryProperty": {
+      "type": "object",
+      "description": "An update history of the ImmutabilityPolicy of a blob container.",
+      "properties": {
+        "update": {
+          "$ref": "#/definitions/ImmutabilityPolicyUpdateType",
+          "description": "The ImmutabilityPolicy update type of a blob container, possible values include: put, lock and extend.",
+          "readOnly": true
+        },
+        "immutabilityPeriodSinceCreationInDays": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The immutability period for the blobs in the container since the policy creation, in days.",
+          "readOnly": true
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Returns the date and time the ImmutabilityPolicy was updated.",
+          "readOnly": true
+        },
+        "objectIdentifier": {
+          "type": "string",
+          "description": "Returns the Object ID of the user who updated the ImmutabilityPolicy.",
+          "readOnly": true
+        },
+        "tenantId": {
+          "type": "string",
+          "description": "Returns the Tenant ID that issued the token for the user who updated the ImmutabilityPolicy.",
+          "readOnly": true
+        },
+        "upn": {
+          "type": "string",
+          "description": "Returns the User Principal Name of the user who updated the ImmutabilityPolicy.",
+          "readOnly": true
+        },
+        "allowProtectedAppendWrites": {
+          "type": "boolean",
+          "description": "This property can only be changed for unlocked time-based retention policies. When enabled, new blocks can be written to an append blob while maintaining immutability protection and compliance. Only new blocks can be added and any existing blocks cannot be modified or deleted. This property cannot be changed with ExtendImmutabilityPolicy API."
+        },
+        "allowProtectedAppendWritesAll": {
+          "type": "boolean",
+          "description": "This property can only be changed for unlocked time-based retention policies. When enabled, new blocks can be written to both 'Append and Bock Blobs' while maintaining immutability protection and compliance. Only new blocks can be added and any existing blocks cannot be modified or deleted. This property cannot be changed with ExtendImmutabilityPolicy API. The 'allowProtectedAppendWrites' and 'allowProtectedAppendWritesAll' properties are mutually exclusive."
+        }
+      }
+    },
+    "Usage": {
+      "type": "object",
+      "description": "Describes Storage Resource Usage.",
+      "properties": {
+        "unit": {
+          "$ref": "#/definitions/UsageUnit",
+          "description": "Gets the unit of measurement.",
+          "readOnly": true
+        },
+        "currentValue": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Gets the current count of the allocated resources in the subscription.",
+          "readOnly": true
+        },
+        "limit": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Gets the maximum count of the resources that can be allocated in the subscription.",
+          "readOnly": true
+        },
+        "name": {
+          "$ref": "#/definitions/UsageName",
+          "description": "Gets the name of the type of usage.",
+          "readOnly": true
+        }
+      }
+    },
+    "UsageListResult": {
+      "type": "object",
+      "description": "The response from the List Usages operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "Gets or sets the list of Storage Resource Usages.",
+          "items": {
+            "$ref": "#/definitions/Usage"
+          }
+        },
+        "nextLink": {
+          "type": "string"
+        }
+      }
+    },
+    "UsageName": {
+      "type": "object",
+      "description": "The usage names that can be used; currently limited to StorageAccount.",
+      "properties": {
+        "value": {
+          "type": "string",
+          "description": "Gets a string describing the resource name.",
+          "readOnly": true
+        },
+        "localizedValue": {
+          "type": "string",
+          "description": "Gets a localized string describing the resource name.",
+          "readOnly": true
+        }
+      }
+    },
+    "UsageUnit": {
+      "type": "string",
+      "description": "Gets the unit of measurement.",
+      "enum": [
+        "Count",
+        "Bytes",
+        "Seconds",
+        "Percent",
+        "CountsPerSecond",
+        "BytesPerSecond"
+      ],
+      "x-ms-enum": {
+        "name": "UsageUnit",
+        "modelAsString": false
+      }
+    },
+    "UserAssignedIdentity": {
+      "type": "object",
+      "description": "UserAssignedIdentity for the resource.",
+      "properties": {
+        "principalId": {
+          "type": "string",
+          "description": "The principal ID of the identity.",
+          "readOnly": true
+        },
+        "clientId": {
+          "type": "string",
+          "description": "The client ID of the identity.",
+          "readOnly": true
+        }
+      }
+    },
+    "VirtualNetworkRule": {
+      "type": "object",
+      "description": "Virtual Network rule.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Resource ID of a subnet, for example: /subscriptions/{subscriptionId}/resourceGroups/{groupName}/providers/Microsoft.Network/virtualNetworks/{vnetName}/subnets/{subnetName}.",
+          "x-ms-client-name": "VirtualNetworkResourceId"
+        },
+        "action": {
+          "type": "string",
+          "description": "The action of virtual network rule.",
+          "enum": [
+            "Allow"
+          ],
+          "x-ms-enum": {
+            "modelAsString": false
+          }
+        },
+        "state": {
+          "$ref": "#/definitions/State",
+          "description": "Gets the state of virtual network rule."
+        }
+      },
+      "required": [
+        "id"
+      ]
+    },
+    "ZonePlacementPolicy": {
+      "type": "string",
+      "description": "The availability zone pinning policy for the storage account.",
+      "enum": [
+        "Any",
+        "None"
+      ],
+      "x-ms-enum": {
+        "name": "ZonePlacementPolicy",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Any",
+            "value": "Any"
+          },
+          {
+            "name": "None",
+            "value": "None"
+          }
+        ]
+      }
+    },
+    "migrationStatus": {
+      "type": "string",
+      "description": "Current status of migration",
+      "enum": [
+        "Invalid",
+        "SubmittedForConversion",
+        "InProgress",
+        "Complete",
+        "Failed"
+      ],
+      "x-ms-enum": {
+        "name": "migrationStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Invalid",
+            "value": "Invalid"
+          },
+          {
+            "name": "SubmittedForConversion",
+            "value": "SubmittedForConversion"
+          },
+          {
+            "name": "InProgress",
+            "value": "InProgress"
+          },
+          {
+            "name": "Complete",
+            "value": "Complete"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed"
+          }
+        ]
+      }
+    }
+  },
+  "parameters": {}
+}


### PR DESCRIPTION
## Changes

- Add the `2026-09-01` Storage Management API version.
- Add and update examples for `2026-09-01`.
- Generate the corresponding `2026-09-01` OpenAPI specification.

## Validation

- `npx tsp compile .` passed.
- `npx tsv specification/storage/Storage.Management` passed.