### PR TITLE
[AI Foundry][Data Plane] Cherry-pick idle timeout 120s onto current foundry-release pin

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -81217,9 +81217,9 @@
           "idle_timeout_seconds": {
             "type": "integer",
             "format": "int32",
-            "minimum": 300,
+            "minimum": 120,
             "maximum": 3600,
-            "description": "The idle duration, in seconds, before a session's sandbox is suspended. Optional — when\nunset, the server default of 900 seconds is used. Must be between 300 and 3600 seconds\n(inclusive).",
+            "description": "The idle duration, in seconds, before a session's sandbox is suspended. Optional — when\nunset, the server default of 900 seconds is used. Must be between 120 and 3600 seconds\n(inclusive).",
             "examples": [
               300
             ],

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -77548,11 +77548,11 @@ components:
         idle_timeout_seconds:
           type: integer
           format: int32
-          minimum: 300
+          minimum: 120
           maximum: 3600
           description: |-
             The idle duration, in seconds, before a session's sandbox is suspended. Optional — when
-            unset, the server default of 900 seconds is used. Must be between 300 and 3600 seconds
+            unset, the server default of 900 seconds is used. Must be between 120 and 3600 seconds
             (inclusive).
           examples:
             - 300

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -85769,9 +85769,9 @@
           "idle_timeout_seconds": {
             "type": "integer",
             "format": "int32",
-            "minimum": 300,
+            "minimum": 120,
             "maximum": 3600,
-            "description": "The idle duration, in seconds, before a session's sandbox is suspended. Optional — when\nunset, the server default of 900 seconds is used. Must be between 300 and 3600 seconds\n(inclusive).",
+            "description": "The idle duration, in seconds, before a session's sandbox is suspended. Optional — when\nunset, the server default of 900 seconds is used. Must be between 120 and 3600 seconds\n(inclusive).",
             "examples": [
               300
             ],

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -80683,11 +80683,11 @@ components:
         idle_timeout_seconds:
           type: integer
           format: int32
-          minimum: 300
+          minimum: 120
           maximum: 3600
           description: |-
             The idle duration, in seconds, before a session's sandbox is suspended. Optional — when
-            unset, the server default of 900 seconds is used. Must be between 300 and 3600 seconds
+            unset, the server default of 900 seconds is used. Must be between 120 and 3600 seconds
             (inclusive).
           examples:
             - 300

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
@@ -398,10 +398,10 @@ model ContainerConfiguration {
 model SessionConfiguration {
   @doc("""
     The idle duration, in seconds, before a session's sandbox is suspended. Optional — when
-    unset, the server default of 900 seconds is used. Must be between 300 and 3600 seconds
+    unset, the server default of 900 seconds is used. Must be between 120 and 3600 seconds
     (inclusive).
     """)
-  @minValue(duration.fromISO("PT300S"))
+  @minValue(duration.fromISO("PT120S"))
   @maxValue(duration.fromISO("PT3600S"))
   @example(duration.fromISO("PT300S"))
   @encode(DurationKnownEncoding.seconds, int32)


### PR DESCRIPTION
Cherry-picks the idle timeout change (PR #45778, commit 23b3fda5) cleanly onto commit 2a713120 (the current Vienna Agents pin). This creates a minimal commit that only contains the session config `@minValue(PT120S)` change — no other upstream commits.

Purpose: allow the Vienna backend to bump its TypeSpec pin to just this change, avoiding 5 unrelated upstream commits (voice-agents, access boundaries, publish approval status, model selection details, GA spec fixes) that introduce major integration conflicts.

**Files changed (5):**
- `models.tsp`: `@minValue(duration.fromISO8601String("PT300S"))` → `@minValue(duration.fromISO8601String("PT120S"))`
- 4 regenerated OpenAPI files (v1 + virtual-public-preview, JSON + YAML)

No new types, no breaking changes, no API surface changes beyond the relaxed minimum.