### PR TITLE
feat(chaos): add required region to connection properties in 2026-11-01

### DIFF
--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/connection.models.tsp
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/connection.models.tsp
@@ -48,6 +48,23 @@ model ConnectionProperties {
   targetResourceId: Azure.Core.armResourceIdentifier;
 
   /**
+   * The Azure region of the target resource. Chaos Studio assigns this connection's
+   * regional data-plane endpoint from this value, so it must name a region in which
+   * Chaos Studio operates a data plane; the service rejects the request otherwise.
+   *
+   * This is supplied by the client because an Azure Resource Manager resource ID does
+   * not encode the location of the resource it names, and resolving it service-side
+   * would require a read against the target resource that the caller may not have
+   * granted. This mirrors the established pattern for resources whose DNS or endpoint
+   * configuration is regional — for example
+   * `Microsoft.Search/searchServices/sharedPrivateLinkResources.resourceRegion`, whose
+   * own documentation calls it out as required specifically for targets such as Azure
+   * Kubernetes Service.
+   */
+  @added(Microsoft.Chaos.Versions.v2026_11_01)
+  region: Azure.Core.azureLocation;
+
+  /**
    * The Microsoft Entra principal (object) ID of the identity used by the connection.
    */
   principalId?: Azure.Core.uuid;

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Connections_CreateOrUpdate.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Connections_CreateOrUpdate.json
@@ -9,6 +9,7 @@
       "properties": {
         "kind": "AksExtension",
         "targetResourceId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.ContainerService/managedClusters/exampleCluster",
+        "region": "eastus",
         "principalId": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
         "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
       }
@@ -23,6 +24,7 @@
         "properties": {
           "kind": "AksExtension",
           "targetResourceId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.ContainerService/managedClusters/exampleCluster",
+          "region": "eastus",
           "principalId": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
           "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
           "dataPlaneEndpoint": "https://dataplane.eastus.chaos-prod.azure.com",
@@ -48,6 +50,7 @@
         "properties": {
           "kind": "AksExtension",
           "targetResourceId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.ContainerService/managedClusters/exampleCluster",
+          "region": "eastus",
           "principalId": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
           "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
           "status": "Pending",

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Connections_Get.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Connections_Get.json
@@ -15,6 +15,7 @@
         "properties": {
           "kind": "AksExtension",
           "targetResourceId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.ContainerService/managedClusters/exampleCluster",
+          "region": "eastus",
           "principalId": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
           "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
           "dataPlaneEndpoint": "https://dataplane.eastus.chaos-prod.azure.com",

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Connections_ListAll.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Connections_ListAll.json
@@ -16,6 +16,7 @@
             "properties": {
               "kind": "AksExtension",
               "targetResourceId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.ContainerService/managedClusters/exampleCluster",
+              "region": "eastus",
               "principalId": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
               "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
               "dataPlaneEndpoint": "https://dataplane.eastus.chaos-prod.azure.com",
@@ -38,6 +39,7 @@
             "properties": {
               "kind": "Csfi",
               "targetResourceId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/exampleVm",
+              "region": "eastus",
               "principalId": "9f8e7d6c-5b4a-3c2d-1e0f-9a8b7c6d5e4f",
               "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
               "certificateSubjectName": "CN=chaos-csfi.dsts.core.windows.net",

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Connections_CreateOrUpdate.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Connections_CreateOrUpdate.json
@@ -9,6 +9,7 @@
       "properties": {
         "kind": "AksExtension",
         "targetResourceId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.ContainerService/managedClusters/exampleCluster",
+        "region": "eastus",
         "principalId": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
         "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
       }
@@ -23,6 +24,7 @@
         "properties": {
           "kind": "AksExtension",
           "targetResourceId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.ContainerService/managedClusters/exampleCluster",
+          "region": "eastus",
           "principalId": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
           "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
           "dataPlaneEndpoint": "https://dataplane.eastus.chaos-prod.azure.com",
@@ -48,6 +50,7 @@
         "properties": {
           "kind": "AksExtension",
           "targetResourceId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.ContainerService/managedClusters/exampleCluster",
+          "region": "eastus",
           "principalId": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
           "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
           "status": "Pending",

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Connections_Get.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Connections_Get.json
@@ -15,6 +15,7 @@
         "properties": {
           "kind": "AksExtension",
           "targetResourceId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.ContainerService/managedClusters/exampleCluster",
+          "region": "eastus",
           "principalId": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
           "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
           "dataPlaneEndpoint": "https://dataplane.eastus.chaos-prod.azure.com",

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Connections_ListAll.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Connections_ListAll.json
@@ -16,6 +16,7 @@
             "properties": {
               "kind": "AksExtension",
               "targetResourceId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.ContainerService/managedClusters/exampleCluster",
+              "region": "eastus",
               "principalId": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
               "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
               "dataPlaneEndpoint": "https://dataplane.eastus.chaos-prod.azure.com",
@@ -38,6 +39,7 @@
             "properties": {
               "kind": "Csfi",
               "targetResourceId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/exampleVm",
+              "region": "eastus",
               "principalId": "9f8e7d6c-5b4a-3c2d-1e0f-9a8b7c6d5e4f",
               "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
               "certificateSubjectName": "CN=chaos-csfi.dsts.core.windows.net",

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/openapi.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/openapi.json
@@ -5291,6 +5291,10 @@
           "format": "arm-id",
           "description": "The fully qualified Azure resource ID of the target resource this connection is established with."
         },
+        "region": {
+          "$ref": "#/definitions/Azure.Core.azureLocation",
+          "description": "The Azure region of the target resource. Chaos Studio assigns this connection's\nregional data-plane endpoint from this value, so it must name a region in which\nChaos Studio operates a data plane; the service rejects the request otherwise.\n\nThis is supplied by the client because an Azure Resource Manager resource ID does\nnot encode the location of the resource it names, and resolving it service-side\nwould require a read against the target resource that the caller may not have\ngranted. This mirrors the established pattern for resources whose DNS or endpoint\nconfiguration is regional — for example\n`Microsoft.Search/searchServices/sharedPrivateLinkResources.resourceRegion`, whose\nown documentation calls it out as required specifically for targets such as Azure\nKubernetes Service."
+        },
         "principalId": {
           "$ref": "#/definitions/Azure.Core.uuid",
           "description": "The Microsoft Entra principal (object) ID of the identity used by the connection."
@@ -5330,7 +5334,8 @@
       },
       "required": [
         "kind",
-        "targetResourceId"
+        "targetResourceId",
+        "region"
       ]
     },
     "ConnectionStatus": {


### PR DESCRIPTION
> **Opened for @juliagao-microsoft's decision, not as a fait accompli.** This adds a member to your in-flight GA promotion, so please treat it as a proposal — happy to withdraw it or reshape it.

## What this adds

A **required** `region` property on `ConnectionProperties`, scoped to **`2026-11-01` only**.

Chaos Studio assigns each connection's regional data-plane endpoint (`dataPlaneEndpoint`, read-only) from the target's region, so the service must know that region at create time.

## Why the client supplies it rather than the service resolving it

This is the part most likely to draw ARM-review scrutiny, so the argument up front:

**An ARM resource ID does not encode the location of the resource it names.** `targetResourceId` gives us subscription, resource group, provider and name — not region. Resolving it service-side would require a read against the customer's target resource, and the caller has not necessarily granted us that.

The pattern is established for exactly this situation — resources whose **DNS or endpoint configuration is regional**:

- **`Microsoft.Search/searchServices/sharedPrivateLinkResources.resourceRegion`** — its own documentation says it is *"only required for those resources whose DNS configuration are regional (such as Azure Kubernetes Service)"*. Our target here is AKS.
- **Azure Front Door** does the same with `privateLinkLocation`.
- **`Microsoft.Chaos/targets`** already accepts a client-supplied `location` in this same RP.

The discriminator across Azure is consistent: where the region is needed for **endpoint provisioning at create**, the client supplies it; where it is needed only to validate a policy rule, the service resolves it. We assign a regional DNS endpoint, so we are on the first side.

## Why required, and why that is safe here

The endpoint cannot be assigned without it, so an optional field would only move the failure later and make it less clear. Requests naming a region where Chaos Studio operates no data plane are rejected with `400`.

**It is added only in `2026-11-01`.** Connections were introduced in `2026-08-01-preview`, so a member without `@added` would have applied from that version onward and **silently changed a shipped preview**. Verified after compiling:

- `stable/2026-11-01/openapi.json` — `region` present and listed in `required`
- `preview/2026-08-01-preview/openapi.json` — `region` **absent**, `required` unchanged

A client moving preview → GA must start supplying it. That is a deliberate preview-to-GA change, stated here rather than left to be discovered.

## Mechanics

- Type is `Azure.Core.azureLocation`.
- Swagger and example output **regenerated with `tsp compile`**; nothing hand-edited.
- Examples updated for the three operations with a body; `region: "eastus"` is consistent with the existing `dataplane.eastus.chaos-prod.azure.com` endpoint in those same examples.

## Context

Backs `Microsoft.Chaos/workspaces/connections`, the trust anchor authorizing an AKS cluster to reach the Chaos Studio data plane for a workspace. Internal design reference: D32 in the workspace-connections decision log; work item AB#38851037.
