### PR TITLE
Remove internal terms from Service Fabric examples

### DIFF
--- a/specification/servicefabric/resource-manager/Microsoft.ServiceFabric/ServiceFabric/preview/2020-01-01-preview/examples/NodeTypeListOperation_example.json
+++ b/specification/servicefabric/resource-manager/Microsoft.ServiceFabric/ServiceFabric/preview/2020-01-01-preview/examples/NodeTypeListOperation_example.json
@@ -56,18 +56,6 @@
                     }
                   ]
                 }
-              ],
-              "vmExtensions": [
-                {
-                  "name": "Microsoft.Azure.Geneva.GenevaMonitoring",
-                  "properties": {
-                    "autoUpgradeMinorVersion": true,
-                    "publisher": "Microsoft.Azure.Geneva",
-                    "type": "GenevaMonitoring",
-                    "typeHandlerVersion": "2.0",
-                    "settings": {}
-                  }
-                }
               ]
             }
           }

--- a/specification/servicefabric/resource-manager/Microsoft.ServiceFabric/ServiceFabric/preview/2020-01-01-preview/examples/NodeTypePatchOperation_example.json
+++ b/specification/servicefabric/resource-manager/Microsoft.ServiceFabric/ServiceFabric/preview/2020-01-01-preview/examples/NodeTypePatchOperation_example.json
@@ -31,18 +31,6 @@
               }
             ]
           }
-        ],
-        "vmExtensions": [
-          {
-            "name": "Microsoft.Azure.Geneva.GenevaMonitoring",
-            "properties": {
-              "autoUpgradeMinorVersion": true,
-              "publisher": "Microsoft.Azure.Geneva",
-              "type": "GenevaMonitoring",
-              "typeHandlerVersion": "2.0",
-              "settings": {}
-            }
-          }
         ]
       }
     }
@@ -89,18 +77,6 @@
                 }
               ]
             }
-          ],
-          "vmExtensions": [
-            {
-              "name": "Microsoft.Azure.Geneva.GenevaMonitoring",
-              "properties": {
-                "autoUpgradeMinorVersion": true,
-                "publisher": "Microsoft.Azure.Geneva",
-                "type": "GenevaMonitoring",
-                "typeHandlerVersion": "2.0",
-                "settings": {}
-              }
-            }
           ]
         }
       }
@@ -145,18 +121,6 @@
                   "certificateUrl": "https://myVault.vault.azure.net:443/secrets/myCert/ef1a31d39e1f46bca33def54b6cda54c"
                 }
               ]
-            }
-          ],
-          "vmExtensions": [
-            {
-              "name": "Microsoft.Azure.Geneva.GenevaMonitoring",
-              "properties": {
-                "autoUpgradeMinorVersion": true,
-                "publisher": "Microsoft.Azure.Geneva",
-                "type": "GenevaMonitoring",
-                "typeHandlerVersion": "2.0",
-                "settings": {}
-              }
             }
           ]
         }

--- a/specification/servicefabric/resource-manager/Microsoft.ServiceFabric/ServiceFabric/preview/2020-01-01-preview/examples/NodeTypePutOperation_example_max.json
+++ b/specification/servicefabric/resource-manager/Microsoft.ServiceFabric/ServiceFabric/preview/2020-01-01-preview/examples/NodeTypePutOperation_example_max.json
@@ -35,18 +35,6 @@
               }
             ]
           }
-        ],
-        "vmExtensions": [
-          {
-            "name": "Microsoft.Azure.Geneva.GenevaMonitoring",
-            "properties": {
-              "autoUpgradeMinorVersion": true,
-              "publisher": "Microsoft.Azure.Geneva",
-              "type": "GenevaMonitoring",
-              "typeHandlerVersion": "2.0",
-              "settings": {}
-            }
-          }
         ]
       }
     }
@@ -91,18 +79,6 @@
                 }
               ]
             }
-          ],
-          "vmExtensions": [
-            {
-              "name": "Microsoft.Azure.Geneva.GenevaMonitoring",
-              "properties": {
-                "autoUpgradeMinorVersion": true,
-                "publisher": "Microsoft.Azure.Geneva",
-                "type": "GenevaMonitoring",
-                "typeHandlerVersion": "2.0",
-                "settings": {}
-              }
-            }
           ]
         }
       }
@@ -146,19 +122,6 @@
                 }
               ]
             }
-          ],
-          "vmExtensions": [
-            {
-              "name": "Microsoft.Azure.Geneva.GenevaMonitoring",
-              "properties": {
-                "autoUpgradeMinorVersion": true,
-                "forceUpdateTag": "v.1.0",
-                "publisher": "Microsoft.Azure.Geneva",
-                "type": "GenevaMonitoring",
-                "typeHandlerVersion": "2.0",
-                "settings": {}
-              }
-            }
           ]
         }
       }
@@ -201,19 +164,6 @@
                   "certificateUrl": "https://myVault.vault.azure.net:443/secrets/myCert/ef1a31d39e1f46bca33def54b6cda54c"
                 }
               ]
-            }
-          ],
-          "vmExtensions": [
-            {
-              "name": "Microsoft.Azure.Geneva.GenevaMonitoring",
-              "properties": {
-                "autoUpgradeMinorVersion": true,
-                "forceUpdateTag": "v.1.0",
-                "publisher": "Microsoft.Azure.Geneva",
-                "type": "GenevaMonitoring",
-                "typeHandlerVersion": "2.0",
-                "settings": {}
-              }
             }
           ]
         }


### PR DESCRIPTION
## Summary

Remove all Geneva monitoring VM extension instances from the Service Fabric resource-manager examples for API version `2020-01-01-preview`.

This updates the list, patch, and maximum node type examples while leaving unrelated example content unchanged.