### PR TITLE
Redis: raise accessPolicyAssignmentName maxLength from 63 to 256

### DIFF
--- a/specification/redis/resource-manager/Microsoft.Cache/Redis/RedisCacheAccessPolicyAssignment.tsp
+++ b/specification/redis/resource-manager/Microsoft.Cache/Redis/RedisCacheAccessPolicyAssignment.tsp
@@ -61,7 +61,7 @@ interface RedisCacheAccessPolicyAssignments {
   >;
 }
 
-@@maxLength(RedisCacheAccessPolicyAssignment.name, 63);
+@@maxLength(RedisCacheAccessPolicyAssignment.name, 256);
 @@minLength(RedisCacheAccessPolicyAssignment.name, 3);
 @@doc(
   RedisCacheAccessPolicyAssignment.name,

--- a/specification/redis/resource-manager/Microsoft.Cache/Redis/preview/2025-08-01-preview/redis.json
+++ b/specification/redis/resource-manager/Microsoft.Cache/Redis/preview/2025-08-01-preview/redis.json
@@ -879,7 +879,7 @@
             "required": true,
             "type": "string",
             "minLength": 3,
-            "maxLength": 63,
+            "maxLength": 256,
             "pattern": "^([a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]|[a-zA-Z0-9])$"
           }
         ],
@@ -934,7 +934,7 @@
             "required": true,
             "type": "string",
             "minLength": 3,
-            "maxLength": 63,
+            "maxLength": 256,
             "pattern": "^([a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]|[a-zA-Z0-9])$"
           },
           {
@@ -1020,7 +1020,7 @@
             "required": true,
             "type": "string",
             "minLength": 3,
-            "maxLength": 63,
+            "maxLength": 256,
             "pattern": "^([a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]|[a-zA-Z0-9])$"
           }
         ],

--- a/specification/redis/resource-manager/Microsoft.Cache/Redis/stable/2024-11-01/redis.json
+++ b/specification/redis/resource-manager/Microsoft.Cache/Redis/stable/2024-11-01/redis.json
@@ -879,7 +879,7 @@
             "required": true,
             "type": "string",
             "minLength": 3,
-            "maxLength": 63,
+            "maxLength": 256,
             "pattern": "^([a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]|[a-zA-Z0-9])$"
           }
         ],
@@ -934,7 +934,7 @@
             "required": true,
             "type": "string",
             "minLength": 3,
-            "maxLength": 63,
+            "maxLength": 256,
             "pattern": "^([a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]|[a-zA-Z0-9])$"
           },
           {
@@ -1020,7 +1020,7 @@
             "required": true,
             "type": "string",
             "minLength": 3,
-            "maxLength": 63,
+            "maxLength": 256,
             "pattern": "^([a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]|[a-zA-Z0-9])$"
           }
         ],


### PR DESCRIPTION
## What

Raises the `name` length bound on `Microsoft.Cache/redis/accessPolicyAssignments` from `3..63` to
`3..256`. `minLength` and the name pattern are unchanged.

- `RedisCacheAccessPolicyAssignment.tsp` — `@@maxLength(RedisCacheAccessPolicyAssignment.name, 256)`
- regenerated with `tsp compile`, which updates only the two emitted specs
  (`stable/2024-11-01/redis.json`, `preview/2025-08-01-preview/redis.json`). Older frozen versions
  are untouched. The whole diff is 7 lines.

## Why — the declared bound is stricter than the service

The RP accepts, stores and serves assignment names longer than 63 characters. A live read of a
64-character assignment at the current stable version:

```
GET .../providers/Microsoft.Cache/redis/<cache>/accessPolicyAssignments/<64-char name>?api-version=2024-11-01

name: autopilot-everyone-aic-nst-ne-01-jarvis-aic-nst-ne-01-redis-reda   (64 chars)
provisioningState: Succeeded
accessPolicyName: Data Owner
```

We also operate an 84-character assignment in production, likewise `Succeeded`. Both were created
through ordinary ARM PUTs (via the Terraform/Upjet provider, which does not enforce the swagger
bound), so the service has been accepting these names for well over a year.

The consequence is that clients which *do* enforce the declared bound cannot manage resources the
service happily created. In our case Azure Service Operator generates
`+kubebuilder:validation:MaxLength=63` from this spec, so its CRD rejects the object outright:

```
RedisAccessPolicyAssignment.cache.azure.com "<64-char name>" is invalid:
spec.azureName: Too long: may not be more than 63 bytes
```

Because the assignment name must match the existing Azure resource for an in-place adoption, and
Azure rejects a second assignment for the same identity, such resources cannot be adopted by any
spec-conformant client at all until the bound is corrected. 43 of our assignments are over the
limit.

## Why 256

There is no ARM-level rule pinning this child resource to 63:

- [Naming rules and restrictions for Azure resources](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules)
  lists no entry for `accessPolicyAssignments` under Microsoft.Cache. It does document the sibling
  child of the same parent, **`Redis / firewallRules`, at 1-256**.
- The bound predates the TypeSpec migration: hand-written `stable/2023-08-01/redis.json` already
  declared `AccessPolicyAssignmentNameParameter` with `minLength: 3, maxLength: 63`, and
  `ResourceNameParameter` in typespec-azure-resource-manager applies no length decorators of its own,
  so the value comes from the augment decorators in this spec.

256 matches the sibling child resource and comfortably covers what the service already accepts. If
the service team knows the true maximum, I am happy to change the number — and equally happy to
scope the change to `2025-08-01-preview` only if relaxing a released stable version is not
acceptable, though relaxing a bound should not break existing clients.