### PR TITLE
Preserve Java names for Realtime MCP models

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/src/sdk-java-azure-ai-agents/client.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/sdk-java-azure-ai-agents/client.tsp
@@ -98,6 +98,31 @@ using Azure.AI.Projects;
 @@clientName(OpenAI.MCPToolRequireApproval, "McpToolRequireApproval");
 @@clientName(MCPToolboxTool, "McpToolboxTool");
 
+@@clientName(
+  OpenAI.RealtimeMCPApprovalRequest,
+  "RealtimeMcpApprovalRequest",
+  "java"
+);
+@@clientName(
+  OpenAI.RealtimeMCPApprovalResponse,
+  "RealtimeMcpApprovalResponse",
+  "java"
+);
+@@clientName(OpenAI.RealtimeMCPError, "RealtimeMcpError", "java");
+@@clientName(OpenAI.RealtimeMCPHTTPError, "RealtimeMcpHttpError", "java");
+@@clientName(OpenAI.RealtimeMCPListTools, "RealtimeMcpListTools", "java");
+@@clientName(
+  OpenAI.RealtimeMCPProtocolError,
+  "RealtimeMcpProtocolError",
+  "java"
+);
+@@clientName(OpenAI.RealtimeMCPToolCall, "RealtimeMcpToolCall", "java");
+@@clientName(
+  OpenAI.RealtimeMCPToolExecutionError,
+  "RealtimeMcpToolExecutionError",
+  "java"
+);
+
 @@clientName(MemorySearchPreviewTool.update_delay, "updateDelaySeconds");
 
 @@clientName(AgentObject.blueprint, "blueprintIdentity");


### PR DESCRIPTION
## Summary

- Add Java-scoped client names for eight OpenAI Realtime MCP models.
- Use Azure Java SDK acronym casing (`Mcp` and `Http`) in the generated public type names.
- Keep the TypeSpec wire contract and all non-Java language names unchanged.

## Validation

- Generated `azure-ai-agents` from `feature/foundry-release` with `@azure-tools/openai-typespec` 1.25.0, `@azure-tools/typespec-java` 0.46.1, and tsp-client 0.33.1.
- Verified all eight generated Java models and their references consistently use `RealtimeMcp*` names.
- Verified repeated generation converges deterministically; the second and third outputs were byte-identical across all 200 generated files.
- The compile and determinism run also included a separate local scope workaround for the nested Realtime message discriminator issue described below. That workaround is not part of this PR; the eight naming decorators themselves were independently verified in the generated output.

## Related codegen issue

Nested Realtime message discriminator generation currently requires a separate workaround and is tracked in microsoft/typespec#11802. That workaround is intentionally excluded from this PR so this change remains limited to the validated Java naming customizations.