### PR TITLE
Restore AppContainers job detector resource name

### DIFF
--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/Job.tsp
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/Job.tsp
@@ -254,18 +254,7 @@ interface Jobs {
   @tag("Jobs")
   @tag("Diagnostics")
   @summary("Get the properties of a Container App Job.")
-  proxyGet is ArmResourceRead<
-    Job,
-    Parameters = {
-      /** Proxy API Name for Container App Job. */
-      @path
-      @segment("detectorProperties")
-      @key
-      @pattern("^[-\\w\\._]+$")
-      apiName: string;
-    },
-    Error = DefaultErrorResponse
-  >;
+  proxyGet is JobDetectorPropertyOps.Read<Job, Response = ArmResponse<Job>>;
 
   /**
    * Get the list of diagnostics for a Container App Job.


### PR DESCRIPTION
## Summary

Restore `JobDetectorPropertyOps.Read<Job>` for `Jobs.proxyGet` so the detector-property resource retains its explicit `ContainerAppJobDetectorProperty` resource name.

## Why this is needed

The `Job` model backs two different ARM resource identities:

- `Microsoft.App/jobs`
- `Microsoft.App/jobs/detectorProperties`

`JobDetectorPropertyOps` explicitly supplies `ResourceName = "ContainerAppJobDetectorProperty"` to distinguish the second identity. [PR #42504 changed `proxyGet` to a direct `ArmResourceRead<Job>`](https://github.com/Azure/azure-rest-api-specs/pull/42504/changes#r3892136749), which preserved the HTTP shape but dropped that resource-name metadata.

Without the explicit operation template, both resources are projected as `ContainerAppJob`:

- The .NET management generator replaces the main job resource with the detector-property resource and emits duplicate `GetContainerAppJobResource(ResourceIdentifier)` methods, causing `CS0111` build failures.
- The .NET provisioning generator similarly overwrites the real `ContainerAppJob` projection with `Microsoft.App/jobs/detectorProperties`.

Restoring the specialized template generates the intended distinct wrappers:

- `ContainerAppJobResource` for `Microsoft.App/jobs`
- `ContainerAppJobDetectorPropertyResource` for `Microsoft.App/jobs/detectorProperties`

The same correction currently also appears in the broader AppContainers provisioning configuration PR, [#45955](https://github.com/Azure/azure-rest-api-specs/pull/45955), but this PR isolates it for focused review.

## Validation

- TypeSpec compilation succeeds.
- Controlled .NET regeneration with API version `2026-01-01` confirms the two distinct resource identities and eliminates the duplicate factory-method errors.

## Follow-up

We plan to introduce linting that prevents resource operation template changes from silently dropping explicit resource naming metadata.