### PR TITLE
Fix Container Registry provisioning output path

### DIFF
--- a/specification/containerregistry/resource-manager/Microsoft.ContainerRegistry/Registry/tspconfig.yaml
+++ b/specification/containerregistry/resource-manager/Microsoft.ContainerRegistry/Registry/tspconfig.yaml
@@ -19,7 +19,7 @@ options:
     enable-wire-path-attribute: true
   "@azure-typespec/http-client-csharp-provisioning":
     namespace: "Azure.Provisioning.ContainerRegistry"
-    emitter-output-dir: "{project-root}/Azure.Provisioning.ContainerRegistry"
+    emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
     api-version: "2025-11-01"
   "@azure-tools/typespec-python":
     service-dir: "sdk/containerregistry"


### PR DESCRIPTION
Updates the Container Registry provisioning emitter output directory to use the SDK repository output path. The previous project-root-based path generated the SDK under TempTypeSpecFiles, so dotnet build /t:GenerateCode completed without updating Azure.Provisioning.ContainerRegistry.