### PR TITLE
ContainerService: fix .NET NIC acronym casing

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/client.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/client.tsp
@@ -67,6 +67,16 @@ using Microsoft.ContainerService;
   "csharp"
 );
 @@clientName(DRANETMode, "DranetMode", "csharp");
+@@clientName(
+  AgentPoolNICPublicIPAddressConfiguration,
+  "AgentPoolNicPublicIPAddressConfiguration",
+  "csharp"
+);
+@@clientName(
+  AgentPoolNICPublicIPAddressVersion,
+  "AgentPoolNicPublicIPAddressVersion",
+  "csharp"
+);
 
 // Java specific renaming for backward compatibility
 @@clientName(


### PR DESCRIPTION
## Summary

- add C# client names for `AgentPoolNICPublicIPAddressConfiguration` and `AgentPoolNICPublicIPAddressVersion`
- use PascalCase `Nic` in the generated .NET surface without changing the wire/API names or other SDK languages
- address ACRONYM001 feedback on Azure/azure-sdk-for-net#62589

## Validation

- `tsp format -c specification/containerservice/resource-manager/Microsoft.ContainerService/aks/client.tsp`
- `tsp compile specification/containerservice/resource-manager/Microsoft.ContainerService/aks --no-emit --warn-as-error`