### PR TITLE
Add C# provisioning emitter configuration for Private DNS

### DIFF
--- a/specification/privatedns/resource-manager/Microsoft.Network/PrivateDns/tspconfig.yaml
+++ b/specification/privatedns/resource-manager/Microsoft.Network/PrivateDns/tspconfig.yaml
@@ -49,6 +49,10 @@ options:
     model-namespace: true
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
     enable-wire-path-attribute: true
+  "@azure-typespec/http-client-csharp-provisioning":
+    namespace: "Azure.Provisioning.PrivateDns"
+    emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
+    api-version: "2024-06-01"
 linter:
   extends:
     - "@azure-tools/typespec-azure-rulesets/resource-manager"


### PR DESCRIPTION
## Summary

- Configure `@azure-typespec/http-client-csharp-provisioning` for Private DNS.
- Generate `Azure.Provisioning.PrivateDns` under `sdk/privatedns`.
- Pin provisioning generation to the stable `2024-06-01` API version.
- Preserve the existing management emitter and C# record-type resource expansion configuration.

## Validation

- `npm exec --no -- tsv specification\privatedns\resource-manager\Microsoft.Network\PrivateDns`
- TypeSpec validation against `origin/main...HEAD`, including compile, format, SDK tspconfig validation, and API-version pin checks.