### PR TITLE
Add C# customizations for Programmable Connectivity SDK

### DIFF
--- a/specification/programmableconnectivity/ProgrammableConnectivity.Management/client.tsp
+++ b/specification/programmableconnectivity/ProgrammableConnectivity.Management/client.tsp
@@ -2,6 +2,7 @@ import "./main.tsp";
 import "@azure-tools/typespec-client-generator-core";
 
 using Azure.ClientGenerator.Core;
+using Microsoft.ProgrammableConnectivity;
 
 @@clientName(
   Microsoft.ProgrammableConnectivity,
@@ -12,4 +13,42 @@ using Azure.ClientGenerator.Core;
   Microsoft.ProgrammableConnectivity,
   "ProgrammableConnectivityMgmtClient",
   "java"
+);
+
+// Apply .NET-specific names that provide sufficient domain context in the public API.
+@@clientName(Gateway, "ProgrammableConnectivityGateway", "csharp");
+@@clientName(
+  GatewayProperties,
+  "ProgrammableConnectivityGatewayProperties",
+  "csharp"
+);
+@@clientName(
+  ApplicationOwnerProperties,
+  "GatewayApplicationOwnerProperties",
+  "csharp"
+);
+@@clientName(ApplicationProperties, "GatewayApplicationProperties", "csharp");
+@@clientName(Person, "ApplicationContactPerson", "csharp");
+@@clientName(GeographicAddress, "ApplicationGeographicAddress", "csharp");
+@@clientName(LocalRepresentative, "ApplicationLocalRepresentative", "csharp");
+@@clientName(Category, "ApplicationCategory", "csharp");
+@@clientName(OrganizationType, "ApplicationOwnerOrganizationType", "csharp");
+@@clientName(DataProcessing, "OperatorApiConnectionDataProcessing", "csharp");
+@@clientName(DataRegions, "OperatorApiConnectionDataRegion", "csharp");
+@@clientName(Frequency, "DataProcessingFrequency", "csharp");
+@@clientName(Duration, "DataProcessingDuration", "csharp");
+@@clientName(Context, "DataProcessingContext", "csharp");
+@@clientName(ProcessingOperation, "DataProcessingOperation", "csharp");
+@@clientName(Purpose, "OperatorApiConnectionPurpose", "csharp");
+@@clientName(Status, "OperatorApiConnectionStatus", "csharp");
+@@clientName(
+  MarketplaceProperties,
+  "OperatorApiPlanMarketplaceProperties",
+  "csharp"
+);
+@@clientName(DataRegions.commercialActivity, "IsCommercialActivity", "csharp");
+@@clientName(
+  OperatorApiConnectionProperties.planTermsAndConditionsAccepted,
+  "IsPlanTermsAndConditionsAccepted",
+  "csharp"
 );

--- a/specification/programmableconnectivity/ProgrammableConnectivity.Management/client.tsp
+++ b/specification/programmableconnectivity/ProgrammableConnectivity.Management/client.tsp
@@ -31,7 +31,7 @@ using Microsoft.ProgrammableConnectivity;
 @@clientName(Person, "ApplicationContactPerson", "csharp");
 @@clientName(GeographicAddress, "ApplicationGeographicAddress", "csharp");
 @@clientName(LocalRepresentative, "ApplicationLocalRepresentative", "csharp");
-@@clientName(Category, "ApplicationCategory", "csharp");
+@@clientName(Category, "ProgrammableConnectivityApplicationCategory", "csharp");
 @@clientName(OrganizationType, "ApplicationOwnerOrganizationType", "csharp");
 @@clientName(DataProcessing, "OperatorApiConnectionDataProcessing", "csharp");
 @@clientName(DataRegions, "OperatorApiConnectionDataRegion", "csharp");
@@ -41,6 +41,11 @@ using Microsoft.ProgrammableConnectivity;
 @@clientName(ProcessingOperation, "DataProcessingOperation", "csharp");
 @@clientName(Purpose, "OperatorApiConnectionPurpose", "csharp");
 @@clientName(Status, "OperatorApiConnectionStatus", "csharp");
+@@clientName(
+  ProvisioningState,
+  "ProgrammableConnectivityProvisioningState",
+  "csharp"
+);
 @@clientName(
   MarketplaceProperties,
   "OperatorApiPlanMarketplaceProperties",


### PR DESCRIPTION
## Summary

- add C#-scoped names for the Programmable Connectivity management SDK
- add contextual names for generic resource and model types
- apply .NET Boolean property naming conventions

## Validation

- `tsp format client.tsp`
- `tsp compile .`
- confirmed no generated Swagger changes

SDK package: `Azure.ResourceManager.ProgrammableConnectivity`

Namespace approval: Azure/azure-sdk#8715