### PR TITLE
AKS: Pin SDK emitters to 2026-07-01

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/tspconfig.yaml
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/tspconfig.yaml
@@ -19,6 +19,7 @@ options:
     generate-test: true
     generate-sample: true
     flavor: azure
+    api-version: "2026-07-01"
   "@azure-tools/typespec-java":
     emitter-output-dir: "{output-dir}/{service-dir}/azure-resourcemanager-containerservice"
     namespace: "com.azure.resourcemanager.containerservice"
@@ -41,6 +42,7 @@ options:
     generate-fakes: true
     head-as-boolean: true
     inject-spans: true
+    api-version: "2026-07-01"
   "@azure-tools/typespec-ts":
     service-dir: "sdk/containerservice"
     flavor: azure
@@ -49,6 +51,7 @@ options:
     emitter-output-dir: "{output-dir}/{service-dir}/arm-containerservice"
     package-details:
       name: "@azure/arm-containerservice"
+    api-version: "2026-07-01"
   "@azure-typespec/http-client-csharp-mgmt":
     namespace: "Azure.ResourceManager.ContainerService"
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"


### PR DESCRIPTION
## Summary
- pin the Python, Go, and TypeScript SDK emitters to `2026-07-01`
- align all configured SDK emitters for the stable API release before `2026-07-02-preview`
- fix the `MultipleNewApiVersions` TypeSpec validation failure in #45855

## Validation
- `npx tsp compile --no-emit --warn-as-error specification/containerservice/resource-manager/Microsoft.ContainerService/aks/client.tsp`
- `npx tsv specification/containerservice/resource-manager/Microsoft.ContainerService/aks '{"baseCommitish":"origin/main","headCommitish":"HEAD"}'`