### PR TITLE
Fix Container Apps 2026-03-02-preview CI findings

### DIFF
--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/SourceControl.tsp
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/SourceControl.tsp
@@ -46,7 +46,6 @@ interface ContainerAppsSourceControls {
        */
       #suppress "@azure-tools/typespec-azure-core/casing-style" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
       @removed(Versions.v2026_01_01)
-      @added(Versions.v2026_03_02_preview)
       @header
       `x-ms-github-auxiliary`?: string;
     },
@@ -68,7 +67,6 @@ interface ContainerAppsSourceControls {
        */
       #suppress "@azure-tools/typespec-azure-core/casing-style" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
       @removed(Versions.v2026_01_01)
-      @added(Versions.v2026_03_02_preview)
       @header
       `x-ms-github-auxiliary`?: string;
 
@@ -76,7 +74,6 @@ interface ContainerAppsSourceControls {
        * Ignore Workflow Deletion Failure.
        */
       @removed(Versions.v2026_01_01)
-      @added(Versions.v2026_03_02_preview)
       @query("ignoreWorkflowDeletionFailure")
       ignoreWorkflowDeletionFailure?: boolean;
 
@@ -84,7 +81,6 @@ interface ContainerAppsSourceControls {
        * Delete workflow.
        */
       @removed(Versions.v2026_01_01)
-      @added(Versions.v2026_03_02_preview)
       @query("deleteWorkflow")
       deleteWorkflow?: boolean;
     },

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/SourceControls_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/SourceControls_CreateOrUpdate.json
@@ -26,8 +26,7 @@
       }
     },
     "sourceControlName": "current",
-    "subscriptionId": "651f8027-33e8-4ec4-97b4-f6e9f3dc8744",
-    "x-ms-github-auxiliary": "githubaccesstoken"
+    "subscriptionId": "651f8027-33e8-4ec4-97b4-f6e9f3dc8744"
   },
   "responses": {
     "200": {

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/SourceControls_Delete.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/SourceControls_Delete.json
@@ -2,12 +2,9 @@
   "parameters": {
     "api-version": "2026-03-02-preview",
     "containerAppName": "testcanadacentral",
-    "deleteWorkflow": false,
-    "ignoreWorkflowDeletionFailure": false,
     "resourceGroupName": "workerapps-rg-xj",
     "sourceControlName": "current",
-    "subscriptionId": "651f8027-33e8-4ec4-97b4-f6e9f3dc8744",
-    "x-ms-github-auxiliary": "githubaccesstoken"
+    "subscriptionId": "651f8027-33e8-4ec4-97b4-f6e9f3dc8744"
   },
   "responses": {
     "200": {},

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/SourceControls_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/SourceControls_CreateOrUpdate.json
@@ -26,8 +26,7 @@
       }
     },
     "sourceControlName": "current",
-    "subscriptionId": "651f8027-33e8-4ec4-97b4-f6e9f3dc8744",
-    "x-ms-github-auxiliary": "githubaccesstoken"
+    "subscriptionId": "651f8027-33e8-4ec4-97b4-f6e9f3dc8744"
   },
   "responses": {
     "200": {

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/SourceControls_Delete.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/SourceControls_Delete.json
@@ -2,12 +2,9 @@
   "parameters": {
     "api-version": "2026-03-02-preview",
     "containerAppName": "testcanadacentral",
-    "deleteWorkflow": false,
-    "ignoreWorkflowDeletionFailure": false,
     "resourceGroupName": "workerapps-rg-xj",
     "sourceControlName": "current",
-    "subscriptionId": "651f8027-33e8-4ec4-97b4-f6e9f3dc8744",
-    "x-ms-github-auxiliary": "githubaccesstoken"
+    "subscriptionId": "651f8027-33e8-4ec4-97b4-f6e9f3dc8744"
   },
   "responses": {
     "200": {},

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/openapi.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/openapi.json
@@ -5669,13 +5669,6 @@
             "type": "string"
           },
           {
-            "name": "x-ms-github-auxiliary",
-            "in": "header",
-            "description": "Github personal access token used for SourceControl.",
-            "required": false,
-            "type": "string"
-          },
-          {
             "name": "sourceControlEnvelope",
             "in": "body",
             "description": "Properties used to create a Container App SourceControl",
@@ -5757,27 +5750,6 @@
             "description": "Name of the Container App SourceControl.",
             "required": true,
             "type": "string"
-          },
-          {
-            "name": "x-ms-github-auxiliary",
-            "in": "header",
-            "description": "Github personal access token used for SourceControl.",
-            "required": false,
-            "type": "string"
-          },
-          {
-            "name": "ignoreWorkflowDeletionFailure",
-            "in": "query",
-            "description": "Ignore Workflow Deletion Failure.",
-            "required": false,
-            "type": "boolean"
-          },
-          {
-            "name": "deleteWorkflow",
-            "in": "query",
-            "description": "Delete workflow.",
-            "required": false,
-            "type": "boolean"
           }
         ],
         "responses": {

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/readme.md
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/readme.md
@@ -57,6 +57,39 @@ These settings apply only when `--tag=package-preview-2026-03-02-preview` is spe
 ```yaml $(tag) == 'package-preview-2026-03-02-preview'
 input-file:
   - preview/2026-03-02-preview/openapi.json
+directive:
+  - suppress: PatchBodyParametersSchema
+    from: openapi.json
+    reason: |
+      Pre-existing preview contract. Patch models retain required and defaulted properties for compatibility.
+  - suppress: AvoidAdditionalProperties
+    from: openapi.json
+    reason: |
+      Pre-existing preview contract. Metadata and customized key dictionaries use additionalProperties.
+  - suppress: PutResponseCodes
+    from: openapi.json
+    reason: |
+      Pre-existing preview contract. Do not change response codes while restoring the preview surface.
+  - suppress: PostResponseCodes
+    from: openapi.json
+    reason: |
+      Pre-existing preview contract. Do not change response codes while restoring the preview surface.
+  - suppress: LroErrorContent
+    from: openapi.json
+    reason: |
+      Pre-existing preview contract. These operations use the service's existing error response shape.
+  - suppress: ProvisioningStateMustBeReadOnly
+    from: openapi.json
+    reason: |
+      Pre-existing preview contract. Restored resource models preserve their original provisioningState behavior.
+  - suppress: UnSupportedPatchProperties
+    from: openapi.json
+    reason: |
+      Pre-existing preview contract. Patch request shapes are preserved for compatibility.
+  - suppress: DescriptionMustNotBeNodeName
+    from: openapi.json
+    reason: |
+      Pre-existing preview contract. Existing wire-value descriptions are preserved without changing generated clients.
 ```
 
 ### Tag: package-preview-2025-10-02-preview

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/suppressions.yaml
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/suppressions.yaml
@@ -52,3 +52,6 @@
 - tool: TypeSpecRequirement
   path: ./stable/2025-07-01/*.json
   reason: Brownfield service not ready to migrate
+- tool: SwaggerAvocado
+  path: ./preview/2025-10-02-preview/openapi.json
+  reason: The Functions host invoke operation is an internal RP-to-RP API that was intentionally retired starting with 2026-01-01, so it is intentionally absent from the default tag.


### PR DESCRIPTION
Removes the restored Source Control parameters that caused cross-version rule 1042 (ChangedParameterOrder), cleans the corresponding examples, carries forward pre-existing preview lint suppressions, and suppresses Avocado for the intentionally retired internal Functions invoke operation.\n\nThis updates #45788 without introducing a breaking-change approval requirement.