### PR TITLE
Move lease.yaml path

### DIFF
--- a/.github/arm-leases/healthdataaiservices/Microsoft.HealthDataAIServices/HealthDataAIServices/lease.yaml
+++ b/.github/arm-leases/healthdataaiservices/Microsoft.HealthDataAIServices/HealthDataAIServices/lease.yaml
@@ -1,5 +1,5 @@
 lease:
   resource-provider: Microsoft.HealthDataAIServices
-  startdate: "2026-07-06"
+  startdate: "2026-08-28"
   duration: P180D
   reviewer: "@tejaswiminnu"


### PR DESCRIPTION
Updated the startdate for the following resource providers to "2026-08-28" and move folder:
* `.github/arm-leases/healthdataaiservices/Microsoft.HealthDataAIServices/HealthDataAIServices/lease.yaml`