### PR TITLE
RecoveryServicesBackup: preserve Java public model classes

### DIFF
--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/tspconfig.yaml
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/tspconfig.yaml
@@ -29,6 +29,9 @@ options:
     service-name: "Recovery Services Backup"
     flavor: azure
     use-object-for-unknown: true
+    remove-inner:
+      - InstantItemRecoveryTarget
+      - OperationStatusProvisionIlrExtendedInfo
   "@azure-tools/typespec-ts":
     compatibility-lro: true
     emitter-output-dir: "{output-dir}/{service-dir}/arm-recoveryservicesbackup"


### PR DESCRIPTION
Configure the Java emitter to keep these existing public models instead of generating interface/inner-model pairs:

- `InstantItemRecoveryTarget`
- `OperationStatusProvisionIlrExtendedInfo`

This avoids class-to-interface compatibility breaks in the generated Java management SDK.
