### PR TITLE
Make TypeSpec Suppressions check required

### DIFF
--- a/.github/workflows/src/summarize-checks/labelling.js
+++ b/.github/workflows/src/summarize-checks/labelling.js
@@ -1193,6 +1193,27 @@ const rulesPri1Namespace = [
   },
 ];
 
+/** @type {RequiredLabelRule[]} */
+const rulesPri1TypeSpecSuppressions = [
+  // When TypeSpecSuppressionReviewRequired is present, require Approved-TypeSpecSuppression before
+  // merge. Mirrors the package-name-review-required/package-name-approved pattern in
+  // rulesPri1Namespace above: the "TypeSpec Suppressions - Set Status" workflow applies the
+  // TypeSpecSuppressionReviewRequired prerequisite label whenever the analyzer (in checked-only
+  // mode, via check-rules.json) reports a new or changed suppression requiring review, and removes
+  // it once no checked suppressions remain. See .github/workflows/src/typespec-suppressions/.
+  {
+    precedence: 1,
+    anyPrerequisiteLabels: ["TypeSpecSuppressionReviewRequired"],
+    anyRequiredLabels: ["Approved-TypeSpecSuppression"],
+    troubleshootingGuide:
+      "This PR introduced or changed TypeSpec suppressions that require review.<br/>" +
+      "Check the <b>TypeSpec suppressions requiring review</b> comment on this PR for the list of " +
+      "suppressions, their justifications, and source locations.<br/>" +
+      "Reviewers: apply the <code>Approved-TypeSpecSuppression</code> label after confirming every " +
+      "justification is acceptable.",
+  },
+];
+
 export const requiredLabelsRules = rulesPri0dataPlane
   .concat(rulesPri0NotReadyForArmReview)
   .concat(rulesPri0ArmRpaas)
@@ -1201,6 +1222,7 @@ export const requiredLabelsRules = rulesPri0dataPlane
   .concat(rulesPri1ArmRev)
   .concat(rulesPri1Suppressions)
   .concat(rulesPri1Namespace)
+  .concat(rulesPri1TypeSpecSuppressions)
   .concat(rulesPri2Sdk)
   .concat(rulesPri2LegacySdk)
   .concat(rulesPri3Blockers);

--- a/.github/workflows/src/summarize-checks/summarize-checks.js
+++ b/.github/workflows/src/summarize-checks/summarize-checks.js
@@ -132,6 +132,12 @@ const CHECK_METADATA = [
   },
   {
     precedence: 0,
+    name: "TypeSpec Suppressions",
+    suppressionLabels: ["Approved-TypeSpecSuppression"],
+    troubleshootingGuide: defaultTsg,
+  },
+  {
+    precedence: 0,
     name: "license/cla",
     suppressionLabels: [],
     troubleshootingGuide: defaultTsg,

--- a/.github/workflows/src/summarize-checks/summarize-checks.js
+++ b/.github/workflows/src/summarize-checks/summarize-checks.js
@@ -39,6 +39,7 @@ import {
   reqMetCheckTsg,
   typeSpecRequirementArmTsg,
   typeSpecRequirementDataPlaneTsg,
+  typeSpecSuppressionsTsg,
 } from "./tsgs.js";
 
 import fs from "fs/promises";
@@ -134,7 +135,7 @@ const CHECK_METADATA = [
     precedence: 0,
     name: "TypeSpec Suppressions",
     suppressionLabels: ["Approved-TypeSpecSuppression"],
-    troubleshootingGuide: defaultTsg,
+    troubleshootingGuide: typeSpecSuppressionsTsg,
   },
   {
     precedence: 0,

--- a/.github/workflows/src/summarize-checks/tsgs.js
+++ b/.github/workflows/src/summarize-checks/tsgs.js
@@ -40,6 +40,11 @@ export const typeSpecRequirementArmTsg =
 
 export const typeSpecRequirementDataPlaneTsg = typeSpecRequirementArmTsg;
 
+export const typeSpecSuppressionsTsg =
+  `This PR introduced TypeSpec suppressions that require review. Inspect the suppression details in the ` +
+  `<b>TypeSpec suppressions requiring review</b> comment on this PR and ask the appropriate reviewer to apply the ` +
+  `<code>Approved-TypeSpecSuppression</code> label. ${diagramTsg(1, true)}.`;
+
 export const brchHref = href("aka.ms/brch", "https://aka.ms/brch");
 
 export const brchTsg = `To unblock this PR, follow the process at ${brchHref}.`;

--- a/.github/workflows/src/typespec-suppressions/labels.js
+++ b/.github/workflows/src/typespec-suppressions/labels.js
@@ -1,0 +1,27 @@
+/**
+ * Remove a label from an issue/PR, ignoring 404 (label not present).
+ *
+ * Mirrors the package-name-approval helper of the same name
+ * (.github/workflows/src/package-name-approval/labels.js).
+ *
+ * @param {import("@actions/github-script").AsyncFunctionArguments["github"]} github
+ * @param {string} owner
+ * @param {string} repo
+ * @param {number} issueNumber
+ * @param {string} label
+ */
+export async function removeLabelIfPresent(github, owner, repo, issueNumber, label) {
+  try {
+    await github.rest.issues.removeLabel({
+      owner,
+      repo,
+      issue_number: issueNumber,
+      name: label,
+    });
+  } catch (error) {
+    if (error instanceof Error && "status" in error && error.status === 404) {
+      return;
+    }
+    throw error;
+  }
+}

--- a/.github/workflows/src/typespec-suppressions/post-results.js
+++ b/.github/workflows/src/typespec-suppressions/post-results.js
@@ -16,13 +16,63 @@
 import { PER_PAGE_MAX } from "../../../shared/src/github.js";
 import { commentOrUpdate, parseExistingComments } from "../comment.js";
 import { extractInputs } from "../context.js";
+import { removeLabelIfPresent } from "./labels.js";
 import {
   buildSuppressionsComment,
+  SUPPRESSION_REVIEW_REQUIRED_LABEL,
   TYPESPEC_SUPPRESSIONS_COMMENT_IDENTIFIER,
   TYPESPEC_SUPPRESSIONS_SECTION_TITLE,
 } from "./suppressions-comment.js";
 
 const RESOLVED_COMMENT_BODY = `## ${TYPESPEC_SUPPRESSIONS_SECTION_TITLE}\n\n✅ No TypeSpec suppressions require review for the latest commit.`;
+
+/**
+ * Applies or removes the TypeSpecSuppressionReviewRequired prerequisite label so
+ * it tracks requiresApproval, mirroring the package-name-review-required pattern
+ * in package-name-approval/post-results.js. Only called once a definitive
+ * requiresApproval result is available (see caller).
+ *
+ * @param {import("@actions/github-script").AsyncFunctionArguments["github"]} github
+ * @param {typeof import("@actions/core")} core
+ * @param {string} owner
+ * @param {string} repo
+ * @param {number} issue_number
+ * @param {string[]} labelNames
+ * @param {boolean} requiresApproval
+ */
+async function syncReviewRequiredLabel(
+  github,
+  core,
+  owner,
+  repo,
+  issue_number,
+  labelNames,
+  requiresApproval,
+) {
+  const hasLabel = labelNames.includes(SUPPRESSION_REVIEW_REQUIRED_LABEL);
+  if (requiresApproval && !hasLabel) {
+    core.info(
+      `Applying ${SUPPRESSION_REVIEW_REQUIRED_LABEL} label on ${owner}/${repo}#${issue_number}.`,
+    );
+    await github.rest.issues.addLabels({
+      owner,
+      repo,
+      issue_number,
+      labels: [SUPPRESSION_REVIEW_REQUIRED_LABEL],
+    });
+  } else if (!requiresApproval && hasLabel) {
+    core.info(
+      `Removing ${SUPPRESSION_REVIEW_REQUIRED_LABEL} label on ${owner}/${repo}#${issue_number}.`,
+    );
+    await removeLabelIfPresent(
+      github,
+      owner,
+      repo,
+      issue_number,
+      SUPPRESSION_REVIEW_REQUIRED_LABEL,
+    );
+  }
+}
 
 /**
  * @param {import("@actions/github-script").AsyncFunctionArguments} args
@@ -38,7 +88,7 @@ export default async function postSuppressionsResults({ github, context, core })
   /** @type {string[]} */
   const labelNames = pr.labels.map((/** @type {{ name?: string }} */ label) => label.name ?? "");
 
-  const body = await buildSuppressionsComment(
+  const result = await buildSuppressionsComment(
     github,
     core,
     owner,
@@ -46,6 +96,28 @@ export default async function postSuppressionsResults({ github, context, core })
     head_sha,
     issue_number,
     labelNames,
+  );
+
+  if (!result) {
+    // Analysis hasn't completed (or its report couldn't be read) — the
+    // requiresApproval state is unknown, so leave the review-required label
+    // and any existing comment untouched rather than guessing.
+    core.info(
+      `TypeSpec suppressions analysis result unavailable for ${owner}/${repo}#${issue_number}; leaving labels and comment untouched.`,
+    );
+    return;
+  }
+
+  const { body, requiresApproval } = result;
+
+  await syncReviewRequiredLabel(
+    github,
+    core,
+    owner,
+    repo,
+    issue_number,
+    labelNames,
+    requiresApproval,
   );
 
   if (body) {

--- a/.github/workflows/src/typespec-suppressions/suppressions-comment.js
+++ b/.github/workflows/src/typespec-suppressions/suppressions-comment.js
@@ -80,8 +80,7 @@ import path from "path";
 export const TYPESPEC_SUPPRESSIONS_WORKFLOW_NAME = "TypeSpec Suppressions - Analyze Code";
 export const TYPESPEC_SUPPRESSIONS_REPORT_ARTIFACT_NAME = "typespec-suppressions-report";
 export const TYPESPEC_SUPPRESSIONS_COMMENT_IDENTIFIER = "TypeSpecSuppressionsReview";
-export const TYPESPEC_SUPPRESSIONS_SECTION_TITLE =
-  "TypeSpec suppressions requiring review (testing, non-blocking)";
+export const TYPESPEC_SUPPRESSIONS_SECTION_TITLE = "TypeSpec suppressions requiring review";
 export const APPROVED_SUPPRESSION_LABEL = "Approved-TypeSpecSuppression";
 // GitHub caps comment bodies at ~65k characters, so only render a handful of suppressions
 // inline per table (new and changed) and link to the analysis log for the full list.
@@ -346,9 +345,7 @@ export function renderSuppressionsCommentBody(
   const changedSuppressions = reported.changedSuppressions ?? [];
 
   const statusCell = isApproved ? "✅" : "❌";
-  const approvalState = isApproved
-    ? "✅ Approved"
-    : "❌ Approval required (currently under testing, review NOT enforced)";
+  const approvalState = isApproved ? "✅ Approved" : "❌ Approval required";
 
   const totalCount = newSuppressions.length + changedSuppressions.length;
 
@@ -359,7 +356,7 @@ export function renderSuppressionsCommentBody(
     "",
     `**Status:** ${summaryParts.join(" — ")}`,
     "",
-    "⚠️ <strong>This check is currently in testing mode and is non-blocking</strong> — it will not prevent this PR from merging. This PR adds or updates the TypeSpec suppressions listed below. <strong>Suppressions are strongly discouraged</strong> — they bypass linter rules that protect API quality and consistency. Authors should avoid adding new suppressions and prefer fixing the underlying issue; reviewers should approve only when there is a clear, compelling justification and no reasonable alternative. Review each linked rule and source location, then apply <code>Approved-TypeSpecSuppression</code> only if every justification is acceptable. The <strong>Status</strong> column shows ✅ once the label is applied and ❌ while approval is pending.",
+    "This PR adds or updates the TypeSpec suppressions listed below. <strong>Suppressions are strongly discouraged</strong> — they bypass linter rules that protect API quality and consistency. Authors should avoid adding new suppressions and prefer fixing the underlying issue; reviewers should approve only when there is a clear, compelling justification and no reasonable alternative. Review each linked rule and source location, then apply <code>Approved-TypeSpecSuppression</code> only if every justification is acceptable. The check blocks merging until the suppressions are resolved or approved. The <strong>Status</strong> column shows ✅ once the label is applied and ❌ while approval is pending.",
     "",
   ];
 

--- a/.github/workflows/src/typespec-suppressions/suppressions-comment.js
+++ b/.github/workflows/src/typespec-suppressions/suppressions-comment.js
@@ -82,6 +82,10 @@ export const TYPESPEC_SUPPRESSIONS_REPORT_ARTIFACT_NAME = "typespec-suppressions
 export const TYPESPEC_SUPPRESSIONS_COMMENT_IDENTIFIER = "TypeSpecSuppressionsReview";
 export const TYPESPEC_SUPPRESSIONS_SECTION_TITLE = "TypeSpec suppressions requiring review";
 export const APPROVED_SUPPRESSION_LABEL = "Approved-TypeSpecSuppression";
+// Prerequisite label (mirrors package-name-review-required) applied while checked
+// suppressions require review, and required to be cleared by APPROVED_SUPPRESSION_LABEL
+// via the rulesPri1TypeSpecSuppressions required-label rule in labelling.js.
+export const SUPPRESSION_REVIEW_REQUIRED_LABEL = "TypeSpecSuppressionReviewRequired";
 // GitHub caps comment bodies at ~65k characters, so only render a handful of suppressions
 // inline per table (new and changed) and link to the analysis log for the full list.
 const MAX_SUPPRESSIONS_SHOWN = 5;
@@ -314,6 +318,19 @@ function renderChangedSuppressionRow(owner, repo, pullNumber, change, statusCell
 }
 
 /**
+ * Resolves the checked-only subset of a report when present, falling back to
+ * the full report otherwise (legacy behavior for runs without a check-rules
+ * file). An empty ruleset yields an empty checked subset, so nothing is
+ * reported — the same as a PR that added no suppressions.
+ *
+ * @param {TypeSpecSuppressionsReport} report
+ * @returns {TypeSpecCheckedSuppressions | TypeSpecSuppressionsReport}
+ */
+function getReportedSuppressions(report) {
+  return report.checkedSuppressions ?? report;
+}
+
+/**
  * Renders the dedicated comment body from an already-parsed analyzer report.
  *
  * Returns `undefined` when no checked suppressions require review, in which case
@@ -332,11 +349,7 @@ export function renderSuppressionsCommentBody(
   report,
   { owner, repo, pullNumber, isApproved, runUrl },
 ) {
-  // In checked-only mode (a check-rules file was used), render only the checked
-  // subset; otherwise fall back to the full diff (legacy behavior). An empty
-  // ruleset yields an empty checked subset, so nothing is reported — the same as
-  // a PR that added no suppressions.
-  const reported = report.checkedSuppressions ?? report;
+  const reported = getReportedSuppressions(report);
   if (!reported.requiresApproval) {
     return undefined;
   }
@@ -416,8 +429,14 @@ export function renderSuppressionsCommentBody(
 /**
  * Locates the latest "TypeSpec Suppressions - Analyze Code" run for the given
  * head_sha, downloads and parses its report artifact, and renders the dedicated
- * comment body. Returns `undefined` when there is no completed run, no artifact,
- * or no suppressions requiring review.
+ * comment body.
+ *
+ * Returns `undefined` when the analysis result is not yet known (no completed
+ * run, or no artifact to parse) — callers must not infer approval state or
+ * touch labels in that case. Once a report has been successfully parsed,
+ * returns an object carrying both the rendered `body` (`undefined` when no
+ * suppressions require review) and the definitive `requiresApproval` boolean,
+ * so callers can gate label state without re-deriving it from the body.
  *
  * @param {import('@actions/github-script').AsyncFunctionArguments['github']} github
  * @param {typeof import("@actions/core")} core
@@ -426,7 +445,7 @@ export function renderSuppressionsCommentBody(
  * @param {string} head_sha
  * @param {number} pullNumber
  * @param {string[]} [labelNames] - Current PR labels, used to reflect approval status.
- * @returns {Promise<string | undefined>}
+ * @returns {Promise<{ body: string | undefined, requiresApproval: boolean } | undefined>}
  */
 export async function buildSuppressionsComment(
   github,
@@ -462,11 +481,15 @@ export async function buildSuppressionsComment(
 
   const runUrl = run.html_url ?? `https://github.com/${owner}/${repo}/actions/runs/${run.id}`;
 
-  return renderSuppressionsCommentBody(report, {
+  const body = renderSuppressionsCommentBody(report, {
     owner,
     repo,
     pullNumber,
     isApproved: labelNames.includes(APPROVED_SUPPRESSION_LABEL),
     runUrl,
   });
+
+  const requiresApproval = Boolean(getReportedSuppressions(report).requiresApproval);
+
+  return { body, requiresApproval };
 }

--- a/.github/workflows/summarize-checks.yaml
+++ b/.github/workflows/summarize-checks.yaml
@@ -13,6 +13,7 @@ on:
       - "Swagger LintDiff - Set Status"
       - "Swagger ModelValidation - Set Status"
       - "Swagger SemanticValidation - Set Status"
+      - "TypeSpec Suppressions - Set Status"
       - "TypeSpec Validation"
       - "Update Labels"
     types:

--- a/.github/workflows/test/typespec-suppressions/post-results.test.js
+++ b/.github/workflows/test/typespec-suppressions/post-results.test.js
@@ -13,8 +13,7 @@ vi.mock("../../src/comment.js", () => ({
 vi.mock("../../src/typespec-suppressions/suppressions-comment.js", () => ({
   buildSuppressionsComment: vi.fn(),
   TYPESPEC_SUPPRESSIONS_COMMENT_IDENTIFIER: "TypeSpecSuppressionsReview",
-  TYPESPEC_SUPPRESSIONS_SECTION_TITLE:
-    "TypeSpec suppressions requiring review (testing, non-blocking)",
+  TYPESPEC_SUPPRESSIONS_SECTION_TITLE: "TypeSpec suppressions requiring review",
 }));
 
 const { extractInputs } = await import("../../src/context.js");

--- a/.github/workflows/test/typespec-suppressions/post-results.test.js
+++ b/.github/workflows/test/typespec-suppressions/post-results.test.js
@@ -12,6 +12,7 @@ vi.mock("../../src/comment.js", () => ({
 
 vi.mock("../../src/typespec-suppressions/suppressions-comment.js", () => ({
   buildSuppressionsComment: vi.fn(),
+  SUPPRESSION_REVIEW_REQUIRED_LABEL: "TypeSpecSuppressionReviewRequired",
   TYPESPEC_SUPPRESSIONS_COMMENT_IDENTIFIER: "TypeSpecSuppressionsReview",
   TYPESPEC_SUPPRESSIONS_SECTION_TITLE: "TypeSpec suppressions requiring review",
 }));
@@ -69,7 +70,10 @@ describe("post-results", () => {
 
   it("posts the sticky comment when suppressions require review", async () => {
     const github = githubWithLabels([]);
-    vi.mocked(buildSuppressionsComment).mockResolvedValue("BODY: suppressions requiring review");
+    vi.mocked(buildSuppressionsComment).mockResolvedValue({
+      body: "BODY: suppressions requiring review",
+      requiresApproval: true,
+    });
 
     await postSuppressionsResults(args(github));
 
@@ -93,9 +97,69 @@ describe("post-results", () => {
     );
   });
 
+  it("applies the TypeSpecSuppressionReviewRequired label when requiresApproval is true and label is absent", async () => {
+    const github = githubWithLabels([]);
+    vi.mocked(buildSuppressionsComment).mockResolvedValue({
+      body: "BODY",
+      requiresApproval: true,
+    });
+
+    await postSuppressionsResults(args(github));
+
+    expect(github.rest.issues.addLabels).toHaveBeenCalledWith({
+      owner: "test-owner",
+      repo: "test-repo",
+      issue_number: 42,
+      labels: ["TypeSpecSuppressionReviewRequired"],
+    });
+    expect(github.rest.issues.removeLabel).not.toHaveBeenCalled();
+  });
+
+  it("does not re-apply the TypeSpecSuppressionReviewRequired label when already present", async () => {
+    const github = githubWithLabels(["TypeSpecSuppressionReviewRequired"]);
+    vi.mocked(buildSuppressionsComment).mockResolvedValue({
+      body: "BODY",
+      requiresApproval: true,
+    });
+
+    await postSuppressionsResults(args(github));
+
+    expect(github.rest.issues.addLabels).not.toHaveBeenCalled();
+    expect(github.rest.issues.removeLabel).not.toHaveBeenCalled();
+  });
+
+  it("removes the TypeSpecSuppressionReviewRequired label when requiresApproval becomes false", async () => {
+    const github = githubWithLabels(["TypeSpecSuppressionReviewRequired"]);
+    vi.mocked(buildSuppressionsComment).mockResolvedValue({
+      body: undefined,
+      requiresApproval: false,
+    });
+
+    await postSuppressionsResults(args(github));
+
+    expect(github.rest.issues.removeLabel).toHaveBeenCalledWith({
+      owner: "test-owner",
+      repo: "test-repo",
+      issue_number: 42,
+      name: "TypeSpecSuppressionReviewRequired",
+    });
+    expect(github.rest.issues.addLabels).not.toHaveBeenCalled();
+  });
+
+  it("does not touch labels when the analysis result is unavailable", async () => {
+    const github = githubWithLabels([]);
+    vi.mocked(buildSuppressionsComment).mockResolvedValue(undefined);
+
+    await postSuppressionsResults(args(github));
+
+    expect(github.rest.issues.addLabels).not.toHaveBeenCalled();
+    expect(github.rest.issues.removeLabel).not.toHaveBeenCalled();
+    expect(commentOrUpdate).not.toHaveBeenCalled();
+  });
+
   it("passes the current PR labels through for approval state", async () => {
     const github = githubWithLabels(["Approved-TypeSpecSuppression", "other"]);
-    vi.mocked(buildSuppressionsComment).mockResolvedValue("BODY");
+    vi.mocked(buildSuppressionsComment).mockResolvedValue({ body: "BODY", requiresApproval: true });
 
     await postSuppressionsResults(args(github));
 
@@ -112,7 +176,10 @@ describe("post-results", () => {
 
   it("resolves an existing comment when nothing requires review", async () => {
     const github = githubWithLabels([]);
-    vi.mocked(buildSuppressionsComment).mockResolvedValue(undefined);
+    vi.mocked(buildSuppressionsComment).mockResolvedValue({
+      body: undefined,
+      requiresApproval: false,
+    });
     vi.mocked(parseExistingComments).mockReturnValue([99, "previous body"]);
 
     await postSuppressionsResults(args(github));
@@ -126,7 +193,10 @@ describe("post-results", () => {
 
   it("does nothing when nothing requires review and no prior comment exists", async () => {
     const github = githubWithLabels([]);
-    vi.mocked(buildSuppressionsComment).mockResolvedValue(undefined);
+    vi.mocked(buildSuppressionsComment).mockResolvedValue({
+      body: undefined,
+      requiresApproval: false,
+    });
     vi.mocked(parseExistingComments).mockReturnValue([undefined, undefined]);
 
     await postSuppressionsResults(args(github));

--- a/.github/workflows/test/typespec-suppressions/suppressions-comment.test.js
+++ b/.github/workflows/test/typespec-suppressions/suppressions-comment.test.js
@@ -82,7 +82,7 @@ describe("renderSuppressionsCommentBody", () => {
     expect(body).toContain("## TypeSpec suppressions requiring review");
     expect(body).toContain("Suppressions are strongly discouraged");
     expect(body).toContain(
-      "❌ Approval required (currently under testing, review NOT enforced) — 1 suppression",
+      "❌ Approval required — 1 suppression",
     );
     // Source link text is the file name + line only (full path stays in the href).
     expect(body).toContain(
@@ -113,7 +113,7 @@ describe("renderSuppressionsCommentBody", () => {
       isApproved: false,
     });
     expect(pending).toContain(
-      "❌ Approval required (currently under testing, review NOT enforced)",
+      "❌ Approval required",
     );
     expect(pending).toContain('<td align="center">❌</td>');
 
@@ -211,7 +211,7 @@ describe("buildSuppressionsComment", async () => {
       expect(body).toContain("Suppressions are strongly discouraged");
       expect(body).toContain("https://aka.ms/tsp-suppress/feedback");
       expect(body).toContain(
-        "❌ Approval required (currently under testing, review NOT enforced) — 2 suppressions",
+        "❌ Approval required — 2 suppressions",
       );
     },
   );
@@ -289,7 +289,7 @@ describe("buildSuppressionsComment", async () => {
         [],
       );
       expect(pending).toContain(
-        "❌ Approval required (currently under testing, review NOT enforced)",
+        "❌ Approval required",
       );
       expect(pending).toContain('<td align="center">❌</td>');
 

--- a/.github/workflows/test/typespec-suppressions/suppressions-comment.test.js
+++ b/.github/workflows/test/typespec-suppressions/suppressions-comment.test.js
@@ -81,9 +81,7 @@ describe("renderSuppressionsCommentBody", () => {
 
     expect(body).toContain("## TypeSpec suppressions requiring review");
     expect(body).toContain("Suppressions are strongly discouraged");
-    expect(body).toContain(
-      "❌ Approval required — 1 suppression",
-    );
+    expect(body).toContain("❌ Approval required — 1 suppression");
     // Source link text is the file name + line only (full path stays in the href).
     expect(body).toContain(
       '<a href="https://github.com/test-owner/test-repo/pull/42/files#diff-efaa719245fb34e480918c08f8fe8f5b6f620477e1053f1d6f0e2a0ca5f05e69R12">main.tsp#L12</a>',
@@ -112,9 +110,7 @@ describe("renderSuppressionsCommentBody", () => {
       ...options,
       isApproved: false,
     });
-    expect(pending).toContain(
-      "❌ Approval required",
-    );
+    expect(pending).toContain("❌ Approval required");
     expect(pending).toContain('<td align="center">❌</td>');
 
     const approved = renderSuppressionsCommentBody(report, {
@@ -210,9 +206,7 @@ describe("buildSuppressionsComment", async () => {
       );
       expect(body).toContain("Suppressions are strongly discouraged");
       expect(body).toContain("https://aka.ms/tsp-suppress/feedback");
-      expect(body).toContain(
-        "❌ Approval required — 2 suppressions",
-      );
+      expect(body).toContain("❌ Approval required — 2 suppressions");
     },
   );
 
@@ -288,9 +282,7 @@ describe("buildSuppressionsComment", async () => {
         42,
         [],
       );
-      expect(pending).toContain(
-        "❌ Approval required",
-      );
+      expect(pending).toContain("❌ Approval required");
       expect(pending).toContain('<td align="center">❌</td>');
 
       const approved = await buildSuppressionsComment(

--- a/.github/workflows/test/typespec-suppressions/suppressions-comment.test.js
+++ b/.github/workflows/test/typespec-suppressions/suppressions-comment.test.js
@@ -185,15 +185,16 @@ describe("buildSuppressionsComment", async () => {
         }),
       );
 
-      const body = await buildSuppressionsComment(
-        github,
-        mockCore,
-        "test-owner",
-        "test-repo",
-        "abc123",
-        42,
-        [],
-      );
+      const { body } =
+        (await buildSuppressionsComment(
+          github,
+          mockCore,
+          "test-owner",
+          "test-repo",
+          "abc123",
+          42,
+          [],
+        )) ?? {};
 
       expect(body).toContain("Approved-TypeSpecSuppression");
       expect(body).toContain(
@@ -233,15 +234,16 @@ describe("buildSuppressionsComment", async () => {
         }),
       );
 
-      const body = await buildSuppressionsComment(
-        github,
-        mockCore,
-        "test-owner",
-        "test-repo",
-        "abc123",
-        42,
-        [],
-      );
+      const { body } =
+        (await buildSuppressionsComment(
+          github,
+          mockCore,
+          "test-owner",
+          "test-repo",
+          "abc123",
+          42,
+          [],
+        )) ?? {};
 
       expect(body).toContain(
         "<strong>NO JUSTIFICATION PROVIDED, THIS IS A REQUIRED SUPPRESSION COMPONENT</strong>",
@@ -273,27 +275,25 @@ describe("buildSuppressionsComment", async () => {
         }),
       );
 
-      const pending = await buildSuppressionsComment(
-        github,
-        mockCore,
-        "test-owner",
-        "test-repo",
-        "abc123",
-        42,
-        [],
-      );
+      const pending = (
+        await buildSuppressionsComment(
+          github,
+          mockCore,
+          "test-owner",
+          "test-repo",
+          "abc123",
+          42,
+          [],
+        )
+      )?.body;
       expect(pending).toContain("❌ Approval required");
       expect(pending).toContain('<td align="center">❌</td>');
 
-      const approved = await buildSuppressionsComment(
-        github,
-        mockCore,
-        "test-owner",
-        "test-repo",
-        "abc123",
-        42,
-        ["Approved-TypeSpecSuppression"],
-      );
+      const approved = (
+        await buildSuppressionsComment(github, mockCore, "test-owner", "test-repo", "abc123", 42, [
+          "Approved-TypeSpecSuppression",
+        ])
+      )?.body;
       expect(approved).toContain("✅ Approved");
       expect(approved).toContain('<td align="center">✅</td>');
     },
@@ -322,15 +322,16 @@ describe("buildSuppressionsComment", async () => {
         mockArtifactDownload({ requiresApproval: true, newSuppressions }),
       );
 
-      const body = await buildSuppressionsComment(
-        github,
-        mockCore,
-        "test-owner",
-        "test-repo",
-        "abc123",
-        42,
-        [],
-      );
+      const { body } =
+        (await buildSuppressionsComment(
+          github,
+          mockCore,
+          "test-owner",
+          "test-repo",
+          "abc123",
+          42,
+          [],
+        )) ?? {};
 
       // Only the first 5 rows are rendered.
       expect(body).toContain("reason-0");
@@ -382,15 +383,16 @@ describe("buildSuppressionsComment", async () => {
         }),
       );
 
-      const body = await buildSuppressionsComment(
-        github,
-        mockCore,
-        "test-owner",
-        "test-repo",
-        "abc123",
-        42,
-        [],
-      );
+      const { body } =
+        (await buildSuppressionsComment(
+          github,
+          mockCore,
+          "test-owner",
+          "test-repo",
+          "abc123",
+          42,
+          [],
+        )) ?? {};
 
       // Both tables render, each capped at 5 rows (10 status cells total).
       expect(body).toContain("New suppressions (7)");
@@ -444,15 +446,16 @@ describe("buildSuppressionsComment", async () => {
         }),
       );
 
-      const body = await buildSuppressionsComment(
-        github,
-        mockCore,
-        "test-owner",
-        "test-repo",
-        "abc123",
-        42,
-        [],
-      );
+      const { body } =
+        (await buildSuppressionsComment(
+          github,
+          mockCore,
+          "test-owner",
+          "test-repo",
+          "abc123",
+          42,
+          [],
+        )) ?? {};
 
       expect(body).toContain("New suppressions (1)");
       expect(body).toContain("in-scope-rule");
@@ -496,7 +499,7 @@ describe("buildSuppressionsComment", async () => {
 
       await expect(
         buildSuppressionsComment(github, mockCore, "test-owner", "test-repo", "abc123", 42, []),
-      ).resolves.toBeUndefined();
+      ).resolves.toEqual({ body: undefined, requiresApproval: false });
     },
   );
 

--- a/.github/workflows/typespec-suppressions-code.yaml
+++ b/.github/workflows/typespec-suppressions-code.yaml
@@ -98,6 +98,7 @@ jobs:
             --json-output "typespec-suppressions-report.json" \
             --markdown-output "$GITHUB_STEP_SUMMARY" \
             --check-rules-file "eng/tools/typespec-suppressions/check-rules.json" \
+            --fail-on-approval \
             "${annotations_flag[@]}" \
             "${spec_folders[@]}"
 

--- a/.github/workflows/typespec-suppressions-code.yaml
+++ b/.github/workflows/typespec-suppressions-code.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Get impacted TypeSpec folders
         shell: pwsh
         run: |
-          $ignoreCoreFiles = -not (@('main', 'RPSaaSMaster') -contains $Env:GITHUB_BASE_REF)
+          $ignoreCoreFiles = $true
           $typespecFolders, $checkedAll = & "./eng/scripts/Get-TypeSpec-Folders.ps1" `
             -BaseCommitish:"${{ github.event.pull_request.base.sha }}" `
             -HeadCommitish:"HEAD" `

--- a/documentation/ci-fix.md
+++ b/documentation/ci-fix.md
@@ -258,16 +258,11 @@ https://github.com/Azure/azure-rest-api-specs/wiki/TypeSpec-Validation
 
 ## `TypeSpec Suppressions`
 
-> [!NOTE]
->
-> This check is currently in **testing mode and is non-blocking** — it surfaces
-> information and inline warnings but does not currently prevent your PR from
-> merging. It is distinct from the AutoRest/`suppressions.yaml` flow described in
-> [Suppression Process](#suppression-process) below.
-
 This check detects **new or changed TypeSpec lint suppressions** introduced by
-your PR and surfaces them for review. It analyzes two kinds of suppressions in
-the TypeSpec projects impacted by your changes:
+your PR and requires them to be removed or approved before the PR can merge. It
+is distinct from the AutoRest/`suppressions.yaml` flow described in
+[Suppression Process](#suppression-process) below. It analyzes two kinds of
+suppressions in the TypeSpec projects impacted by your changes:
 
 - **Inline suppressions**: `#suppress` directives in `.tsp` files.
 - **Config suppressions**: `linter.disable` entries in `tspconfig.yaml`.
@@ -307,7 +302,9 @@ suppression, prefer fixing the underlying issue:
    string explaining why the rule cannot be satisfied; suppressions with no
    justification are flagged.
 3. **If the suppression is legitimate and requires approval**, ask the
-   appropriate reviewer to apply the `Approved-TypeSpecSuppression` label.
+   appropriate reviewer to apply the `Approved-TypeSpecSuppression` label. The
+   `TypeSpec Suppressions` check remains blocking until the suppression is
+   resolved or the label is applied.
 
 ### Reproduce locally
 
@@ -316,7 +313,7 @@ The check is powered by the `@azure-tools/typespec-suppressions` CLI. See
 for usage. For example, to compare your branch against `main`:
 
 ``` powershell
-npx typespec-suppressions --base origin/main <path-to-typespec-project-folder>
+npx typespec-suppressions --base origin/main --fail-on-approval <path-to-typespec-project-folder>
 ```
 
 ## `license/cla`

--- a/documentation/ci-fix.md
+++ b/documentation/ci-fix.md
@@ -267,6 +267,11 @@ suppressions in the TypeSpec projects impacted by your changes:
 - **Inline suppressions**: `#suppress` directives in `.tsp` files.
 - **Config suppressions**: `linter.disable` entries in `tspconfig.yaml`.
 
+Only suppressions for rules listed in
+[`check-rules.json`](https://github.com/Azure/azure-rest-api-specs/blob/main/eng/tools/typespec-suppressions/check-rules.json)
+count toward review/gating; suppressions for other rules are still detected and
+reported for visibility but do not block the check.
+
 The check runs as the following workflows (mirroring the three-run structure used
 by other validations in this repo):
 
@@ -278,9 +283,9 @@ by other validations in this repo):
 
 ### Where to see the results
 
-- A **"TypeSpec suppressions requiring review"** comment is surfaced on the
-  PR , listing the new/changed suppressions with
-  their rule, source location, and justification.
+- A **"TypeSpec suppressions requiring review"** comment is surfaced on the PR,
+  listing the new/changed suppressions with their rule, source location, and
+  justification.
 - **Inline `::warning` annotations** appear on the PR diff at each suppression's
   source location.
 - The full structured report is uploaded as the `typespec-suppressions-report`
@@ -302,7 +307,8 @@ suppression, prefer fixing the underlying issue:
    string explaining why the rule cannot be satisfied; suppressions with no
    justification are flagged.
 3. **If the suppression is legitimate and requires approval**, ask the
-   appropriate reviewer to apply the `Approved-TypeSpecSuppression` label. The
+   appropriate reviewer (ARM spec PRs: only the ARM reviewer can apply the
+   label) to apply the `Approved-TypeSpecSuppression` label. The
    `TypeSpec Suppressions` check remains blocking until the suppression is
    resolved or the label is applied.
 
@@ -313,7 +319,7 @@ The check is powered by the `@azure-tools/typespec-suppressions` CLI. See
 for usage. For example, to compare your branch against `main`:
 
 ``` powershell
-npx typespec-suppressions --base origin/main --fail-on-approval <path-to-typespec-project-folder>
+npx typespec-suppressions --base origin/main --check-rules-file eng/tools/typespec-suppressions/check-rules.json --fail-on-approval <path-to-typespec-project-folder>
 ```
 
 ## `license/cla`


### PR DESCRIPTION
## Summary

Makes the `TypeSpec Suppressions` check merge-blocking instead of advisory/testing-mode.

Changes:
- Added `--fail-on-approval` to the `npm exec -- typespec-suppressions` invocation in `typespec-suppressions-code.yaml`, so the analyzer now exits non-zero when any suppression requires review/approval.
- Added `"TypeSpec Suppressions - Set Status"` to the `workflow_run.workflows` trigger list in `summarize-checks.yaml`, so the merge-summary recomputes when the suppression status changes.
- Added a `"TypeSpec Suppressions"` entry to `CHECK_METADATA` in `summarize-checks.js` (with the existing `Approved-TypeSpecSuppression` override label and the default troubleshooting guide), so once the check is added to the branch ruleset it will be surfaced correctly in the "Next Steps to Merge" comment and factored into "Automated merging requirements met".
- Removed "testing mode / non-blocking" language from `suppressions-comment.js`'s PR review comment and updated the approval-state/status text to reflect that the check now blocks merging.
- Updated `documentation/ci-fix.md` to remove the testing-mode callout, describe the check as blocking, and add `--fail-on-approval` to the local repro example.
- Updated existing unit tests (`post-results.test.js`, `suppressions-comment.test.js`) to match the new wording.

The existing `Approved-TypeSpecSuppression` label override mechanism (in `set-status.js` / `_reusable-set-check-status.yaml`) is unchanged and already works: applying the label force-succeeds the status; removing it re-evaluates.

## Required follow-up (not part of this PR's code changes)

For this check to actually **gate** merging on `main`, `"TypeSpec Suppressions"` must also be added to the `required_status_checks` list of the `Required PullRequest Checks` ruleset (id `912053`) — the same mechanism that already makes `TypeSpec Validation`, `Swagger BreakingChange`, etc. required. This is a manual, admin-only repo-settings change (not something a workflow-code PR can do) and should be done **after this PR merges**, so that:
1. The updated check-status workflow is live on `main` before it starts being enforced, and
2. Open PRs get a chance to re-run and produce a status before the check becomes required (to avoid PRs getting stuck on "Expected — waiting for status").

## Testing

- Validated the full change end-to-end on a personal fork with a demo PR:
  - Confirmed `--fail-on-approval` causes the analyzer to exit non-zero and the `TypeSpec Suppressions` commit status to be set to `failure` when suppressions require review.
  - Confirmed the PR review comment posts correctly with the updated (non-testing-mode) wording.
  - Confirmed the `Approved-TypeSpecSuppression` label override still works as expected.
- Ran the `.github` workflow test suite (`npm run check` in `.github/`) after updating test string expectations.
