### PR TITLE
[package.json] Revert avocado to 0.11.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@azure-tools/typespec-client-generator-core": "0.71.0",
         "@azure-tools/typespec-liftr-base": "0.13.0",
         "@azure-tools/typespec-metadata": "0.3.0",
-        "@azure/avocado": "0.12.0",
+        "@azure/avocado": "0.11.0",
         "@azure/oad": "0.12.4",
         "@microsoft.azure/openapi-validator": "2.2.4",
         "@microsoft.azure/openapi-validator-core": "1.0.7",
@@ -1363,9 +1363,9 @@
       }
     },
     "node_modules/@azure/avocado": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@azure/avocado/-/avocado-0.12.0.tgz",
-      "integrity": "sha512-H5oV6h9KIjiYUOIOdLTBr4Uu+HwU6hyvsrCaagaz8PCMjw5j/FXr17lBiurxZklbZ8OJiSoaUUfqH36Offcsow==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@azure/avocado/-/avocado-0.11.0.tgz",
+      "integrity": "sha512-9nua3lKQjtQZxrBmqGwfyG7rrX7etN4DnCPXiNJTPW6Y8CP/KxrCrzb0bX2voVnGMbDhv/QPB/XuTzQkkGQYGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1380,19 +1380,16 @@
         "@ts-common/string-map": "^1.1.1",
         "commonmark": "0.31.2",
         "glob": "^13.0.0",
-        "js-yaml": "^5.2.0",
+        "js-yaml": "^4.1.0",
         "jsonpath-plus": "^10.0.0",
-        "minimatch": "^10.2.6",
         "node-object-hash": "^3.1.1",
-        "yaml": "^2.9.0",
-        "yargs": "^15.4.1",
-        "zod": "^4.4.3"
+        "yargs": "^15.4.1"
       },
       "bin": {
         "avocado": "bin/cli.js"
       },
       "engines": {
-        "node": ">=22.0.0"
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@azure/avocado/node_modules/ansi-regex": {
@@ -1403,29 +1400,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@azure/avocado/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@azure/avocado/node_modules/brace-expansion": {
-      "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
-      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
       }
     },
     "node_modules/@azure/avocado/node_modules/cliui": {
@@ -1454,29 +1428,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/@azure/avocado/node_modules/js-yaml": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.3.tgz",
-      "integrity": "sha512-n+mUVyUX5bVv7G/G2zyIHOhdxfuU1dY2NOFzTQUWiMUbFss8b57NFlgCCaggU78wSw5KVS9cllzeLyzyR+n5nw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.mjs"
-      }
-    },
     "node_modules/@azure/avocado/node_modules/locate-path": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -1488,22 +1439,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@azure/avocado/node_modules/minimatch": {
-      "version": "10.2.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
-      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.8"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@azure/avocado/node_modules/p-limit": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@azure-tools/typespec-client-generator-core": "0.71.0",
     "@azure-tools/typespec-liftr-base": "0.13.0",
     "@azure-tools/typespec-metadata": "0.3.0",
-    "@azure/avocado": "0.12.0",
+    "@azure/avocado": "0.11.0",
     "@azure/oad": "0.12.4",
     "@microsoft.azure/openapi-validator": "2.2.4",
     "@microsoft.azure/openapi-validator-core": "1.0.7",


### PR DESCRIPTION
- 0.12.0 causes regressions if "before" readme.md is missing (like a brand new spec)
