### PR TITLE
Clarify comments for JavaScript operation names

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/src/sdk-python-js-azure-ai-projects/client.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/sdk-python-js-azure-ai-projects/client.tsp
@@ -472,14 +472,14 @@ using Azure.AI.Projects;
 // Beta Agent Insights sub‐client
 // --------------------------------------------------------------------------------
 
-// Preserve the existing JavaScript operation name.
+// Override default JS emitter behavior that emits "delete<model>". ("delete" is a reserved word, but we want to use namespaced "delete" for JS).
 @@clientName(AgentInsightMonitors.delete, "delete", "javascript");
 
 // --------------------------------------------------------------------------------
 // Beta Schedules sub‐client
 // --------------------------------------------------------------------------------
 
-// Preserve the existing JavaScript operation name.
+// Override default JS emitter behavior that emits "delete<model>". ("delete" is a reserved word, but we want to use namespaced "delete" for JS).
 @@clientName(Schedules.delete, "delete", "javascript");
 
 @@clientName(SchedulesCreateOrUpdateParams.resource, "schedule");
@@ -518,7 +518,7 @@ using Azure.AI.Projects;
 // Beta Evaluation Taxonomies sub-client
 // --------------------------------------------------------------------------------
 
-// Preserve the existing JavaScript operation name.
+// Override default JS emitter behavior that emits "delete<model>". ("delete" is a reserved word, but we want to use namespaced "delete" for JS).
 @@clientName(EvaluationTaxonomies.delete, "delete", "javascript");
 
 // Note that we can't rename it in src\openai-evaluations\models.tsp, since in


### PR DESCRIPTION
Updated comments to clarify the override of default JS emitter behavior for namespaced 'delete' operations.

