### PR TITLE
[CodeTransparency] Correct /jwks public verification-key contract

### DIFF
--- a/specification/confidentialledger/Microsoft.CodeTransparency/client.tsp
+++ b/specification/confidentialledger/Microsoft.CodeTransparency/client.tsp
@@ -20,3 +20,19 @@ using Azure.ClientGenerator.Core;
   string,
   "javascript"
 );
+
+@@access(
+  Microsoft.CodeTransparency.GetPublicKeysResponse,
+  Access.internal,
+  "csharp"
+);
+@@access(Microsoft.CodeTransparency.JsonWebKeySet, Access.internal, "csharp");
+@@access(
+  Microsoft.CodeTransparency.PublicJsonWebKey,
+  Access.internal,
+  "csharp"
+);
+
+@@convenientAPI(Microsoft.CodeTransparency.getPublicKeys, false, "csharp");
+@@convenientAPI(Microsoft.CodeTransparency.listScittKeys, false, "csharp");
+@@convenientAPI(Microsoft.CodeTransparency.getScittKey, false, "csharp");

--- a/specification/confidentialledger/Microsoft.CodeTransparency/client.tsp
+++ b/specification/confidentialledger/Microsoft.CodeTransparency/client.tsp
@@ -33,6 +33,6 @@ using Azure.ClientGenerator.Core;
   "csharp"
 );
 
-@@convenientAPI(Microsoft.CodeTransparency.getPublicKeys, false, "csharp");
+@@convenientAPI(Microsoft.CodeTransparency.getPublicKeysV09, false, "csharp");
 @@convenientAPI(Microsoft.CodeTransparency.listScittKeys, false, "csharp");
 @@convenientAPI(Microsoft.CodeTransparency.getScittKey, false, "csharp");

--- a/specification/confidentialledger/Microsoft.CodeTransparency/examples/2025-01-31-preview/GetPublicKeys.json
+++ b/specification/confidentialledger/Microsoft.CodeTransparency/examples/2025-01-31-preview/GetPublicKeys.json
@@ -12,13 +12,25 @@
       "body": {
         "keys": [
           {
-            "alg": "ES256",
-            "crv": "P-256",
-            "kid": "service-signing-key-1",
-            "kty": "EC",
-            "use": "sig",
-            "x": "f83OJ3D2xF4WfPZrQFbnjKJvBf7vY5H5XzX7Q2x4g4A",
-            "y": "x_FEzRu9m36HLNFY2R9w7q7lW11Q9Lq6X5AU2E8YbV0"
+            "alg": "ismwdpkyzdpcdsxlhdrcyu",
+            "crv": "krvghelqczlomlykmvq",
+            "d": "sjrntenzgpayzxqeyylodzzot",
+            "dp": "okaildkxkhdiuz",
+            "dq": "cr",
+            "e": "whulawpi",
+            "k": "umuebehxryklpmphgvfflgxhmw",
+            "kid": "sjvhzuxmiidkyt",
+            "kty": "aleunvywecrqn",
+            "n": "agbjjczwjkuzidwazv",
+            "p": "mwqnfqougntmfkkqrhwfawqdfvc",
+            "q": "ihgggpjpvqrugoctea",
+            "qi": "hauoxhsdatbqpwyjy",
+            "use": "sobsnevfheiclufbfronhqufiry",
+            "x": "jiifvniadtvfdosxgtdgju",
+            "x5c": [
+              "bpqymrr"
+            ],
+            "y": "owpcmhs"
           }
         ]
       }

--- a/specification/confidentialledger/Microsoft.CodeTransparency/examples/2025-01-31-preview/GetPublicKeys.json
+++ b/specification/confidentialledger/Microsoft.CodeTransparency/examples/2025-01-31-preview/GetPublicKeys.json
@@ -12,25 +12,13 @@
       "body": {
         "keys": [
           {
-            "alg": "ismwdpkyzdpcdsxlhdrcyu",
-            "crv": "krvghelqczlomlykmvq",
-            "d": "sjrntenzgpayzxqeyylodzzot",
-            "dp": "okaildkxkhdiuz",
-            "dq": "cr",
-            "e": "whulawpi",
-            "k": "umuebehxryklpmphgvfflgxhmw",
-            "kid": "sjvhzuxmiidkyt",
-            "kty": "aleunvywecrqn",
-            "n": "agbjjczwjkuzidwazv",
-            "p": "mwqnfqougntmfkkqrhwfawqdfvc",
-            "q": "ihgggpjpvqrugoctea",
-            "qi": "hauoxhsdatbqpwyjy",
-            "use": "sobsnevfheiclufbfronhqufiry",
-            "x": "jiifvniadtvfdosxgtdgju",
-            "x5c": [
-              "bpqymrr"
-            ],
-            "y": "owpcmhs"
+            "alg": "ES256",
+            "crv": "P-256",
+            "kid": "service-signing-key-1",
+            "kty": "EC",
+            "use": "sig",
+            "x": "f83OJ3D2xF4WfPZrQFbnjKJvBf7vY5H5XzX7Q2x4g4A",
+            "y": "x_FEzRu9m36HLNFY2R9w7q7lW11Q9Lq6X5AU2E8YbV0"
           }
         ]
       }

--- a/specification/confidentialledger/Microsoft.CodeTransparency/examples/2026-03-26/GetPublicKeys.json
+++ b/specification/confidentialledger/Microsoft.CodeTransparency/examples/2026-03-26/GetPublicKeys.json
@@ -12,25 +12,13 @@
       "body": {
         "keys": [
           {
-            "alg": "ismwdpkyzdpcdsxlhdrcyu",
-            "crv": "krvghelqczlomlykmvq",
-            "d": "sjrntenzgpayzxqeyylodzzot",
-            "dp": "okaildkxkhdiuz",
-            "dq": "cr",
-            "e": "whulawpi",
-            "k": "umuebehxryklpmphgvfflgxhmw",
-            "kid": "sjvhzuxmiidkyt",
-            "kty": "aleunvywecrqn",
-            "n": "agbjjczwjkuzidwazv",
-            "p": "mwqnfqougntmfkkqrhwfawqdfvc",
-            "q": "ihgggpjpvqrugoctea",
-            "qi": "hauoxhsdatbqpwyjy",
-            "use": "sobsnevfheiclufbfronhqufiry",
-            "x": "jiifvniadtvfdosxgtdgju",
-            "x5c": [
-              "bpqymrr"
-            ],
-            "y": "owpcmhs"
+            "alg": "ES256",
+            "crv": "P-256",
+            "kid": "service-signing-key-1",
+            "kty": "EC",
+            "use": "sig",
+            "x": "f83OJ3D2xF4WfPZrQFbnjKJvBf7vY5H5XzX7Q2x4g4A",
+            "y": "x_FEzRu9m36HLNFY2R9w7q7lW11Q9Lq6X5AU2E8YbV0"
           }
         ]
       }

--- a/specification/confidentialledger/Microsoft.CodeTransparency/main.tsp
+++ b/specification/confidentialledger/Microsoft.CodeTransparency/main.tsp
@@ -58,7 +58,7 @@ op getTransparencyConfigCbor is Foundations.Operation<
 @route("/jwks")
 op getPublicKeys is Foundations.Operation<
   {},
-  JwksDocument,
+  GetPublicKeysResponse,
   ServiceTraits,
   AnyCborError
 >;
@@ -509,70 +509,68 @@ model TransparencyConfigurationCbor {
   body: bytes;
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Wire model is C#-internal and normalized to public verification key types; the suffix does not surface in the public API."
 @added(Versions.`2025-01-31-preview`)
-@doc("A JWKS like document")
-model JwksDocument {
-  @doc("Content type header")
-  @header
+@doc("Response containing the service public keys used to verify receipts.")
+model GetPublicKeysResponse {
+  @doc("The response content type.")
+  @header("Content-Type")
   contentType: "application/json";
 
-  @doc("List of public keys used for receipt verification.")
-  keys: JsonWebKey[];
+  @doc("The JSON Web Key Set response body.")
+  @body
+  body: JsonWebKeySet;
 }
 
-#suppress "@azure-tools/typespec-azure-core/casing-style" "Property names follow RFC 7517 (JSON Web Key) and cannot be changed to Azure camelCase."
-@doc("rfc7517 JSON Web Key representation adapted from a shared swagger definition in the common types")
-model JsonWebKey {
-  @doc("The \"alg\" (algorithm) parameter identifies the algorithm intended for\nuse with the key.  The values used should either be registered in the\nIANA \"JSON Web Signature and Encryption Algorithms\" registry\nestablished by [JWA] or be a value that contains a Collision-\nResistant Name.")
-  alg?: string;
+@added(Versions.`2025-01-31-preview`)
+@doc("A JSON Web Key Set containing service receipt-verification keys.")
+model JsonWebKeySet {
+  @doc("The service public keys used to verify receipts.")
+  keys: PublicJsonWebKey[];
+}
 
-  @doc("The \"crv\" (curve) parameter identifies the curve type")
-  crv?: string;
+@added(Versions.`2025-01-31-preview`)
+@doc("A public asymmetric key represented as an RFC 7517 JSON Web Key.")
+model PublicJsonWebKey {
+  @doc("The asymmetric key type, such as EC, RSA, or OKP.")
+  @encodedName("application/json", "kty")
+  keyType: string;
 
-  @doc("RSA private exponent or ECC private key")
-  d?: string;
+  @doc("The case-sensitive key ID.")
+  @encodedName("application/json", "kid")
+  keyId: string;
 
-  @doc("RSA Private Key Parameter")
-  dp?: string;
+  @doc("The algorithm intended for use with the key.")
+  @encodedName("application/json", "alg")
+  algorithm?: string;
 
-  @doc("RSA Private Key Parameter")
-  dq?: string;
+  @doc("The intended public-key use, such as signature verification.")
+  @encodedName("application/json", "use")
+  publicKeyUse?: string;
 
-  @doc("RSA public exponent, in Base64")
-  e?: string;
+  @doc("The named curve for EC or OKP keys.")
+  @encodedName("application/json", "crv")
+  curveName?: string;
 
-  @doc("Symmetric key")
-  k?: string;
+  @doc("The base64url-encoded X coordinate for EC keys, or public key for OKP keys.")
+  @encodedName("application/json", "x")
+  xCoordinate?: string;
 
-  @doc("The \"kid\" (key ID) parameter is used to match a specific key.  This\nis used, for instance, to choose among a set of keys within a JWK Set\nduring key rollover.  The structure of the \"kid\" value is\nunspecified.  When \"kid\" values are used within a JWK Set, different\nkeys within the JWK Set SHOULD use distinct \"kid\" values.  (One\nexample in which different keys might use the same \"kid\" value is if\nthey have different \"kty\" (key type) values but are considered to be\nequivalent alternatives by the application using them.)  The \"kid\"\nvalue is a case-sensitive string.")
-  kid?: string;
+  @doc("The base64url-encoded Y coordinate for EC keys.")
+  @encodedName("application/json", "y")
+  yCoordinate?: string;
 
-  @doc("The \"kty\" (key type) parameter identifies the cryptographic algorithm\nfamily used with the key, such as \"RSA\" or \"EC\". \"kty\" values should\neither be registered in the IANA \"JSON Web Key Types\" registry\nestablished by [JWA] or be a value that contains a Collision-\nResistant Name.  The \"kty\" value is a case-sensitive string.")
-  kty: string;
+  @doc("The base64url-encoded modulus for RSA keys.")
+  @encodedName("application/json", "n")
+  modulus?: string;
 
-  @doc("RSA modulus, in Base64")
-  n?: string;
+  @doc("The base64url-encoded exponent for RSA keys.")
+  @encodedName("application/json", "e")
+  exponent?: string;
 
-  @doc("RSA secret prime")
-  p?: string;
-
-  @doc("RSA secret prime, with p < q")
-  q?: string;
-
-  @doc("RSA Private Key Parameter")
-  qi?: string;
-
-  @doc("Use (\"public key use\") identifies the intended use of\nthe public key. The \"use\" parameter is employed to indicate whether\na public key is used for encrypting data or verifying the signature\non data. Values are commonly \"sig\" (signature) or \"enc\" (encryption).")
-  use?: string;
-
-  @doc("X coordinate for the Elliptic Curve point")
-  x?: string;
-
-  @doc("The \"x5c\" (X.509 certificate chain) parameter contains a chain of one\nor more PKIX certificates [RFC5280].  The certificate chain is\nrepresented as a JSON array of certificate value strings.  Each\nstring in the array is a base64-encoded (Section 4 of [RFC4648] --\nnot base64url-encoded) DER [ITU.X690.1994] PKIX certificate value.\nThe PKIX certificate containing the key value MUST be the first\ncertificate.")
-  x5c?: Array<string>;
-
-  @doc("Y coordinate for the Elliptic Curve point")
-  y?: string;
+  @doc("The base64-encoded X.509 certificate chain.")
+  @encodedName("application/json", "x5c")
+  certificateChain?: string[];
 }
 
 // -----------------------------------------------------------------

--- a/specification/confidentialledger/Microsoft.CodeTransparency/main.tsp
+++ b/specification/confidentialledger/Microsoft.CodeTransparency/main.tsp
@@ -54,9 +54,26 @@ op getTransparencyConfigCbor is Foundations.Operation<
 #suppress "@azure-tools/typespec-azure-core/response-schema-problem" "cannot assign error to directive to cbor binary responses"
 #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "IETF SCITT/SCRAPI operation exchanges raw COSE/CBOR binary payloads and does not map to Azure.Core standard resource operations."
 @added(Versions.`2025-01-31-preview`)
+@removed(Versions.`2026-03-26`)
+@sharedRoute
 @doc("Get the public keys used by the service to sign receipts, mentioned in IETF SCITT draft as part of jwks_uri implementation")
 @route("/jwks")
 op getPublicKeys is Foundations.Operation<
+  {},
+  JwksDocument,
+  ServiceTraits,
+  AnyCborError
+>;
+
+#suppress "@azure-tools/typespec-azure-core/response-schema-problem" "cannot assign error to directive to cbor binary responses"
+#suppress "@azure-tools/typespec-azure-core/use-standard-operations" "IETF SCITT/SCRAPI operation exchanges raw COSE/CBOR binary payloads and does not map to Azure.Core standard resource operations."
+#suppress "@azure-tools/typespec-azure-core/no-openapi" "Preserving canonical GetPublicKeys operationId across versions"
+@added(Versions.`2026-03-26`)
+@operationId("GetPublicKeys")
+@sharedRoute
+@doc("Get the public keys used by the service to sign receipts, mentioned in IETF SCITT draft as part of jwks_uri implementation")
+@route("/jwks")
+op getPublicKeysV09 is Foundations.Operation<
   {},
   GetPublicKeysResponse,
   ServiceTraits,
@@ -509,8 +526,77 @@ model TransparencyConfigurationCbor {
   body: bytes;
 }
 
-#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Wire model is C#-internal and normalized to public verification key types; the suffix does not surface in the public API."
 @added(Versions.`2025-01-31-preview`)
+@removed(Versions.`2026-03-26`)
+@doc("A JWKS like document")
+model JwksDocument {
+  @doc("Content type header")
+  @header
+  contentType: "application/json";
+
+  @doc("List of public keys used for receipt verification.")
+  keys: JsonWebKey[];
+}
+
+#suppress "@azure-tools/typespec-azure-core/casing-style" "Property names follow RFC 7517 (JSON Web Key) and cannot be changed to Azure camelCase."
+@added(Versions.`2025-01-31-preview`)
+@removed(Versions.`2026-03-26`)
+@doc("rfc7517 JSON Web Key representation adapted from a shared swagger definition in the common types")
+model JsonWebKey {
+  @doc("The \"alg\" (algorithm) parameter identifies the algorithm intended for\nuse with the key.  The values used should either be registered in the\nIANA \"JSON Web Signature and Encryption Algorithms\" registry\nestablished by [JWA] or be a value that contains a Collision-\nResistant Name.")
+  alg?: string;
+
+  @doc("The \"crv\" (curve) parameter identifies the curve type")
+  crv?: string;
+
+  @doc("RSA private exponent or ECC private key")
+  d?: string;
+
+  @doc("RSA Private Key Parameter")
+  dp?: string;
+
+  @doc("RSA Private Key Parameter")
+  dq?: string;
+
+  @doc("RSA public exponent, in Base64")
+  e?: string;
+
+  @doc("Symmetric key")
+  k?: string;
+
+  @doc("The \"kid\" (key ID) parameter is used to match a specific key.  This\nis used, for instance, to choose among a set of keys within a JWK Set\nduring key rollover.  The structure of the \"kid\" value is\nunspecified.  When \"kid\" values are used within a JWK Set, different\nkeys within the JWK Set SHOULD use distinct \"kid\" values.  (One\nexample in which different keys might use the same \"kid\" value is if\nthey have different \"kty\" (key type) values but are considered to be\nequivalent alternatives by the application using them.)  The \"kid\"\nvalue is a case-sensitive string.")
+  kid?: string;
+
+  @doc("The \"kty\" (key type) parameter identifies the cryptographic algorithm\nfamily used with the key, such as \"RSA\" or \"EC\". \"kty\" values should\neither be registered in the IANA \"JSON Web Key Types\" registry\nestablished by [JWA] or be a value that contains a Collision-\nResistant Name.  The \"kty\" value is a case-sensitive string.")
+  kty: string;
+
+  @doc("RSA modulus, in Base64")
+  n?: string;
+
+  @doc("RSA secret prime")
+  p?: string;
+
+  @doc("RSA secret prime, with p < q")
+  q?: string;
+
+  @doc("RSA Private Key Parameter")
+  qi?: string;
+
+  @doc("Use (\"public key use\") identifies the intended use of\nthe public key. The \"use\" parameter is employed to indicate whether\na public key is used for encrypting data or verifying the signature\non data. Values are commonly \"sig\" (signature) or \"enc\" (encryption).")
+  use?: string;
+
+  @doc("X coordinate for the Elliptic Curve point")
+  x?: string;
+
+  @doc("The \"x5c\" (X.509 certificate chain) parameter contains a chain of one\nor more PKIX certificates [RFC5280].  The certificate chain is\nrepresented as a JSON array of certificate value strings.  Each\nstring in the array is a base64-encoded (Section 4 of [RFC4648] --\nnot base64url-encoded) DER [ITU.X690.1994] PKIX certificate value.\nThe PKIX certificate containing the key value MUST be the first\ncertificate.")
+  x5c?: Array<string>;
+
+  @doc("Y coordinate for the Elliptic Curve point")
+  y?: string;
+}
+
+#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Wire model is C#-internal and normalized to public verification key types; the suffix does not surface in the public API."
+@added(Versions.`2026-03-26`)
 @doc("Response containing the service public keys used to verify receipts.")
 model GetPublicKeysResponse {
   @doc("The response content type.")
@@ -522,14 +608,14 @@ model GetPublicKeysResponse {
   body: JsonWebKeySet;
 }
 
-@added(Versions.`2025-01-31-preview`)
+@added(Versions.`2026-03-26`)
 @doc("A JSON Web Key Set containing service receipt-verification keys.")
 model JsonWebKeySet {
   @doc("The service public keys used to verify receipts.")
   keys: PublicJsonWebKey[];
 }
 
-@added(Versions.`2025-01-31-preview`)
+@added(Versions.`2026-03-26`)
 @doc("A public asymmetric key represented as an RFC 7517 JSON Web Key.")
 model PublicJsonWebKey {
   @doc("The asymmetric key type, such as EC, RSA, or OKP.")

--- a/specification/confidentialledger/Microsoft.CodeTransparency/suppressions.yaml
+++ b/specification/confidentialledger/Microsoft.CodeTransparency/suppressions.yaml
@@ -4,17 +4,16 @@
   rules:
     - SdkTspConfigValidation
   sub-rules:
-    # JS SDK generation is intentionally not configured for the Code Transparency
-    # Service: the product does not ship a JavaScript SDK. The @azure-tools/typespec-ts
-    # emitter block has been removed from tspconfig.yaml, so options under
-    # options.@azure-tools/typespec-ts.* are intentionally absent.
+    # JS and Python SDK generation are intentionally not configured for the Code
+    # Transparency Service. Their emitter blocks have been removed from
+    # tspconfig.yaml, so their emitter options are intentionally absent.
     - options.@azure-tools/typespec-ts.*
+    - options.@azure-tools/typespec-python.*
   reason: >
-    Code Transparency Service does not require a JavaScript SDK. The
-    @azure-tools/typespec-ts emitter block is intentionally omitted from
-    tspconfig.yaml, so SdkTspConfigValidation sub-rules that require its
-    options to be present do not apply. JS SDK generation is blocked by an
-    upstream emitter bug that leaks NodeJS.ReadableStream into browser
-    builds; tracked at https://github.com/Azure/autorest.typescript/issues/3990.
-    Once that issue is resolved and rolled into the spec-gen-sdk pipeline,
-    JS SDK generation can be re-enabled and this suppression removed.
+    Code Transparency Service does not ship JavaScript or Python SDKs. Their
+    emitter blocks are intentionally omitted from tspconfig.yaml, so
+    SdkTspConfigValidation sub-rules that require their options to be present
+    do not apply. JS SDK generation is also blocked by an upstream emitter bug
+    that leaks NodeJS.ReadableStream into browser builds; tracked at
+    https://github.com/Azure/autorest.typescript/issues/3990. The corresponding
+    suppression can be removed if support for either language is added.

--- a/specification/confidentialledger/Microsoft.CodeTransparency/tspconfig.yaml
+++ b/specification/confidentialledger/Microsoft.CodeTransparency/tspconfig.yaml
@@ -11,14 +11,6 @@ options:
     azure-resource-provider-folder: "./data-plane"
     emitter-output-dir: "{project-root}/.."
     output-file: "{azure-resource-provider-folder}/{service-name}/{version-status}/{version}/cts.json"
-  "@azure-tools/typespec-python":
-    flavor: azure
-    emitter-output-dir: "{output-dir}/{service-dir}/azure-codetransparency"
-    namespace: "azure.codetransparency"
-    package-mode: "dataplane"
-    package-pprint-name: "Code Transparency Service"
-    generate-test: true
-    generate-sample: true
   "@azure-typespec/http-client-csharp":
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
     namespace: Azure.Security.CodeTransparency

--- a/specification/confidentialledger/data-plane/Microsoft.CodeTransparency/preview/2025-01-31-preview/cts.json
+++ b/specification/confidentialledger/data-plane/Microsoft.CodeTransparency/preview/2025-01-31-preview/cts.json
@@ -366,9 +366,9 @@
         ],
         "responses": {
           "200": {
-            "description": "Response containing the service public keys used to verify receipts.",
+            "description": "The request has succeeded.",
             "schema": {
-              "$ref": "#/definitions/JsonWebKeySet"
+              "$ref": "#/definitions/JwksDocument"
             }
           },
           "400": {
@@ -551,28 +551,95 @@
         "body"
       ]
     },
-    "GetPublicKeysResponse": {
+    "JsonWebKey": {
       "type": "object",
-      "description": "Response containing the service public keys used to verify receipts.",
+      "description": "rfc7517 JSON Web Key representation adapted from a shared swagger definition in the common types",
       "properties": {
-        "body": {
-          "$ref": "#/definitions/JsonWebKeySet",
-          "description": "The JSON Web Key Set response body."
+        "alg": {
+          "type": "string",
+          "description": "The \"alg\" (algorithm) parameter identifies the algorithm intended for\nuse with the key.  The values used should either be registered in the\nIANA \"JSON Web Signature and Encryption Algorithms\" registry\nestablished by [JWA] or be a value that contains a Collision-\nResistant Name."
+        },
+        "crv": {
+          "type": "string",
+          "description": "The \"crv\" (curve) parameter identifies the curve type"
+        },
+        "d": {
+          "type": "string",
+          "description": "RSA private exponent or ECC private key"
+        },
+        "dp": {
+          "type": "string",
+          "description": "RSA Private Key Parameter"
+        },
+        "dq": {
+          "type": "string",
+          "description": "RSA Private Key Parameter"
+        },
+        "e": {
+          "type": "string",
+          "description": "RSA public exponent, in Base64"
+        },
+        "k": {
+          "type": "string",
+          "description": "Symmetric key"
+        },
+        "kid": {
+          "type": "string",
+          "description": "The \"kid\" (key ID) parameter is used to match a specific key.  This\nis used, for instance, to choose among a set of keys within a JWK Set\nduring key rollover.  The structure of the \"kid\" value is\nunspecified.  When \"kid\" values are used within a JWK Set, different\nkeys within the JWK Set SHOULD use distinct \"kid\" values.  (One\nexample in which different keys might use the same \"kid\" value is if\nthey have different \"kty\" (key type) values but are considered to be\nequivalent alternatives by the application using them.)  The \"kid\"\nvalue is a case-sensitive string."
+        },
+        "kty": {
+          "type": "string",
+          "description": "The \"kty\" (key type) parameter identifies the cryptographic algorithm\nfamily used with the key, such as \"RSA\" or \"EC\". \"kty\" values should\neither be registered in the IANA \"JSON Web Key Types\" registry\nestablished by [JWA] or be a value that contains a Collision-\nResistant Name.  The \"kty\" value is a case-sensitive string."
+        },
+        "n": {
+          "type": "string",
+          "description": "RSA modulus, in Base64"
+        },
+        "p": {
+          "type": "string",
+          "description": "RSA secret prime"
+        },
+        "q": {
+          "type": "string",
+          "description": "RSA secret prime, with p < q"
+        },
+        "qi": {
+          "type": "string",
+          "description": "RSA Private Key Parameter"
+        },
+        "use": {
+          "type": "string",
+          "description": "Use (\"public key use\") identifies the intended use of\nthe public key. The \"use\" parameter is employed to indicate whether\na public key is used for encrypting data or verifying the signature\non data. Values are commonly \"sig\" (signature) or \"enc\" (encryption)."
+        },
+        "x": {
+          "type": "string",
+          "description": "X coordinate for the Elliptic Curve point"
+        },
+        "x5c": {
+          "type": "array",
+          "description": "The \"x5c\" (X.509 certificate chain) parameter contains a chain of one\nor more PKIX certificates [RFC5280].  The certificate chain is\nrepresented as a JSON array of certificate value strings.  Each\nstring in the array is a base64-encoded (Section 4 of [RFC4648] --\nnot base64url-encoded) DER [ITU.X690.1994] PKIX certificate value.\nThe PKIX certificate containing the key value MUST be the first\ncertificate.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "y": {
+          "type": "string",
+          "description": "Y coordinate for the Elliptic Curve point"
         }
       },
       "required": [
-        "body"
+        "kty"
       ]
     },
-    "JsonWebKeySet": {
+    "JwksDocument": {
       "type": "object",
-      "description": "A JSON Web Key Set containing service receipt-verification keys.",
+      "description": "A JWKS like document",
       "properties": {
         "keys": {
           "type": "array",
-          "description": "The service public keys used to verify receipts.",
+          "description": "List of public keys used for receipt verification.",
           "items": {
-            "$ref": "#/definitions/PublicJsonWebKey"
+            "$ref": "#/definitions/JsonWebKey"
           }
         }
       },
@@ -597,69 +664,6 @@
     "OperationStatusPending": {
       "type": "object",
       "description": "Pending response if the operation was not complete, mandatory in IETF SCITT draft"
-    },
-    "PublicJsonWebKey": {
-      "type": "object",
-      "description": "A public asymmetric key represented as an RFC 7517 JSON Web Key.",
-      "properties": {
-        "kty": {
-          "type": "string",
-          "description": "The asymmetric key type, such as EC, RSA, or OKP.",
-          "x-ms-client-name": "keyType"
-        },
-        "kid": {
-          "type": "string",
-          "description": "The case-sensitive key ID.",
-          "x-ms-client-name": "keyId"
-        },
-        "alg": {
-          "type": "string",
-          "description": "The algorithm intended for use with the key.",
-          "x-ms-client-name": "algorithm"
-        },
-        "use": {
-          "type": "string",
-          "description": "The intended public-key use, such as signature verification.",
-          "x-ms-client-name": "publicKeyUse"
-        },
-        "crv": {
-          "type": "string",
-          "description": "The named curve for EC or OKP keys.",
-          "x-ms-client-name": "curveName"
-        },
-        "x": {
-          "type": "string",
-          "description": "The base64url-encoded X coordinate for EC keys, or public key for OKP keys.",
-          "x-ms-client-name": "xCoordinate"
-        },
-        "y": {
-          "type": "string",
-          "description": "The base64url-encoded Y coordinate for EC keys.",
-          "x-ms-client-name": "yCoordinate"
-        },
-        "n": {
-          "type": "string",
-          "description": "The base64url-encoded modulus for RSA keys.",
-          "x-ms-client-name": "modulus"
-        },
-        "e": {
-          "type": "string",
-          "description": "The base64url-encoded exponent for RSA keys.",
-          "x-ms-client-name": "exponent"
-        },
-        "x5c": {
-          "type": "array",
-          "description": "The base64-encoded X.509 certificate chain.",
-          "items": {
-            "type": "string"
-          },
-          "x-ms-client-name": "certificateChain"
-        }
-      },
-      "required": [
-        "kty",
-        "kid"
-      ]
     },
     "ReceiptEntry": {
       "type": "object",

--- a/specification/confidentialledger/data-plane/Microsoft.CodeTransparency/preview/2025-01-31-preview/cts.json
+++ b/specification/confidentialledger/data-plane/Microsoft.CodeTransparency/preview/2025-01-31-preview/cts.json
@@ -366,9 +366,9 @@
         ],
         "responses": {
           "200": {
-            "description": "The request has succeeded.",
+            "description": "Response containing the service public keys used to verify receipts.",
             "schema": {
-              "$ref": "#/definitions/JwksDocument"
+              "$ref": "#/definitions/JsonWebKeySet"
             }
           },
           "400": {
@@ -551,95 +551,28 @@
         "body"
       ]
     },
-    "JsonWebKey": {
+    "GetPublicKeysResponse": {
       "type": "object",
-      "description": "rfc7517 JSON Web Key representation adapted from a shared swagger definition in the common types",
+      "description": "Response containing the service public keys used to verify receipts.",
       "properties": {
-        "alg": {
-          "type": "string",
-          "description": "The \"alg\" (algorithm) parameter identifies the algorithm intended for\nuse with the key.  The values used should either be registered in the\nIANA \"JSON Web Signature and Encryption Algorithms\" registry\nestablished by [JWA] or be a value that contains a Collision-\nResistant Name."
-        },
-        "crv": {
-          "type": "string",
-          "description": "The \"crv\" (curve) parameter identifies the curve type"
-        },
-        "d": {
-          "type": "string",
-          "description": "RSA private exponent or ECC private key"
-        },
-        "dp": {
-          "type": "string",
-          "description": "RSA Private Key Parameter"
-        },
-        "dq": {
-          "type": "string",
-          "description": "RSA Private Key Parameter"
-        },
-        "e": {
-          "type": "string",
-          "description": "RSA public exponent, in Base64"
-        },
-        "k": {
-          "type": "string",
-          "description": "Symmetric key"
-        },
-        "kid": {
-          "type": "string",
-          "description": "The \"kid\" (key ID) parameter is used to match a specific key.  This\nis used, for instance, to choose among a set of keys within a JWK Set\nduring key rollover.  The structure of the \"kid\" value is\nunspecified.  When \"kid\" values are used within a JWK Set, different\nkeys within the JWK Set SHOULD use distinct \"kid\" values.  (One\nexample in which different keys might use the same \"kid\" value is if\nthey have different \"kty\" (key type) values but are considered to be\nequivalent alternatives by the application using them.)  The \"kid\"\nvalue is a case-sensitive string."
-        },
-        "kty": {
-          "type": "string",
-          "description": "The \"kty\" (key type) parameter identifies the cryptographic algorithm\nfamily used with the key, such as \"RSA\" or \"EC\". \"kty\" values should\neither be registered in the IANA \"JSON Web Key Types\" registry\nestablished by [JWA] or be a value that contains a Collision-\nResistant Name.  The \"kty\" value is a case-sensitive string."
-        },
-        "n": {
-          "type": "string",
-          "description": "RSA modulus, in Base64"
-        },
-        "p": {
-          "type": "string",
-          "description": "RSA secret prime"
-        },
-        "q": {
-          "type": "string",
-          "description": "RSA secret prime, with p < q"
-        },
-        "qi": {
-          "type": "string",
-          "description": "RSA Private Key Parameter"
-        },
-        "use": {
-          "type": "string",
-          "description": "Use (\"public key use\") identifies the intended use of\nthe public key. The \"use\" parameter is employed to indicate whether\na public key is used for encrypting data or verifying the signature\non data. Values are commonly \"sig\" (signature) or \"enc\" (encryption)."
-        },
-        "x": {
-          "type": "string",
-          "description": "X coordinate for the Elliptic Curve point"
-        },
-        "x5c": {
-          "type": "array",
-          "description": "The \"x5c\" (X.509 certificate chain) parameter contains a chain of one\nor more PKIX certificates [RFC5280].  The certificate chain is\nrepresented as a JSON array of certificate value strings.  Each\nstring in the array is a base64-encoded (Section 4 of [RFC4648] --\nnot base64url-encoded) DER [ITU.X690.1994] PKIX certificate value.\nThe PKIX certificate containing the key value MUST be the first\ncertificate.",
-          "items": {
-            "type": "string"
-          }
-        },
-        "y": {
-          "type": "string",
-          "description": "Y coordinate for the Elliptic Curve point"
+        "body": {
+          "$ref": "#/definitions/JsonWebKeySet",
+          "description": "The JSON Web Key Set response body."
         }
       },
       "required": [
-        "kty"
+        "body"
       ]
     },
-    "JwksDocument": {
+    "JsonWebKeySet": {
       "type": "object",
-      "description": "A JWKS like document",
+      "description": "A JSON Web Key Set containing service receipt-verification keys.",
       "properties": {
         "keys": {
           "type": "array",
-          "description": "List of public keys used for receipt verification.",
+          "description": "The service public keys used to verify receipts.",
           "items": {
-            "$ref": "#/definitions/JsonWebKey"
+            "$ref": "#/definitions/PublicJsonWebKey"
           }
         }
       },
@@ -664,6 +597,69 @@
     "OperationStatusPending": {
       "type": "object",
       "description": "Pending response if the operation was not complete, mandatory in IETF SCITT draft"
+    },
+    "PublicJsonWebKey": {
+      "type": "object",
+      "description": "A public asymmetric key represented as an RFC 7517 JSON Web Key.",
+      "properties": {
+        "kty": {
+          "type": "string",
+          "description": "The asymmetric key type, such as EC, RSA, or OKP.",
+          "x-ms-client-name": "keyType"
+        },
+        "kid": {
+          "type": "string",
+          "description": "The case-sensitive key ID.",
+          "x-ms-client-name": "keyId"
+        },
+        "alg": {
+          "type": "string",
+          "description": "The algorithm intended for use with the key.",
+          "x-ms-client-name": "algorithm"
+        },
+        "use": {
+          "type": "string",
+          "description": "The intended public-key use, such as signature verification.",
+          "x-ms-client-name": "publicKeyUse"
+        },
+        "crv": {
+          "type": "string",
+          "description": "The named curve for EC or OKP keys.",
+          "x-ms-client-name": "curveName"
+        },
+        "x": {
+          "type": "string",
+          "description": "The base64url-encoded X coordinate for EC keys, or public key for OKP keys.",
+          "x-ms-client-name": "xCoordinate"
+        },
+        "y": {
+          "type": "string",
+          "description": "The base64url-encoded Y coordinate for EC keys.",
+          "x-ms-client-name": "yCoordinate"
+        },
+        "n": {
+          "type": "string",
+          "description": "The base64url-encoded modulus for RSA keys.",
+          "x-ms-client-name": "modulus"
+        },
+        "e": {
+          "type": "string",
+          "description": "The base64url-encoded exponent for RSA keys.",
+          "x-ms-client-name": "exponent"
+        },
+        "x5c": {
+          "type": "array",
+          "description": "The base64-encoded X.509 certificate chain.",
+          "items": {
+            "type": "string"
+          },
+          "x-ms-client-name": "certificateChain"
+        }
+      },
+      "required": [
+        "kty",
+        "kid"
+      ]
     },
     "ReceiptEntry": {
       "type": "object",

--- a/specification/confidentialledger/data-plane/Microsoft.CodeTransparency/preview/2025-01-31-preview/examples/GetPublicKeys.json
+++ b/specification/confidentialledger/data-plane/Microsoft.CodeTransparency/preview/2025-01-31-preview/examples/GetPublicKeys.json
@@ -12,13 +12,25 @@
       "body": {
         "keys": [
           {
-            "alg": "ES256",
-            "crv": "P-256",
-            "kid": "service-signing-key-1",
-            "kty": "EC",
-            "use": "sig",
-            "x": "f83OJ3D2xF4WfPZrQFbnjKJvBf7vY5H5XzX7Q2x4g4A",
-            "y": "x_FEzRu9m36HLNFY2R9w7q7lW11Q9Lq6X5AU2E8YbV0"
+            "alg": "ismwdpkyzdpcdsxlhdrcyu",
+            "crv": "krvghelqczlomlykmvq",
+            "d": "sjrntenzgpayzxqeyylodzzot",
+            "dp": "okaildkxkhdiuz",
+            "dq": "cr",
+            "e": "whulawpi",
+            "k": "umuebehxryklpmphgvfflgxhmw",
+            "kid": "sjvhzuxmiidkyt",
+            "kty": "aleunvywecrqn",
+            "n": "agbjjczwjkuzidwazv",
+            "p": "mwqnfqougntmfkkqrhwfawqdfvc",
+            "q": "ihgggpjpvqrugoctea",
+            "qi": "hauoxhsdatbqpwyjy",
+            "use": "sobsnevfheiclufbfronhqufiry",
+            "x": "jiifvniadtvfdosxgtdgju",
+            "x5c": [
+              "bpqymrr"
+            ],
+            "y": "owpcmhs"
           }
         ]
       }

--- a/specification/confidentialledger/data-plane/Microsoft.CodeTransparency/preview/2025-01-31-preview/examples/GetPublicKeys.json
+++ b/specification/confidentialledger/data-plane/Microsoft.CodeTransparency/preview/2025-01-31-preview/examples/GetPublicKeys.json
@@ -12,25 +12,13 @@
       "body": {
         "keys": [
           {
-            "alg": "ismwdpkyzdpcdsxlhdrcyu",
-            "crv": "krvghelqczlomlykmvq",
-            "d": "sjrntenzgpayzxqeyylodzzot",
-            "dp": "okaildkxkhdiuz",
-            "dq": "cr",
-            "e": "whulawpi",
-            "k": "umuebehxryklpmphgvfflgxhmw",
-            "kid": "sjvhzuxmiidkyt",
-            "kty": "aleunvywecrqn",
-            "n": "agbjjczwjkuzidwazv",
-            "p": "mwqnfqougntmfkkqrhwfawqdfvc",
-            "q": "ihgggpjpvqrugoctea",
-            "qi": "hauoxhsdatbqpwyjy",
-            "use": "sobsnevfheiclufbfronhqufiry",
-            "x": "jiifvniadtvfdosxgtdgju",
-            "x5c": [
-              "bpqymrr"
-            ],
-            "y": "owpcmhs"
+            "alg": "ES256",
+            "crv": "P-256",
+            "kid": "service-signing-key-1",
+            "kty": "EC",
+            "use": "sig",
+            "x": "f83OJ3D2xF4WfPZrQFbnjKJvBf7vY5H5XzX7Q2x4g4A",
+            "y": "x_FEzRu9m36HLNFY2R9w7q7lW11Q9Lq6X5AU2E8YbV0"
           }
         ]
       }

--- a/specification/confidentialledger/data-plane/Microsoft.CodeTransparency/stable/2026-03-26/cts.json
+++ b/specification/confidentialledger/data-plane/Microsoft.CodeTransparency/stable/2026-03-26/cts.json
@@ -589,9 +589,9 @@
         ],
         "responses": {
           "200": {
-            "description": "The request has succeeded.",
+            "description": "Response containing the service public keys used to verify receipts.",
             "schema": {
-              "$ref": "#/definitions/JwksDocument"
+              "$ref": "#/definitions/JsonWebKeySet"
             }
           },
           "400": {
@@ -783,95 +783,28 @@
       "type": "object",
       "description": "Response for async entry submission in SCRAPI v09, returns 303 See Other with empty body"
     },
-    "JsonWebKey": {
+    "GetPublicKeysResponse": {
       "type": "object",
-      "description": "rfc7517 JSON Web Key representation adapted from a shared swagger definition in the common types",
+      "description": "Response containing the service public keys used to verify receipts.",
       "properties": {
-        "alg": {
-          "type": "string",
-          "description": "The \"alg\" (algorithm) parameter identifies the algorithm intended for\nuse with the key.  The values used should either be registered in the\nIANA \"JSON Web Signature and Encryption Algorithms\" registry\nestablished by [JWA] or be a value that contains a Collision-\nResistant Name."
-        },
-        "crv": {
-          "type": "string",
-          "description": "The \"crv\" (curve) parameter identifies the curve type"
-        },
-        "d": {
-          "type": "string",
-          "description": "RSA private exponent or ECC private key"
-        },
-        "dp": {
-          "type": "string",
-          "description": "RSA Private Key Parameter"
-        },
-        "dq": {
-          "type": "string",
-          "description": "RSA Private Key Parameter"
-        },
-        "e": {
-          "type": "string",
-          "description": "RSA public exponent, in Base64"
-        },
-        "k": {
-          "type": "string",
-          "description": "Symmetric key"
-        },
-        "kid": {
-          "type": "string",
-          "description": "The \"kid\" (key ID) parameter is used to match a specific key.  This\nis used, for instance, to choose among a set of keys within a JWK Set\nduring key rollover.  The structure of the \"kid\" value is\nunspecified.  When \"kid\" values are used within a JWK Set, different\nkeys within the JWK Set SHOULD use distinct \"kid\" values.  (One\nexample in which different keys might use the same \"kid\" value is if\nthey have different \"kty\" (key type) values but are considered to be\nequivalent alternatives by the application using them.)  The \"kid\"\nvalue is a case-sensitive string."
-        },
-        "kty": {
-          "type": "string",
-          "description": "The \"kty\" (key type) parameter identifies the cryptographic algorithm\nfamily used with the key, such as \"RSA\" or \"EC\". \"kty\" values should\neither be registered in the IANA \"JSON Web Key Types\" registry\nestablished by [JWA] or be a value that contains a Collision-\nResistant Name.  The \"kty\" value is a case-sensitive string."
-        },
-        "n": {
-          "type": "string",
-          "description": "RSA modulus, in Base64"
-        },
-        "p": {
-          "type": "string",
-          "description": "RSA secret prime"
-        },
-        "q": {
-          "type": "string",
-          "description": "RSA secret prime, with p < q"
-        },
-        "qi": {
-          "type": "string",
-          "description": "RSA Private Key Parameter"
-        },
-        "use": {
-          "type": "string",
-          "description": "Use (\"public key use\") identifies the intended use of\nthe public key. The \"use\" parameter is employed to indicate whether\na public key is used for encrypting data or verifying the signature\non data. Values are commonly \"sig\" (signature) or \"enc\" (encryption)."
-        },
-        "x": {
-          "type": "string",
-          "description": "X coordinate for the Elliptic Curve point"
-        },
-        "x5c": {
-          "type": "array",
-          "description": "The \"x5c\" (X.509 certificate chain) parameter contains a chain of one\nor more PKIX certificates [RFC5280].  The certificate chain is\nrepresented as a JSON array of certificate value strings.  Each\nstring in the array is a base64-encoded (Section 4 of [RFC4648] --\nnot base64url-encoded) DER [ITU.X690.1994] PKIX certificate value.\nThe PKIX certificate containing the key value MUST be the first\ncertificate.",
-          "items": {
-            "type": "string"
-          }
-        },
-        "y": {
-          "type": "string",
-          "description": "Y coordinate for the Elliptic Curve point"
+        "body": {
+          "$ref": "#/definitions/JsonWebKeySet",
+          "description": "The JSON Web Key Set response body."
         }
       },
       "required": [
-        "kty"
+        "body"
       ]
     },
-    "JwksDocument": {
+    "JsonWebKeySet": {
       "type": "object",
-      "description": "A JWKS like document",
+      "description": "A JSON Web Key Set containing service receipt-verification keys.",
       "properties": {
         "keys": {
           "type": "array",
-          "description": "List of public keys used for receipt verification.",
+          "description": "The service public keys used to verify receipts.",
           "items": {
-            "$ref": "#/definitions/JsonWebKey"
+            "$ref": "#/definitions/PublicJsonWebKey"
           }
         }
       },
@@ -896,6 +829,69 @@
     "OperationStatusPending": {
       "type": "object",
       "description": "Pending response if the operation was not complete, mandatory in IETF SCITT draft"
+    },
+    "PublicJsonWebKey": {
+      "type": "object",
+      "description": "A public asymmetric key represented as an RFC 7517 JSON Web Key.",
+      "properties": {
+        "kty": {
+          "type": "string",
+          "description": "The asymmetric key type, such as EC, RSA, or OKP.",
+          "x-ms-client-name": "keyType"
+        },
+        "kid": {
+          "type": "string",
+          "description": "The case-sensitive key ID.",
+          "x-ms-client-name": "keyId"
+        },
+        "alg": {
+          "type": "string",
+          "description": "The algorithm intended for use with the key.",
+          "x-ms-client-name": "algorithm"
+        },
+        "use": {
+          "type": "string",
+          "description": "The intended public-key use, such as signature verification.",
+          "x-ms-client-name": "publicKeyUse"
+        },
+        "crv": {
+          "type": "string",
+          "description": "The named curve for EC or OKP keys.",
+          "x-ms-client-name": "curveName"
+        },
+        "x": {
+          "type": "string",
+          "description": "The base64url-encoded X coordinate for EC keys, or public key for OKP keys.",
+          "x-ms-client-name": "xCoordinate"
+        },
+        "y": {
+          "type": "string",
+          "description": "The base64url-encoded Y coordinate for EC keys.",
+          "x-ms-client-name": "yCoordinate"
+        },
+        "n": {
+          "type": "string",
+          "description": "The base64url-encoded modulus for RSA keys.",
+          "x-ms-client-name": "modulus"
+        },
+        "e": {
+          "type": "string",
+          "description": "The base64url-encoded exponent for RSA keys.",
+          "x-ms-client-name": "exponent"
+        },
+        "x5c": {
+          "type": "array",
+          "description": "The base64-encoded X.509 certificate chain.",
+          "items": {
+            "type": "string"
+          },
+          "x-ms-client-name": "certificateChain"
+        }
+      },
+      "required": [
+        "kty",
+        "kid"
+      ]
     },
     "ReceiptEntry": {
       "type": "object",

--- a/specification/confidentialledger/data-plane/Microsoft.CodeTransparency/stable/2026-03-26/examples/GetPublicKeys.json
+++ b/specification/confidentialledger/data-plane/Microsoft.CodeTransparency/stable/2026-03-26/examples/GetPublicKeys.json
@@ -12,25 +12,13 @@
       "body": {
         "keys": [
           {
-            "alg": "ismwdpkyzdpcdsxlhdrcyu",
-            "crv": "krvghelqczlomlykmvq",
-            "d": "sjrntenzgpayzxqeyylodzzot",
-            "dp": "okaildkxkhdiuz",
-            "dq": "cr",
-            "e": "whulawpi",
-            "k": "umuebehxryklpmphgvfflgxhmw",
-            "kid": "sjvhzuxmiidkyt",
-            "kty": "aleunvywecrqn",
-            "n": "agbjjczwjkuzidwazv",
-            "p": "mwqnfqougntmfkkqrhwfawqdfvc",
-            "q": "ihgggpjpvqrugoctea",
-            "qi": "hauoxhsdatbqpwyjy",
-            "use": "sobsnevfheiclufbfronhqufiry",
-            "x": "jiifvniadtvfdosxgtdgju",
-            "x5c": [
-              "bpqymrr"
-            ],
-            "y": "owpcmhs"
+            "alg": "ES256",
+            "crv": "P-256",
+            "kid": "service-signing-key-1",
+            "kty": "EC",
+            "use": "sig",
+            "x": "f83OJ3D2xF4WfPZrQFbnjKJvBf7vY5H5XzX7Q2x4g4A",
+            "y": "x_FEzRu9m36HLNFY2R9w7q7lW11Q9Lq6X5AU2E8YbV0"
           }
         ]
       }


### PR DESCRIPTION
## Summary

Corrects the Code Transparency `/jwks` wire contract for stable API version `2026-03-26` so its public receipt-verification-key response does not advertise private or symmetric JWK members.

The service emits EC public JWKs (`kty`, `kid`, `crv`, `x`, `y`), while the previous schema also exposed `d`, `dp`, `dq`, `k`, `p`, `q`, and `qi`.

## Changes

- Preserves the existing `2025-01-31-preview` contract unchanged.
- Adds the stable-only `getPublicKeysV09` operation with canonical operation ID `GetPublicKeys`.
- Models `Content-Type` as a response header and the JWK set as the response body.
- Adds public-asymmetric JWK wire models containing only public key material.
- Regenerates the stable OpenAPI document and example without private-key fields.
- Keeps C# wire models internal and disables generated convenience methods so Azure/azure-sdk-for-net#62471 can expose normalized verification-key APIs while preserving protocol overloads.
- Removes Python SDK generation because Code Transparency does not plan to ship a Python SDK. The existing scoped `SdkTspConfigValidation` suppression now covers the intentionally absent Python emitter options.

No new API version is introduced.

## Validation

- `npx tsv specification/confidentialledger/Microsoft.CodeTransparency`: passed
- TypeSpec compilation: passed
- Preview OpenAPI and example: unchanged from the base branch
- Same-version correction: approved with `Versioning-Approved-BugFix`

## Dependency

This PR is stacked on #45162. Merge #45162 first, then retarget this PR to `main`.

## Related

- .NET SDK PR: Azure/azure-sdk-for-net#62471