### PR TITLE
Pin AppContainers C# management API version

### DIFF
--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/tspconfig.yaml
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/tspconfig.yaml
@@ -50,6 +50,7 @@ options:
   "@azure-typespec/http-client-csharp-mgmt":
     emitter-output-dir: "{output-dir}/sdk/containerapps/Azure.ResourceManager.AppContainers"
     namespace: "Azure.ResourceManager.AppContainers"
+    api-version: "2025-10-02-preview"
     enable-wire-path-attribute: true
 linter:
   extends:


### PR DESCRIPTION
## Summary

Pin the AppContainers C# management emitter to \2025-10-02-preview\.

This prevents the newly introduced \2026-01-01\ service API version and its shared TypeSpec changes from altering the current .NET management SDK public API.