### PR TITLE
Keep RAI policy dependencies top-level

### DIFF
--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-09-15-preview/PutRaiPolicyAcs.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-09-15-preview/PutRaiPolicyAcs.json
@@ -31,9 +31,7 @@
                     {
                       "category": "PromptInjection"
                     }
-                  ],
-                  "blocklists": [],
-                  "external_safety_providers": []
+                  ]
                 }
               }
             }
@@ -103,9 +101,7 @@
                       {
                         "category": "PromptInjection"
                       }
-                    ],
-                    "blocklists": [],
-                    "external_safety_providers": []
+                    ]
                   }
                 }
               }
@@ -171,9 +167,7 @@
                       {
                         "category": "PromptInjection"
                       }
-                    ],
-                    "blocklists": [],
-                    "external_safety_providers": []
+                    ]
                   }
                 }
               }

--- a/specification/cognitiveservices/CognitiveServices.Management/models.tsp
+++ b/specification/cognitiveservices/CognitiveServices.Management/models.tsp
@@ -635,15 +635,6 @@ model RaiAcsModerationBindingExtension {
   @encodedName("application/json", "harm_configs")
   @identifiers(#["category"])
   harmConfigs: RaiAcsHarmConfiguration[];
-
-  /** Reserved for future blocklist tasks. Current service validation permits only an empty optional array. */
-  @identifiers(#[])
-  blocklists?: RaiAcsEmptyObject[];
-
-  /** Reserved for future external-provider tasks. Current service validation permits only an empty optional array. */
-  @encodedName("application/json", "external_safety_providers")
-  @identifiers(#[])
-  externalSafetyProviders?: RaiAcsEmptyObject[];
 }
 
 /** An object that must contain no properties. */

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-09-15-preview/cognitiveservices.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-09-15-preview/cognitiveservices.json
@@ -19791,23 +19791,6 @@
           "x-ms-identifiers": [
             "category"
           ]
-        },
-        "blocklists": {
-          "type": "array",
-          "description": "Reserved for future blocklist tasks. Current service validation permits only an empty optional array.",
-          "items": {
-            "$ref": "#/definitions/RaiAcsEmptyObject"
-          },
-          "x-ms-identifiers": []
-        },
-        "external_safety_providers": {
-          "type": "array",
-          "description": "Reserved for future external-provider tasks. Current service validation permits only an empty optional array.",
-          "items": {
-            "$ref": "#/definitions/RaiAcsEmptyObject"
-          },
-          "x-ms-client-name": "externalSafetyProviders",
-          "x-ms-identifiers": []
         }
       },
       "required": [

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-09-15-preview/examples/PutRaiPolicyAcs.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-09-15-preview/examples/PutRaiPolicyAcs.json
@@ -31,9 +31,7 @@
                     {
                       "category": "PromptInjection"
                     }
-                  ],
-                  "blocklists": [],
-                  "external_safety_providers": []
+                  ]
                 }
               }
             }
@@ -103,9 +101,7 @@
                       {
                         "category": "PromptInjection"
                       }
-                    ],
-                    "blocklists": [],
-                    "external_safety_providers": []
+                    ]
                   }
                 }
               }
@@ -171,9 +167,7 @@
                       {
                         "category": "PromptInjection"
                       }
-                    ],
-                    "blocklists": [],
-                    "external_safety_providers": []
+                    ]
                   }
                 }
               }

--- a/specification/cognitiveservices/resource-manager/readme.md
+++ b/specification/cognitiveservices/resource-manager/readme.md
@@ -54,7 +54,6 @@ suppressions:
       - $.definitions.RaiAcsManifest.properties.intervention_points
       - $.definitions.RaiAcsModerationBindingExtension.properties.subject_format
       - $.definitions.RaiAcsModerationBindingExtension.properties.harm_configs
-      - $.definitions.RaiAcsModerationBindingExtension.properties.external_safety_providers
       - $.definitions.RaiAcsPolicyBinding.properties.aacs_moderation
   - code: AvoidAdditionalProperties
     reason: The canonical ACS manifest defines metadata as an extensible JSON object and policies as a map keyed by logical policy identifier. Replacing these maps with fixed properties or arrays would break ACS manifest portability and round-tripping.


### PR DESCRIPTION
## Summary

- keep reusable blocklist and external safety-provider relationships only in the top-level `raiPolicy` properties
- remove the unreleased nested `aacs_moderation.blocklists` and `aacs_moderation.external_safety_providers` placeholders
- update the authored/emitted PUT example, generated 2026-09-15-preview Swagger, and obsolete AutoRest suppression

## Compatibility

- preserves the existing top-level `customBlocklists` and `customExternalSafetyProviders` shapes
- preserves the shared `RaiPolicyContentSource`, element requiredness/defaults, and legacy ContentFilters behavior
- changes only the unreleased `2026-09-15-preview` output; all earlier generated API versions remain unchanged
- runtime derivation of source-specific blocklist/provider tasks from the top-level relationships remains an RP/PMS/Frontdoor implementation concern and is not changed here

## Validation

- `npx tsp compile specification/cognitiveservices/CognitiveServices.Management --emit @azure-tools/typespec-autorest`
- OAV semantic validation
- OAV x-ms-example validation
- Prettier and cspell checks
- authored/emitted example parity and pre-September output isolation

Depends on #45556.