### PR TITLE
ContainerService: remove stable pins for 2026-06 preview SDK generation

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/tspconfig.yaml
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/tspconfig.yaml
@@ -30,7 +30,6 @@ options:
     enable-sync-stack: false
     uuid-as-string: false
     float32-as-double: false
-    api-version: "2026-06-01"
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/containerservice"
     emitter-output-dir: "{output-dir}/{service-dir}/armcontainerservice"
@@ -53,11 +52,9 @@ options:
     namespace: "Azure.ResourceManager.ContainerService"
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
     enable-wire-path-attribute: true
-    api-version: "2026-06-01"
   "@azure-typespec/http-client-csharp-provisioning":
     namespace: "Azure.Provisioning.ContainerService"
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
-    api-version: "2026-06-01"
 
 linter:
   extends:


### PR DESCRIPTION
## Purpose

Remove the stable `2026-06-01` API-version pins from the ContainerService Java, C# management, and C# provisioning emitters so the `2026-06-02-preview` SDKs can be generated from the latest preview surface.

This changes SDK configuration only; it does not modify the API specification.

## Validation

- `tsp compile specification/containerservice/resource-manager/Microsoft.ContainerService/aks --no-emit --warn-as-error`
- Diff matches the established ContainerService preview-transition pattern from #44994.

## Due diligence checklist

- [x] I confirm this PR modifies only SDK configuration and not API specifications.
- [x] I reviewed the ARM `tspconfig.yaml` template and the prior ContainerService preview-generation configuration change.

Preview SDK generation will use release plan 36041 only after every 2026-06 stable SDK package is published.