### PR TITLE
Remove internal endpoint from Data Factory examples

### DIFF
--- a/specification/datafactory/resource-manager/Microsoft.DataFactory/DataFactory/examples/2018-06-01/IntegrationRuntimes_ListOutboundNetworkDependenciesEndpoints.json
+++ b/specification/datafactory/resource-manager/Microsoft.DataFactory/DataFactory/examples/2018-06-01/IntegrationRuntimes_ListOutboundNetworkDependenciesEndpoints.json
@@ -61,14 +61,6 @@
             "category": "Microsoft Logging service (Internal Use)",
             "endpoints": [
               {
-                "domainName": "gcs.prod.monitoring.core.windows.net",
-                "endpointDetails": [
-                  {
-                    "port": 443
-                  }
-                ]
-              },
-              {
                 "domainName": "prod.warmpath.msftcloudes.com",
                 "endpointDetails": [
                   {

--- a/specification/datafactory/resource-manager/Microsoft.DataFactory/DataFactory/stable/2018-06-01/examples/IntegrationRuntimes_ListOutboundNetworkDependenciesEndpoints.json
+++ b/specification/datafactory/resource-manager/Microsoft.DataFactory/DataFactory/stable/2018-06-01/examples/IntegrationRuntimes_ListOutboundNetworkDependenciesEndpoints.json
@@ -61,14 +61,6 @@
             "category": "Microsoft Logging service (Internal Use)",
             "endpoints": [
               {
-                "domainName": "gcs.prod.monitoring.core.windows.net",
-                "endpointDetails": [
-                  {
-                    "port": 443
-                  }
-                ]
-              },
-              {
                 "domainName": "prod.warmpath.msftcloudes.com",
                 "endpointDetails": [
                   {


### PR DESCRIPTION
## Summary

Remove internal endpoint from both copies of the Data Factory `2018-06-01` outbound network dependencies example.
