### PR TITLE
Add cluster-level FIPS to stable API version 2026-07-01

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/CommonModels.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/CommonModels.tsp
@@ -1930,10 +1930,10 @@ model ManagedClusterProperties {
   supportPlan?: KubernetesSupportPlan;
 
   /**
-   * Whether to enable FIPS mode at the cluster level. When enabled, this setting enforces FIPS compliance for all AKS-managed components, such as the node operating system, addons, and [managed containerized components](https://aka.ms/aks/components/docs). See [Enable cluster-wide FIPS](https://aka.ms/aks/fips) for more details. When this property is enabled, all node pools in the cluster must also be FIPS-enabled.
+   * Whether to enable FIPS mode at the cluster level. When enabled, this setting enforces FIPS compliance for all AKS-managed components, such as the node operating system, addons, and [managed containerized components](https://aka.ms/aks/components/docs). See [Enable cluster-wide FIPS](https://aka.ms/aks/fips) for more details. When this property is enabled, all node pools in the cluster must also be FIPS-enabled. Although this property is available in a stable API version, cluster-wide FIPS remains a preview feature. Write requests whose resulting cluster state has this property set to true require the `Microsoft.ContainerService/EnableFIPSPreview` subscription feature registration.
    */
   #suppress "@azure-tools/typespec-azure-core/casing-style" "Property name maintained for consistency with existing FIPS properties in AKS."
-  @added(Versions.v2026_07_02_preview)
+  @added(Versions.v2026_07_01)
   enableFIPS?: boolean;
 
   /**

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/examples/2026-07-01/ManagedClustersCreate_EnabledFIPS.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/examples/2026-07-01/ManagedClustersCreate_EnabledFIPS.json
@@ -23,6 +23,7 @@
         },
         "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
         "dnsPrefix": "dnsprefix1",
+        "enableFIPS": true,
         "enableRBAC": true,
         "kubernetesVersion": "",
         "linuxProfile": {
@@ -98,6 +99,7 @@
           "currentKubernetesVersion": "1.9.6",
           "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
           "dnsPrefix": "dnsprefix1",
+          "enableFIPS": true,
           "enableRBAC": true,
           "fqdn": "dnsprefix1-abcd1234.hcp.eastus.azmk8s.io",
           "kubernetesVersion": "1.9.6",
@@ -189,6 +191,7 @@
           "currentKubernetesVersion": "1.9.6",
           "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
           "dnsPrefix": "dnsprefix1",
+          "enableFIPS": true,
           "enableRBAC": true,
           "kubernetesVersion": "1.9.6",
           "linuxProfile": {
@@ -251,5 +254,5 @@
     }
   },
   "operationId": "ManagedClusters_CreateOrUpdate",
-  "title": "Create Managed Cluster with FIPS enabled OS"
+  "title": "Create Managed Cluster with cluster-level FIPS enabled"
 }

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/examples/2026-07-02-preview/ManagedClustersCreate_EnabledFIPS.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/examples/2026-07-02-preview/ManagedClustersCreate_EnabledFIPS.json
@@ -23,6 +23,7 @@
         },
         "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
         "dnsPrefix": "dnsprefix1",
+        "enableFIPS": true,
         "enableRBAC": true,
         "kubernetesVersion": "",
         "linuxProfile": {
@@ -97,6 +98,7 @@
           },
           "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
           "dnsPrefix": "dnsprefix1",
+          "enableFIPS": true,
           "enableRBAC": true,
           "fqdn": "dnsprefix1-abcd1234.hcp.eastus.azmk8s.io",
           "kubernetesVersion": "1.9.6",
@@ -187,6 +189,7 @@
           },
           "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
           "dnsPrefix": "dnsprefix1",
+          "enableFIPS": true,
           "enableRBAC": true,
           "kubernetesVersion": "1.9.6",
           "linuxProfile": {
@@ -249,5 +252,5 @@
     }
   },
   "operationId": "ManagedClusters_CreateOrUpdate",
-  "title": "Create Managed Cluster with FIPS enabled OS"
+  "title": "Create Managed Cluster with cluster-level FIPS enabled"
 }

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-07-02-preview/examples/ManagedClustersCreate_EnabledFIPS.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-07-02-preview/examples/ManagedClustersCreate_EnabledFIPS.json
@@ -23,6 +23,7 @@
         },
         "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
         "dnsPrefix": "dnsprefix1",
+        "enableFIPS": true,
         "enableRBAC": true,
         "kubernetesVersion": "",
         "linuxProfile": {
@@ -97,6 +98,7 @@
           },
           "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
           "dnsPrefix": "dnsprefix1",
+          "enableFIPS": true,
           "enableRBAC": true,
           "fqdn": "dnsprefix1-abcd1234.hcp.eastus.azmk8s.io",
           "kubernetesVersion": "1.9.6",
@@ -187,6 +189,7 @@
           },
           "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
           "dnsPrefix": "dnsprefix1",
+          "enableFIPS": true,
           "enableRBAC": true,
           "kubernetesVersion": "1.9.6",
           "linuxProfile": {
@@ -249,5 +252,5 @@
     }
   },
   "operationId": "ManagedClusters_CreateOrUpdate",
-  "title": "Create Managed Cluster with FIPS enabled OS"
+  "title": "Create Managed Cluster with cluster-level FIPS enabled"
 }

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-07-02-preview/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-07-02-preview/managedClusters.json
@@ -1242,9 +1242,6 @@
           "Create Managed Cluster with EncryptionAtHost enabled": {
             "$ref": "./examples/ManagedClustersCreate_EnableEncryptionAtHost.json"
           },
-          "Create Managed Cluster with FIPS enabled OS": {
-            "$ref": "./examples/ManagedClustersCreate_EnabledFIPS.json"
-          },
           "Create Managed Cluster with GPUMIG": {
             "$ref": "./examples/ManagedClustersCreate_GPUMIG.json"
           },
@@ -1283,6 +1280,9 @@
           },
           "Create Managed Cluster with Web App Routing Ingress Profile configured": {
             "$ref": "./examples/ManagedClustersCreate_IngressProfile_WebAppRouting.json"
+          },
+          "Create Managed Cluster with cluster-level FIPS enabled": {
+            "$ref": "./examples/ManagedClustersCreate_EnabledFIPS.json"
           },
           "Create Managed Cluster with user-assigned NAT gateway as outbound type": {
             "$ref": "./examples/ManagedClustersCreate_UserAssignedNATGateway.json"
@@ -13503,7 +13503,7 @@
         },
         "enableFIPS": {
           "type": "boolean",
-          "description": "Whether to enable FIPS mode at the cluster level. When enabled, this setting enforces FIPS compliance for all AKS-managed components, such as the node operating system, addons, and [managed containerized components](https://aka.ms/aks/components/docs). See [Enable cluster-wide FIPS](https://aka.ms/aks/fips) for more details. When this property is enabled, all node pools in the cluster must also be FIPS-enabled."
+          "description": "Whether to enable FIPS mode at the cluster level. When enabled, this setting enforces FIPS compliance for all AKS-managed components, such as the node operating system, addons, and [managed containerized components](https://aka.ms/aks/components/docs). See [Enable cluster-wide FIPS](https://aka.ms/aks/fips) for more details. When this property is enabled, all node pools in the cluster must also be FIPS-enabled. Although this property is available in a stable API version, cluster-wide FIPS remains a preview feature. Write requests whose resulting cluster state has this property set to true require the `Microsoft.ContainerService/EnableFIPSPreview` subscription feature registration."
         },
         "enableNodeHardening": {
           "type": "boolean",

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-07-01/examples/ManagedClustersCreate_EnabledFIPS.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-07-01/examples/ManagedClustersCreate_EnabledFIPS.json
@@ -23,6 +23,7 @@
         },
         "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
         "dnsPrefix": "dnsprefix1",
+        "enableFIPS": true,
         "enableRBAC": true,
         "kubernetesVersion": "",
         "linuxProfile": {
@@ -98,6 +99,7 @@
           "currentKubernetesVersion": "1.9.6",
           "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
           "dnsPrefix": "dnsprefix1",
+          "enableFIPS": true,
           "enableRBAC": true,
           "fqdn": "dnsprefix1-abcd1234.hcp.eastus.azmk8s.io",
           "kubernetesVersion": "1.9.6",
@@ -189,6 +191,7 @@
           "currentKubernetesVersion": "1.9.6",
           "diskEncryptionSetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/diskEncryptionSets/des",
           "dnsPrefix": "dnsprefix1",
+          "enableFIPS": true,
           "enableRBAC": true,
           "kubernetesVersion": "1.9.6",
           "linuxProfile": {
@@ -251,5 +254,5 @@
     }
   },
   "operationId": "ManagedClusters_CreateOrUpdate",
-  "title": "Create Managed Cluster with FIPS enabled OS"
+  "title": "Create Managed Cluster with cluster-level FIPS enabled"
 }

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-07-01/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-07-01/managedClusters.json
@@ -561,9 +561,6 @@
           "Create Managed Cluster with EncryptionAtHost enabled": {
             "$ref": "./examples/ManagedClustersCreate_EnableEncryptionAtHost.json"
           },
-          "Create Managed Cluster with FIPS enabled OS": {
-            "$ref": "./examples/ManagedClustersCreate_EnabledFIPS.json"
-          },
           "Create Managed Cluster with GPUMIG": {
             "$ref": "./examples/ManagedClustersCreate_GPUMIG.json"
           },
@@ -596,6 +593,9 @@
           },
           "Create Managed Cluster with Web App Routing Ingress Profile configured": {
             "$ref": "./examples/ManagedClustersCreate_IngressProfile_WebAppRouting.json"
+          },
+          "Create Managed Cluster with cluster-level FIPS enabled": {
+            "$ref": "./examples/ManagedClustersCreate_EnabledFIPS.json"
           },
           "Create Managed Cluster with user-assigned NAT gateway as outbound type": {
             "$ref": "./examples/ManagedClustersCreate_UserAssignedNATGateway.json"
@@ -8704,6 +8704,10 @@
         "supportPlan": {
           "$ref": "#/definitions/KubernetesSupportPlan",
           "description": "The support plan for the Managed Cluster. If unspecified, the default is 'KubernetesOfficial'."
+        },
+        "enableFIPS": {
+          "type": "boolean",
+          "description": "Whether to enable FIPS mode at the cluster level. When enabled, this setting enforces FIPS compliance for all AKS-managed components, such as the node operating system, addons, and [managed containerized components](https://aka.ms/aks/components/docs). See [Enable cluster-wide FIPS](https://aka.ms/aks/fips) for more details. When this property is enabled, all node pools in the cluster must also be FIPS-enabled. Although this property is available in a stable API version, cluster-wide FIPS remains a preview feature. Write requests whose resulting cluster state has this property set to true require the `Microsoft.ContainerService/EnableFIPSPreview` subscription feature registration."
         },
         "networkProfile": {
           "$ref": "#/definitions/ContainerServiceNetworkProfile",


### PR DESCRIPTION
# ARM (Control Plane) API Specification Update Pull Request

## Purpose of this PR

Publishes the existing cluster-level
`ManagedClusterProperties.enableFIPS` property in the stable AKS
`2026-07-01` REST and SDK contract. Cluster-level FIPS remains a preview
feature: write requests whose resulting cluster state has `enableFIPS=true`
still require subscription registration for
`Microsoft.ContainerService/EnableFIPSPreview`.

- Stable API proposal:
  [aks-handbook#223](https://github.com/azure-management-and-platforms/aks-handbook/pull/223)
- Original preview API proposal:
  [aks-handbook#128](https://github.com/azure-management-and-platforms/aks-handbook/pull/128)
- Original preview spec:
  [azure-rest-api-specs#42799](https://github.com/Azure/azure-rest-api-specs/pull/42799)
- Stable RP model:
  [aks-rp!16514075](https://dev.azure.com/msazure/CloudNativeCompute/_git/aks-rp/pullrequest/16514075)
- Azure SDK GA release plan:
  [35663](https://azsdk-releaseplan-dashboard-hveph5aqhhcfhtgu.westus-01.azurewebsites.net/?releaseplan=35663)
  (`2026-07-01`, August 2026)
- LRB approval was recorded in the stable API proposal on 2026-05-22.

What's the purpose of this PR? Check the specific option that applies. This is
**mandatory**!

- [ ] New resource provider.
- [ ] New API version for an existing resource provider. (If API spec is not
      defined in TypeSpec, the PR should have been created in adherence to
      [OpenAPI specs PR creation guidance](https://aka.ms/azsdkdocs/createopenapispec)).
- [ ] Update existing version for a new feature. (This is applicable only when
      you are revising a private preview API version.)
- [ ] Update existing version to fix OpenAPI spec quality issues in S360.
- [ ] Convert existing
      [OpenAPI spec to TypeSpec spec](https://aka.ms/typespec/conversion) (do
      not combine this with implementing changes for a new API version).
- [x] Other, please clarify:
  - Graduate an existing preview property into stable `2026-07-01`.

## Changes

- Moves the existing cluster-level `enableFIPS` introduction point from
  `Versions.v2026_07_02_preview` to `Versions.v2026_07_01`.
- Preserves the existing wire name and C#/Java client-name customizations.
- Documents that the stable contract does not remove the preview AFEC gate.
- Updates the inherited stable and preview examples to enable FIPS at both the
  cluster and agent-pool levels.
- Regenerates only the affected July stable and preview contracts and examples.

## Runtime behavior is unchanged

- Stable and preview writes whose resulting state has `enableFIPS=true`
  require `Microsoft.ContainerService/EnableFIPSPreview`.
- GET remains ungated.
- Disabling cluster-level FIPS remains allowed without feature context.
- This PR stabilizes the API contract; it does not declare the runtime feature
  generally available or remove its preview gate.

## Due diligence checklist

To merge this PR, you **must** go through the following checklist and confirm
you understood and followed the instructions by checking all the boxes:

- [x] I confirm this PR is modifying Azure Resource Manager (ARM) related
      specifications, and not data plane related specifications.
- [x] I have reviewed following
      [Resource Provider guidelines](https://aka.ms/rpguidelines), including
      [ARM resource provider contract](https://aka.ms/azurerpc) and
      [REST guidelines](https://github.com/microsoft/api-guidelines/blob/vNext/azure/Guidelines.md)
      (estimated time: 4 hours). I understand this is required before I can
      proceed to the diagram Step 2, "ARM API changes review", for this PR.
- [x] A [release plan](https://aka.ms/azsdkdocs/release-plans) has been
      created:
      [AKS GA plan 35663](https://azsdk-releaseplan-dashboard-hveph5aqhhcfhtgu.westus-01.azurewebsites.net/?releaseplan=35663)
      records API `2026-07-01`, target month August 2026, and this PR.

## Validation

- [x] Azure SDK TypeSpec validation
- [x] Repository `tsv` validation
- [x] `tsp compile . --warn-as-error`
- [x] `tsp compile client.tsp --no-emit --warn-as-error`
- [x] TypeSpec and generated JSON formatting
- [x] Stable `2026-07-01` and preview `2026-07-02-preview` expose
      cluster-level `enableFIPS`.
- [x] Stable `2026-06-01` still omits cluster-level `enableFIPS`.
- [x] Historical `2026-06-02-preview` and `2026-03-02-preview` contracts are
      unchanged.
- [x] Stable and preview examples set cluster-level and every agent-pool
      `enableFIPS` value to `true`.

## Additional information

<details>
<summary>Viewing API changes</summary>

Use the Generated ApiView comment added by repository automation to review the
REST and SDK API-version differences.

</details>

<details>
<summary>Suppressing failures</summary>

No new suppression is expected. Any detected suppression must follow the
[suppressions guide](https://aka.ms/azsdk/pr-suppressions).

</details>

## Getting help

- First, please carefully read through this PR description, from top to bottom.
  Please fill out the `Purpose of this PR` and `Due diligence checklist`.
- If you don't have permissions to remove or add labels to the PR, request
  `write access` per
  [aka.ms/azsdk/access#request-access-to-rest-api-or-sdk-repositories](https://aka.ms/azsdk/access#request-access-to-rest-api-or-sdk-repositories).
- To understand what you must do next to merge this PR, see the
  `Next Steps to Merge` comment. It will appear within a few minutes of
  submitting this PR and will continue to be up to date with current PR state.
- For guidance on fixing CI failures, see the hyperlinks provided in the
  failure and [https://aka.ms/ci-fix](https://aka.ms/ci-fix).
- For help with ARM review, see
  [https://aka.ms/azsdk/pr-arm-review](https://aka.ms/azsdk/pr-arm-review).
- If PR CI checks remain queued, add a comment with `/azp run`.
- For additional help, post to
  [https://aka.ms/azsdk/support/specreview-channel](https://aka.ms/azsdk/support/specreview-channel)
  and link this PR.