### PR TITLE
Fix JavaScript realtime model names

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -87461,70 +87461,7 @@
         },
         "allOf": [
           {
-            "type": "object",
-            "properties": {
-              "id": {
-                "type": "string",
-                "description": "The unique ID of the response, will look like `resp_1234`."
-              },
-              "object": {
-                "type": "string",
-                "enum": [
-                  "realtime.response"
-                ],
-                "description": "The object type, must be `realtime.response`.",
-                "x-stainless-const": true
-              },
-              "status": {
-                "type": "string",
-                "enum": [
-                  "completed",
-                  "cancelled",
-                  "failed",
-                  "incomplete",
-                  "in_progress"
-                ],
-                "description": "The final status of the response (`completed`, `cancelled`, `failed`, or\n  `incomplete`, `in_progress`)."
-              },
-              "status_details": {
-                "$ref": "#/components/schemas/OpenAI.RealtimeResponseStatusDetails",
-                "description": "Additional details about the status."
-              },
-              "usage": {
-                "$ref": "#/components/schemas/OpenAI.RealtimeResponseUsage",
-                "description": "Usage statistics for the Response, this will correspond to billing. A\n  Realtime API session will maintain a conversation context and append new\n  Items to the Conversation, thus output from previous turns (text and\n  audio tokens) will become the input for later turns."
-              },
-              "conversation_id": {
-                "type": "string",
-                "description": "Which conversation the response is added to, determined by the `conversation`\n  field in the `response.create` event. If `auto`, the response will be added to\n  the default conversation and the value of `conversation_id` will be an id like\n  `conv_1234`. If `none`, the response will not be added to any conversation and\n  the value of `conversation_id` will be `null`. If responses are being triggered\n  automatically by VAD the response will be added to the default conversation"
-              },
-              "output_modalities": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "enum": [
-                    "text",
-                    "audio"
-                  ]
-                },
-                "description": "The set of modalities the model used to respond, currently the only possible values are\n  `[\\\"audio\\\"]`, `[\\\"text\\\"]`. Audio output always include a text transcript. Setting the\n  output to mode `text` will disable audio output from the model."
-              },
-              "max_output_tokens": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/OpenAI.integer"
-                  },
-                  {
-                    "type": "string",
-                    "enum": [
-                      "inf"
-                    ]
-                  }
-                ],
-                "description": "Maximum number of output tokens for a single assistant response,\n  inclusive of tool calls, that was used in this response."
-              }
-            },
-            "description": "The template for omitting properties."
+            "$ref": "#/components/schemas/VoiceResponseBase"
           }
         ],
         "description": "A persisted voice response representing one model inference turn within a conversation. In list results the\n`output` projection may be omitted; retrieve the\nfull response (`GET .../responses/{response_id}`) or the paged response-items route\n(`GET .../responses/{response_id}/items`) for its output items. `created_at`/`completed_at` are Foundry\ndurable ordering extensions.",
@@ -87575,6 +87512,72 @@
             "VoiceAgents=V1Preview"
           ]
         }
+      },
+      "VoiceResponseBase": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique ID of the response, will look like `resp_1234`."
+          },
+          "object": {
+            "type": "string",
+            "enum": [
+              "realtime.response"
+            ],
+            "description": "The object type, must be `realtime.response`.",
+            "x-stainless-const": true
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "completed",
+              "cancelled",
+              "failed",
+              "incomplete",
+              "in_progress"
+            ],
+            "description": "The final status of the response (`completed`, `cancelled`, `failed`, or\n  `incomplete`, `in_progress`)."
+          },
+          "status_details": {
+            "$ref": "#/components/schemas/OpenAI.RealtimeResponseStatusDetails",
+            "description": "Additional details about the status."
+          },
+          "usage": {
+            "$ref": "#/components/schemas/OpenAI.RealtimeResponseUsage",
+            "description": "Usage statistics for the Response, this will correspond to billing. A\n  Realtime API session will maintain a conversation context and append new\n  Items to the Conversation, thus output from previous turns (text and\n  audio tokens) will become the input for later turns."
+          },
+          "conversation_id": {
+            "type": "string",
+            "description": "Which conversation the response is added to, determined by the `conversation`\n  field in the `response.create` event. If `auto`, the response will be added to\n  the default conversation and the value of `conversation_id` will be an id like\n  `conv_1234`. If `none`, the response will not be added to any conversation and\n  the value of `conversation_id` will be `null`. If responses are being triggered\n  automatically by VAD the response will be added to the default conversation"
+          },
+          "output_modalities": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "text",
+                "audio"
+              ]
+            },
+            "description": "The set of modalities the model used to respond, currently the only possible values are\n  `[\\\"audio\\\"]`, `[\\\"text\\\"]`. Audio output always include a text transcript. Setting the\n  output to mode `text` will disable audio output from the model."
+          },
+          "max_output_tokens": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/OpenAI.integer"
+              },
+              {
+                "type": "string",
+                "enum": [
+                  "inf"
+                ]
+              }
+            ],
+            "description": "Maximum number of output tokens for a single assistant response,\n  inclusive of tool calls, that was used in this response."
+          }
+        },
+        "description": "Properties shared by persisted voice responses."
       },
       "VoiceType": {
         "anyOf": [

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -81960,68 +81960,7 @@ components:
           $ref: '#/components/schemas/FoundryTimestamp'
           description: The Unix timestamp (in seconds) for when the response completed.
       allOf:
-        - type: object
-          properties:
-            id:
-              type: string
-              description: The unique ID of the response, will look like `resp_1234`.
-            object:
-              type: string
-              enum:
-                - realtime.response
-              description: The object type, must be `realtime.response`.
-              x-stainless-const: true
-            status:
-              type: string
-              enum:
-                - completed
-                - cancelled
-                - failed
-                - incomplete
-                - in_progress
-              description: |-
-                The final status of the response (`completed`, `cancelled`, `failed`, or
-                  `incomplete`, `in_progress`).
-            status_details:
-              $ref: '#/components/schemas/OpenAI.RealtimeResponseStatusDetails'
-              description: Additional details about the status.
-            usage:
-              $ref: '#/components/schemas/OpenAI.RealtimeResponseUsage'
-              description: |-
-                Usage statistics for the Response, this will correspond to billing. A
-                  Realtime API session will maintain a conversation context and append new
-                  Items to the Conversation, thus output from previous turns (text and
-                  audio tokens) will become the input for later turns.
-            conversation_id:
-              type: string
-              description: |-
-                Which conversation the response is added to, determined by the `conversation`
-                  field in the `response.create` event. If `auto`, the response will be added to
-                  the default conversation and the value of `conversation_id` will be an id like
-                  `conv_1234`. If `none`, the response will not be added to any conversation and
-                  the value of `conversation_id` will be `null`. If responses are being triggered
-                  automatically by VAD the response will be added to the default conversation
-            output_modalities:
-              type: array
-              items:
-                type: string
-                enum:
-                  - text
-                  - audio
-              description: |-
-                The set of modalities the model used to respond, currently the only possible values are
-                  `[\"audio\"]`, `[\"text\"]`. Audio output always include a text transcript. Setting the
-                  output to mode `text` will disable audio output from the model.
-            max_output_tokens:
-              oneOf:
-                - $ref: '#/components/schemas/OpenAI.integer'
-                - type: string
-                  enum:
-                    - inf
-              description: |-
-                Maximum number of output tokens for a single assistant response,
-                  inclusive of tool calls, that was used in this response.
-          description: The template for omitting properties.
+        - $ref: '#/components/schemas/VoiceResponseBase'
       description: |-
         A persisted voice response representing one model inference turn within a conversation. In list results the
         `output` projection may be omitted; retrieve the
@@ -82060,6 +81999,69 @@ components:
       x-ms-foundry-meta:
         required_previews:
           - VoiceAgents=V1Preview
+    VoiceResponseBase:
+      type: object
+      properties:
+        id:
+          type: string
+          description: The unique ID of the response, will look like `resp_1234`.
+        object:
+          type: string
+          enum:
+            - realtime.response
+          description: The object type, must be `realtime.response`.
+          x-stainless-const: true
+        status:
+          type: string
+          enum:
+            - completed
+            - cancelled
+            - failed
+            - incomplete
+            - in_progress
+          description: |-
+            The final status of the response (`completed`, `cancelled`, `failed`, or
+              `incomplete`, `in_progress`).
+        status_details:
+          $ref: '#/components/schemas/OpenAI.RealtimeResponseStatusDetails'
+          description: Additional details about the status.
+        usage:
+          $ref: '#/components/schemas/OpenAI.RealtimeResponseUsage'
+          description: |-
+            Usage statistics for the Response, this will correspond to billing. A
+              Realtime API session will maintain a conversation context and append new
+              Items to the Conversation, thus output from previous turns (text and
+              audio tokens) will become the input for later turns.
+        conversation_id:
+          type: string
+          description: |-
+            Which conversation the response is added to, determined by the `conversation`
+              field in the `response.create` event. If `auto`, the response will be added to
+              the default conversation and the value of `conversation_id` will be an id like
+              `conv_1234`. If `none`, the response will not be added to any conversation and
+              the value of `conversation_id` will be `null`. If responses are being triggered
+              automatically by VAD the response will be added to the default conversation
+        output_modalities:
+          type: array
+          items:
+            type: string
+            enum:
+              - text
+              - audio
+          description: |-
+            The set of modalities the model used to respond, currently the only possible values are
+              `[\"audio\"]`, `[\"text\"]`. Audio output always include a text transcript. Setting the
+              output to mode `text` will disable audio output from the model.
+        max_output_tokens:
+          oneOf:
+            - $ref: '#/components/schemas/OpenAI.integer'
+            - type: string
+              enum:
+                - inf
+          description: |-
+            Maximum number of output tokens for a single assistant response,
+              inclusive of tool calls, that was used in this response.
+      description: Properties shared by persisted voice responses.
     VoiceType:
       anyOf:
         - type: string

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -92116,70 +92116,7 @@
         },
         "allOf": [
           {
-            "type": "object",
-            "properties": {
-              "id": {
-                "type": "string",
-                "description": "The unique ID of the response, will look like `resp_1234`."
-              },
-              "object": {
-                "type": "string",
-                "enum": [
-                  "realtime.response"
-                ],
-                "description": "The object type, must be `realtime.response`.",
-                "x-stainless-const": true
-              },
-              "status": {
-                "type": "string",
-                "enum": [
-                  "completed",
-                  "cancelled",
-                  "failed",
-                  "incomplete",
-                  "in_progress"
-                ],
-                "description": "The final status of the response (`completed`, `cancelled`, `failed`, or\n  `incomplete`, `in_progress`)."
-              },
-              "status_details": {
-                "$ref": "#/components/schemas/OpenAI.RealtimeResponseStatusDetails",
-                "description": "Additional details about the status."
-              },
-              "usage": {
-                "$ref": "#/components/schemas/OpenAI.RealtimeResponseUsage",
-                "description": "Usage statistics for the Response, this will correspond to billing. A\n  Realtime API session will maintain a conversation context and append new\n  Items to the Conversation, thus output from previous turns (text and\n  audio tokens) will become the input for later turns."
-              },
-              "conversation_id": {
-                "type": "string",
-                "description": "Which conversation the response is added to, determined by the `conversation`\n  field in the `response.create` event. If `auto`, the response will be added to\n  the default conversation and the value of `conversation_id` will be an id like\n  `conv_1234`. If `none`, the response will not be added to any conversation and\n  the value of `conversation_id` will be `null`. If responses are being triggered\n  automatically by VAD the response will be added to the default conversation"
-              },
-              "output_modalities": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "enum": [
-                    "text",
-                    "audio"
-                  ]
-                },
-                "description": "The set of modalities the model used to respond, currently the only possible values are\n  `[\\\"audio\\\"]`, `[\\\"text\\\"]`. Audio output always include a text transcript. Setting the\n  output to mode `text` will disable audio output from the model."
-              },
-              "max_output_tokens": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/OpenAI.integer"
-                  },
-                  {
-                    "type": "string",
-                    "enum": [
-                      "inf"
-                    ]
-                  }
-                ],
-                "description": "Maximum number of output tokens for a single assistant response,\n  inclusive of tool calls, that was used in this response."
-              }
-            },
-            "description": "The template for omitting properties."
+            "$ref": "#/components/schemas/VoiceResponseBase"
           }
         ],
         "description": "A persisted voice response representing one model inference turn within a conversation. In list results the\n`output` projection may be omitted; retrieve the\nfull response (`GET .../responses/{response_id}`) or the paged response-items route\n(`GET .../responses/{response_id}/items`) for its output items. `created_at`/`completed_at` are Foundry\ndurable ordering extensions.",
@@ -92230,6 +92167,72 @@
             "VoiceAgents=V1Preview"
           ]
         }
+      },
+      "VoiceResponseBase": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique ID of the response, will look like `resp_1234`."
+          },
+          "object": {
+            "type": "string",
+            "enum": [
+              "realtime.response"
+            ],
+            "description": "The object type, must be `realtime.response`.",
+            "x-stainless-const": true
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "completed",
+              "cancelled",
+              "failed",
+              "incomplete",
+              "in_progress"
+            ],
+            "description": "The final status of the response (`completed`, `cancelled`, `failed`, or\n  `incomplete`, `in_progress`)."
+          },
+          "status_details": {
+            "$ref": "#/components/schemas/OpenAI.RealtimeResponseStatusDetails",
+            "description": "Additional details about the status."
+          },
+          "usage": {
+            "$ref": "#/components/schemas/OpenAI.RealtimeResponseUsage",
+            "description": "Usage statistics for the Response, this will correspond to billing. A\n  Realtime API session will maintain a conversation context and append new\n  Items to the Conversation, thus output from previous turns (text and\n  audio tokens) will become the input for later turns."
+          },
+          "conversation_id": {
+            "type": "string",
+            "description": "Which conversation the response is added to, determined by the `conversation`\n  field in the `response.create` event. If `auto`, the response will be added to\n  the default conversation and the value of `conversation_id` will be an id like\n  `conv_1234`. If `none`, the response will not be added to any conversation and\n  the value of `conversation_id` will be `null`. If responses are being triggered\n  automatically by VAD the response will be added to the default conversation"
+          },
+          "output_modalities": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "text",
+                "audio"
+              ]
+            },
+            "description": "The set of modalities the model used to respond, currently the only possible values are\n  `[\\\"audio\\\"]`, `[\\\"text\\\"]`. Audio output always include a text transcript. Setting the\n  output to mode `text` will disable audio output from the model."
+          },
+          "max_output_tokens": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/OpenAI.integer"
+              },
+              {
+                "type": "string",
+                "enum": [
+                  "inf"
+                ]
+              }
+            ],
+            "description": "Maximum number of output tokens for a single assistant response,\n  inclusive of tool calls, that was used in this response."
+          }
+        },
+        "description": "Properties shared by persisted voice responses."
       },
       "VoiceType": {
         "anyOf": [

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -85164,68 +85164,7 @@ components:
           $ref: '#/components/schemas/FoundryTimestamp'
           description: The Unix timestamp (in seconds) for when the response completed.
       allOf:
-        - type: object
-          properties:
-            id:
-              type: string
-              description: The unique ID of the response, will look like `resp_1234`.
-            object:
-              type: string
-              enum:
-                - realtime.response
-              description: The object type, must be `realtime.response`.
-              x-stainless-const: true
-            status:
-              type: string
-              enum:
-                - completed
-                - cancelled
-                - failed
-                - incomplete
-                - in_progress
-              description: |-
-                The final status of the response (`completed`, `cancelled`, `failed`, or
-                  `incomplete`, `in_progress`).
-            status_details:
-              $ref: '#/components/schemas/OpenAI.RealtimeResponseStatusDetails'
-              description: Additional details about the status.
-            usage:
-              $ref: '#/components/schemas/OpenAI.RealtimeResponseUsage'
-              description: |-
-                Usage statistics for the Response, this will correspond to billing. A
-                  Realtime API session will maintain a conversation context and append new
-                  Items to the Conversation, thus output from previous turns (text and
-                  audio tokens) will become the input for later turns.
-            conversation_id:
-              type: string
-              description: |-
-                Which conversation the response is added to, determined by the `conversation`
-                  field in the `response.create` event. If `auto`, the response will be added to
-                  the default conversation and the value of `conversation_id` will be an id like
-                  `conv_1234`. If `none`, the response will not be added to any conversation and
-                  the value of `conversation_id` will be `null`. If responses are being triggered
-                  automatically by VAD the response will be added to the default conversation
-            output_modalities:
-              type: array
-              items:
-                type: string
-                enum:
-                  - text
-                  - audio
-              description: |-
-                The set of modalities the model used to respond, currently the only possible values are
-                  `[\"audio\"]`, `[\"text\"]`. Audio output always include a text transcript. Setting the
-                  output to mode `text` will disable audio output from the model.
-            max_output_tokens:
-              oneOf:
-                - $ref: '#/components/schemas/OpenAI.integer'
-                - type: string
-                  enum:
-                    - inf
-              description: |-
-                Maximum number of output tokens for a single assistant response,
-                  inclusive of tool calls, that was used in this response.
-          description: The template for omitting properties.
+        - $ref: '#/components/schemas/VoiceResponseBase'
       description: |-
         A persisted voice response representing one model inference turn within a conversation. In list results the
         `output` projection may be omitted; retrieve the
@@ -85264,6 +85203,69 @@ components:
       x-ms-foundry-meta:
         required_previews:
           - VoiceAgents=V1Preview
+    VoiceResponseBase:
+      type: object
+      properties:
+        id:
+          type: string
+          description: The unique ID of the response, will look like `resp_1234`.
+        object:
+          type: string
+          enum:
+            - realtime.response
+          description: The object type, must be `realtime.response`.
+          x-stainless-const: true
+        status:
+          type: string
+          enum:
+            - completed
+            - cancelled
+            - failed
+            - incomplete
+            - in_progress
+          description: |-
+            The final status of the response (`completed`, `cancelled`, `failed`, or
+              `incomplete`, `in_progress`).
+        status_details:
+          $ref: '#/components/schemas/OpenAI.RealtimeResponseStatusDetails'
+          description: Additional details about the status.
+        usage:
+          $ref: '#/components/schemas/OpenAI.RealtimeResponseUsage'
+          description: |-
+            Usage statistics for the Response, this will correspond to billing. A
+              Realtime API session will maintain a conversation context and append new
+              Items to the Conversation, thus output from previous turns (text and
+              audio tokens) will become the input for later turns.
+        conversation_id:
+          type: string
+          description: |-
+            Which conversation the response is added to, determined by the `conversation`
+              field in the `response.create` event. If `auto`, the response will be added to
+              the default conversation and the value of `conversation_id` will be an id like
+              `conv_1234`. If `none`, the response will not be added to any conversation and
+              the value of `conversation_id` will be `null`. If responses are being triggered
+              automatically by VAD the response will be added to the default conversation
+        output_modalities:
+          type: array
+          items:
+            type: string
+            enum:
+              - text
+              - audio
+          description: |-
+            The set of modalities the model used to respond, currently the only possible values are
+              `[\"audio\"]`, `[\"text\"]`. Audio output always include a text transcript. Setting the
+              output to mode `text` will disable audio output from the model.
+        max_output_tokens:
+          oneOf:
+            - $ref: '#/components/schemas/OpenAI.integer'
+            - type: string
+              enum:
+                - inf
+          description: |-
+            Maximum number of output tokens for a single assistant response,
+              inclusive of tool calls, that was used in this response.
+      description: Properties shared by persisted voice responses.
     VoiceType:
       anyOf:
         - type: string

--- a/specification/ai-foundry/data-plane/Foundry/src/sdk-python-js-azure-ai-projects/client.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/sdk-python-js-azure-ai-projects/client.tsp
@@ -296,16 +296,8 @@ using Azure.AI.Projects;
 // Allow assigning a `dict[str, Any]` object directly to the "schema" property of TextResponseFormatJsonSchema
 @@alternateType(OpenAI.ResponseFormatJsonSchemaSchema, Record<unknown>);
 
-@@clientName(
-  OpenAI.RealtimeMcpErrorType,
-  "RealtimeMCPErrorType",
-  "javascript"
-);
-@@clientName(
-  OpenAI.RealtimeMCPHTTPError,
-  "RealtimeMCPHttpError",
-  "javascript"
-);
+@@clientName(OpenAI.RealtimeMcpErrorType, "RealtimeMCPErrorType", "javascript");
+@@clientName(OpenAI.RealtimeMCPHTTPError, "RealtimeMCPHttpError", "javascript");
 
 // Note there is also OpenAI.TextResponseFormatJsonSchema (which extends OpenAI.TextResponseFormatConfiguration). It already has a good name.
 @@clientName(OpenAI.TextResponseFormatConfiguration, "TextResponseFormat");

--- a/specification/ai-foundry/data-plane/Foundry/src/sdk-python-js-azure-ai-projects/client.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/sdk-python-js-azure-ai-projects/client.tsp
@@ -296,6 +296,17 @@ using Azure.AI.Projects;
 // Allow assigning a `dict[str, Any]` object directly to the "schema" property of TextResponseFormatJsonSchema
 @@alternateType(OpenAI.ResponseFormatJsonSchemaSchema, Record<unknown>);
 
+@@clientName(
+  OpenAI.RealtimeMcpErrorType,
+  "RealtimeMCPErrorType",
+  "javascript"
+);
+@@clientName(
+  OpenAI.RealtimeMCPHTTPError,
+  "RealtimeMCPHttpError",
+  "javascript"
+);
+
 // Note there is also OpenAI.TextResponseFormatJsonSchema (which extends OpenAI.TextResponseFormatConfiguration). It already has a good name.
 @@clientName(OpenAI.TextResponseFormatConfiguration, "TextResponseFormat");
 @@clientName(

--- a/specification/ai-foundry/data-plane/Foundry/src/voice-agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/voice-agents/models.tsp
@@ -102,6 +102,14 @@ model VoiceResponseAudio {
   output?: VoiceResponseAudioOutput;
 }
 
+@doc("Properties shared by persisted voice responses.")
+model VoiceResponseBase {
+  ...OmitProperties<
+    OpenAI.RealtimeResponse,
+    "audio" | "output" | "metadata"
+  >;
+}
+
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "Inheritance preserves the shared OpenAI response contract while the persisted projection replaces audio, output, and metadata."
 #suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Keeping for backward compatibility."
 @doc("""
@@ -112,10 +120,7 @@ model VoiceResponseAudio {
   durable ordering extensions.
   """)
 @extension("x-ms-foundry-meta", VoiceAgentRequiredPreview)
-model VoiceResponse extends OmitProperties<
-  OpenAI.RealtimeResponse,
-  "audio" | "output" | "metadata"
-> {
+model VoiceResponse extends VoiceResponseBase {
   @doc("The unique id of the response.")
   id: string;
 

--- a/specification/ai-foundry/data-plane/Foundry/src/voice-agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/voice-agents/models.tsp
@@ -104,10 +104,7 @@ model VoiceResponseAudio {
 
 @doc("Properties shared by persisted voice responses.")
 model VoiceResponseBase {
-  ...OmitProperties<
-    OpenAI.RealtimeResponse,
-    "audio" | "output" | "metadata"
-  >;
+  ...OmitProperties<OpenAI.RealtimeResponse, "audio" | "output" | "metadata">;
 }
 
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "Inheritance preserves the shared OpenAI response contract while the persisted projection replaces audio, output, and metadata."

--- a/specification/ai-foundry/data-plane/Foundry/src/voice-agents/protocol.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/voice-agents/protocol.tsp
@@ -288,13 +288,15 @@ model VoiceAgentResponseCreateParams {
   }
 );
 
+@doc("Properties shared by realtime responses returned by the voice-agent service.")
+model VoiceAgentRealtimeResponseBase {
+  ...OmitProperties<OpenAI.RealtimeResponse, "audio" | "output">;
+}
+
 #suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "Inheritance preserves the upstream live response contract, including conversation_id, while replacing audio and output."
 @doc("A live realtime response returned by the voice-agent service in both `response.created` and `response.done` events.")
-model VoiceAgentRealtimeResponse extends OmitProperties<
-  OpenAI.RealtimeResponse,
-  "audio" | "output"
-> {
+model VoiceAgentRealtimeResponse extends VoiceAgentRealtimeResponseBase {
   @doc("The audio configuration used by the live response, including flat voice provider, locale, and format fields under `output`.")
   audio?: VoiceResponseAudio;
 


### PR DESCRIPTION
## Summary

- Give the persisted and live voice response projections semantic base model names so generated JavaScript no longer exposes `OmitPropertiesRealtimeResponse*` types.
- Add JavaScript-scoped client names for `RealtimeMCPErrorType` and `RealtimeMCPHttpError`.
- Regenerate the v1 and virtual-public-preview OpenAPI artifacts.

Addresses the source issues identified in:
- https://github.com/Azure/azure-sdk-for-js/pull/39782#discussion_r3881560747
- https://github.com/Azure/azure-sdk-for-js/pull/39782#discussion_r3881560790

## Validation

- Full Foundry TypeSpec 1.15.0 compile with OpenAI TypeSpec 1.26.0: zero diagnostics.
- `@azure-tools/typespec-ts` 0.56.0 generation: zero errors.
- Confirmed generated exports include `VoiceResponseBase`, `VoiceAgentRealtimeResponseBase`, `RealtimeMCPErrorType`, `RealtimeMCPProtocolError`, `RealtimeMCPToolExecutionError`, and `RealtimeMCPHttpError`.
- Confirmed no generated `OmitPropertiesRealtimeResponse*`, `RealtimeMcpErrorType`, `RealtimeMcphttpError`, or `RealtimeMCPHTTPError` names remain.