### PR TITLE
Fix New Relic resubscribe documentation

### DIFF
--- a/specification/newrelic/resource-manager/NewRelic.Observability/NewRelicObservability/NewRelicMonitorResource.tsp
+++ b/specification/newrelic/resource-manager/NewRelic.Observability/NewRelicObservability/NewRelicMonitorResource.tsp
@@ -199,7 +199,7 @@ interface NewRelicMonitorResources {
   #suppress "@azure-tools/typespec-azure-resource-manager/lro-location-header" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
   @doc("A long-running resource action.")
   @Azure.Core.useFinalStateVia("azure-async-operation")
-  @summary("Resubscribes the New Relic Organization of the underline Monitor Resource to be billed by Azure Marketplace")
+  @summary("Resubscribes the New Relic Organization of the underlying Monitor Resource to be billed by Azure Marketplace.")
   resubscribe is ArmResourceActionAsync<
     NewRelicMonitorResource,
     ResubscribeProperties,

--- a/specification/newrelic/resource-manager/NewRelic.Observability/NewRelicObservability/preview/2025-05-01-preview/NewRelic.json
+++ b/specification/newrelic/resource-manager/NewRelic.Observability/NewRelicObservability/preview/2025-05-01-preview/NewRelic.json
@@ -1672,7 +1672,7 @@
         "tags": [
           "NewRelicMonitorResources"
         ],
-        "summary": "Resubscribes the New Relic Organization of the underline Monitor Resource to be billed by Azure Marketplace",
+        "summary": "Resubscribes the New Relic Organization of the underlying Monitor Resource to be billed by Azure Marketplace.",
         "description": "A long-running resource action.",
         "parameters": [
           {

--- a/specification/newrelic/resource-manager/NewRelic.Observability/NewRelicObservability/stable/2026-06-01/NewRelic.json
+++ b/specification/newrelic/resource-manager/NewRelic.Observability/NewRelicObservability/stable/2026-06-01/NewRelic.json
@@ -1672,7 +1672,7 @@
         "tags": [
           "NewRelicMonitorResources"
         ],
-        "summary": "Resubscribes the New Relic Organization of the underline Monitor Resource to be billed by Azure Marketplace",
+        "summary": "Resubscribes the New Relic Organization of the underlying Monitor Resource to be billed by Azure Marketplace.",
         "description": "A long-running resource action.",
         "parameters": [
           {


### PR DESCRIPTION
## Summary

- correct the word 'underline' to 'underlying' in the New Relic resubscribe operation summary
- add terminal punctuation so generated SDK documentation satisfies Java review guidance

## Validation

- TypeSpec validation succeeded for specification/newrelic/resource-manager/NewRelic.Observability/NewRelicObservability

This source correction addresses the unresolved documentation comments in Azure/azure-sdk-for-java#50093 before regenerating the SDK AutoPR.