### PR TITLE
Fix VPN VirtualWAN listSharedKey POST to return 202 (align spec with NRP API behavior)

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/ConnectionSharedKeyResult.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/ConnectionSharedKeyResult.tsp
@@ -71,6 +71,22 @@ alias VpnLinkConnectionSharedKeyOps = Azure.ResourceManager.Legacy.LegacyOperati
   }
 >;
 
+/**
+ * The response of the VpnLink connection ListDefaultSharedKey operation.
+ * The underlying Network Resource Provider implementation completes this
+ * operation asynchronously and returns HTTP 202 (Accepted) with the shared
+ * key in the response body. The status code is declared here so that spec
+ * generated SDKs (e.g. the Terraform azurerm provider) expect 202 instead of
+ * the previously (incorrectly) documented 200.
+ */
+model ConnectionSharedKeyAcceptedResponse {
+  @statusCode
+  statusCode: 202;
+
+  @bodyRoot
+  body: ConnectionSharedKeyResult;
+}
+
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 @Azure.ResourceManager.Legacy.feature(Features.virtualWAN)
 @armResourceOperations(#{ omitTags: true })
@@ -107,7 +123,7 @@ interface ConnectionSharedKeyResults {
   listDefaultSharedKey is VpnLinkConnectionSharedKeyOps.ActionSync<
     ConnectionSharedKeyResult,
     void,
-    ArmResponse<ConnectionSharedKeyResult>,
+    ConnectionSharedKeyAcceptedResponse,
     OverrideErrorType = CloudError
   >;
 }

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/examples/VpnSiteLinkConnectionDefaultSharedKeyList.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/examples/VpnSiteLinkConnectionDefaultSharedKeyList.json
@@ -8,7 +8,7 @@
     "subscriptionId": "00000000-0000-0000-0000-000000000000"
   },
   "responses": {
-    "200": {
+    "202": {
       "body": {
         "name": "default",
         "type": "Microsoft.Network/vpnGateways/vpnConnections/vpnLinkConnections/sharedKeys",

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/virtualWan.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-05-01/virtualWan.json
@@ -6202,8 +6202,8 @@
           }
         ],
         "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
+          "202": {
+            "description": "Request successful. Returns the shared key of the vpn link connection.",
             "schema": {
               "$ref": "#/definitions/ConnectionSharedKeyResult"
             }

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/examples/VpnSiteLinkConnectionDefaultSharedKeyList.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/examples/VpnSiteLinkConnectionDefaultSharedKeyList.json
@@ -8,7 +8,7 @@
     "subscriptionId": "00000000-0000-0000-0000-000000000000"
   },
   "responses": {
-    "200": {
+    "202": {
       "body": {
         "name": "default",
         "type": "Microsoft.Network/vpnGateways/vpnConnections/vpnLinkConnections/sharedKeys",

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/virtualWan.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/virtualWan.json
@@ -6897,8 +6897,8 @@
           }
         ],
         "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
+          "202": {
+            "description": "Request successful. Returns the shared key of the vpn link connection.",
             "schema": {
               "$ref": "#/definitions/ConnectionSharedKeyResult"
             }

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/examples/VpnSiteLinkConnectionDefaultSharedKeyList.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/examples/VpnSiteLinkConnectionDefaultSharedKeyList.json
@@ -8,7 +8,7 @@
     "subscriptionId": "00000000-0000-0000-0000-000000000000"
   },
   "responses": {
-    "200": {
+    "202": {
       "body": {
         "name": "default",
         "type": "Microsoft.Network/vpnGateways/vpnConnections/vpnLinkConnections/sharedKeys",

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/virtualWan.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/virtualWan.json
@@ -6897,8 +6897,8 @@
           }
         ],
         "responses": {
-          "200": {
-            "description": "Azure operation completed successfully.",
+          "202": {
+            "description": "Request successful. Returns the shared key of the vpn link connection.",
             "schema": {
               "$ref": "#/definitions/ConnectionSharedKeyResult"
             }


### PR DESCRIPTION
## Summary

Corrects the documented success status code of the VPN VirtualWAN **`VpnLinkConnections_ListDefaultSharedKey`** operation (`POST .../vpnLinkConnections/{linkConnectionName}/sharedKeys/default/listSharedKey`) from **`200`** to **`202`**, to match the actual Network Resource Provider (NRP) runtime behavior.

The NRP implementation completes this operation asynchronously and returns **HTTP 202 (Accepted)** with the shared key in the response body. The spec previously declared `200`, so spec-generated SDKs (notably the Terraform `azurerm` provider, which validates the response against the declared status code) cannot consume this API.

## Why

Following an MSRC security fix, `sharedKey` is no longer returned on GET/PUT/PATCH; callers must use this dedicated `listSharedKey` POST. Because the emitted swagger declared `200` while the service returns `202`, the strict SDK path fails.

- Verified runtime behavior: `POST .../listSharedKey` returns **`202`** on `api-version=2025-01-01` and `2025-05-01` (customer-provided traces).
- Customer impact: hashicorp/terraform-provider-azurerm#30630 (`shared_key` on `azurerm_vpn_gateway_connection` drifts / cannot be read).
- ICM: 689954721 · Future 200-vs-202 API-implementation decision tracked in Task 36237920.

## Root cause (TypeSpec)

The operation was modeled with `ActionSync` + `ArmResponse<ConnectionSharedKeyResult>`, which emits a synchronous **200**. This PR introduces a dedicated `ConnectionSharedKeyAcceptedResponse` (`@statusCode 202` + `ConnectionSharedKeyResult` body) and points `listDefaultSharedKey` at it.

## Changes

- **Source of truth:** `Microsoft.Network/Network/Network/ConnectionSharedKeyResult.tsp`
  - Add `ConnectionSharedKeyAcceptedResponse` (202 + body).
  - `listDefaultSharedKey` response `ArmResponse<ConnectionSharedKeyResult>` → `ConnectionSharedKeyAcceptedResponse`.
- **Emitted swagger + examples** (hand-applied to mirror the source change for reviewers) across all affected TypeSpec versions: `2025-05-01`, `2025-07-01`, `2025-09-01`.

## Relationship to #39605

This supersedes the approach in #39605 (which edited only the emitted `2025-07-01` `virtualWan.json` and is now behind the `2025-09-01` version). That PR is left untouched. This PR instead fixes the **TypeSpec source** and applies the correction across all current TypeSpec versions.

## Reviewer notes / open questions

- [ ] **Draft:** the emitted swagger here was hand-edited to reflect the source change; please run the standard `tsp compile` to confirm the generated output matches (and to catch any diff churn).
- [ ] **Breaking-change review:** this changes a documented `200`→`202`. Runtime behavior is unchanged (the service already returns `202` on every api-version), so this is a documentation-accuracy correction rather than a behavioral break — requesting a breaking-change exception on that basis.
- [ ] **202-with-body shape:** an ARM LintDiff rule may expect `Location`/`Azure-AsyncOperation` headers for `202`. The service does emit those headers today; confirm whether they should be added to the response model or the current minimal `202 + body` shape is acceptable.
- [ ] **Legacy versions** `2025-01-01` / `2025-03-01` are pre-TypeSpec and are intentionally **not** modified. The `azurerm` provider (currently pinned to `2025-01-01`) will need to bump its `go-azure-sdk` import to a corrected version (`2025-05-01`+) to pick up the fix.

## Related

- hashicorp/terraform-provider-azurerm#30630
- Azure/azure-rest-api-specs#39605
