### PR TITLE
[Microsoft.Network] Add provider-led ExpressRoute circuit migration APIs

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/ExpressRouteCrossConnection.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/ExpressRouteCrossConnection.tsp
@@ -2,6 +2,7 @@ import "@azure-tools/typespec-azure-core";
 import "@azure-tools/typespec-azure-resource-manager";
 import "@typespec/openapi";
 import "@typespec/rest";
+import "@typespec/versioning";
 import "./models.tsp";
 import "../Common/main.tsp";
 
@@ -9,6 +10,7 @@ using TypeSpec.Rest;
 using Azure.ResourceManager;
 using TypeSpec.Http;
 using TypeSpec.OpenAPI;
+using TypeSpec.Versioning;
 using Common;
 
 namespace Microsoft.Network;
@@ -285,6 +287,126 @@ interface ExpressRouteCrossConnections {
         >,
     OverrideErrorType = CloudError
   >;
+
+  /**
+   * Validates express route circuit migration for a cross connection.
+   */
+  @tag("ExpressRouteCrossConnections")
+  @action("validateCircuitMigration")
+  @added(Versions.v2026_01_01)
+  @Azure.Core.useFinalStateVia("location")
+  validateCircuitMigration is ArmResourceActionAsync<
+    ExpressRouteCrossConnection,
+    MigrateExpressRouteCircuitValidateAndHealthCheckRequest,
+    MigrateExpressRouteCircuitValidateResponse,
+    LroHeaders = ArmCombinedLroHeaders<FinalResult = MigrateExpressRouteCircuitValidateResponse>,
+    Error = CloudError
+  >;
+
+  /**
+   * Gets migration health information for an express route circuit cross connection.
+   */
+  @tag("ExpressRouteCrossConnections")
+  @action("getCircuitMigrationInfo")
+  @added(Versions.v2026_01_01)
+  @Azure.Core.useFinalStateVia("location")
+  getCircuitMigrationInfo is ArmResourceActionAsync<
+    ExpressRouteCrossConnection,
+    MigrateExpressRouteCircuitValidateAndHealthCheckRequest,
+    MigrateExpressRouteCircuitHealthCheckResponse,
+    LroHeaders = ArmCombinedLroHeaders<FinalResult = MigrateExpressRouteCircuitHealthCheckResponse>,
+    Error = CloudError
+  >;
+
+  /**
+   * Prepares an express route circuit migration for a cross connection.
+   */
+  @tag("ExpressRouteCrossConnections")
+  @action("prepareCircuitMigration")
+  @added(Versions.v2026_01_01)
+  @Azure.Core.useFinalStateVia("location")
+  prepareCircuitMigration is ArmResourceActionAsync<
+    ExpressRouteCrossConnection,
+    MigrateExpressRouteCircuitRequest,
+    MigrateExpressRouteCircuitHealthCheckResponse,
+    LroHeaders = ArmCombinedLroHeaders<FinalResult = MigrateExpressRouteCircuitHealthCheckResponse>,
+    Error = CloudError
+  >;
+
+  /**
+   * Shuts down BGP sessions as part of an express route circuit migration for a cross connection.
+   */
+  @tag("ExpressRouteCrossConnections")
+  @action("shutDownBgpForCircuitMigration")
+  @added(Versions.v2026_01_01)
+  @Azure.Core.useFinalStateVia("location")
+  shutDownBgpForCircuitMigration is ArmResourceActionAsync<
+    ExpressRouteCrossConnection,
+    MigrateExpressRouteCircuitRequest,
+    MigrateExpressRouteCircuitHealthCheckResponse,
+    LroHeaders = ArmCombinedLroHeaders<FinalResult = MigrateExpressRouteCircuitHealthCheckResponse>,
+    Error = CloudError
+  >;
+
+  /**
+   * Restores BGP sessions as part of an express route circuit migration for a cross connection.
+   */
+  @tag("ExpressRouteCrossConnections")
+  @action("restoreBgpForCircuitMigration")
+  @added(Versions.v2026_01_01)
+  @Azure.Core.useFinalStateVia("location")
+  restoreBgpForCircuitMigration is ArmResourceActionAsync<
+    ExpressRouteCrossConnection,
+    MigrateExpressRouteCircuitRequest,
+    MigrateExpressRouteCircuitHealthCheckResponse,
+    LroHeaders = ArmCombinedLroHeaders<FinalResult = MigrateExpressRouteCircuitHealthCheckResponse>,
+    Error = CloudError
+  >;
+
+  /**
+   * Executes the express route circuit migration for a cross connection.
+   */
+  @tag("ExpressRouteCrossConnections")
+  @action("migrateCircuit")
+  @added(Versions.v2026_01_01)
+  @Azure.Core.useFinalStateVia("location")
+  migrateCircuit is ArmResourceActionAsync<
+    ExpressRouteCrossConnection,
+    MigrateExpressRouteCircuitRequest,
+    MigrateExpressRouteCircuitHealthCheckResponse,
+    LroHeaders = ArmCombinedLroHeaders<FinalResult = MigrateExpressRouteCircuitHealthCheckResponse>,
+    Error = CloudError
+  >;
+
+  /**
+   * Commits the express route circuit migration for a cross connection.
+   */
+  @tag("ExpressRouteCrossConnections")
+  @action("commitCircuitMigration")
+  @added(Versions.v2026_01_01)
+  @Azure.Core.useFinalStateVia("location")
+  commitCircuitMigration is ArmResourceActionAsync<
+    ExpressRouteCrossConnection,
+    MigrateExpressRouteCircuitRequest,
+    MigrateExpressRouteCircuitHealthCheckResponse,
+    LroHeaders = ArmCombinedLroHeaders<FinalResult = MigrateExpressRouteCircuitHealthCheckResponse>,
+    Error = CloudError
+  >;
+
+  /**
+   * Rolls back the express route circuit migration for a cross connection.
+   */
+  @tag("ExpressRouteCrossConnections")
+  @action("rollbackCircuitMigration")
+  @added(Versions.v2026_01_01)
+  @Azure.Core.useFinalStateVia("location")
+  rollbackCircuitMigration is ArmResourceActionAsync<
+    ExpressRouteCrossConnection,
+    MigrateExpressRouteCircuitRequest,
+    MigrateExpressRouteCircuitHealthCheckResponse,
+    LroHeaders = ArmCombinedLroHeaders<FinalResult = MigrateExpressRouteCircuitHealthCheckResponse>,
+    Error = CloudError
+  >;
 }
 
 @@doc(
@@ -306,4 +428,36 @@ interface ExpressRouteCrossConnections {
 @@doc(
   ExpressRouteCrossConnections.expressRouteCrossConnectionPeeringsCreateOrUpdate::parameters.body,
   "Parameters supplied to the create or update ExpressRouteCrossConnection peering operation."
+);
+@@doc(
+  ExpressRouteCrossConnections.validateCircuitMigration::parameters.body,
+  "Parameters supplied to validate express route circuit migration."
+);
+@@doc(
+  ExpressRouteCrossConnections.getCircuitMigrationInfo::parameters.body,
+  "Parameters supplied to get express route circuit migration information."
+);
+@@doc(
+  ExpressRouteCrossConnections.prepareCircuitMigration::parameters.body,
+  "Parameters supplied to prepare the express route circuit migration."
+);
+@@doc(
+  ExpressRouteCrossConnections.shutDownBgpForCircuitMigration::parameters.body,
+  "Parameters supplied to shut down BGP for the express route circuit migration."
+);
+@@doc(
+  ExpressRouteCrossConnections.restoreBgpForCircuitMigration::parameters.body,
+  "Parameters supplied to restore BGP for the express route circuit migration."
+);
+@@doc(
+  ExpressRouteCrossConnections.migrateCircuit::parameters.body,
+  "Parameters supplied to execute the express route circuit migration."
+);
+@@doc(
+  ExpressRouteCrossConnections.commitCircuitMigration::parameters.body,
+  "Parameters supplied to commit the express route circuit migration."
+);
+@@doc(
+  ExpressRouteCrossConnections.rollbackCircuitMigration::parameters.body,
+  "Parameters supplied to roll back the express route circuit migration."
 );

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/back-compatible.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/back-compatible.tsp
@@ -903,6 +903,63 @@ using TypeSpec.Versioning;
   ExpressRouteCrossConnections.expressRouteCrossConnectionPeeringsCreateOrUpdate::parameters.body,
   "peeringParameters"
 );
+@@clientName(
+  ExpressRouteCrossConnections.validateCircuitMigration::parameters.body,
+  "parameters"
+);
+@@clientName(
+  ExpressRouteCrossConnections.getCircuitMigrationInfo::parameters.body,
+  "parameters"
+);
+@@clientName(
+  ExpressRouteCrossConnections.prepareCircuitMigration::parameters.body,
+  "parameters"
+);
+@@clientName(
+  ExpressRouteCrossConnections.shutDownBgpForCircuitMigration::parameters.body,
+  "parameters"
+);
+@@clientName(
+  ExpressRouteCrossConnections.restoreBgpForCircuitMigration::parameters.body,
+  "parameters"
+);
+@@clientName(
+  ExpressRouteCrossConnections.migrateCircuit::parameters.body,
+  "parameters"
+);
+@@clientName(
+  ExpressRouteCrossConnections.commitCircuitMigration::parameters.body,
+  "parameters"
+);
+@@clientName(
+  ExpressRouteCrossConnections.rollbackCircuitMigration::parameters.body,
+  "parameters"
+);
+@@clientName(
+  MigrateExpressRouteCircuitValidateAndHealthCheckRequest,
+  "MigrateExpressRouteCircuitValidateAndHealthCheckContent",
+  "csharp"
+);
+@@clientName(
+  MigrateExpressRouteCircuitValidateResponse,
+  "MigrateExpressRouteCircuitValidateResult",
+  "csharp"
+);
+@@clientName(
+  MigrateExpressRouteCircuitRequest,
+  "MigrateExpressRouteCircuitContent",
+  "csharp"
+);
+@@clientName(
+  MigrateExpressRouteCircuitHealthCheckResponse,
+  "MigrateExpressRouteCircuitHealthCheckResult",
+  "csharp"
+);
+@@clientName(
+  MigrateExpressRouteCircuitHealthCheckResponse.newCrossConnectionUrl,
+  "newCrossConnectionUri",
+  "csharp"
+);
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 @@Legacy.flattenProperty(ExpressRouteCrossConnection.properties);
 

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/ExpressRouteCrossConnectionCommitCircuitMigration.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/ExpressRouteCrossConnectionCommitCircuitMigration.json
@@ -1,7 +1,7 @@
 {
   "parameters": {
     "api-version": "2026-01-01",
-    "subscriptionId": "subid",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
     "resourceGroupName": "CrossConnection-SiliconValley",
     "crossConnectionName": "<circuitServiceKey>",
     "parameters": {
@@ -160,5 +160,7 @@
         }
       }
     }
-  }
+  },
+  "operationId": "ExpressRouteCrossConnections_CommitCircuitMigration",
+  "title": "CommitExpressRouteCircuitMigration"
 }

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/ExpressRouteCrossConnectionCommitCircuitMigration.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/ExpressRouteCrossConnectionCommitCircuitMigration.json
@@ -1,0 +1,164 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "subscriptionId": "subid",
+    "resourceGroupName": "CrossConnection-SiliconValley",
+    "crossConnectionName": "<circuitServiceKey>",
+    "parameters": {
+      "targetPeeringLocation": "SiliconValley",
+      "targetPortMapping": [
+        {
+          "sourcePortId": "sourcePort1",
+          "targetPortId": "targetPort1"
+        },
+        {
+          "sourcePortId": "sourcePort2",
+          "targetPortId": "targetPort2"
+        }
+      ],
+      "portId": "sourcePort1"
+    }
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/subid/providers/Microsoft.Network/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-01-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/subid/providers/Microsoft.Network/locations/eastus/operationStatuses/00000000-0000-0000-0000-000000000000?api-version=2026-01-01"
+      }
+    },
+    "200": {
+      "body": {
+        "status": "Succeeded",
+        "phase": "Committed",
+        "failureReason": "",
+        "newSTag": "12345",
+        "preparedAt": "2026-08-05T11:30:00Z",
+        "prepareExpiryTime": "2026-08-05T12:30:00Z",
+        "newCrossConnectionUrl": "https://management.azure.com/subscriptions/subid/resourceGroups/CrossConnection-SiliconValley/providers/Microsoft.Network/expressRouteCrossConnections/newCircuitServiceKey?api-version=2026-01-01",
+        "shouldRollback": false,
+        "details": {
+          "portMigrationInfos": [
+            {
+              "portId": "targetPort1",
+              "status": "Succeeded",
+              "phase": "Committed",
+              "failureReason": "",
+              "peerings": [
+                {
+                  "type": "Private",
+                  "statsCurrent": {
+                    "timestamp": "2026-08-05T11:40:00Z",
+                    "metrics": [
+                      {
+                        "name": "PacketsIn",
+                        "value": 150,
+                        "unit": "count"
+                      }
+                    ]
+                  },
+                  "statsAtPrepare": {
+                    "timestamp": "2026-08-05T11:30:00Z",
+                    "metrics": [
+                      {
+                        "name": "PacketsIn",
+                        "value": 98,
+                        "unit": "count"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "sourcePortId": "sourcePort1",
+              "sourcePortStats": {
+                "peerings": [
+                  {
+                    "type": "Private",
+                    "statsCurrent": {
+                      "timestamp": "2026-08-05T11:40:00Z",
+                      "metrics": [
+                        {
+                          "name": "PacketsIn",
+                          "value": 150,
+                          "unit": "count"
+                        }
+                      ]
+                    },
+                    "statsAtPrepare": {
+                      "timestamp": "2026-08-05T11:30:00Z",
+                      "metrics": [
+                        {
+                          "name": "PacketsIn",
+                          "value": 98,
+                          "unit": "count"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "portId": "targetPort2",
+              "status": "Succeeded",
+              "phase": "Committed",
+              "failureReason": "",
+              "peerings": [
+                {
+                  "type": "Private",
+                  "statsCurrent": {
+                    "timestamp": "2026-08-05T11:40:00Z",
+                    "metrics": [
+                      {
+                        "name": "PacketsIn",
+                        "value": 145,
+                        "unit": "count"
+                      }
+                    ]
+                  },
+                  "statsAtPrepare": {
+                    "timestamp": "2026-08-05T11:30:00Z",
+                    "metrics": [
+                      {
+                        "name": "PacketsIn",
+                        "value": 95,
+                        "unit": "count"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "sourcePortId": "sourcePort2",
+              "sourcePortStats": {
+                "peerings": [
+                  {
+                    "type": "Private",
+                    "statsCurrent": {
+                      "timestamp": "2026-08-05T11:40:00Z",
+                      "metrics": [
+                        {
+                          "name": "PacketsIn",
+                          "value": 145,
+                          "unit": "count"
+                        }
+                      ]
+                    },
+                    "statsAtPrepare": {
+                      "timestamp": "2026-08-05T11:30:00Z",
+                      "metrics": [
+                        {
+                          "name": "PacketsIn",
+                          "value": 95,
+                          "unit": "count"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/ExpressRouteCrossConnectionGetCircuitMigrationInfo.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/ExpressRouteCrossConnectionGetCircuitMigrationInfo.json
@@ -1,7 +1,7 @@
 {
   "parameters": {
     "api-version": "2026-01-01",
-    "subscriptionId": "subid",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
     "resourceGroupName": "CrossConnection-SiliconValley",
     "crossConnectionName": "<circuitServiceKey>",
     "parameters": {
@@ -159,5 +159,7 @@
         }
       }
     }
-  }
+  },
+  "operationId": "ExpressRouteCrossConnections_GetCircuitMigrationInfo",
+  "title": "GetExpressRouteCircuitMigrationInfo"
 }

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/ExpressRouteCrossConnectionGetCircuitMigrationInfo.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/ExpressRouteCrossConnectionGetCircuitMigrationInfo.json
@@ -1,0 +1,163 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "subscriptionId": "subid",
+    "resourceGroupName": "CrossConnection-SiliconValley",
+    "crossConnectionName": "<circuitServiceKey>",
+    "parameters": {
+      "targetPeeringLocation": "SiliconValley",
+      "targetPortMapping": [
+        {
+          "sourcePortId": "sourcePort1",
+          "targetPortId": "targetPort1"
+        },
+        {
+          "sourcePortId": "sourcePort2",
+          "targetPortId": "targetPort2"
+        }
+      ]
+    }
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/subid/providers/Microsoft.Network/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-01-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/subid/providers/Microsoft.Network/locations/eastus/operationStatuses/00000000-0000-0000-0000-000000000000?api-version=2026-01-01"
+      }
+    },
+    "200": {
+      "body": {
+        "status": "Succeeded",
+        "phase": "Prepared",
+        "failureReason": "",
+        "newSTag": "12345",
+        "preparedAt": "2026-08-05T11:30:00Z",
+        "prepareExpiryTime": "2026-08-05T12:30:00Z",
+        "newCrossConnectionUrl": "https://management.azure.com/subscriptions/subid/resourceGroups/CrossConnection-SiliconValley/providers/Microsoft.Network/expressRouteCrossConnections/newCircuitServiceKey?api-version=2026-01-01",
+        "shouldRollback": false,
+        "details": {
+          "portMigrationInfos": [
+            {
+              "portId": "targetPort1",
+              "status": "Ready",
+              "phase": "Prepared",
+              "failureReason": "",
+              "peerings": [
+                {
+                  "type": "Private",
+                  "statsCurrent": {
+                    "timestamp": "2026-08-05T11:31:00Z",
+                    "metrics": [
+                      {
+                        "name": "PacketsIn",
+                        "value": 100,
+                        "unit": "count"
+                      }
+                    ]
+                  },
+                  "statsAtPrepare": {
+                    "timestamp": "2026-08-05T11:30:00Z",
+                    "metrics": [
+                      {
+                        "name": "PacketsIn",
+                        "value": 98,
+                        "unit": "count"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "sourcePortId": "sourcePort1",
+              "sourcePortStats": {
+                "peerings": [
+                  {
+                    "type": "Private",
+                    "statsCurrent": {
+                      "timestamp": "2026-08-05T11:31:00Z",
+                      "metrics": [
+                        {
+                          "name": "PacketsIn",
+                          "value": 100,
+                          "unit": "count"
+                        }
+                      ]
+                    },
+                    "statsAtPrepare": {
+                      "timestamp": "2026-08-05T11:30:00Z",
+                      "metrics": [
+                        {
+                          "name": "PacketsIn",
+                          "value": 98,
+                          "unit": "count"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "portId": "targetPort2",
+              "status": "Ready",
+              "phase": "Prepared",
+              "failureReason": "",
+              "peerings": [
+                {
+                  "type": "Private",
+                  "statsCurrent": {
+                    "timestamp": "2026-08-05T11:31:00Z",
+                    "metrics": [
+                      {
+                        "name": "PacketsIn",
+                        "value": 97,
+                        "unit": "count"
+                      }
+                    ]
+                  },
+                  "statsAtPrepare": {
+                    "timestamp": "2026-08-05T11:30:00Z",
+                    "metrics": [
+                      {
+                        "name": "PacketsIn",
+                        "value": 96,
+                        "unit": "count"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "sourcePortId": "sourcePort2",
+              "sourcePortStats": {
+                "peerings": [
+                  {
+                    "type": "Private",
+                    "statsCurrent": {
+                      "timestamp": "2026-08-05T11:31:00Z",
+                      "metrics": [
+                        {
+                          "name": "PacketsIn",
+                          "value": 97,
+                          "unit": "count"
+                        }
+                      ]
+                    },
+                    "statsAtPrepare": {
+                      "timestamp": "2026-08-05T11:30:00Z",
+                      "metrics": [
+                        {
+                          "name": "PacketsIn",
+                          "value": 96,
+                          "unit": "count"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/ExpressRouteCrossConnectionMigrateCircuit.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/ExpressRouteCrossConnectionMigrateCircuit.json
@@ -1,0 +1,164 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "subscriptionId": "subid",
+    "resourceGroupName": "CrossConnection-SiliconValley",
+    "crossConnectionName": "<circuitServiceKey>",
+    "parameters": {
+      "targetPeeringLocation": "SiliconValley",
+      "targetPortMapping": [
+        {
+          "sourcePortId": "sourcePort1",
+          "targetPortId": "targetPort1"
+        },
+        {
+          "sourcePortId": "sourcePort2",
+          "targetPortId": "targetPort2"
+        }
+      ],
+      "portId": "sourcePort1"
+    }
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/subid/providers/Microsoft.Network/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-01-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/subid/providers/Microsoft.Network/locations/eastus/operationStatuses/00000000-0000-0000-0000-000000000000?api-version=2026-01-01"
+      }
+    },
+    "200": {
+      "body": {
+        "status": "Succeeded",
+        "phase": "Migrated",
+        "failureReason": "",
+        "newSTag": "12345",
+        "preparedAt": "2026-08-05T11:30:00Z",
+        "prepareExpiryTime": "2026-08-05T12:30:00Z",
+        "newCrossConnectionUrl": "https://management.azure.com/subscriptions/subid/resourceGroups/CrossConnection-SiliconValley/providers/Microsoft.Network/expressRouteCrossConnections/newCircuitServiceKey?api-version=2026-01-01",
+        "shouldRollback": false,
+        "details": {
+          "portMigrationInfos": [
+            {
+              "portId": "targetPort1",
+              "status": "Succeeded",
+              "phase": "Migrated",
+              "failureReason": "",
+              "peerings": [
+                {
+                  "type": "Private",
+                  "statsCurrent": {
+                    "timestamp": "2026-08-05T11:40:00Z",
+                    "metrics": [
+                      {
+                        "name": "PacketsIn",
+                        "value": 150,
+                        "unit": "count"
+                      }
+                    ]
+                  },
+                  "statsAtPrepare": {
+                    "timestamp": "2026-08-05T11:30:00Z",
+                    "metrics": [
+                      {
+                        "name": "PacketsIn",
+                        "value": 98,
+                        "unit": "count"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "sourcePortId": "sourcePort1",
+              "sourcePortStats": {
+                "peerings": [
+                  {
+                    "type": "Private",
+                    "statsCurrent": {
+                      "timestamp": "2026-08-05T11:40:00Z",
+                      "metrics": [
+                        {
+                          "name": "PacketsIn",
+                          "value": 150,
+                          "unit": "count"
+                        }
+                      ]
+                    },
+                    "statsAtPrepare": {
+                      "timestamp": "2026-08-05T11:30:00Z",
+                      "metrics": [
+                        {
+                          "name": "PacketsIn",
+                          "value": 98,
+                          "unit": "count"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "portId": "targetPort2",
+              "status": "Succeeded",
+              "phase": "Migrated",
+              "failureReason": "",
+              "peerings": [
+                {
+                  "type": "Private",
+                  "statsCurrent": {
+                    "timestamp": "2026-08-05T11:40:00Z",
+                    "metrics": [
+                      {
+                        "name": "PacketsIn",
+                        "value": 145,
+                        "unit": "count"
+                      }
+                    ]
+                  },
+                  "statsAtPrepare": {
+                    "timestamp": "2026-08-05T11:30:00Z",
+                    "metrics": [
+                      {
+                        "name": "PacketsIn",
+                        "value": 95,
+                        "unit": "count"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "sourcePortId": "sourcePort2",
+              "sourcePortStats": {
+                "peerings": [
+                  {
+                    "type": "Private",
+                    "statsCurrent": {
+                      "timestamp": "2026-08-05T11:40:00Z",
+                      "metrics": [
+                        {
+                          "name": "PacketsIn",
+                          "value": 145,
+                          "unit": "count"
+                        }
+                      ]
+                    },
+                    "statsAtPrepare": {
+                      "timestamp": "2026-08-05T11:30:00Z",
+                      "metrics": [
+                        {
+                          "name": "PacketsIn",
+                          "value": 95,
+                          "unit": "count"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/ExpressRouteCrossConnectionMigrateCircuit.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/ExpressRouteCrossConnectionMigrateCircuit.json
@@ -1,7 +1,7 @@
 {
   "parameters": {
     "api-version": "2026-01-01",
-    "subscriptionId": "subid",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
     "resourceGroupName": "CrossConnection-SiliconValley",
     "crossConnectionName": "<circuitServiceKey>",
     "parameters": {
@@ -160,5 +160,7 @@
         }
       }
     }
-  }
+  },
+  "operationId": "ExpressRouteCrossConnections_MigrateCircuit",
+  "title": "MigrateExpressRouteCircuit"
 }

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/ExpressRouteCrossConnectionPrepareCircuitMigration.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/ExpressRouteCrossConnectionPrepareCircuitMigration.json
@@ -1,0 +1,164 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "subscriptionId": "subid",
+    "resourceGroupName": "CrossConnection-SiliconValley",
+    "crossConnectionName": "<circuitServiceKey>",
+    "parameters": {
+      "targetPeeringLocation": "SiliconValley",
+      "targetPortMapping": [
+        {
+          "sourcePortId": "sourcePort1",
+          "targetPortId": "targetPort1"
+        },
+        {
+          "sourcePortId": "sourcePort2",
+          "targetPortId": "targetPort2"
+        }
+      ],
+      "portId": "sourcePort1"
+    }
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/subid/providers/Microsoft.Network/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-01-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/subid/providers/Microsoft.Network/locations/eastus/operationStatuses/00000000-0000-0000-0000-000000000000?api-version=2026-01-01"
+      }
+    },
+    "200": {
+      "body": {
+        "status": "Succeeded",
+        "phase": "Prepared",
+        "failureReason": "",
+        "newSTag": "12345",
+        "preparedAt": "2026-08-05T11:30:00Z",
+        "prepareExpiryTime": "2026-08-05T12:30:00Z",
+        "newCrossConnectionUrl": "https://management.azure.com/subscriptions/subid/resourceGroups/CrossConnection-SiliconValley/providers/Microsoft.Network/expressRouteCrossConnections/newCircuitServiceKey?api-version=2026-01-01",
+        "shouldRollback": false,
+        "details": {
+          "portMigrationInfos": [
+            {
+              "portId": "targetPort1",
+              "status": "Succeeded",
+              "phase": "Prepared",
+              "failureReason": "",
+              "peerings": [
+                {
+                  "type": "Private",
+                  "statsCurrent": {
+                    "timestamp": "2026-08-05T11:40:00Z",
+                    "metrics": [
+                      {
+                        "name": "PacketsIn",
+                        "value": 150,
+                        "unit": "count"
+                      }
+                    ]
+                  },
+                  "statsAtPrepare": {
+                    "timestamp": "2026-08-05T11:30:00Z",
+                    "metrics": [
+                      {
+                        "name": "PacketsIn",
+                        "value": 98,
+                        "unit": "count"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "sourcePortId": "sourcePort1",
+              "sourcePortStats": {
+                "peerings": [
+                  {
+                    "type": "Private",
+                    "statsCurrent": {
+                      "timestamp": "2026-08-05T11:40:00Z",
+                      "metrics": [
+                        {
+                          "name": "PacketsIn",
+                          "value": 150,
+                          "unit": "count"
+                        }
+                      ]
+                    },
+                    "statsAtPrepare": {
+                      "timestamp": "2026-08-05T11:30:00Z",
+                      "metrics": [
+                        {
+                          "name": "PacketsIn",
+                          "value": 98,
+                          "unit": "count"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "portId": "targetPort2",
+              "status": "Succeeded",
+              "phase": "Prepared",
+              "failureReason": "",
+              "peerings": [
+                {
+                  "type": "Private",
+                  "statsCurrent": {
+                    "timestamp": "2026-08-05T11:40:00Z",
+                    "metrics": [
+                      {
+                        "name": "PacketsIn",
+                        "value": 145,
+                        "unit": "count"
+                      }
+                    ]
+                  },
+                  "statsAtPrepare": {
+                    "timestamp": "2026-08-05T11:30:00Z",
+                    "metrics": [
+                      {
+                        "name": "PacketsIn",
+                        "value": 95,
+                        "unit": "count"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "sourcePortId": "sourcePort2",
+              "sourcePortStats": {
+                "peerings": [
+                  {
+                    "type": "Private",
+                    "statsCurrent": {
+                      "timestamp": "2026-08-05T11:40:00Z",
+                      "metrics": [
+                        {
+                          "name": "PacketsIn",
+                          "value": 145,
+                          "unit": "count"
+                        }
+                      ]
+                    },
+                    "statsAtPrepare": {
+                      "timestamp": "2026-08-05T11:30:00Z",
+                      "metrics": [
+                        {
+                          "name": "PacketsIn",
+                          "value": 95,
+                          "unit": "count"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/ExpressRouteCrossConnectionPrepareCircuitMigration.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/ExpressRouteCrossConnectionPrepareCircuitMigration.json
@@ -1,7 +1,7 @@
 {
   "parameters": {
     "api-version": "2026-01-01",
-    "subscriptionId": "subid",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
     "resourceGroupName": "CrossConnection-SiliconValley",
     "crossConnectionName": "<circuitServiceKey>",
     "parameters": {
@@ -160,5 +160,7 @@
         }
       }
     }
-  }
+  },
+  "operationId": "ExpressRouteCrossConnections_PrepareCircuitMigration",
+  "title": "PrepareExpressRouteCircuitMigration"
 }

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/ExpressRouteCrossConnectionRestoreBgpForCircuitMigration.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/ExpressRouteCrossConnectionRestoreBgpForCircuitMigration.json
@@ -1,0 +1,164 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "subscriptionId": "subid",
+    "resourceGroupName": "CrossConnection-SiliconValley",
+    "crossConnectionName": "<circuitServiceKey>",
+    "parameters": {
+      "targetPeeringLocation": "SiliconValley",
+      "targetPortMapping": [
+        {
+          "sourcePortId": "sourcePort1",
+          "targetPortId": "targetPort1"
+        },
+        {
+          "sourcePortId": "sourcePort2",
+          "targetPortId": "targetPort2"
+        }
+      ],
+      "portId": "sourcePort1"
+    }
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/subid/providers/Microsoft.Network/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-01-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/subid/providers/Microsoft.Network/locations/eastus/operationStatuses/00000000-0000-0000-0000-000000000000?api-version=2026-01-01"
+      }
+    },
+    "200": {
+      "body": {
+        "status": "Succeeded",
+        "phase": "BgpRestored",
+        "failureReason": "",
+        "newSTag": "12345",
+        "preparedAt": "2026-08-05T11:30:00Z",
+        "prepareExpiryTime": "2026-08-05T12:30:00Z",
+        "newCrossConnectionUrl": "https://management.azure.com/subscriptions/subid/resourceGroups/CrossConnection-SiliconValley/providers/Microsoft.Network/expressRouteCrossConnections/newCircuitServiceKey?api-version=2026-01-01",
+        "shouldRollback": false,
+        "details": {
+          "portMigrationInfos": [
+            {
+              "portId": "targetPort1",
+              "status": "Succeeded",
+              "phase": "BgpRestored",
+              "failureReason": "",
+              "peerings": [
+                {
+                  "type": "Private",
+                  "statsCurrent": {
+                    "timestamp": "2026-08-05T11:40:00Z",
+                    "metrics": [
+                      {
+                        "name": "PacketsIn",
+                        "value": 150,
+                        "unit": "count"
+                      }
+                    ]
+                  },
+                  "statsAtPrepare": {
+                    "timestamp": "2026-08-05T11:30:00Z",
+                    "metrics": [
+                      {
+                        "name": "PacketsIn",
+                        "value": 98,
+                        "unit": "count"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "sourcePortId": "sourcePort1",
+              "sourcePortStats": {
+                "peerings": [
+                  {
+                    "type": "Private",
+                    "statsCurrent": {
+                      "timestamp": "2026-08-05T11:40:00Z",
+                      "metrics": [
+                        {
+                          "name": "PacketsIn",
+                          "value": 150,
+                          "unit": "count"
+                        }
+                      ]
+                    },
+                    "statsAtPrepare": {
+                      "timestamp": "2026-08-05T11:30:00Z",
+                      "metrics": [
+                        {
+                          "name": "PacketsIn",
+                          "value": 98,
+                          "unit": "count"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "portId": "targetPort2",
+              "status": "Succeeded",
+              "phase": "BgpRestored",
+              "failureReason": "",
+              "peerings": [
+                {
+                  "type": "Private",
+                  "statsCurrent": {
+                    "timestamp": "2026-08-05T11:40:00Z",
+                    "metrics": [
+                      {
+                        "name": "PacketsIn",
+                        "value": 145,
+                        "unit": "count"
+                      }
+                    ]
+                  },
+                  "statsAtPrepare": {
+                    "timestamp": "2026-08-05T11:30:00Z",
+                    "metrics": [
+                      {
+                        "name": "PacketsIn",
+                        "value": 95,
+                        "unit": "count"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "sourcePortId": "sourcePort2",
+              "sourcePortStats": {
+                "peerings": [
+                  {
+                    "type": "Private",
+                    "statsCurrent": {
+                      "timestamp": "2026-08-05T11:40:00Z",
+                      "metrics": [
+                        {
+                          "name": "PacketsIn",
+                          "value": 145,
+                          "unit": "count"
+                        }
+                      ]
+                    },
+                    "statsAtPrepare": {
+                      "timestamp": "2026-08-05T11:30:00Z",
+                      "metrics": [
+                        {
+                          "name": "PacketsIn",
+                          "value": 95,
+                          "unit": "count"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/ExpressRouteCrossConnectionRestoreBgpForCircuitMigration.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/ExpressRouteCrossConnectionRestoreBgpForCircuitMigration.json
@@ -1,7 +1,7 @@
 {
   "parameters": {
     "api-version": "2026-01-01",
-    "subscriptionId": "subid",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
     "resourceGroupName": "CrossConnection-SiliconValley",
     "crossConnectionName": "<circuitServiceKey>",
     "parameters": {
@@ -160,5 +160,7 @@
         }
       }
     }
-  }
+  },
+  "operationId": "ExpressRouteCrossConnections_RestoreBgpForCircuitMigration",
+  "title": "RestoreBgpForExpressRouteCircuitMigration"
 }

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/ExpressRouteCrossConnectionRollbackCircuitMigration.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/ExpressRouteCrossConnectionRollbackCircuitMigration.json
@@ -1,7 +1,7 @@
 {
   "parameters": {
     "api-version": "2026-01-01",
-    "subscriptionId": "subid",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
     "resourceGroupName": "CrossConnection-SiliconValley",
     "crossConnectionName": "<circuitServiceKey>",
     "parameters": {
@@ -160,5 +160,7 @@
         }
       }
     }
-  }
+  },
+  "operationId": "ExpressRouteCrossConnections_RollbackCircuitMigration",
+  "title": "RollbackExpressRouteCircuitMigration"
 }

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/ExpressRouteCrossConnectionRollbackCircuitMigration.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/ExpressRouteCrossConnectionRollbackCircuitMigration.json
@@ -1,0 +1,164 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "subscriptionId": "subid",
+    "resourceGroupName": "CrossConnection-SiliconValley",
+    "crossConnectionName": "<circuitServiceKey>",
+    "parameters": {
+      "targetPeeringLocation": "SiliconValley",
+      "targetPortMapping": [
+        {
+          "sourcePortId": "sourcePort1",
+          "targetPortId": "targetPort1"
+        },
+        {
+          "sourcePortId": "sourcePort2",
+          "targetPortId": "targetPort2"
+        }
+      ],
+      "portId": "sourcePort1"
+    }
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/subid/providers/Microsoft.Network/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-01-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/subid/providers/Microsoft.Network/locations/eastus/operationStatuses/00000000-0000-0000-0000-000000000000?api-version=2026-01-01"
+      }
+    },
+    "200": {
+      "body": {
+        "status": "Succeeded",
+        "phase": "RolledBack",
+        "failureReason": "",
+        "newSTag": "12345",
+        "preparedAt": "2026-08-05T11:30:00Z",
+        "prepareExpiryTime": "2026-08-05T12:30:00Z",
+        "newCrossConnectionUrl": "https://management.azure.com/subscriptions/subid/resourceGroups/CrossConnection-SiliconValley/providers/Microsoft.Network/expressRouteCrossConnections/newCircuitServiceKey?api-version=2026-01-01",
+        "shouldRollback": true,
+        "details": {
+          "portMigrationInfos": [
+            {
+              "portId": "targetPort1",
+              "status": "Succeeded",
+              "phase": "RolledBack",
+              "failureReason": "",
+              "peerings": [
+                {
+                  "type": "Private",
+                  "statsCurrent": {
+                    "timestamp": "2026-08-05T11:40:00Z",
+                    "metrics": [
+                      {
+                        "name": "PacketsIn",
+                        "value": 150,
+                        "unit": "count"
+                      }
+                    ]
+                  },
+                  "statsAtPrepare": {
+                    "timestamp": "2026-08-05T11:30:00Z",
+                    "metrics": [
+                      {
+                        "name": "PacketsIn",
+                        "value": 98,
+                        "unit": "count"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "sourcePortId": "sourcePort1",
+              "sourcePortStats": {
+                "peerings": [
+                  {
+                    "type": "Private",
+                    "statsCurrent": {
+                      "timestamp": "2026-08-05T11:40:00Z",
+                      "metrics": [
+                        {
+                          "name": "PacketsIn",
+                          "value": 150,
+                          "unit": "count"
+                        }
+                      ]
+                    },
+                    "statsAtPrepare": {
+                      "timestamp": "2026-08-05T11:30:00Z",
+                      "metrics": [
+                        {
+                          "name": "PacketsIn",
+                          "value": 98,
+                          "unit": "count"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "portId": "targetPort2",
+              "status": "Succeeded",
+              "phase": "RolledBack",
+              "failureReason": "",
+              "peerings": [
+                {
+                  "type": "Private",
+                  "statsCurrent": {
+                    "timestamp": "2026-08-05T11:40:00Z",
+                    "metrics": [
+                      {
+                        "name": "PacketsIn",
+                        "value": 145,
+                        "unit": "count"
+                      }
+                    ]
+                  },
+                  "statsAtPrepare": {
+                    "timestamp": "2026-08-05T11:30:00Z",
+                    "metrics": [
+                      {
+                        "name": "PacketsIn",
+                        "value": 95,
+                        "unit": "count"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "sourcePortId": "sourcePort2",
+              "sourcePortStats": {
+                "peerings": [
+                  {
+                    "type": "Private",
+                    "statsCurrent": {
+                      "timestamp": "2026-08-05T11:40:00Z",
+                      "metrics": [
+                        {
+                          "name": "PacketsIn",
+                          "value": 145,
+                          "unit": "count"
+                        }
+                      ]
+                    },
+                    "statsAtPrepare": {
+                      "timestamp": "2026-08-05T11:30:00Z",
+                      "metrics": [
+                        {
+                          "name": "PacketsIn",
+                          "value": 95,
+                          "unit": "count"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/ExpressRouteCrossConnectionShutDownBgpForCircuitMigration.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/ExpressRouteCrossConnectionShutDownBgpForCircuitMigration.json
@@ -1,0 +1,164 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "subscriptionId": "subid",
+    "resourceGroupName": "CrossConnection-SiliconValley",
+    "crossConnectionName": "<circuitServiceKey>",
+    "parameters": {
+      "targetPeeringLocation": "SiliconValley",
+      "targetPortMapping": [
+        {
+          "sourcePortId": "sourcePort1",
+          "targetPortId": "targetPort1"
+        },
+        {
+          "sourcePortId": "sourcePort2",
+          "targetPortId": "targetPort2"
+        }
+      ],
+      "portId": "sourcePort1"
+    }
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/subid/providers/Microsoft.Network/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-01-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/subid/providers/Microsoft.Network/locations/eastus/operationStatuses/00000000-0000-0000-0000-000000000000?api-version=2026-01-01"
+      }
+    },
+    "200": {
+      "body": {
+        "status": "Succeeded",
+        "phase": "BgpShutDown",
+        "failureReason": "",
+        "newSTag": "12345",
+        "preparedAt": "2026-08-05T11:30:00Z",
+        "prepareExpiryTime": "2026-08-05T12:30:00Z",
+        "newCrossConnectionUrl": "https://management.azure.com/subscriptions/subid/resourceGroups/CrossConnection-SiliconValley/providers/Microsoft.Network/expressRouteCrossConnections/newCircuitServiceKey?api-version=2026-01-01",
+        "shouldRollback": false,
+        "details": {
+          "portMigrationInfos": [
+            {
+              "portId": "targetPort1",
+              "status": "Succeeded",
+              "phase": "BgpShutDown",
+              "failureReason": "",
+              "peerings": [
+                {
+                  "type": "Private",
+                  "statsCurrent": {
+                    "timestamp": "2026-08-05T11:40:00Z",
+                    "metrics": [
+                      {
+                        "name": "PacketsIn",
+                        "value": 150,
+                        "unit": "count"
+                      }
+                    ]
+                  },
+                  "statsAtPrepare": {
+                    "timestamp": "2026-08-05T11:30:00Z",
+                    "metrics": [
+                      {
+                        "name": "PacketsIn",
+                        "value": 98,
+                        "unit": "count"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "sourcePortId": "sourcePort1",
+              "sourcePortStats": {
+                "peerings": [
+                  {
+                    "type": "Private",
+                    "statsCurrent": {
+                      "timestamp": "2026-08-05T11:40:00Z",
+                      "metrics": [
+                        {
+                          "name": "PacketsIn",
+                          "value": 150,
+                          "unit": "count"
+                        }
+                      ]
+                    },
+                    "statsAtPrepare": {
+                      "timestamp": "2026-08-05T11:30:00Z",
+                      "metrics": [
+                        {
+                          "name": "PacketsIn",
+                          "value": 98,
+                          "unit": "count"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "portId": "targetPort2",
+              "status": "Succeeded",
+              "phase": "BgpShutDown",
+              "failureReason": "",
+              "peerings": [
+                {
+                  "type": "Private",
+                  "statsCurrent": {
+                    "timestamp": "2026-08-05T11:40:00Z",
+                    "metrics": [
+                      {
+                        "name": "PacketsIn",
+                        "value": 145,
+                        "unit": "count"
+                      }
+                    ]
+                  },
+                  "statsAtPrepare": {
+                    "timestamp": "2026-08-05T11:30:00Z",
+                    "metrics": [
+                      {
+                        "name": "PacketsIn",
+                        "value": 95,
+                        "unit": "count"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "sourcePortId": "sourcePort2",
+              "sourcePortStats": {
+                "peerings": [
+                  {
+                    "type": "Private",
+                    "statsCurrent": {
+                      "timestamp": "2026-08-05T11:40:00Z",
+                      "metrics": [
+                        {
+                          "name": "PacketsIn",
+                          "value": 145,
+                          "unit": "count"
+                        }
+                      ]
+                    },
+                    "statsAtPrepare": {
+                      "timestamp": "2026-08-05T11:30:00Z",
+                      "metrics": [
+                        {
+                          "name": "PacketsIn",
+                          "value": 95,
+                          "unit": "count"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/ExpressRouteCrossConnectionShutDownBgpForCircuitMigration.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/ExpressRouteCrossConnectionShutDownBgpForCircuitMigration.json
@@ -1,7 +1,7 @@
 {
   "parameters": {
     "api-version": "2026-01-01",
-    "subscriptionId": "subid",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
     "resourceGroupName": "CrossConnection-SiliconValley",
     "crossConnectionName": "<circuitServiceKey>",
     "parameters": {
@@ -160,5 +160,7 @@
         }
       }
     }
-  }
+  },
+  "operationId": "ExpressRouteCrossConnections_ShutDownBgpForCircuitMigration",
+  "title": "ShutDownBgpForExpressRouteCircuitMigration"
 }

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/ExpressRouteCrossConnectionValidateCircuitMigration.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/ExpressRouteCrossConnectionValidateCircuitMigration.json
@@ -1,7 +1,7 @@
 {
   "parameters": {
     "api-version": "2026-01-01",
-    "subscriptionId": "subid",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
     "resourceGroupName": "CrossConnection-SiliconValley",
     "crossConnectionName": "<circuitServiceKey>",
     "parameters": {
@@ -30,5 +30,7 @@
         "status": "Succeeded"
       }
     }
-  }
+  },
+  "operationId": "ExpressRouteCrossConnections_ValidateCircuitMigration",
+  "title": "ValidateExpressRouteCircuitMigration"
 }

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/ExpressRouteCrossConnectionValidateCircuitMigration.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/ExpressRouteCrossConnectionValidateCircuitMigration.json
@@ -1,0 +1,34 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "subscriptionId": "subid",
+    "resourceGroupName": "CrossConnection-SiliconValley",
+    "crossConnectionName": "<circuitServiceKey>",
+    "parameters": {
+      "targetPeeringLocation": "SiliconValley",
+      "targetPortMapping": [
+        {
+          "sourcePortId": "sourcePort1",
+          "targetPortId": "targetPort1"
+        },
+        {
+          "sourcePortId": "sourcePort2",
+          "targetPortId": "targetPort2"
+        }
+      ]
+    }
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/subid/providers/Microsoft.Network/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-01-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/subid/providers/Microsoft.Network/locations/eastus/operationStatuses/00000000-0000-0000-0000-000000000000?api-version=2026-01-01"
+      }
+    },
+    "200": {
+      "body": {
+        "status": "Succeeded"
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/models.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/models.tsp
@@ -12294,6 +12294,203 @@ model ExpressRouteCrossConnectionsRoutesTableSummaryListResult
 );
 
 /**
+ * Request model used by validate and health check circuit migration operations.
+ */
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Legacy feature decorator required for Network RP ExpressRoute feature gating, consistent with existing ExpressRoute models"
+@added(Versions.v2026_01_01)
+@Azure.ResourceManager.Legacy.feature(Features.expressRoute)
+model MigrateExpressRouteCircuitValidateAndHealthCheckRequest {
+  /** The target peering location for circuit migration. */
+  targetPeeringLocation: string;
+
+  /** The source-to-target port mappings for circuit migration. */
+  @identifiers(#["sourcePortId"])
+  targetPortMapping: PortMapping[];
+}
+
+/**
+ * Response for express route circuit migration validation operation.
+ */
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Legacy feature decorator required for Network RP ExpressRoute feature gating, consistent with existing ExpressRoute models"
+@added(Versions.v2026_01_01)
+@Azure.ResourceManager.Legacy.feature(Features.expressRoute)
+model MigrateExpressRouteCircuitValidateResponse {
+  /** The validation status. */
+  status?: string;
+}
+
+/**
+ * Request model for express route circuit migration operations.
+ */
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Legacy feature decorator required for Network RP ExpressRoute feature gating, consistent with existing ExpressRoute models"
+@added(Versions.v2026_01_01)
+@Azure.ResourceManager.Legacy.feature(Features.expressRoute)
+model MigrateExpressRouteCircuitRequest {
+  /** The target peering location for circuit migration. */
+  targetPeeringLocation?: string;
+
+  /** The source-to-target port mappings for circuit migration. */
+  @identifiers(#["sourcePortId"])
+  targetPortMapping?: PortMapping[];
+
+  /** The port identifier used for shutDownBgp, migrate, restoreBgp, and rollback operations. */
+  portId?: string;
+}
+
+/**
+ * Response for express route circuit migration health check and migration operations.
+ */
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Legacy feature decorator required for Network RP ExpressRoute feature gating, consistent with existing ExpressRoute models"
+@added(Versions.v2026_01_01)
+@Azure.ResourceManager.Legacy.feature(Features.expressRoute)
+model MigrateExpressRouteCircuitHealthCheckResponse {
+  /** The overall status of the migration operation. */
+  status?: string;
+
+  /** The current phase of the migration operation. */
+  phase?: string;
+
+  /** The failure reason if the migration operation failed. */
+  failureReason?: string;
+
+  /** The new service tag assigned after migration. */
+  #suppress "@azure-tools/typespec-azure-core/casing-style" "The wire property name newSTag is required to match the approved provider-led circuit migration contract."
+  newSTag?: string;
+
+  /** The timestamp when the migration was prepared. */
+  preparedAt?: utcDateTime;
+
+  /** The expiry time for the prepare phase. */
+  prepareExpiryTime?: utcDateTime;
+
+  /** The URL of the new cross connection after migration. */
+  newCrossConnectionUrl?: url;
+
+  /** Indicates whether rollback should be performed. */
+  shouldRollback?: boolean;
+
+  /** Detailed health check information for migration. */
+  details?: MigrateExpressRouteCircuitHealthCheckDetails;
+}
+
+/**
+ * Detailed migration health information.
+ */
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Legacy feature decorator required for Network RP ExpressRoute feature gating, consistent with existing ExpressRoute models"
+@added(Versions.v2026_01_01)
+@Azure.ResourceManager.Legacy.feature(Features.expressRoute)
+model MigrateExpressRouteCircuitHealthCheckDetails {
+  /** Per-port migration details. */
+  @identifiers(#["portId"])
+  portMigrationInfos?: PortMigrationInfo[];
+}
+
+/**
+ * A mapping between source and target ports for migration.
+ */
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Legacy feature decorator required for Network RP ExpressRoute feature gating, consistent with existing ExpressRoute models"
+@added(Versions.v2026_01_01)
+@Azure.ResourceManager.Legacy.feature(Features.expressRoute)
+model PortMapping {
+  /** The source port identifier. */
+  sourcePortId: string;
+
+  /** The target port identifier. */
+  targetPortId: string;
+}
+
+/**
+ * Information about a port migration status.
+ */
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Legacy feature decorator required for Network RP ExpressRoute feature gating, consistent with existing ExpressRoute models"
+@added(Versions.v2026_01_01)
+@Azure.ResourceManager.Legacy.feature(Features.expressRoute)
+model PortMigrationInfo {
+  /** The identifier of the port being migrated. */
+  portId?: string;
+
+  /** The migration status for the port. */
+  status?: string;
+
+  /** The current migration phase for the port. */
+  phase?: string;
+
+  /** The reason for failure if migration failed for the port. */
+  failureReason?: string;
+
+  /** The peering health details for the port. */
+  @identifiers(#["type"])
+  peerings?: PeeringHealth[];
+
+  /** The source port identifier before migration. */
+  sourcePortId?: string;
+
+  /** The source port statistics before migration. */
+  sourcePortStats?: SourcePortStats;
+}
+
+/**
+ * Statistics from the source port before migration.
+ */
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Legacy feature decorator required for Network RP ExpressRoute feature gating, consistent with existing ExpressRoute models"
+@added(Versions.v2026_01_01)
+@Azure.ResourceManager.Legacy.feature(Features.expressRoute)
+model SourcePortStats {
+  /** The peering health information from the source port. */
+  @identifiers(#["type"])
+  peerings?: PeeringHealth[];
+}
+
+/**
+ * Health information for a peering connection.
+ */
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Legacy feature decorator required for Network RP ExpressRoute feature gating, consistent with existing ExpressRoute models"
+@added(Versions.v2026_01_01)
+@Azure.ResourceManager.Legacy.feature(Features.expressRoute)
+model PeeringHealth {
+  /** The type of peering (for example, Private, Microsoft, Public). */
+  type?: string;
+
+  /** The current peering statistics. */
+  statsCurrent?: PeeringStats;
+
+  /** The peering statistics captured at prepare phase. */
+  statsAtPrepare?: PeeringStats;
+}
+
+/**
+ * Statistical information for a peering connection.
+ */
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Legacy feature decorator required for Network RP ExpressRoute feature gating, consistent with existing ExpressRoute models"
+@added(Versions.v2026_01_01)
+@Azure.ResourceManager.Legacy.feature(Features.expressRoute)
+model PeeringStats {
+  /** The timestamp when these statistics were captured. */
+  timestamp?: utcDateTime;
+
+  /** The collection of peering metrics. */
+  @identifiers(#["name"])
+  metrics?: Metric[];
+}
+
+/**
+ * Metric entry for migration peering statistics.
+ */
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Legacy feature decorator required for Network RP ExpressRoute feature gating, consistent with existing ExpressRoute models"
+@added(Versions.v2026_01_01)
+@Azure.ResourceManager.Legacy.feature(Features.expressRoute)
+model Metric {
+  /** The metric name. */
+  name?: string;
+
+  /** The metric value. */
+  value?: float64;
+
+  /** The metric unit. */
+  unit?: string;
+}
+
+/**
  * Response for ListExpressRouteProviderPort API service call.
  */
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/suppressions.yaml
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/suppressions.yaml
@@ -208,6 +208,3 @@
 - tool: TypeSpecRequirement
   path: ./stable/2025-05-01/*.json
   reason: Brownfield service not ready to migrate
-- tool: SwaggerAvocado
-  path: ./stable/2018-10-01/vmssNetwork.json
-  reason: The package-2026-01-01 default tag intentionally retains the frozen 2018-10-01 VMSS network surface for backward compatibility; moving it to 2026-01-01 would break existing clients.

--- a/specification/network/resource-manager/Microsoft.Network/Network/readme.md
+++ b/specification/network/resource-manager/Microsoft.Network/Network/readme.md
@@ -253,7 +253,26 @@ suppressions:
     from: expressRoute.json
     reason: The crossConnectionName parameter is used consistently across all ExpressRoute operations for backward compatibility. Adding a pattern constraint to a brownfield resource parameter would break existing API clients that rely on the current parameter definition.
     where:
-      - $.paths[*].*.parameters[?(@.name == 'crossConnectionName')]
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCrossConnections/{crossConnectionName}/validateCircuitMigration"]
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCrossConnections/{crossConnectionName}/getCircuitMigrationInfo"]
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCrossConnections/{crossConnectionName}/prepareCircuitMigration"]
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCrossConnections/{crossConnectionName}/shutDownBgpForCircuitMigration"]
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCrossConnections/{crossConnectionName}/restoreBgpForCircuitMigration"]
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCrossConnections/{crossConnectionName}/migrateCircuit"]
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCrossConnections/{crossConnectionName}/commitCircuitMigration"]
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCrossConnections/{crossConnectionName}/rollbackCircuitMigration"]
+  - code: LatestVersionOfCommonTypesMustBeUsed
+    from: expressRoute.json
+    reason: The Network TypeSpec project currently targets ARM common types v5. These actions follow the same project-wide common-types version to avoid unrelated contract churn.
+    where:
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCrossConnections/{crossConnectionName}/validateCircuitMigration"]
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCrossConnections/{crossConnectionName}/getCircuitMigrationInfo"]
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCrossConnections/{crossConnectionName}/prepareCircuitMigration"]
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCrossConnections/{crossConnectionName}/shutDownBgpForCircuitMigration"]
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCrossConnections/{crossConnectionName}/restoreBgpForCircuitMigration"]
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCrossConnections/{crossConnectionName}/migrateCircuit"]
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCrossConnections/{crossConnectionName}/commitCircuitMigration"]
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCrossConnections/{crossConnectionName}/rollbackCircuitMigration"]
   - code: ResourceNameRestriction
     from: virtualNetwork.json
     reason: The resource name parameter 'virtualNetworkName' is not defined with a 'pattern' restriction. Suppress it to avoid breaking change because it is referenced by all Virtual Network APIs.

--- a/specification/network/resource-manager/Microsoft.Network/Network/readme.md
+++ b/specification/network/resource-manager/Microsoft.Network/Network/readme.md
@@ -42,9 +42,6 @@ title: NetworkManagementClient
 description: Network Client
 openapi-type: arm
 tag: package-2026-01-01
-directive:
-  - suppress: MULTIPLE_API_VERSION
-    reason: The combined Network package intentionally includes the frozen VMSS 2018-10-01 captured-schema surface for backward compatibility.
 ```
 
 ### Tag: package-2026-01-01

--- a/specification/network/resource-manager/Microsoft.Network/Network/readme.md
+++ b/specification/network/resource-manager/Microsoft.Network/Network/readme.md
@@ -42,6 +42,9 @@ title: NetworkManagementClient
 description: Network Client
 openapi-type: arm
 tag: package-2026-01-01
+directive:
+  - suppress: MULTIPLE_API_VERSION
+    reason: The combined Network package intentionally includes the frozen VMSS 2018-10-01 captured-schema surface for backward compatibility.
 ```
 
 ### Tag: package-2026-01-01

--- a/specification/network/resource-manager/Microsoft.Network/Network/readme.md
+++ b/specification/network/resource-manager/Microsoft.Network/Network/readme.md
@@ -250,6 +250,11 @@ suppressions:
       - $.definitions.ExpressRouteCircuit.properties.properties.properties.activationKey
       - $.definitions.ExpressRouteCircuitPropertiesFormat.properties.activationKey
   - code: ResourceNameRestriction
+    from: expressRoute.json
+    reason: The crossConnectionName parameter is used consistently across all ExpressRoute operations for backward compatibility. Adding a pattern constraint to a brownfield resource parameter would break existing API clients that rely on the current parameter definition.
+    where:
+      - $.paths[*].*.parameters[?(@.name == 'crossConnectionName')]
+  - code: ResourceNameRestriction
     from: virtualNetwork.json
     reason: The resource name parameter 'virtualNetworkName' is not defined with a 'pattern' restriction. Suppress it to avoid breaking change because it is referenced by all Virtual Network APIs.
     where:

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/ExpressRouteCrossConnectionCommitCircuitMigration.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/ExpressRouteCrossConnectionCommitCircuitMigration.json
@@ -1,7 +1,7 @@
 {
   "parameters": {
     "api-version": "2026-01-01",
-    "subscriptionId": "subid",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
     "resourceGroupName": "CrossConnection-SiliconValley",
     "crossConnectionName": "<circuitServiceKey>",
     "parameters": {
@@ -160,5 +160,7 @@
         }
       }
     }
-  }
+  },
+  "operationId": "ExpressRouteCrossConnections_CommitCircuitMigration",
+  "title": "CommitExpressRouteCircuitMigration"
 }

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/ExpressRouteCrossConnectionCommitCircuitMigration.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/ExpressRouteCrossConnectionCommitCircuitMigration.json
@@ -1,0 +1,164 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "subscriptionId": "subid",
+    "resourceGroupName": "CrossConnection-SiliconValley",
+    "crossConnectionName": "<circuitServiceKey>",
+    "parameters": {
+      "targetPeeringLocation": "SiliconValley",
+      "targetPortMapping": [
+        {
+          "sourcePortId": "sourcePort1",
+          "targetPortId": "targetPort1"
+        },
+        {
+          "sourcePortId": "sourcePort2",
+          "targetPortId": "targetPort2"
+        }
+      ],
+      "portId": "sourcePort1"
+    }
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/subid/providers/Microsoft.Network/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-01-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/subid/providers/Microsoft.Network/locations/eastus/operationStatuses/00000000-0000-0000-0000-000000000000?api-version=2026-01-01"
+      }
+    },
+    "200": {
+      "body": {
+        "status": "Succeeded",
+        "phase": "Committed",
+        "failureReason": "",
+        "newSTag": "12345",
+        "preparedAt": "2026-08-05T11:30:00Z",
+        "prepareExpiryTime": "2026-08-05T12:30:00Z",
+        "newCrossConnectionUrl": "https://management.azure.com/subscriptions/subid/resourceGroups/CrossConnection-SiliconValley/providers/Microsoft.Network/expressRouteCrossConnections/newCircuitServiceKey?api-version=2026-01-01",
+        "shouldRollback": false,
+        "details": {
+          "portMigrationInfos": [
+            {
+              "portId": "targetPort1",
+              "status": "Succeeded",
+              "phase": "Committed",
+              "failureReason": "",
+              "peerings": [
+                {
+                  "type": "Private",
+                  "statsCurrent": {
+                    "timestamp": "2026-08-05T11:40:00Z",
+                    "metrics": [
+                      {
+                        "name": "PacketsIn",
+                        "value": 150,
+                        "unit": "count"
+                      }
+                    ]
+                  },
+                  "statsAtPrepare": {
+                    "timestamp": "2026-08-05T11:30:00Z",
+                    "metrics": [
+                      {
+                        "name": "PacketsIn",
+                        "value": 98,
+                        "unit": "count"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "sourcePortId": "sourcePort1",
+              "sourcePortStats": {
+                "peerings": [
+                  {
+                    "type": "Private",
+                    "statsCurrent": {
+                      "timestamp": "2026-08-05T11:40:00Z",
+                      "metrics": [
+                        {
+                          "name": "PacketsIn",
+                          "value": 150,
+                          "unit": "count"
+                        }
+                      ]
+                    },
+                    "statsAtPrepare": {
+                      "timestamp": "2026-08-05T11:30:00Z",
+                      "metrics": [
+                        {
+                          "name": "PacketsIn",
+                          "value": 98,
+                          "unit": "count"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "portId": "targetPort2",
+              "status": "Succeeded",
+              "phase": "Committed",
+              "failureReason": "",
+              "peerings": [
+                {
+                  "type": "Private",
+                  "statsCurrent": {
+                    "timestamp": "2026-08-05T11:40:00Z",
+                    "metrics": [
+                      {
+                        "name": "PacketsIn",
+                        "value": 145,
+                        "unit": "count"
+                      }
+                    ]
+                  },
+                  "statsAtPrepare": {
+                    "timestamp": "2026-08-05T11:30:00Z",
+                    "metrics": [
+                      {
+                        "name": "PacketsIn",
+                        "value": 95,
+                        "unit": "count"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "sourcePortId": "sourcePort2",
+              "sourcePortStats": {
+                "peerings": [
+                  {
+                    "type": "Private",
+                    "statsCurrent": {
+                      "timestamp": "2026-08-05T11:40:00Z",
+                      "metrics": [
+                        {
+                          "name": "PacketsIn",
+                          "value": 145,
+                          "unit": "count"
+                        }
+                      ]
+                    },
+                    "statsAtPrepare": {
+                      "timestamp": "2026-08-05T11:30:00Z",
+                      "metrics": [
+                        {
+                          "name": "PacketsIn",
+                          "value": 95,
+                          "unit": "count"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/ExpressRouteCrossConnectionGetCircuitMigrationInfo.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/ExpressRouteCrossConnectionGetCircuitMigrationInfo.json
@@ -1,7 +1,7 @@
 {
   "parameters": {
     "api-version": "2026-01-01",
-    "subscriptionId": "subid",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
     "resourceGroupName": "CrossConnection-SiliconValley",
     "crossConnectionName": "<circuitServiceKey>",
     "parameters": {
@@ -159,5 +159,7 @@
         }
       }
     }
-  }
+  },
+  "operationId": "ExpressRouteCrossConnections_GetCircuitMigrationInfo",
+  "title": "GetExpressRouteCircuitMigrationInfo"
 }

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/ExpressRouteCrossConnectionGetCircuitMigrationInfo.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/ExpressRouteCrossConnectionGetCircuitMigrationInfo.json
@@ -1,0 +1,163 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "subscriptionId": "subid",
+    "resourceGroupName": "CrossConnection-SiliconValley",
+    "crossConnectionName": "<circuitServiceKey>",
+    "parameters": {
+      "targetPeeringLocation": "SiliconValley",
+      "targetPortMapping": [
+        {
+          "sourcePortId": "sourcePort1",
+          "targetPortId": "targetPort1"
+        },
+        {
+          "sourcePortId": "sourcePort2",
+          "targetPortId": "targetPort2"
+        }
+      ]
+    }
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/subid/providers/Microsoft.Network/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-01-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/subid/providers/Microsoft.Network/locations/eastus/operationStatuses/00000000-0000-0000-0000-000000000000?api-version=2026-01-01"
+      }
+    },
+    "200": {
+      "body": {
+        "status": "Succeeded",
+        "phase": "Prepared",
+        "failureReason": "",
+        "newSTag": "12345",
+        "preparedAt": "2026-08-05T11:30:00Z",
+        "prepareExpiryTime": "2026-08-05T12:30:00Z",
+        "newCrossConnectionUrl": "https://management.azure.com/subscriptions/subid/resourceGroups/CrossConnection-SiliconValley/providers/Microsoft.Network/expressRouteCrossConnections/newCircuitServiceKey?api-version=2026-01-01",
+        "shouldRollback": false,
+        "details": {
+          "portMigrationInfos": [
+            {
+              "portId": "targetPort1",
+              "status": "Ready",
+              "phase": "Prepared",
+              "failureReason": "",
+              "peerings": [
+                {
+                  "type": "Private",
+                  "statsCurrent": {
+                    "timestamp": "2026-08-05T11:31:00Z",
+                    "metrics": [
+                      {
+                        "name": "PacketsIn",
+                        "value": 100,
+                        "unit": "count"
+                      }
+                    ]
+                  },
+                  "statsAtPrepare": {
+                    "timestamp": "2026-08-05T11:30:00Z",
+                    "metrics": [
+                      {
+                        "name": "PacketsIn",
+                        "value": 98,
+                        "unit": "count"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "sourcePortId": "sourcePort1",
+              "sourcePortStats": {
+                "peerings": [
+                  {
+                    "type": "Private",
+                    "statsCurrent": {
+                      "timestamp": "2026-08-05T11:31:00Z",
+                      "metrics": [
+                        {
+                          "name": "PacketsIn",
+                          "value": 100,
+                          "unit": "count"
+                        }
+                      ]
+                    },
+                    "statsAtPrepare": {
+                      "timestamp": "2026-08-05T11:30:00Z",
+                      "metrics": [
+                        {
+                          "name": "PacketsIn",
+                          "value": 98,
+                          "unit": "count"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "portId": "targetPort2",
+              "status": "Ready",
+              "phase": "Prepared",
+              "failureReason": "",
+              "peerings": [
+                {
+                  "type": "Private",
+                  "statsCurrent": {
+                    "timestamp": "2026-08-05T11:31:00Z",
+                    "metrics": [
+                      {
+                        "name": "PacketsIn",
+                        "value": 97,
+                        "unit": "count"
+                      }
+                    ]
+                  },
+                  "statsAtPrepare": {
+                    "timestamp": "2026-08-05T11:30:00Z",
+                    "metrics": [
+                      {
+                        "name": "PacketsIn",
+                        "value": 96,
+                        "unit": "count"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "sourcePortId": "sourcePort2",
+              "sourcePortStats": {
+                "peerings": [
+                  {
+                    "type": "Private",
+                    "statsCurrent": {
+                      "timestamp": "2026-08-05T11:31:00Z",
+                      "metrics": [
+                        {
+                          "name": "PacketsIn",
+                          "value": 97,
+                          "unit": "count"
+                        }
+                      ]
+                    },
+                    "statsAtPrepare": {
+                      "timestamp": "2026-08-05T11:30:00Z",
+                      "metrics": [
+                        {
+                          "name": "PacketsIn",
+                          "value": 96,
+                          "unit": "count"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/ExpressRouteCrossConnectionMigrateCircuit.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/ExpressRouteCrossConnectionMigrateCircuit.json
@@ -1,0 +1,164 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "subscriptionId": "subid",
+    "resourceGroupName": "CrossConnection-SiliconValley",
+    "crossConnectionName": "<circuitServiceKey>",
+    "parameters": {
+      "targetPeeringLocation": "SiliconValley",
+      "targetPortMapping": [
+        {
+          "sourcePortId": "sourcePort1",
+          "targetPortId": "targetPort1"
+        },
+        {
+          "sourcePortId": "sourcePort2",
+          "targetPortId": "targetPort2"
+        }
+      ],
+      "portId": "sourcePort1"
+    }
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/subid/providers/Microsoft.Network/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-01-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/subid/providers/Microsoft.Network/locations/eastus/operationStatuses/00000000-0000-0000-0000-000000000000?api-version=2026-01-01"
+      }
+    },
+    "200": {
+      "body": {
+        "status": "Succeeded",
+        "phase": "Migrated",
+        "failureReason": "",
+        "newSTag": "12345",
+        "preparedAt": "2026-08-05T11:30:00Z",
+        "prepareExpiryTime": "2026-08-05T12:30:00Z",
+        "newCrossConnectionUrl": "https://management.azure.com/subscriptions/subid/resourceGroups/CrossConnection-SiliconValley/providers/Microsoft.Network/expressRouteCrossConnections/newCircuitServiceKey?api-version=2026-01-01",
+        "shouldRollback": false,
+        "details": {
+          "portMigrationInfos": [
+            {
+              "portId": "targetPort1",
+              "status": "Succeeded",
+              "phase": "Migrated",
+              "failureReason": "",
+              "peerings": [
+                {
+                  "type": "Private",
+                  "statsCurrent": {
+                    "timestamp": "2026-08-05T11:40:00Z",
+                    "metrics": [
+                      {
+                        "name": "PacketsIn",
+                        "value": 150,
+                        "unit": "count"
+                      }
+                    ]
+                  },
+                  "statsAtPrepare": {
+                    "timestamp": "2026-08-05T11:30:00Z",
+                    "metrics": [
+                      {
+                        "name": "PacketsIn",
+                        "value": 98,
+                        "unit": "count"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "sourcePortId": "sourcePort1",
+              "sourcePortStats": {
+                "peerings": [
+                  {
+                    "type": "Private",
+                    "statsCurrent": {
+                      "timestamp": "2026-08-05T11:40:00Z",
+                      "metrics": [
+                        {
+                          "name": "PacketsIn",
+                          "value": 150,
+                          "unit": "count"
+                        }
+                      ]
+                    },
+                    "statsAtPrepare": {
+                      "timestamp": "2026-08-05T11:30:00Z",
+                      "metrics": [
+                        {
+                          "name": "PacketsIn",
+                          "value": 98,
+                          "unit": "count"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "portId": "targetPort2",
+              "status": "Succeeded",
+              "phase": "Migrated",
+              "failureReason": "",
+              "peerings": [
+                {
+                  "type": "Private",
+                  "statsCurrent": {
+                    "timestamp": "2026-08-05T11:40:00Z",
+                    "metrics": [
+                      {
+                        "name": "PacketsIn",
+                        "value": 145,
+                        "unit": "count"
+                      }
+                    ]
+                  },
+                  "statsAtPrepare": {
+                    "timestamp": "2026-08-05T11:30:00Z",
+                    "metrics": [
+                      {
+                        "name": "PacketsIn",
+                        "value": 95,
+                        "unit": "count"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "sourcePortId": "sourcePort2",
+              "sourcePortStats": {
+                "peerings": [
+                  {
+                    "type": "Private",
+                    "statsCurrent": {
+                      "timestamp": "2026-08-05T11:40:00Z",
+                      "metrics": [
+                        {
+                          "name": "PacketsIn",
+                          "value": 145,
+                          "unit": "count"
+                        }
+                      ]
+                    },
+                    "statsAtPrepare": {
+                      "timestamp": "2026-08-05T11:30:00Z",
+                      "metrics": [
+                        {
+                          "name": "PacketsIn",
+                          "value": 95,
+                          "unit": "count"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/ExpressRouteCrossConnectionMigrateCircuit.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/ExpressRouteCrossConnectionMigrateCircuit.json
@@ -1,7 +1,7 @@
 {
   "parameters": {
     "api-version": "2026-01-01",
-    "subscriptionId": "subid",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
     "resourceGroupName": "CrossConnection-SiliconValley",
     "crossConnectionName": "<circuitServiceKey>",
     "parameters": {
@@ -160,5 +160,7 @@
         }
       }
     }
-  }
+  },
+  "operationId": "ExpressRouteCrossConnections_MigrateCircuit",
+  "title": "MigrateExpressRouteCircuit"
 }

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/ExpressRouteCrossConnectionPrepareCircuitMigration.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/ExpressRouteCrossConnectionPrepareCircuitMigration.json
@@ -1,0 +1,164 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "subscriptionId": "subid",
+    "resourceGroupName": "CrossConnection-SiliconValley",
+    "crossConnectionName": "<circuitServiceKey>",
+    "parameters": {
+      "targetPeeringLocation": "SiliconValley",
+      "targetPortMapping": [
+        {
+          "sourcePortId": "sourcePort1",
+          "targetPortId": "targetPort1"
+        },
+        {
+          "sourcePortId": "sourcePort2",
+          "targetPortId": "targetPort2"
+        }
+      ],
+      "portId": "sourcePort1"
+    }
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/subid/providers/Microsoft.Network/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-01-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/subid/providers/Microsoft.Network/locations/eastus/operationStatuses/00000000-0000-0000-0000-000000000000?api-version=2026-01-01"
+      }
+    },
+    "200": {
+      "body": {
+        "status": "Succeeded",
+        "phase": "Prepared",
+        "failureReason": "",
+        "newSTag": "12345",
+        "preparedAt": "2026-08-05T11:30:00Z",
+        "prepareExpiryTime": "2026-08-05T12:30:00Z",
+        "newCrossConnectionUrl": "https://management.azure.com/subscriptions/subid/resourceGroups/CrossConnection-SiliconValley/providers/Microsoft.Network/expressRouteCrossConnections/newCircuitServiceKey?api-version=2026-01-01",
+        "shouldRollback": false,
+        "details": {
+          "portMigrationInfos": [
+            {
+              "portId": "targetPort1",
+              "status": "Succeeded",
+              "phase": "Prepared",
+              "failureReason": "",
+              "peerings": [
+                {
+                  "type": "Private",
+                  "statsCurrent": {
+                    "timestamp": "2026-08-05T11:40:00Z",
+                    "metrics": [
+                      {
+                        "name": "PacketsIn",
+                        "value": 150,
+                        "unit": "count"
+                      }
+                    ]
+                  },
+                  "statsAtPrepare": {
+                    "timestamp": "2026-08-05T11:30:00Z",
+                    "metrics": [
+                      {
+                        "name": "PacketsIn",
+                        "value": 98,
+                        "unit": "count"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "sourcePortId": "sourcePort1",
+              "sourcePortStats": {
+                "peerings": [
+                  {
+                    "type": "Private",
+                    "statsCurrent": {
+                      "timestamp": "2026-08-05T11:40:00Z",
+                      "metrics": [
+                        {
+                          "name": "PacketsIn",
+                          "value": 150,
+                          "unit": "count"
+                        }
+                      ]
+                    },
+                    "statsAtPrepare": {
+                      "timestamp": "2026-08-05T11:30:00Z",
+                      "metrics": [
+                        {
+                          "name": "PacketsIn",
+                          "value": 98,
+                          "unit": "count"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "portId": "targetPort2",
+              "status": "Succeeded",
+              "phase": "Prepared",
+              "failureReason": "",
+              "peerings": [
+                {
+                  "type": "Private",
+                  "statsCurrent": {
+                    "timestamp": "2026-08-05T11:40:00Z",
+                    "metrics": [
+                      {
+                        "name": "PacketsIn",
+                        "value": 145,
+                        "unit": "count"
+                      }
+                    ]
+                  },
+                  "statsAtPrepare": {
+                    "timestamp": "2026-08-05T11:30:00Z",
+                    "metrics": [
+                      {
+                        "name": "PacketsIn",
+                        "value": 95,
+                        "unit": "count"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "sourcePortId": "sourcePort2",
+              "sourcePortStats": {
+                "peerings": [
+                  {
+                    "type": "Private",
+                    "statsCurrent": {
+                      "timestamp": "2026-08-05T11:40:00Z",
+                      "metrics": [
+                        {
+                          "name": "PacketsIn",
+                          "value": 145,
+                          "unit": "count"
+                        }
+                      ]
+                    },
+                    "statsAtPrepare": {
+                      "timestamp": "2026-08-05T11:30:00Z",
+                      "metrics": [
+                        {
+                          "name": "PacketsIn",
+                          "value": 95,
+                          "unit": "count"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/ExpressRouteCrossConnectionPrepareCircuitMigration.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/ExpressRouteCrossConnectionPrepareCircuitMigration.json
@@ -1,7 +1,7 @@
 {
   "parameters": {
     "api-version": "2026-01-01",
-    "subscriptionId": "subid",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
     "resourceGroupName": "CrossConnection-SiliconValley",
     "crossConnectionName": "<circuitServiceKey>",
     "parameters": {
@@ -160,5 +160,7 @@
         }
       }
     }
-  }
+  },
+  "operationId": "ExpressRouteCrossConnections_PrepareCircuitMigration",
+  "title": "PrepareExpressRouteCircuitMigration"
 }

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/ExpressRouteCrossConnectionRestoreBgpForCircuitMigration.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/ExpressRouteCrossConnectionRestoreBgpForCircuitMigration.json
@@ -1,0 +1,164 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "subscriptionId": "subid",
+    "resourceGroupName": "CrossConnection-SiliconValley",
+    "crossConnectionName": "<circuitServiceKey>",
+    "parameters": {
+      "targetPeeringLocation": "SiliconValley",
+      "targetPortMapping": [
+        {
+          "sourcePortId": "sourcePort1",
+          "targetPortId": "targetPort1"
+        },
+        {
+          "sourcePortId": "sourcePort2",
+          "targetPortId": "targetPort2"
+        }
+      ],
+      "portId": "sourcePort1"
+    }
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/subid/providers/Microsoft.Network/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-01-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/subid/providers/Microsoft.Network/locations/eastus/operationStatuses/00000000-0000-0000-0000-000000000000?api-version=2026-01-01"
+      }
+    },
+    "200": {
+      "body": {
+        "status": "Succeeded",
+        "phase": "BgpRestored",
+        "failureReason": "",
+        "newSTag": "12345",
+        "preparedAt": "2026-08-05T11:30:00Z",
+        "prepareExpiryTime": "2026-08-05T12:30:00Z",
+        "newCrossConnectionUrl": "https://management.azure.com/subscriptions/subid/resourceGroups/CrossConnection-SiliconValley/providers/Microsoft.Network/expressRouteCrossConnections/newCircuitServiceKey?api-version=2026-01-01",
+        "shouldRollback": false,
+        "details": {
+          "portMigrationInfos": [
+            {
+              "portId": "targetPort1",
+              "status": "Succeeded",
+              "phase": "BgpRestored",
+              "failureReason": "",
+              "peerings": [
+                {
+                  "type": "Private",
+                  "statsCurrent": {
+                    "timestamp": "2026-08-05T11:40:00Z",
+                    "metrics": [
+                      {
+                        "name": "PacketsIn",
+                        "value": 150,
+                        "unit": "count"
+                      }
+                    ]
+                  },
+                  "statsAtPrepare": {
+                    "timestamp": "2026-08-05T11:30:00Z",
+                    "metrics": [
+                      {
+                        "name": "PacketsIn",
+                        "value": 98,
+                        "unit": "count"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "sourcePortId": "sourcePort1",
+              "sourcePortStats": {
+                "peerings": [
+                  {
+                    "type": "Private",
+                    "statsCurrent": {
+                      "timestamp": "2026-08-05T11:40:00Z",
+                      "metrics": [
+                        {
+                          "name": "PacketsIn",
+                          "value": 150,
+                          "unit": "count"
+                        }
+                      ]
+                    },
+                    "statsAtPrepare": {
+                      "timestamp": "2026-08-05T11:30:00Z",
+                      "metrics": [
+                        {
+                          "name": "PacketsIn",
+                          "value": 98,
+                          "unit": "count"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "portId": "targetPort2",
+              "status": "Succeeded",
+              "phase": "BgpRestored",
+              "failureReason": "",
+              "peerings": [
+                {
+                  "type": "Private",
+                  "statsCurrent": {
+                    "timestamp": "2026-08-05T11:40:00Z",
+                    "metrics": [
+                      {
+                        "name": "PacketsIn",
+                        "value": 145,
+                        "unit": "count"
+                      }
+                    ]
+                  },
+                  "statsAtPrepare": {
+                    "timestamp": "2026-08-05T11:30:00Z",
+                    "metrics": [
+                      {
+                        "name": "PacketsIn",
+                        "value": 95,
+                        "unit": "count"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "sourcePortId": "sourcePort2",
+              "sourcePortStats": {
+                "peerings": [
+                  {
+                    "type": "Private",
+                    "statsCurrent": {
+                      "timestamp": "2026-08-05T11:40:00Z",
+                      "metrics": [
+                        {
+                          "name": "PacketsIn",
+                          "value": 145,
+                          "unit": "count"
+                        }
+                      ]
+                    },
+                    "statsAtPrepare": {
+                      "timestamp": "2026-08-05T11:30:00Z",
+                      "metrics": [
+                        {
+                          "name": "PacketsIn",
+                          "value": 95,
+                          "unit": "count"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/ExpressRouteCrossConnectionRestoreBgpForCircuitMigration.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/ExpressRouteCrossConnectionRestoreBgpForCircuitMigration.json
@@ -1,7 +1,7 @@
 {
   "parameters": {
     "api-version": "2026-01-01",
-    "subscriptionId": "subid",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
     "resourceGroupName": "CrossConnection-SiliconValley",
     "crossConnectionName": "<circuitServiceKey>",
     "parameters": {
@@ -160,5 +160,7 @@
         }
       }
     }
-  }
+  },
+  "operationId": "ExpressRouteCrossConnections_RestoreBgpForCircuitMigration",
+  "title": "RestoreBgpForExpressRouteCircuitMigration"
 }

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/ExpressRouteCrossConnectionRollbackCircuitMigration.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/ExpressRouteCrossConnectionRollbackCircuitMigration.json
@@ -1,7 +1,7 @@
 {
   "parameters": {
     "api-version": "2026-01-01",
-    "subscriptionId": "subid",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
     "resourceGroupName": "CrossConnection-SiliconValley",
     "crossConnectionName": "<circuitServiceKey>",
     "parameters": {
@@ -160,5 +160,7 @@
         }
       }
     }
-  }
+  },
+  "operationId": "ExpressRouteCrossConnections_RollbackCircuitMigration",
+  "title": "RollbackExpressRouteCircuitMigration"
 }

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/ExpressRouteCrossConnectionRollbackCircuitMigration.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/ExpressRouteCrossConnectionRollbackCircuitMigration.json
@@ -1,0 +1,164 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "subscriptionId": "subid",
+    "resourceGroupName": "CrossConnection-SiliconValley",
+    "crossConnectionName": "<circuitServiceKey>",
+    "parameters": {
+      "targetPeeringLocation": "SiliconValley",
+      "targetPortMapping": [
+        {
+          "sourcePortId": "sourcePort1",
+          "targetPortId": "targetPort1"
+        },
+        {
+          "sourcePortId": "sourcePort2",
+          "targetPortId": "targetPort2"
+        }
+      ],
+      "portId": "sourcePort1"
+    }
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/subid/providers/Microsoft.Network/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-01-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/subid/providers/Microsoft.Network/locations/eastus/operationStatuses/00000000-0000-0000-0000-000000000000?api-version=2026-01-01"
+      }
+    },
+    "200": {
+      "body": {
+        "status": "Succeeded",
+        "phase": "RolledBack",
+        "failureReason": "",
+        "newSTag": "12345",
+        "preparedAt": "2026-08-05T11:30:00Z",
+        "prepareExpiryTime": "2026-08-05T12:30:00Z",
+        "newCrossConnectionUrl": "https://management.azure.com/subscriptions/subid/resourceGroups/CrossConnection-SiliconValley/providers/Microsoft.Network/expressRouteCrossConnections/newCircuitServiceKey?api-version=2026-01-01",
+        "shouldRollback": true,
+        "details": {
+          "portMigrationInfos": [
+            {
+              "portId": "targetPort1",
+              "status": "Succeeded",
+              "phase": "RolledBack",
+              "failureReason": "",
+              "peerings": [
+                {
+                  "type": "Private",
+                  "statsCurrent": {
+                    "timestamp": "2026-08-05T11:40:00Z",
+                    "metrics": [
+                      {
+                        "name": "PacketsIn",
+                        "value": 150,
+                        "unit": "count"
+                      }
+                    ]
+                  },
+                  "statsAtPrepare": {
+                    "timestamp": "2026-08-05T11:30:00Z",
+                    "metrics": [
+                      {
+                        "name": "PacketsIn",
+                        "value": 98,
+                        "unit": "count"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "sourcePortId": "sourcePort1",
+              "sourcePortStats": {
+                "peerings": [
+                  {
+                    "type": "Private",
+                    "statsCurrent": {
+                      "timestamp": "2026-08-05T11:40:00Z",
+                      "metrics": [
+                        {
+                          "name": "PacketsIn",
+                          "value": 150,
+                          "unit": "count"
+                        }
+                      ]
+                    },
+                    "statsAtPrepare": {
+                      "timestamp": "2026-08-05T11:30:00Z",
+                      "metrics": [
+                        {
+                          "name": "PacketsIn",
+                          "value": 98,
+                          "unit": "count"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "portId": "targetPort2",
+              "status": "Succeeded",
+              "phase": "RolledBack",
+              "failureReason": "",
+              "peerings": [
+                {
+                  "type": "Private",
+                  "statsCurrent": {
+                    "timestamp": "2026-08-05T11:40:00Z",
+                    "metrics": [
+                      {
+                        "name": "PacketsIn",
+                        "value": 145,
+                        "unit": "count"
+                      }
+                    ]
+                  },
+                  "statsAtPrepare": {
+                    "timestamp": "2026-08-05T11:30:00Z",
+                    "metrics": [
+                      {
+                        "name": "PacketsIn",
+                        "value": 95,
+                        "unit": "count"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "sourcePortId": "sourcePort2",
+              "sourcePortStats": {
+                "peerings": [
+                  {
+                    "type": "Private",
+                    "statsCurrent": {
+                      "timestamp": "2026-08-05T11:40:00Z",
+                      "metrics": [
+                        {
+                          "name": "PacketsIn",
+                          "value": 145,
+                          "unit": "count"
+                        }
+                      ]
+                    },
+                    "statsAtPrepare": {
+                      "timestamp": "2026-08-05T11:30:00Z",
+                      "metrics": [
+                        {
+                          "name": "PacketsIn",
+                          "value": 95,
+                          "unit": "count"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/ExpressRouteCrossConnectionShutDownBgpForCircuitMigration.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/ExpressRouteCrossConnectionShutDownBgpForCircuitMigration.json
@@ -1,0 +1,164 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "subscriptionId": "subid",
+    "resourceGroupName": "CrossConnection-SiliconValley",
+    "crossConnectionName": "<circuitServiceKey>",
+    "parameters": {
+      "targetPeeringLocation": "SiliconValley",
+      "targetPortMapping": [
+        {
+          "sourcePortId": "sourcePort1",
+          "targetPortId": "targetPort1"
+        },
+        {
+          "sourcePortId": "sourcePort2",
+          "targetPortId": "targetPort2"
+        }
+      ],
+      "portId": "sourcePort1"
+    }
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/subid/providers/Microsoft.Network/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-01-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/subid/providers/Microsoft.Network/locations/eastus/operationStatuses/00000000-0000-0000-0000-000000000000?api-version=2026-01-01"
+      }
+    },
+    "200": {
+      "body": {
+        "status": "Succeeded",
+        "phase": "BgpShutDown",
+        "failureReason": "",
+        "newSTag": "12345",
+        "preparedAt": "2026-08-05T11:30:00Z",
+        "prepareExpiryTime": "2026-08-05T12:30:00Z",
+        "newCrossConnectionUrl": "https://management.azure.com/subscriptions/subid/resourceGroups/CrossConnection-SiliconValley/providers/Microsoft.Network/expressRouteCrossConnections/newCircuitServiceKey?api-version=2026-01-01",
+        "shouldRollback": false,
+        "details": {
+          "portMigrationInfos": [
+            {
+              "portId": "targetPort1",
+              "status": "Succeeded",
+              "phase": "BgpShutDown",
+              "failureReason": "",
+              "peerings": [
+                {
+                  "type": "Private",
+                  "statsCurrent": {
+                    "timestamp": "2026-08-05T11:40:00Z",
+                    "metrics": [
+                      {
+                        "name": "PacketsIn",
+                        "value": 150,
+                        "unit": "count"
+                      }
+                    ]
+                  },
+                  "statsAtPrepare": {
+                    "timestamp": "2026-08-05T11:30:00Z",
+                    "metrics": [
+                      {
+                        "name": "PacketsIn",
+                        "value": 98,
+                        "unit": "count"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "sourcePortId": "sourcePort1",
+              "sourcePortStats": {
+                "peerings": [
+                  {
+                    "type": "Private",
+                    "statsCurrent": {
+                      "timestamp": "2026-08-05T11:40:00Z",
+                      "metrics": [
+                        {
+                          "name": "PacketsIn",
+                          "value": 150,
+                          "unit": "count"
+                        }
+                      ]
+                    },
+                    "statsAtPrepare": {
+                      "timestamp": "2026-08-05T11:30:00Z",
+                      "metrics": [
+                        {
+                          "name": "PacketsIn",
+                          "value": 98,
+                          "unit": "count"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "portId": "targetPort2",
+              "status": "Succeeded",
+              "phase": "BgpShutDown",
+              "failureReason": "",
+              "peerings": [
+                {
+                  "type": "Private",
+                  "statsCurrent": {
+                    "timestamp": "2026-08-05T11:40:00Z",
+                    "metrics": [
+                      {
+                        "name": "PacketsIn",
+                        "value": 145,
+                        "unit": "count"
+                      }
+                    ]
+                  },
+                  "statsAtPrepare": {
+                    "timestamp": "2026-08-05T11:30:00Z",
+                    "metrics": [
+                      {
+                        "name": "PacketsIn",
+                        "value": 95,
+                        "unit": "count"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "sourcePortId": "sourcePort2",
+              "sourcePortStats": {
+                "peerings": [
+                  {
+                    "type": "Private",
+                    "statsCurrent": {
+                      "timestamp": "2026-08-05T11:40:00Z",
+                      "metrics": [
+                        {
+                          "name": "PacketsIn",
+                          "value": 145,
+                          "unit": "count"
+                        }
+                      ]
+                    },
+                    "statsAtPrepare": {
+                      "timestamp": "2026-08-05T11:30:00Z",
+                      "metrics": [
+                        {
+                          "name": "PacketsIn",
+                          "value": 95,
+                          "unit": "count"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/ExpressRouteCrossConnectionShutDownBgpForCircuitMigration.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/ExpressRouteCrossConnectionShutDownBgpForCircuitMigration.json
@@ -1,7 +1,7 @@
 {
   "parameters": {
     "api-version": "2026-01-01",
-    "subscriptionId": "subid",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
     "resourceGroupName": "CrossConnection-SiliconValley",
     "crossConnectionName": "<circuitServiceKey>",
     "parameters": {
@@ -160,5 +160,7 @@
         }
       }
     }
-  }
+  },
+  "operationId": "ExpressRouteCrossConnections_ShutDownBgpForCircuitMigration",
+  "title": "ShutDownBgpForExpressRouteCircuitMigration"
 }

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/ExpressRouteCrossConnectionValidateCircuitMigration.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/ExpressRouteCrossConnectionValidateCircuitMigration.json
@@ -1,7 +1,7 @@
 {
   "parameters": {
     "api-version": "2026-01-01",
-    "subscriptionId": "subid",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
     "resourceGroupName": "CrossConnection-SiliconValley",
     "crossConnectionName": "<circuitServiceKey>",
     "parameters": {
@@ -30,5 +30,7 @@
         "status": "Succeeded"
       }
     }
-  }
+  },
+  "operationId": "ExpressRouteCrossConnections_ValidateCircuitMigration",
+  "title": "ValidateExpressRouteCircuitMigration"
 }

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/ExpressRouteCrossConnectionValidateCircuitMigration.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/ExpressRouteCrossConnectionValidateCircuitMigration.json
@@ -1,0 +1,34 @@
+{
+  "parameters": {
+    "api-version": "2026-01-01",
+    "subscriptionId": "subid",
+    "resourceGroupName": "CrossConnection-SiliconValley",
+    "crossConnectionName": "<circuitServiceKey>",
+    "parameters": {
+      "targetPeeringLocation": "SiliconValley",
+      "targetPortMapping": [
+        {
+          "sourcePortId": "sourcePort1",
+          "targetPortId": "targetPort1"
+        },
+        {
+          "sourcePortId": "sourcePort2",
+          "targetPortId": "targetPort2"
+        }
+      ]
+    }
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/subid/providers/Microsoft.Network/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-01-01",
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/subid/providers/Microsoft.Network/locations/eastus/operationStatuses/00000000-0000-0000-0000-000000000000?api-version=2026-01-01"
+      }
+    },
+    "200": {
+      "body": {
+        "status": "Succeeded"
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/expressRoute.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/expressRoute.json
@@ -3122,6 +3122,225 @@
         }
       }
     },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCrossConnections/{crossConnectionName}/commitCircuitMigration": {
+      "post": {
+        "operationId": "ExpressRouteCrossConnections_CommitCircuitMigration",
+        "tags": [
+          "ExpressRouteCrossConnections"
+        ],
+        "description": "Commits the express route circuit migration for a cross connection.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "crossConnectionName",
+            "in": "path",
+            "description": "The name of the ExpressRouteCrossConnection (service key of the circuit).",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to commit the express route circuit migration.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/MigrateExpressRouteCircuitRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/MigrateExpressRouteCircuitHealthCheckResponse"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "CommitExpressRouteCircuitMigration": {
+            "$ref": "./examples/ExpressRouteCrossConnectionCommitCircuitMigration.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCrossConnections/{crossConnectionName}/getCircuitMigrationInfo": {
+      "post": {
+        "operationId": "ExpressRouteCrossConnections_GetCircuitMigrationInfo",
+        "tags": [
+          "ExpressRouteCrossConnections"
+        ],
+        "description": "Gets migration health information for an express route circuit cross connection.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "crossConnectionName",
+            "in": "path",
+            "description": "The name of the ExpressRouteCrossConnection (service key of the circuit).",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to get express route circuit migration information.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/MigrateExpressRouteCircuitValidateAndHealthCheckRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/MigrateExpressRouteCircuitHealthCheckResponse"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "GetExpressRouteCircuitMigrationInfo": {
+            "$ref": "./examples/ExpressRouteCrossConnectionGetCircuitMigrationInfo.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCrossConnections/{crossConnectionName}/migrateCircuit": {
+      "post": {
+        "operationId": "ExpressRouteCrossConnections_MigrateCircuit",
+        "tags": [
+          "ExpressRouteCrossConnections"
+        ],
+        "description": "Executes the express route circuit migration for a cross connection.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "crossConnectionName",
+            "in": "path",
+            "description": "The name of the ExpressRouteCrossConnection (service key of the circuit).",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to execute the express route circuit migration.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/MigrateExpressRouteCircuitRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/MigrateExpressRouteCircuitHealthCheckResponse"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "MigrateExpressRouteCircuit": {
+            "$ref": "./examples/ExpressRouteCrossConnectionMigrateCircuit.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCrossConnections/{crossConnectionName}/peerings": {
       "get": {
         "operationId": "ExpressRouteCrossConnectionPeerings_List",
@@ -3608,6 +3827,371 @@
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/ExpressRouteCrossConnectionsRoutesTableSummaryListResult"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCrossConnections/{crossConnectionName}/prepareCircuitMigration": {
+      "post": {
+        "operationId": "ExpressRouteCrossConnections_PrepareCircuitMigration",
+        "tags": [
+          "ExpressRouteCrossConnections"
+        ],
+        "description": "Prepares an express route circuit migration for a cross connection.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "crossConnectionName",
+            "in": "path",
+            "description": "The name of the ExpressRouteCrossConnection (service key of the circuit).",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to prepare the express route circuit migration.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/MigrateExpressRouteCircuitRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/MigrateExpressRouteCircuitHealthCheckResponse"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PrepareExpressRouteCircuitMigration": {
+            "$ref": "./examples/ExpressRouteCrossConnectionPrepareCircuitMigration.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCrossConnections/{crossConnectionName}/restoreBgpForCircuitMigration": {
+      "post": {
+        "operationId": "ExpressRouteCrossConnections_RestoreBgpForCircuitMigration",
+        "tags": [
+          "ExpressRouteCrossConnections"
+        ],
+        "description": "Restores BGP sessions as part of an express route circuit migration for a cross connection.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "crossConnectionName",
+            "in": "path",
+            "description": "The name of the ExpressRouteCrossConnection (service key of the circuit).",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to restore BGP for the express route circuit migration.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/MigrateExpressRouteCircuitRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/MigrateExpressRouteCircuitHealthCheckResponse"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RestoreBgpForExpressRouteCircuitMigration": {
+            "$ref": "./examples/ExpressRouteCrossConnectionRestoreBgpForCircuitMigration.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCrossConnections/{crossConnectionName}/rollbackCircuitMigration": {
+      "post": {
+        "operationId": "ExpressRouteCrossConnections_RollbackCircuitMigration",
+        "tags": [
+          "ExpressRouteCrossConnections"
+        ],
+        "description": "Rolls back the express route circuit migration for a cross connection.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "crossConnectionName",
+            "in": "path",
+            "description": "The name of the ExpressRouteCrossConnection (service key of the circuit).",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to roll back the express route circuit migration.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/MigrateExpressRouteCircuitRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/MigrateExpressRouteCircuitHealthCheckResponse"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RollbackExpressRouteCircuitMigration": {
+            "$ref": "./examples/ExpressRouteCrossConnectionRollbackCircuitMigration.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCrossConnections/{crossConnectionName}/shutDownBgpForCircuitMigration": {
+      "post": {
+        "operationId": "ExpressRouteCrossConnections_ShutDownBgpForCircuitMigration",
+        "tags": [
+          "ExpressRouteCrossConnections"
+        ],
+        "description": "Shuts down BGP sessions as part of an express route circuit migration for a cross connection.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "crossConnectionName",
+            "in": "path",
+            "description": "The name of the ExpressRouteCrossConnection (service key of the circuit).",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to shut down BGP for the express route circuit migration.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/MigrateExpressRouteCircuitRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/MigrateExpressRouteCircuitHealthCheckResponse"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ShutDownBgpForExpressRouteCircuitMigration": {
+            "$ref": "./examples/ExpressRouteCrossConnectionShutDownBgpForCircuitMigration.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCrossConnections/{crossConnectionName}/validateCircuitMigration": {
+      "post": {
+        "operationId": "ExpressRouteCrossConnections_ValidateCircuitMigration",
+        "tags": [
+          "ExpressRouteCrossConnections"
+        ],
+        "description": "Validates express route circuit migration for a cross connection.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "crossConnectionName",
+            "in": "path",
+            "description": "The name of the ExpressRouteCrossConnection (service key of the circuit).",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to validate express route circuit migration.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/MigrateExpressRouteCircuitValidateAndHealthCheckRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/MigrateExpressRouteCircuitValidateResponse"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ValidateExpressRouteCircuitMigration": {
+            "$ref": "./examples/ExpressRouteCrossConnectionValidateCircuitMigration.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
         },
         "x-ms-long-running-operation": true
       }
@@ -7846,6 +8430,144 @@
         }
       }
     },
+    "Metric": {
+      "type": "object",
+      "description": "Metric entry for migration peering statistics.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The metric name."
+        },
+        "value": {
+          "type": "number",
+          "format": "double",
+          "description": "The metric value."
+        },
+        "unit": {
+          "type": "string",
+          "description": "The metric unit."
+        }
+      }
+    },
+    "MigrateExpressRouteCircuitHealthCheckDetails": {
+      "type": "object",
+      "description": "Detailed migration health information.",
+      "properties": {
+        "portMigrationInfos": {
+          "type": "array",
+          "description": "Per-port migration details.",
+          "items": {
+            "$ref": "#/definitions/PortMigrationInfo"
+          },
+          "x-ms-identifiers": [
+            "portId"
+          ]
+        }
+      }
+    },
+    "MigrateExpressRouteCircuitHealthCheckResponse": {
+      "type": "object",
+      "description": "Response for express route circuit migration health check and migration operations.",
+      "properties": {
+        "status": {
+          "type": "string",
+          "description": "The overall status of the migration operation."
+        },
+        "phase": {
+          "type": "string",
+          "description": "The current phase of the migration operation."
+        },
+        "failureReason": {
+          "type": "string",
+          "description": "The failure reason if the migration operation failed."
+        },
+        "newSTag": {
+          "type": "string",
+          "description": "The new service tag assigned after migration."
+        },
+        "preparedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The timestamp when the migration was prepared."
+        },
+        "prepareExpiryTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The expiry time for the prepare phase."
+        },
+        "newCrossConnectionUrl": {
+          "type": "string",
+          "format": "uri",
+          "description": "The URL of the new cross connection after migration."
+        },
+        "shouldRollback": {
+          "type": "boolean",
+          "description": "Indicates whether rollback should be performed."
+        },
+        "details": {
+          "$ref": "#/definitions/MigrateExpressRouteCircuitHealthCheckDetails",
+          "description": "Detailed health check information for migration."
+        }
+      }
+    },
+    "MigrateExpressRouteCircuitRequest": {
+      "type": "object",
+      "description": "Request model for express route circuit migration operations.",
+      "properties": {
+        "targetPeeringLocation": {
+          "type": "string",
+          "description": "The target peering location for circuit migration."
+        },
+        "targetPortMapping": {
+          "type": "array",
+          "description": "The source-to-target port mappings for circuit migration.",
+          "items": {
+            "$ref": "#/definitions/PortMapping"
+          },
+          "x-ms-identifiers": [
+            "sourcePortId"
+          ]
+        },
+        "portId": {
+          "type": "string",
+          "description": "The port identifier used for shutDownBgp, migrate, restoreBgp, and rollback operations."
+        }
+      }
+    },
+    "MigrateExpressRouteCircuitValidateAndHealthCheckRequest": {
+      "type": "object",
+      "description": "Request model used by validate and health check circuit migration operations.",
+      "properties": {
+        "targetPeeringLocation": {
+          "type": "string",
+          "description": "The target peering location for circuit migration."
+        },
+        "targetPortMapping": {
+          "type": "array",
+          "description": "The source-to-target port mappings for circuit migration.",
+          "items": {
+            "$ref": "#/definitions/PortMapping"
+          },
+          "x-ms-identifiers": [
+            "sourcePortId"
+          ]
+        }
+      },
+      "required": [
+        "targetPeeringLocation",
+        "targetPortMapping"
+      ]
+    },
+    "MigrateExpressRouteCircuitValidateResponse": {
+      "type": "object",
+      "description": "Response for express route circuit migration validation operation.",
+      "properties": {
+        "status": {
+          "type": "string",
+          "description": "The validation status."
+        }
+      }
+    },
     "PatchRouteFilter": {
       "type": "object",
       "description": "Route Filter Resource.",
@@ -7985,6 +8707,103 @@
           "$ref": "./common.json#/definitions/ProvisioningState",
           "description": "The provisioning state of the peer express route circuit connection resource.",
           "readOnly": true
+        }
+      }
+    },
+    "PeeringHealth": {
+      "type": "object",
+      "description": "Health information for a peering connection.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The type of peering (for example, Private, Microsoft, Public)."
+        },
+        "statsCurrent": {
+          "$ref": "#/definitions/PeeringStats",
+          "description": "The current peering statistics."
+        },
+        "statsAtPrepare": {
+          "$ref": "#/definitions/PeeringStats",
+          "description": "The peering statistics captured at prepare phase."
+        }
+      }
+    },
+    "PeeringStats": {
+      "type": "object",
+      "description": "Statistical information for a peering connection.",
+      "properties": {
+        "timestamp": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The timestamp when these statistics were captured."
+        },
+        "metrics": {
+          "type": "array",
+          "description": "The collection of peering metrics.",
+          "items": {
+            "$ref": "#/definitions/Metric"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        }
+      }
+    },
+    "PortMapping": {
+      "type": "object",
+      "description": "A mapping between source and target ports for migration.",
+      "properties": {
+        "sourcePortId": {
+          "type": "string",
+          "description": "The source port identifier."
+        },
+        "targetPortId": {
+          "type": "string",
+          "description": "The target port identifier."
+        }
+      },
+      "required": [
+        "sourcePortId",
+        "targetPortId"
+      ]
+    },
+    "PortMigrationInfo": {
+      "type": "object",
+      "description": "Information about a port migration status.",
+      "properties": {
+        "portId": {
+          "type": "string",
+          "description": "The identifier of the port being migrated."
+        },
+        "status": {
+          "type": "string",
+          "description": "The migration status for the port."
+        },
+        "phase": {
+          "type": "string",
+          "description": "The current migration phase for the port."
+        },
+        "failureReason": {
+          "type": "string",
+          "description": "The reason for failure if migration failed for the port."
+        },
+        "peerings": {
+          "type": "array",
+          "description": "The peering health details for the port.",
+          "items": {
+            "$ref": "#/definitions/PeeringHealth"
+          },
+          "x-ms-identifiers": [
+            "type"
+          ]
+        },
+        "sourcePortId": {
+          "type": "string",
+          "description": "The source port identifier before migration."
+        },
+        "sourcePortStats": {
+          "$ref": "#/definitions/SourcePortStats",
+          "description": "The source port statistics before migration."
         }
       }
     },
@@ -8299,6 +9118,22 @@
           "items": {
             "type": "string"
           }
+        }
+      }
+    },
+    "SourcePortStats": {
+      "type": "object",
+      "description": "Statistics from the source port before migration.",
+      "properties": {
+        "peerings": {
+          "type": "array",
+          "description": "The peering health information from the source port.",
+          "items": {
+            "$ref": "#/definitions/PeeringHealth"
+          },
+          "x-ms-identifiers": [
+            "type"
+          ]
         }
       }
     }

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/expressRoute.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/expressRoute.json
@@ -3190,7 +3190,8 @@
           }
         },
         "x-ms-long-running-operation-options": {
-          "final-state-via": "location"
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/MigrateExpressRouteCircuitHealthCheckResponse"
         },
         "x-ms-long-running-operation": true
       }
@@ -3263,7 +3264,8 @@
           }
         },
         "x-ms-long-running-operation-options": {
-          "final-state-via": "location"
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/MigrateExpressRouteCircuitHealthCheckResponse"
         },
         "x-ms-long-running-operation": true
       }
@@ -3336,7 +3338,8 @@
           }
         },
         "x-ms-long-running-operation-options": {
-          "final-state-via": "location"
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/MigrateExpressRouteCircuitHealthCheckResponse"
         },
         "x-ms-long-running-operation": true
       }
@@ -3899,7 +3902,8 @@
           }
         },
         "x-ms-long-running-operation-options": {
-          "final-state-via": "location"
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/MigrateExpressRouteCircuitHealthCheckResponse"
         },
         "x-ms-long-running-operation": true
       }
@@ -3972,7 +3976,8 @@
           }
         },
         "x-ms-long-running-operation-options": {
-          "final-state-via": "location"
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/MigrateExpressRouteCircuitHealthCheckResponse"
         },
         "x-ms-long-running-operation": true
       }
@@ -4045,7 +4050,8 @@
           }
         },
         "x-ms-long-running-operation-options": {
-          "final-state-via": "location"
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/MigrateExpressRouteCircuitHealthCheckResponse"
         },
         "x-ms-long-running-operation": true
       }
@@ -4118,7 +4124,8 @@
           }
         },
         "x-ms-long-running-operation-options": {
-          "final-state-via": "location"
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/MigrateExpressRouteCircuitHealthCheckResponse"
         },
         "x-ms-long-running-operation": true
       }
@@ -4191,7 +4198,8 @@
           }
         },
         "x-ms-long-running-operation-options": {
-          "final-state-via": "location"
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/MigrateExpressRouteCircuitValidateResponse"
         },
         "x-ms-long-running-operation": true
       }

--- a/specification/network/resource-manager/Microsoft.Network/Network/suppressions.yaml
+++ b/specification/network/resource-manager/Microsoft.Network/Network/suppressions.yaml
@@ -21,6 +21,6 @@
     - Network/tspconfig.yaml
     - Vmss/tspconfig.yaml   
 
-- tool: Swagger Avocado
+- tool: SwaggerAvocado
   path: readme.md
   reason: The package-2026-01-01 default tag intentionally retains the frozen stable/2018-10-01/vmssNetwork.json surface for backward compatibility; moving it to 2026-01-01 would break existing clients.

--- a/specification/network/resource-manager/Microsoft.Network/Network/suppressions.yaml
+++ b/specification/network/resource-manager/Microsoft.Network/Network/suppressions.yaml
@@ -20,3 +20,7 @@
   paths: 
     - Network/tspconfig.yaml
     - Vmss/tspconfig.yaml   
+
+- tool: SwaggerAvocado
+  path: readme.md
+  reason: The package-2026-01-01 default tag intentionally retains the frozen stable/2018-10-01/vmssNetwork.json surface for backward compatibility; moving it to 2026-01-01 would break existing clients.

--- a/specification/network/resource-manager/Microsoft.Network/Network/suppressions.yaml
+++ b/specification/network/resource-manager/Microsoft.Network/Network/suppressions.yaml
@@ -21,6 +21,6 @@
     - Network/tspconfig.yaml
     - Vmss/tspconfig.yaml   
 
-- tool: SwaggerAvocado
+- tool: Swagger Avocado
   path: readme.md
   reason: The package-2026-01-01 default tag intentionally retains the frozen stable/2018-10-01/vmssNetwork.json surface for backward compatibility; moving it to 2026-01-01 would break existing clients.


### PR DESCRIPTION
## Summary
- add eight provider-led ExpressRoute cross-connection circuit migration operations in TypeSpec
- add the versioned request and response models for API version `2026-01-01`
- add source and generated examples based on Azure/azure-rest-api-specs-pr#29875
- regenerate the ExpressRoute Swagger and add the scoped brownfield resource-name suppression

## Validation
- TypeSpec compilation completed successfully
- generated Swagger contains eight new paths and eleven new definitions
- semantic comparison confirms no changes to pre-existing Swagger paths or definitions
- changed TypeSpec and Swagger files have no editor diagnostics
- `git diff --check` passed

Reference: Azure/azure-rest-api-specs-pr#29875