### PR TITLE
[Automation] Fix 2024-10-23 SDK generation compatibility

### DIFF
--- a/specification/automation/resource-manager/Microsoft.Automation/stable/2024-10-23/openapi.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/stable/2024-10-23/openapi.json
@@ -4695,6 +4695,17 @@
             "description": "Resource 'DscNodeConfiguration' create operation succeeded",
             "schema": {
               "$ref": "#/definitions/DscNodeConfiguration"
+            },
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
             }
           },
           "default": {
@@ -5526,7 +5537,18 @@
             }
           },
           "202": {
-            "description": "Resource operation accepted."
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
           },
           "default": {
             "description": "An unexpected error response.",
@@ -5579,7 +5601,18 @@
         ],
         "responses": {
           "202": {
-            "description": "Resource deletion accepted."
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
           },
           "204": {
             "description": "Resource does not exist."
@@ -6764,21 +6797,7 @@
         ],
         "responses": {
           "202": {
-            "description": "Resource operation accepted.",
-            "headers": {
-              "Azure-AsyncOperation": {
-                "type": "string",
-                "description": "A link to the status monitor"
-              },
-              "Location": {
-                "type": "string"
-              },
-              "Retry-After": {
-                "type": "integer",
-                "format": "int32",
-                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
-              }
-            }
+            "description": "Resource operation accepted."
           },
           "default": {
             "description": "An unexpected error response.",
@@ -7307,7 +7326,18 @@
         ],
         "responses": {
           "202": {
-            "description": "Resource operation accepted."
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
           },
           "default": {
             "description": "An unexpected error response.",

--- a/specification/automation/resource-manager/Microsoft.Automation/stable/2024-10-23/openapi.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/stable/2024-10-23/openapi.json
@@ -4695,17 +4695,6 @@
             "description": "Resource 'DscNodeConfiguration' create operation succeeded",
             "schema": {
               "$ref": "#/definitions/DscNodeConfiguration"
-            },
-            "headers": {
-              "Location": {
-                "type": "string",
-                "description": "The Location header contains the URL where the status of the long running operation can be checked."
-              },
-              "Retry-After": {
-                "type": "integer",
-                "format": "int32",
-                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
-              }
             }
           },
           "default": {
@@ -5537,18 +5526,7 @@
             }
           },
           "202": {
-            "description": "Resource operation accepted.",
-            "headers": {
-              "Location": {
-                "type": "string",
-                "description": "The Location header contains the URL where the status of the long running operation can be checked."
-              },
-              "Retry-After": {
-                "type": "integer",
-                "format": "int32",
-                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
-              }
-            }
+            "description": "Resource operation accepted."
           },
           "default": {
             "description": "An unexpected error response.",
@@ -5601,18 +5579,7 @@
         ],
         "responses": {
           "202": {
-            "description": "Resource deletion accepted.",
-            "headers": {
-              "Location": {
-                "type": "string",
-                "description": "The Location header contains the URL where the status of the long running operation can be checked."
-              },
-              "Retry-After": {
-                "type": "integer",
-                "format": "int32",
-                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
-              }
-            }
+            "description": "Resource deletion accepted."
           },
           "204": {
             "description": "Resource does not exist."
@@ -7340,18 +7307,7 @@
         ],
         "responses": {
           "202": {
-            "description": "Resource operation accepted.",
-            "headers": {
-              "Location": {
-                "type": "string",
-                "description": "The Location header contains the URL where the status of the long running operation can be checked."
-              },
-              "Retry-After": {
-                "type": "integer",
-                "format": "int32",
-                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
-              }
-            }
+            "description": "Resource operation accepted."
           },
           "default": {
             "description": "An unexpected error response.",

--- a/specification/automation/resource-manager/Microsoft.Automation/stable/2024-10-23/openapi.json
+++ b/specification/automation/resource-manager/Microsoft.Automation/stable/2024-10-23/openapi.json
@@ -13437,12 +13437,14 @@
         "registeredDateTime": {
           "type": "string",
           "format": "date-time",
-          "description": "Gets or sets the registration time of the worker machine."
+          "description": "Gets or sets the registration time of the worker machine.",
+          "x-nullable": false
         },
         "lastSeenDateTime": {
           "type": "string",
           "format": "date-time",
-          "description": "Last Heartbeat from the Worker"
+          "description": "Last Heartbeat from the Worker",
+          "x-nullable": false
         },
         "vmResourceId": {
           "type": "string",


### PR DESCRIPTION
## Summary

- Remove long-running-operation response headers from the `RunbookDraft_ReplaceContent` 202 response.
- Mark `HybridRunbookWorker.registeredDateTime` and `lastSeenDateTime` explicitly non-nullable.

## Motivation

The 202 response headers caused AutoRest PowerShell to generate an incompatible long-running-operation header response type. The timestamp properties were also generated as `DateTimeOffset?`, introducing breaking output-type changes in the Azure PowerShell Automation module.

These corrections allow the `2024-10-23` specification to generate a compatible Automation SDK while preserving the existing Hybrid Runbook Worker public types.

## Validation

- Regenerated 432 SDK files with AutoRest core 3.10.9 and `@autorest/powershell` 4.0.754.
- Azure PowerShell Automation Release build completed with 0 warnings and 0 errors.
- Automation tests: 181 passed, 27 skipped, 0 failed.
- Breaking-change, signature, UX metadata, and cmdlet-diff analysis passed.

Downstream validation: Azure/azure-powershell#29867