### PR TITLE
Add mixed MIG profiles to AKS preview API

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/AgentPoolModels.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/AgentPoolModels.tsp
@@ -1103,7 +1103,7 @@ model NvidiaGPUProfile {
   migStrategy?: MigStrategy;
 
   /**
-   * The ordered list of Multi-Instance GPU (MIG) partition profiles to assign to each supported NVIDIA GPU. When `migStrategy` is `Single`, exactly one profile must be specified. When `migStrategy` is `Mixed`, one or more profiles may be specified and the combination is validated against the supported MIG geometry for the agent pool's GPU VM size. The same value may appear more than once to request multiple partitions of that size. This field is mutually exclusive with the top-level `gpuInstanceProfile` property, which is deprecated. For more information, see https://aka.ms/aks/managed-gpu.
+   * The ordered list of Multi-Instance GPU (MIG) partition profiles to assign to each supported NVIDIA GPU. When `migStrategy` is `Single`, exactly one profile must be specified. When `migStrategy` is `Mixed`, one or more profiles may be specified and the combination is validated against the supported MIG geometry for the agent pool's GPU VM size. The same value may appear more than once to request multiple partitions of that size. This field is mutually exclusive with the top-level `gpuInstanceProfile` property. For more information, see https://aka.ms/aks/managed-gpu.
    */
   @added(Versions.v2026_07_02_preview)
   @minItems(1)

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/AgentPoolModels.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/AgentPoolModels.tsp
@@ -1103,7 +1103,7 @@ model NvidiaGPUProfile {
   migStrategy?: MigStrategy;
 
   /**
-   * The ordered list of Multi-Instance GPU (MIG) partition profiles to assign to each supported NVIDIA GPU. When `migStrategy` is `Single`, exactly one profile must be specified. When `migStrategy` is `Mixed`, one or more profiles may be specified and the combination is validated against the supported MIG geometry for the agent pool's GPU VM size. The same value may appear more than once to request multiple partitions of that size. This field is mutually exclusive with the top-level `gpuInstanceProfile` property. For more information, see https://aka.ms/aks/managed-gpu.
+   * The ordered list of MIG (Multi-Instance GPU) partition profiles to assign to each supported NVIDIA GPU. When `migStrategy` is `Single`, exactly one profile must be specified. When `migStrategy` is `Mixed`, one or more profiles may be specified and the combination is validated against the supported MIG geometry for the agent pool's GPU VM size. The same value may appear more than once to request multiple partitions of that size. This field is mutually exclusive with the top-level `gpuInstanceProfile` property. For more information, see https://aka.ms/aks/managed-gpu.
    */
   @added(Versions.v2026_07_02_preview)
   @minItems(1)

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/AgentPoolModels.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/AgentPoolModels.tsp
@@ -1101,6 +1101,13 @@ model NvidiaGPUProfile {
    * Sets the MIG (Multi-Instance GPU) strategy that will be used for managed MIG support. For more information about the different strategies, visit aka.ms/aks/managed-gpu. When not specified, the default is None.
    */
   migStrategy?: MigStrategy;
+
+  /**
+   * The ordered list of Multi-Instance GPU (MIG) partition profiles to assign to each supported NVIDIA GPU. When `migStrategy` is `Single`, exactly one profile must be specified. When `migStrategy` is `Mixed`, one or more profiles may be specified and the combination is validated against the supported MIG geometry for the agent pool's GPU VM size. The same value may appear more than once to request multiple partitions of that size. This field is mutually exclusive with the top-level `gpuInstanceProfile` property, which is deprecated. For more information, see https://aka.ms/aks/managed-gpu.
+   */
+  @added(Versions.v2026_07_02_preview)
+  @minItems(1)
+  migProfiles?: GPUInstanceProfile[];
 }
 
 /**

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/CommonModels.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/CommonModels.tsp
@@ -592,17 +592,17 @@ union MigStrategy {
   string,
 
   /**
-   * No MIG partitioning is applied; the GPU is exposed as a single unified whole-device instance. Specifying this value removes any previously active MIG strategy.
+   * Don't set a MIG strategy. If you previously had one set, this will override it and set remove the set MIG strategy.
    */
   None: "None",
 
   /**
-   * All MIG partitions on every GPU in the pool are the same size (`nvidia.com/mig.strategy: single`). The uniform partition size is controlled by `nvidia.migProfiles` (exactly one element required).
+   * Set the MIG strategy for managed MIG as single.
    */
   Single: "Single",
 
   /**
-   * Each GPU in the pool can host heterogeneous partitions of different sizes simultaneously (`nvidia.com/mig.strategy: mixed`). The exact partition mix per GPU is declared via `nvidia.migProfiles`.
+   * Set the MIG strategy for managed MIG as mixed.
    */
   Mixed: "Mixed",
 }

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/CommonModels.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/CommonModels.tsp
@@ -597,7 +597,7 @@ union MigStrategy {
   None: "None",
 
   /**
-   * All MIG partitions on every GPU in the pool are the same size (`nvidia.com/mig.strategy: single`). The uniform partition size is controlled by `nvidia.migProfiles` (exactly one element required). The top-level `gpuInstanceProfile` property is deprecated in favour of `nvidia.migProfiles`.
+   * All MIG partitions on every GPU in the pool are the same size (`nvidia.com/mig.strategy: single`). The uniform partition size is controlled by `nvidia.migProfiles` (exactly one element required).
    */
   Single: "Single",
 

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/CommonModels.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/CommonModels.tsp
@@ -592,17 +592,17 @@ union MigStrategy {
   string,
 
   /**
-   * Don't set a MIG strategy. If you previously had one set, this will override it and set remove the set MIG strategy.
+   * No MIG partitioning is applied; the GPU is exposed as a single unified whole-device instance. Specifying this value removes any previously active MIG strategy.
    */
   None: "None",
 
   /**
-   * Set the MIG strategy for managed MIG as single.
+   * All MIG partitions on every GPU in the pool are the same size (`nvidia.com/mig.strategy: single`). The uniform partition size is controlled by `nvidia.migProfiles` (exactly one element required).
    */
   Single: "Single",
 
   /**
-   * Set the MIG strategy for managed MIG as mixed.
+   * Each GPU in the pool can host heterogeneous partitions of different sizes simultaneously (`nvidia.com/mig.strategy: mixed`). The exact partition mix per GPU is declared via `nvidia.migProfiles`.
    */
   Mixed: "Mixed",
 }

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/CommonModels.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/CommonModels.tsp
@@ -592,17 +592,17 @@ union MigStrategy {
   string,
 
   /**
-   * Don't set a MIG strategy. If you previously had one set, this will override it and set remove the set MIG strategy.
+   * No MIG partitioning is applied; the GPU is exposed as a single unified whole-device instance. Specifying this value removes any previously active MIG strategy.
    */
   None: "None",
 
   /**
-   * Set the MIG strategy for managed MIG as single.
+   * All MIG partitions on every GPU in the pool are the same size (`nvidia.com/mig.strategy: single`). The uniform partition size is controlled by `nvidia.migProfiles` (exactly one element required). The top-level `gpuInstanceProfile` property is deprecated in favour of `nvidia.migProfiles`.
    */
   Single: "Single",
 
   /**
-   * Set the MIG strategy for managed MIG as mixed.
+   * Each GPU in the pool can host heterogeneous partitions of different sizes simultaneously (`nvidia.com/mig.strategy: mixed`). The exact partition mix per GPU is declared via `nvidia.migProfiles`.
    */
   Mixed: "Mixed",
 }

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/examples/2026-07-02-preview/AgentPoolsCreate_MixedMIG.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/examples/2026-07-02-preview/AgentPoolsCreate_MixedMIG.json
@@ -1,0 +1,88 @@
+{
+  "parameters": {
+    "agentPoolName": "agentpool1",
+    "api-version": "2026-07-02-preview",
+    "parameters": {
+      "properties": {
+        "count": 3,
+        "gpuProfile": {
+          "driver": "Install",
+          "nvidia": {
+            "managementMode": "Managed",
+            "migStrategy": "Mixed",
+            "migProfiles": [
+              "MIG3g",
+              "MIG2g",
+              "MIG1g",
+              "MIG1g"
+            ]
+          }
+        },
+        "mode": "User",
+        "osType": "Linux",
+        "vmSize": "Standard_ND96asr_v4"
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "agentpool1",
+        "type": "Microsoft.ContainerService/managedClusters/agentPools",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1",
+        "properties": {
+          "count": 3,
+          "gpuProfile": {
+            "driver": "Install",
+            "nvidia": {
+              "managementMode": "Managed",
+              "migStrategy": "Mixed",
+              "migProfiles": [
+                "MIG3g",
+                "MIG2g",
+                "MIG1g",
+                "MIG1g"
+              ]
+            }
+          },
+          "mode": "User",
+          "osType": "Linux",
+          "provisioningState": "Succeeded",
+          "vmSize": "Standard_ND96asr_v4"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "agentpool1",
+        "type": "Microsoft.ContainerService/managedClusters/agentPools",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1",
+        "properties": {
+          "count": 3,
+          "gpuProfile": {
+            "driver": "Install",
+            "nvidia": {
+              "managementMode": "Managed",
+              "migStrategy": "Mixed",
+              "migProfiles": [
+                "MIG3g",
+                "MIG2g",
+                "MIG1g",
+                "MIG1g"
+              ]
+            }
+          },
+          "mode": "User",
+          "osType": "Linux",
+          "provisioningState": "Creating",
+          "vmSize": "Standard_ND96asr_v4"
+        }
+      }
+    }
+  },
+  "operationId": "AgentPools_CreateOrUpdate",
+  "title": "Create Agent Pool with mixed MIG profiles"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/examples/2026-07-02-preview/AgentPoolsCreate_SingleMIG.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/examples/2026-07-02-preview/AgentPoolsCreate_SingleMIG.json
@@ -1,0 +1,79 @@
+{
+  "parameters": {
+    "agentPoolName": "agentpool1",
+    "api-version": "2026-07-02-preview",
+    "parameters": {
+      "properties": {
+        "count": 3,
+        "gpuProfile": {
+          "driver": "Install",
+          "nvidia": {
+            "managementMode": "Managed",
+            "migStrategy": "Single",
+            "migProfiles": [
+              "MIG3g"
+            ]
+          }
+        },
+        "mode": "User",
+        "osType": "Linux",
+        "vmSize": "Standard_ND96asr_v4"
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "agentpool1",
+        "type": "Microsoft.ContainerService/managedClusters/agentPools",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1",
+        "properties": {
+          "count": 3,
+          "gpuProfile": {
+            "driver": "Install",
+            "nvidia": {
+              "managementMode": "Managed",
+              "migStrategy": "Single",
+              "migProfiles": [
+                "MIG3g"
+              ]
+            }
+          },
+          "mode": "User",
+          "osType": "Linux",
+          "provisioningState": "Succeeded",
+          "vmSize": "Standard_ND96asr_v4"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "agentpool1",
+        "type": "Microsoft.ContainerService/managedClusters/agentPools",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1",
+        "properties": {
+          "count": 3,
+          "gpuProfile": {
+            "driver": "Install",
+            "nvidia": {
+              "managementMode": "Managed",
+              "migStrategy": "Single",
+              "migProfiles": [
+                "MIG3g"
+              ]
+            }
+          },
+          "mode": "User",
+          "osType": "Linux",
+          "provisioningState": "Creating",
+          "vmSize": "Standard_ND96asr_v4"
+        }
+      }
+    }
+  },
+  "operationId": "AgentPools_CreateOrUpdate",
+  "title": "Create Agent Pool with single MIG profile"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-07-02-preview/examples/AgentPoolsCreate_MixedMIG.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-07-02-preview/examples/AgentPoolsCreate_MixedMIG.json
@@ -1,0 +1,88 @@
+{
+  "parameters": {
+    "agentPoolName": "agentpool1",
+    "api-version": "2026-07-02-preview",
+    "parameters": {
+      "properties": {
+        "count": 3,
+        "gpuProfile": {
+          "driver": "Install",
+          "nvidia": {
+            "managementMode": "Managed",
+            "migStrategy": "Mixed",
+            "migProfiles": [
+              "MIG3g",
+              "MIG2g",
+              "MIG1g",
+              "MIG1g"
+            ]
+          }
+        },
+        "mode": "User",
+        "osType": "Linux",
+        "vmSize": "Standard_ND96asr_v4"
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "agentpool1",
+        "type": "Microsoft.ContainerService/managedClusters/agentPools",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1",
+        "properties": {
+          "count": 3,
+          "gpuProfile": {
+            "driver": "Install",
+            "nvidia": {
+              "managementMode": "Managed",
+              "migStrategy": "Mixed",
+              "migProfiles": [
+                "MIG3g",
+                "MIG2g",
+                "MIG1g",
+                "MIG1g"
+              ]
+            }
+          },
+          "mode": "User",
+          "osType": "Linux",
+          "provisioningState": "Succeeded",
+          "vmSize": "Standard_ND96asr_v4"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "agentpool1",
+        "type": "Microsoft.ContainerService/managedClusters/agentPools",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1",
+        "properties": {
+          "count": 3,
+          "gpuProfile": {
+            "driver": "Install",
+            "nvidia": {
+              "managementMode": "Managed",
+              "migStrategy": "Mixed",
+              "migProfiles": [
+                "MIG3g",
+                "MIG2g",
+                "MIG1g",
+                "MIG1g"
+              ]
+            }
+          },
+          "mode": "User",
+          "osType": "Linux",
+          "provisioningState": "Creating",
+          "vmSize": "Standard_ND96asr_v4"
+        }
+      }
+    }
+  },
+  "operationId": "AgentPools_CreateOrUpdate",
+  "title": "Create Agent Pool with mixed MIG profiles"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-07-02-preview/examples/AgentPoolsCreate_SingleMIG.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-07-02-preview/examples/AgentPoolsCreate_SingleMIG.json
@@ -1,0 +1,79 @@
+{
+  "parameters": {
+    "agentPoolName": "agentpool1",
+    "api-version": "2026-07-02-preview",
+    "parameters": {
+      "properties": {
+        "count": 3,
+        "gpuProfile": {
+          "driver": "Install",
+          "nvidia": {
+            "managementMode": "Managed",
+            "migStrategy": "Single",
+            "migProfiles": [
+              "MIG3g"
+            ]
+          }
+        },
+        "mode": "User",
+        "osType": "Linux",
+        "vmSize": "Standard_ND96asr_v4"
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "agentpool1",
+        "type": "Microsoft.ContainerService/managedClusters/agentPools",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1",
+        "properties": {
+          "count": 3,
+          "gpuProfile": {
+            "driver": "Install",
+            "nvidia": {
+              "managementMode": "Managed",
+              "migStrategy": "Single",
+              "migProfiles": [
+                "MIG3g"
+              ]
+            }
+          },
+          "mode": "User",
+          "osType": "Linux",
+          "provisioningState": "Succeeded",
+          "vmSize": "Standard_ND96asr_v4"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "agentpool1",
+        "type": "Microsoft.ContainerService/managedClusters/agentPools",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1",
+        "properties": {
+          "count": 3,
+          "gpuProfile": {
+            "driver": "Install",
+            "nvidia": {
+              "managementMode": "Managed",
+              "migStrategy": "Single",
+              "migProfiles": [
+                "MIG3g"
+              ]
+            }
+          },
+          "mode": "User",
+          "osType": "Linux",
+          "provisioningState": "Creating",
+          "vmSize": "Standard_ND96asr_v4"
+        }
+      }
+    }
+  },
+  "operationId": "AgentPools_CreateOrUpdate",
+  "title": "Create Agent Pool with single MIG profile"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-07-02-preview/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-07-02-preview/managedClusters.json
@@ -15360,7 +15360,7 @@
         },
         "migProfiles": {
           "type": "array",
-          "description": "The ordered list of Multi-Instance GPU (MIG) partition profiles to assign to each supported NVIDIA GPU. When `migStrategy` is `Single`, exactly one profile must be specified. When `migStrategy` is `Mixed`, one or more profiles may be specified and the combination is validated against the supported MIG geometry for the agent pool's GPU VM size. The same value may appear more than once to request multiple partitions of that size. This field is mutually exclusive with the top-level `gpuInstanceProfile` property. For more information, see https://aka.ms/aks/managed-gpu.",
+          "description": "The ordered list of MIG (Multi-Instance GPU) partition profiles to assign to each supported NVIDIA GPU. When `migStrategy` is `Single`, exactly one profile must be specified. When `migStrategy` is `Mixed`, one or more profiles may be specified and the combination is validated against the supported MIG geometry for the agent pool's GPU VM size. The same value may appear more than once to request multiple partitions of that size. This field is mutually exclusive with the top-level `gpuInstanceProfile` property. For more information, see https://aka.ms/aks/managed-gpu.",
           "minItems": 1,
           "items": {
             "$ref": "#/definitions/GPUInstanceProfile"

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-07-02-preview/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-07-02-preview/managedClusters.json
@@ -14776,17 +14776,17 @@
           {
             "name": "None",
             "value": "None",
-            "description": "Don't set a MIG strategy. If you previously had one set, this will override it and set remove the set MIG strategy."
+            "description": "No MIG partitioning is applied; the GPU is exposed as a single unified whole-device instance. Specifying this value removes any previously active MIG strategy."
           },
           {
             "name": "Single",
             "value": "Single",
-            "description": "Set the MIG strategy for managed MIG as single."
+            "description": "All MIG partitions on every GPU in the pool are the same size (`nvidia.com/mig.strategy: single`). The uniform partition size is controlled by `nvidia.migProfiles` (exactly one element required)."
           },
           {
             "name": "Mixed",
             "value": "Mixed",
-            "description": "Set the MIG strategy for managed MIG as mixed."
+            "description": "Each GPU in the pool can host heterogeneous partitions of different sizes simultaneously (`nvidia.com/mig.strategy: mixed`). The exact partition mix per GPU is declared via `nvidia.migProfiles`."
           }
         ]
       }

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-07-02-preview/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-07-02-preview/managedClusters.json
@@ -14778,7 +14778,7 @@
           {
             "name": "Single",
             "value": "Single",
-            "description": "All MIG partitions on every GPU in the pool are the same size (`nvidia.com/mig.strategy: single`). The uniform partition size is controlled by `nvidia.migProfiles` (exactly one element required). The top-level `gpuInstanceProfile` property is deprecated in favour of `nvidia.migProfiles`."
+            "description": "All MIG partitions on every GPU in the pool are the same size (`nvidia.com/mig.strategy: single`). The uniform partition size is controlled by `nvidia.migProfiles` (exactly one element required)."
           },
           {
             "name": "Mixed",
@@ -15357,7 +15357,7 @@
         },
         "migProfiles": {
           "type": "array",
-          "description": "The ordered list of Multi-Instance GPU (MIG) partition profiles to assign to each supported NVIDIA GPU. When `migStrategy` is `Single`, exactly one profile must be specified. When `migStrategy` is `Mixed`, one or more profiles may be specified and the combination is validated against the supported MIG geometry for the agent pool's GPU VM size. The same value may appear more than once to request multiple partitions of that size. This field is mutually exclusive with the top-level `gpuInstanceProfile` property, which is deprecated. For more information, see https://aka.ms/aks/managed-gpu.",
+          "description": "The ordered list of Multi-Instance GPU (MIG) partition profiles to assign to each supported NVIDIA GPU. When `migStrategy` is `Single`, exactly one profile must be specified. When `migStrategy` is `Mixed`, one or more profiles may be specified and the combination is validated against the supported MIG geometry for the agent pool's GPU VM size. The same value may appear more than once to request multiple partitions of that size. This field is mutually exclusive with the top-level `gpuInstanceProfile` property. For more information, see https://aka.ms/aks/managed-gpu.",
           "minItems": 1,
           "items": {
             "$ref": "#/definitions/GPUInstanceProfile"

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-07-02-preview/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-07-02-preview/managedClusters.json
@@ -1884,6 +1884,9 @@
           "Create Agent Pool with per-NIC public IP configuration": {
             "$ref": "./examples/AgentPoolsCreate_PerNICPublicIP.json"
           },
+          "Create Agent Pool with single MIG profile": {
+            "$ref": "./examples/AgentPoolsCreate_SingleMIG.json"
+          },
           "Create Agent Pool with upgrade gate enabled": {
             "$ref": "./examples/AgentPoolsCreate_UpgradeGate.json"
           },
@@ -14773,17 +14776,17 @@
           {
             "name": "None",
             "value": "None",
-            "description": "No MIG partitioning is applied; the GPU is exposed as a single unified whole-device instance. Specifying this value removes any previously active MIG strategy."
+            "description": "Don't set a MIG strategy. If you previously had one set, this will override it and set remove the set MIG strategy."
           },
           {
             "name": "Single",
             "value": "Single",
-            "description": "All MIG partitions on every GPU in the pool are the same size (`nvidia.com/mig.strategy: single`). The uniform partition size is controlled by `nvidia.migProfiles` (exactly one element required)."
+            "description": "Set the MIG strategy for managed MIG as single."
           },
           {
             "name": "Mixed",
             "value": "Mixed",
-            "description": "Each GPU in the pool can host heterogeneous partitions of different sizes simultaneously (`nvidia.com/mig.strategy: mixed`). The exact partition mix per GPU is declared via `nvidia.migProfiles`."
+            "description": "Set the MIG strategy for managed MIG as mixed."
           }
         ]
       }

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-07-02-preview/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-07-02-preview/managedClusters.json
@@ -1878,6 +1878,9 @@
           "Create Agent Pool with Windows OSSKU": {
             "$ref": "./examples/AgentPoolsCreate_WindowsOSSKU.json"
           },
+          "Create Agent Pool with mixed MIG profiles": {
+            "$ref": "./examples/AgentPoolsCreate_MixedMIG.json"
+          },
           "Create Agent Pool with per-NIC public IP configuration": {
             "$ref": "./examples/AgentPoolsCreate_PerNICPublicIP.json"
           },
@@ -14770,17 +14773,17 @@
           {
             "name": "None",
             "value": "None",
-            "description": "Don't set a MIG strategy. If you previously had one set, this will override it and set remove the set MIG strategy."
+            "description": "No MIG partitioning is applied; the GPU is exposed as a single unified whole-device instance. Specifying this value removes any previously active MIG strategy."
           },
           {
             "name": "Single",
             "value": "Single",
-            "description": "Set the MIG strategy for managed MIG as single."
+            "description": "All MIG partitions on every GPU in the pool are the same size (`nvidia.com/mig.strategy: single`). The uniform partition size is controlled by `nvidia.migProfiles` (exactly one element required). The top-level `gpuInstanceProfile` property is deprecated in favour of `nvidia.migProfiles`."
           },
           {
             "name": "Mixed",
             "value": "Mixed",
-            "description": "Set the MIG strategy for managed MIG as mixed."
+            "description": "Each GPU in the pool can host heterogeneous partitions of different sizes simultaneously (`nvidia.com/mig.strategy: mixed`). The exact partition mix per GPU is declared via `nvidia.migProfiles`."
           }
         ]
       }
@@ -15351,6 +15354,14 @@
         "migStrategy": {
           "$ref": "#/definitions/MigStrategy",
           "description": "Sets the MIG (Multi-Instance GPU) strategy that will be used for managed MIG support. For more information about the different strategies, visit aka.ms/aks/managed-gpu. When not specified, the default is None."
+        },
+        "migProfiles": {
+          "type": "array",
+          "description": "The ordered list of Multi-Instance GPU (MIG) partition profiles to assign to each supported NVIDIA GPU. When `migStrategy` is `Single`, exactly one profile must be specified. When `migStrategy` is `Mixed`, one or more profiles may be specified and the combination is validated against the supported MIG geometry for the agent pool's GPU VM size. The same value may appear more than once to request multiple partitions of that size. This field is mutually exclusive with the top-level `gpuInstanceProfile` property, which is deprecated. For more information, see https://aka.ms/aks/managed-gpu.",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/GPUInstanceProfile"
+          }
         }
       }
     },


### PR DESCRIPTION
## Summary

- add the optional ordered `migProfiles` list to `NvidiaGPUProfile` for `Single` and `Mixed` MIG strategies
- clarify the `None`, `Single`, and `Mixed` strategy behavior, including how `Single` and `Mixed` use `nvidia.migProfiles`
- keep `migProfiles` mutually exclusive with the existing top-level `gpuInstanceProfile` field
- do not deprecate `gpuInstanceProfile` in the 2026-07-02-preview API version
- add 2026-07-02-preview agent pool examples for both mixed and single MIG strategies
- preserve ordered and repeated profiles through PUT responses in the mixed example

Design: https://github.com/azure-management-and-platforms/aks-handbook/blob/main/api/2026-06-02-preview/mixed-mig-gpu-instance-profiles.md

## Validation

- `npx tsp compile specification/containerservice/resource-manager/Microsoft.ContainerService/aks --warn-as-error`
- TypeSpec-generated OpenAPI and example copies are up to date
- JSON parsing and generated/source example comparison
- `git diff --check`
- confirmed the stable 2026-07-01 OpenAPI is unchanged
