### PR TITLE
Manually sync latest TypeSpec authoring skill from azure-sdk-tools

### DIFF
--- a/.github/skills/azure-typespec-author/SKILL.md
+++ b/.github/skills/azure-typespec-author/SKILL.md
@@ -29,10 +29,10 @@ This includes but is not limited to:
 
 ## MCP Tools
 
-| Tool                                                   | Purpose                                                   |
-| ------------------------------------------------------ | --------------------------------------------------------- |
+| Tool                                                   | Purpose                                                                                                                                                                                                              |
+| ------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `azure-sdk-mcp:azsdk_typespec_generate_authoring_plan` | Generate a grounded authoring plan for requests **not** covered by the eight cases in [reference-document-links.md](references/reference-document-links.md). Covered cases use agentic search (`web_fetch`) instead. |
-| `azure-sdk-mcp:azsdk_run_typespec_validation`          | Validate TypeSpec                                         |
+| `azure-sdk-mcp:azsdk_run_typespec_validation`          | Validate TypeSpec                                                                                                                                                                                                    |
 
 **Prerequisite:** `azure-sdk-mcp` server must be running.
 

--- a/.github/skills/azure-typespec-author/SKILL.md
+++ b/.github/skills/azure-typespec-author/SKILL.md
@@ -3,33 +3,42 @@ name: azure-typespec-author
 license: MIT
 metadata:
   version: "1.0.0"
-description: "Authors and modifies Azure TypeSpec (.tsp) API specifications. USE FOR: any TypeSpec/tsp change — api versions (add, bump, preview, stable, promote), resources, operations, models, properties, decorators, visibility, constraints, breaking changes, LRO, suppressions, operationId, spread model. Covers ARM resource-manager and data-plane services. DO NOT USE FOR: SDK generation, releasing SDK packages, or single MCP tool calls. INVOKES: azure-sdk-mcp:azsdk_typespec_generate_authoring_plan, azure-sdk-mcp:azsdk_run_typespec_validation."
+description: "Authors and modifies Azure TypeSpec (.tsp) API specifications. MUST BE USED FOR ALL TypeSpec changes regardless of complexity — even adding a single property or enum value requires this skill's validation workflow. USE FOR: any TypeSpec/tsp change — api versions (add, bump, preview, stable, promote), resources, operations, models, properties, decorators, visibility, constraints, breaking changes, LRO, suppressions, operationId, spread model. Covers both ARM resource-manager (Azure.ResourceManager) and data-plane (Azure.Core) services. DO NOT USE FOR: SDK generation, releasing SDK packages, or single MCP tool calls. INVOKES: azure-sdk-mcp:azsdk_typespec_generate_authoring_plan, azure-sdk-mcp:azsdk_run_typespec_validation."
 compatibility: "azure-sdk-mcp server with azsdk_typespec_generate_authoring_plan and azsdk_run_typespec_validation tools"
 ---
 
 # Azure TypeSpec Author
 
-## MCP Tools
+This skill authors and modifies Azure TypeSpec (`.tsp`) API specifications for ARM resource-manager and data-plane services, covering versioning, resources, operations, models, decorators, constraints, and other schema changes that must follow the repository's TypeSpec authoring workflow.
 
-| Tool                                                   | Purpose                                                   |
-| ------------------------------------------------------ | --------------------------------------------------------- |
-| `azure-sdk-mcp:azsdk_typespec_generate_authoring_plan` | Generate grounded authoring plan (General Authoring only) |
-| `azure-sdk-mcp:azsdk_run_typespec_validation`          | Validate TypeSpec                                         |
+## Triggers
 
-**Prerequisite:** `azure-sdk-mcp` server must be running.
+USE FOR: any TypeSpec/tsp change — api versions (add, bump, preview, stable, promote), resources, operations, models, properties, decorators, visibility, constraints, breaking changes, LRO, suppressions, operationId, spread model
+WHEN: "add TypeSpec API version", "modify .tsp file", "change TypeSpec decorators", "update TypeSpec models or operations", "author Azure TypeSpec"
+DO NOT USE FOR: SDK generation, releasing SDK packages, or single MCP tool calls
 
-# When to invoke the azure-typespec-author skill
+The `azure-typespec-author` skill **must** be invoked immediately in all modes (including plan mode) for any task that involves creating and modifying TypeSpec (`.tsp`) files except for `client.tsp` under the specification directory in this repository. **This skill MUST be used regardless of how simple the task appears** — there are no "simple" TypeSpec edits. Even trivial-seeming changes (adding a single enum value, one property, one operation) require the full workflow because versioning decorators, validation, and compliance checks are mandatory.
 
-The `azure-typespec-author` skill **must** be invoked immediately in all modes (including plan mode) for any task that involves creating and modifying TypeSpec (`.tsp`) files except for `client.tsp` under the specification directory in this repository. This includes but is not limited to:
+This includes but is not limited to:
 
-- Adding, bumping, or promoting API versions (preview, stable)
+- Adding, bumping, or promoting API versions (preview, stable) for ARM or data-plane services
 - Adding or modifying resources, operations, models, properties, or decorators
 - Changing visibility, constraints, breaking changes, LRO patterns, or suppressions
 - Defining or updating operationId, spread models, or extension resources
 - Converting Swagger to TypeSpec (post-conversion edits)
 
-## Constraints
+## MCP Tools
 
+| Tool                                                   | Purpose                                                   |
+| ------------------------------------------------------ | --------------------------------------------------------- |
+| `azure-sdk-mcp:azsdk_typespec_generate_authoring_plan` | Generate a grounded authoring plan for requests **not** covered by the eight cases in [reference-document-links.md](references/reference-document-links.md). Covered cases use agentic search (`web_fetch`) instead. |
+| `azure-sdk-mcp:azsdk_run_typespec_validation`          | Validate TypeSpec                                         |
+
+**Prerequisite:** `azure-sdk-mcp` server must be running.
+
+## Rules
+
+- **Do NOT skip this skill for "simple" tasks** — there are no simple TypeSpec edits. A single property addition can require `@added` decorators, version gating, and validation. Always invoke this skill.
 - **Always follow the full workflow** — even seemingly simple changes (e.g. adding a default value) can require complex versioning decorator changes. Never skip steps.
 - **Mandatory for ALL `.tsp` edits** — even a single `?` change can be breaking.
 - **Minimal, scoped edits** — only change what the request requires.
@@ -37,7 +46,7 @@ The `azure-typespec-author` skill **must** be invoked immediately in all modes (
 - **Always cite references** — provide links that justify the approach.
 - **Follow the authoring plan exactly** — code changes in Step 4 MUST follow the authoring plan generated in Step 3. Do not deviate by referring to existing code patterns in the TypeSpec project; the authoring plan is the single source of truth for what to change.
 
-## Workflow
+## Steps
 
 > Analyze → Intake → Plan → Apply → Validate → Output reference links
 
@@ -66,7 +75,9 @@ Make minimal `.tsp` edits following the plan from Step 3. Confirm uncertainties 
 
 ### Step 5: Validate
 
-See [validation.md](references/validation.md). Run 5.1 (TypeSpec validation) and 5.2 (`tsp compile .`) always; 5.3 (example verification) for API version evolution only.
+See [validation.md](references/validation.md). Always run 5.1 general validation (5.1.1 TypeSpec validation and 5.1.2 `tsp compile .`); run 5.2 case-specific validation whenever its case matches.
+
+**Output the validation results as a checklist.** Report one line per check, each marked ✅ (pass) or ❌ (fail) with a short note. Fix every ❌ and re-run until all checks pass. For API Versioning (Case 3) the checklist **must** cover every §5.2 Case 3 check — including: the new version's `examples/` folder exists; no example folder remains for a version absent from the `Versions` enum; no decorator references a version absent from the enum; every carried-over feature is present with its decorators rebased onto the new version (not reverted); every excluded feature is fully removed.
 
 ### Step 6: Output Reference Links
 
@@ -88,3 +99,6 @@ Output all referenced document URLs from Step 3. This gives the user direct link
 - "Add a new preview API version 2026-01-01-preview for widget resource manager"
 - "Add an ARM resource named Asset with CRUD operations"
 - "Add a new property to the Widget model"
+- "Add a list operation for the WidgetSuite resource using Azure.Core templates"
+- "Add a new preview API version to a data-plane service"
+- "Create a data-plane resource interface with full CRUD and list operations"

--- a/.github/skills/azure-typespec-author/references/analyze-project.md
+++ b/.github/skills/azure-typespec-author/references/analyze-project.md
@@ -4,7 +4,7 @@ Collect the inputs below from the TypeSpec project. Ask **up to 6 concise questi
 
 | #   | Input                       | Example                                                          |
 | --- | --------------------------- | ---------------------------------------------------------------- |
-| 1   | TypeSpec project root       | `/specification/widget/resource-manager/Microsoft.Widget/Widget` |
+| 1   | TypeSpec project root       | ARM: `/specification/widget/resource-manager/Microsoft.Widget/Widget`<br>Data-plane: `/specification/widget/data-plane/WidgetAnalytics` |
 | 2   | Path to `tspconfig.yaml`    | `<spec-root>/tspconfig.yaml`                                     |
 | 3   | Service type                | ARM / data-plane                                                 |
 | 4   | Existing API versions       | `2024-01-01 (stable)`, `2024-06-01-preview`                      |

--- a/.github/skills/azure-typespec-author/references/analyze-project.md
+++ b/.github/skills/azure-typespec-author/references/analyze-project.md
@@ -2,17 +2,17 @@
 
 Collect the inputs below from the TypeSpec project. Ask **up to 6 concise questions** for any that are missing.
 
-| #   | Input                       | Example                                                          |
-| --- | --------------------------- | ---------------------------------------------------------------- |
+| #   | Input                       | Example                                                                                                                                 |
+| --- | --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
 | 1   | TypeSpec project root       | ARM: `/specification/widget/resource-manager/Microsoft.Widget/Widget`<br>Data-plane: `/specification/widget/data-plane/WidgetAnalytics` |
-| 2   | Path to `tspconfig.yaml`    | `<spec-root>/tspconfig.yaml`                                     |
-| 3   | Service type                | ARM / data-plane                                                 |
-| 4   | Existing API versions       | `2024-01-01 (stable)`, `2024-06-01-preview`                      |
-| 5   | Latest API version          | Most recent entry in the `Versions` enum                         |
-| 6   | Current working API version | The version being added or modified this session                 |
-| 7   | Intent                      | add / modify / fix                                               |
-| 8   | Target resource/interface   | Resource or operation name (if known)                            |
-| 9   | Constraints                 | Breaking-change limits, naming rules, emitter targets, etc.      |
+| 2   | Path to `tspconfig.yaml`    | `<spec-root>/tspconfig.yaml`                                                                                                            |
+| 3   | Service type                | ARM / data-plane                                                                                                                        |
+| 4   | Existing API versions       | `2024-01-01 (stable)`, `2024-06-01-preview`                                                                                             |
+| 5   | Latest API version          | Most recent entry in the `Versions` enum                                                                                                |
+| 6   | Current working API version | The version being added or modified this session                                                                                        |
+| 7   | Intent                      | add / modify / fix                                                                                                                      |
+| 8   | Target resource/interface   | Resource or operation name (if known)                                                                                                   |
+| 9   | Constraints                 | Breaking-change limits, naming rules, emitter targets, etc.                                                                             |
 
 ## Output
 

--- a/.github/skills/azure-typespec-author/references/authoring-plan.md
+++ b/.github/skills/azure-typespec-author/references/authoring-plan.md
@@ -4,22 +4,33 @@
 
 ## 3.1 General (All Cases)
 
-Use **both** tools to build an authoring plan, if the retrieved results have conflict, rely on agentic search.
+Choose the grounding source based on whether the request's case is covered by [reference-document-links.md](reference-document-links.md):
 
-1. **MCP Tool** — call `azsdk_typespec_generate_authoring_plan` with:
+1. **Case found in the reference doc → Agentic Search.** Run [agentic search](agentic-search.md) — you **MUST** call `web_fetch` on the matching URLs and follow their steps. Synthesize the extracted content into a concrete plan. Do **not** call the MCP tool.
+
+2. **Case not found in the reference doc → MCP Tool.** Call `azsdk_typespec_generate_authoring_plan` and build the plan from its result:
    - `request`: user request (verbatim)
    - `additionalInformation`: all context from Steps 1–2
    - `typeSpecProjectRootPath`: project root path
-
-2. **Agentic Search** — run [agentic search](agentic-search.md) with URLs from [reference-document-links.md](reference-document-links.md) and a query from the user's request. Synthesize extracted content into a concrete plan.
 
 ---
 
 ## 3.2 Case-Specific Authoring Plan
 
-### Case 3 — API Version Evolution
+### Case 3 — API Versioning
 
-> **Must** use Agentic Search (option 2 above) to build the plan — do not call the MCP tool.
+> API Versioning **is covered** by [reference-document-links.md](reference-document-links.md), so use **Agentic Search** (per [3.1 General](#31-general-all-cases)) — you **MUST** call `web_fetch` on the matching versioning doc and follow its steps. Do **not** call the MCP tool `azsdk_typespec_generate_authoring_plan` for this case.
 
-1. Copy `.json` files from latest version's `examples/` into new version's `examples/`. Update `api-version` in each file. Delete old version's example folder if old version is no longer existed.
+1. Create the new version's `examples/<new-version>/` folder by copying the latest retained version's `examples/` into it, and update `api-version` in each `.json` file.
 2. Update `readme.md`.
+
+> These steps apply to both ARM and data-plane services. The same versioning decorators (`@added`, `@removed`, `@renamedFrom`, `@typeChangedFrom`) apply regardless of service type.
+
+### Case 4 — Add Data-Plane Operations
+
+Key guidance for data-plane:
+
+1. Use `Azure.Core` resource operation templates (see [intake.md](intake.md) Case 4 for the template table).
+2. Define operations inside an `interface` block.
+3. Add `/** */` documentation to all operations.
+4. Data-plane services use `@azure-tools/typespec-azure-core`, not `@azure-tools/typespec-azure-resource-manager`.

--- a/.github/skills/azure-typespec-author/references/intake.md
+++ b/.github/skills/azure-typespec-author/references/intake.md
@@ -7,12 +7,12 @@
 1. Run [agentic search](agentic-search.md) using the Step 1 result and the user's request.
 2. Identify the case from the table below and gather more information if case matches. If no case matches, skip Step 2.2.
 
-| Case | Name                      | Description                                            | Service Type     |
-| ---- | ------------------------- | ------------------------------------------------------ | ---------------- |
-| 1    | Add ARM Resource Type     | Define a new ARM resource with operations              | ARM              |
+| Case | Name                       | Description                                            | Service Type     |
+| ---- | -------------------------- | ------------------------------------------------------ | ---------------- |
+| 1    | Add ARM Resource Type      | Define a new ARM resource with operations              | ARM              |
 | 2    | Add ARM Resource Operation | Add CRUD or custom actions on an existing resource     | ARM              |
-| 3    | API Versioning            | Add, bump, or promote an API version (preview/stable)  | ARM / Data-plane |
-| 4    | Add Data-Plane Operations | Add CRUD or custom operations on a data-plane resource | Data-plane       |
+| 3    | API Versioning             | Add, bump, or promote an API version (preview/stable)  | ARM / Data-plane |
+| 4    | Add Data-Plane Operations  | Add CRUD or custom operations on a data-plane resource | Data-plane       |
 
 ---
 

--- a/.github/skills/azure-typespec-author/references/intake.md
+++ b/.github/skills/azure-typespec-author/references/intake.md
@@ -7,17 +7,18 @@
 1. Run [agentic search](agentic-search.md) using the Step 1 result and the user's request.
 2. Identify the case from the table below and gather more information if case matches. If no case matches, skip Step 2.2.
 
-| Case | Name                    | Description                                           | Service Type |
-| ---- | ----------------------- | ----------------------------------------------------- | ------------ |
-| 1    | Add Resource Type       | Define a new ARM resource with operations             | ARM          |
-| 2    | Add Resource Operations | Add CRUD or custom actions on an existing resource    | ARM          |
-| 3    | API Version Evolution   | Add, bump, or promote an API version (preview/stable) | ARM          |
+| Case | Name                      | Description                                            | Service Type     |
+| ---- | ------------------------- | ------------------------------------------------------ | ---------------- |
+| 1    | Add ARM Resource Type     | Define a new ARM resource with operations              | ARM              |
+| 2    | Add ARM Resource Operation | Add CRUD or custom actions on an existing resource     | ARM              |
+| 3    | API Versioning            | Add, bump, or promote an API version (preview/stable)  | ARM / Data-plane |
+| 4    | Add Data-Plane Operations | Add CRUD or custom operations on a data-plane resource | Data-plane       |
 
 ---
 
 ## 2.2 Case-Specific Intake
 
-### Case 1 — Add Resource Type (ARM)
+### Case 1 — Add ARM Resource Type
 
 Collect: target API version, resource name (PascalCase), hierarchy (top-level or nested + parent), properties (name, type, required/optional).
 
@@ -26,7 +27,7 @@ Defaults: top-level → `TrackedResource`, child → `ProxyResource`. Operations
 > Use `createOrReplace` (not `createOrUpdate`). Use `ArmCustomPatch` for PATCH.
 > Top-level tracked resources MUST have `listByResourceGroup` and `listBySubscription`.
 
-### Case 2 — Add Resource Operations (ARM)
+### Case 2 — Add ARM Resource Operation
 
 Collect: target resource, operation type (CRUD or custom), operation name (custom actions), request/response models (custom actions).
 
@@ -35,7 +36,7 @@ Defaults: never async → GET, LIST, HEAD. Default async → PUT, DELETE. Defaul
 > Use `createOrReplace` (not `createOrUpdate`). Use `ArmCustomPatch` for PATCH.
 > For async POST, use ARM combined headers: `LroHeaders = ArmCombinedLroHeaders<FinalResult = ExportResult>`.
 
-### Case 3 — API Version Evolution (ARM)
+### Case 3 — API Versioning
 
 Collect from user:
 
@@ -45,6 +46,18 @@ Collect from user:
    2. Present the list to the user as a numbered checklist.
    3. Ask: _"All features will be carried over to the new version. Are there any you want to exclude? List by number, or say 'none'."_
    4. Wait for the user's response before proceeding.
+
+---
+
+> This case applies to both ARM and data-plane services. The same versioning decorators (`@added`, `@removed`, `@renamedFrom`, `@typeChangedFrom`) apply regardless of service type.
+
+### Case 4 — Add Data-Plane Operations
+
+Collect: target resource, operation type (CRUD, list, or custom action), operation name.
+
+> Data-plane services use `Azure.Core` (not `Azure.ResourceManager`). No `@armProviderNamespace` decorator.
+> All operations, models, enums/unions, and properties should have `/** */` documentation.
+> For async operations (long-running), refer to the [Deep Dive: Long-running (Asynchronous) Operations](https://azure.github.io/typespec-azure/docs/howtos/azure-core/long-running-operations/) documentation
 
 ---
 

--- a/.github/skills/azure-typespec-author/references/reference-document-links.md
+++ b/.github/skills/azure-typespec-author/references/reference-document-links.md
@@ -1,10 +1,58 @@
 # Reference Document Links
 
-## API Version Evolution
+## Add ARM Resource Type
 
-- [Versioning overview](https://azure.github.io/typespec-azure/docs/howtos/versioning/01-about-versioning/): Overview of how API versioning works in TypeSpec Azure.
-- [preview → preview](https://azure.github.io/typespec-azure/docs/howtos/versioning/02-preview-after-preview/): How to add a new preview version after an existing preview version.
-- [preview → stable](https://azure.github.io/typespec-azure/docs/howtos/versioning/03-stable-after-preview/): How to promote a preview version to stable.
-- [stable → preview](https://azure.github.io/typespec-azure/docs/howtos/versioning/04-preview-after-stable/): How to add a new preview version after a stable version.
-- [stable → stable](https://azure.github.io/typespec-azure/docs/howtos/versioning/05-stable-after-stable/): How to add a new stable version after an existing stable version.
-- [Evolving APIs](https://azure.github.io/typespec-azure/docs/howtos/versioning/06-evolving-apis/): How to evolve your API across versions by adding, removing, or modifying resources, operations, and properties using versioning decorators.
+- [ARM resource types and modeling](https://azure.github.io/typespec-azure/docs/howtos/arm/resource-type/): Define tracked, proxy, tenant, extension, and child resources with the standard ARM resource templates.
+- [Specific extension resource sample](https://azure.github.io/typespec-azure/docs/samples/resource-manager/resource-types/specific-extension/): Define an extension resource and its scoped operations with the `Extension.*` templates.
+- [Agent base type](https://azure.github.io/typespec-azure/docs/howtos/arm/agent-base-type/): Model ARM agent resources and their conversation and response child resources with the standard base types.
+- [Private endpoints](https://azure.github.io/typespec-azure/docs/howtos/arm/private-endpoints/): Add private endpoint connection resources and their standard operations to an ARM resource provider.
+- [Private links](https://azure.github.io/typespec-azure/docs/howtos/arm/private-links/): Add private link resources and their standard operations to an ARM resource provider.
+- [Network security perimeter](https://azure.github.io/typespec-azure/docs/howtos/arm/network-security-perimeter/): Add network security perimeter configuration resources and operations to an ARM service.
+
+## Add ARM Resource Operation
+
+- [ARM resource operations](https://azure.github.io/typespec-azure/docs/howtos/arm/resource-operations/): Use standard ARM templates for read, create or replace, update, delete, existence check, list, custom action, and provider action operations.
+- [Azure.ResourceManager interface reference](https://azure.github.io/typespec-azure/docs/libraries/azure-resource-manager/reference/interfaces/): Look up exact signatures and parameters for ARM resource and extension operation templates.
+- [Azure.Core operation interfaces](https://azure.github.io/typespec-azure/docs/getstarted/azure-core/step05/): Add data-plane resource interfaces with standard Azure.Core create, read, update, delete, list, and polling operation templates.
+- [Azure.Core interface reference](https://azure.github.io/typespec-azure/docs/libraries/azure-core/reference/interfaces/): Use Azure.Core resource operation templates for data-plane create, read, update, delete, and list operations.
+
+## API Versioning
+
+- [Versioning overview](https://azure.github.io/typespec-azure/docs/howtos/versioning/01-about-versioning/): Understand Azure API versioning, version enum ordering, and active preview guidance.
+- [Add preview after preview](https://azure.github.io/typespec-azure/docs/howtos/versioning/02-preview-after-preview/): Add a preview version when the latest existing version is also a preview.
+- [Add stable after preview](https://azure.github.io/typespec-azure/docs/howtos/versioning/03-stable-after-preview/): Promote preview changes into a new stable version.
+- [Add preview after stable](https://azure.github.io/typespec-azure/docs/howtos/versioning/04-preview-after-stable/): Add a preview version after the latest stable version.
+- [Add stable after stable](https://azure.github.io/typespec-azure/docs/howtos/versioning/05-stable-after-stable/): Add a stable version after the latest stable version.
+- [Evolving APIs](https://azure.github.io/typespec-azure/docs/howtos/versioning/06-evolving-apis/): Add, remove, rename, or modify resources, operations, parameters, and properties across API versions.
+
+## Long-Running Operations (LRO)
+
+- [ARM long-running operations](https://azure.github.io/typespec-azure/docs/howtos/arm/long-running-operations/): Define ARM LROs and customize Azure-AsyncOperation, Location, and Retry-After response headers.
+- [Azure.Core long-running operations](https://azure.github.io/typespec-azure/docs/howtos/azure-core/long-running-operations/): Define polling and status-monitor patterns for Azure.Core asynchronous operations.
+
+## Paging
+
+- [TypeSpec pagination](https://typespec.io/docs/standard-library/pagination/): Model client-driven and server-driven paging with TypeSpec's standard pagination decorators.
+- [Azure.ResourceManager data types](https://azure.github.io/typespec-azure/docs/libraries/azure-resource-manager/reference/data-types/): Use standard ARM paging parameters such as `ArmTopParameter` and `ArmSkipParameter`.
+- [Azure.Core interface reference](https://azure.github.io/typespec-azure/docs/libraries/azure-core/reference/interfaces/): Define data-plane list operations and paged response shapes with Azure.Core resource templates.
+
+## Models and Enums
+
+- [ARM common types](https://azure.github.io/typespec-azure/docs/howtos/arm/add-common-types/): Author and version common ARM model definitions and expose them with `@@armCommonDefinition`.
+- [Models](https://typespec.io/docs/language-basics/models/): Define model properties, optional values, defaults, spreads, inheritance, and composition.
+- [Enums](https://typespec.io/docs/language-basics/enums/): Define named enum members and service-facing enum values.
+- [Scalars](https://typespec.io/docs/language-basics/scalars/): Define reusable custom scalar types and constrained primitive values.
+
+## Decorators
+
+- [Decorators](https://typespec.io/docs/language-basics/decorators/): Apply decorators and augment decorators to TypeSpec declarations.
+- [Built-in decorators](https://typespec.io/docs/standard-library/built-in-decorators/): Use standard decorators for documentation, visibility, and value constraints such as minimum and maximum length.
+- [OpenAPI decorators](https://typespec.io/docs/libraries/openapi/reference/decorators/): Reference OpenAPI-specific decorators such as `@operationId`.
+- [Change provider namespace](https://azure.github.io/typespec-azure/docs/howtos/arm/change-provider-namespace/): Set an ARM provider namespace that differs from the TypeSpec namespace with `@armProviderNamespace`.
+- [Azure Portal default experiences](https://azure.github.io/typespec-azure/docs/howtos/azure-portal/default-experiences/): Understand the default Azure Portal experiences generated for ARM resource types and the available customization areas.
+- [Content negotiation](https://azure.github.io/typespec-azure/docs/howtos/azure-core/content-negotiation/): Model Azure.Core content negotiation with shared routes and typed Accept headers.
+
+## Warnings
+
+- [Directives](https://typespec.io/docs/language-basics/directives/): Suppress specific compiler or linter warnings with `#suppress` and a justification.
+- [Azure Core `no-openapi` rule](https://azure.github.io/typespec-azure/docs/libraries/azure-core/rules/no-openapi/): Understand the warning against OpenAPI-specific decorators in Azure TypeSpec and when suppression is appropriate.

--- a/.github/skills/azure-typespec-author/references/validation.md
+++ b/.github/skills/azure-typespec-author/references/validation.md
@@ -1,25 +1,43 @@
 # Validation
 
-Run all sub-steps in order after applying changes.
+> Prerequisite: Step 4 (Apply Changes) must be complete.
 
-| Sub-step | Action                                        | When                       |
-| -------- | --------------------------------------------- | -------------------------- |
-| 5.1      | `azure-sdk-mcp:azsdk_run_typespec_validation` | Always                     |
-| 5.2      | `tsp compile .`                               | Always                     |
-| 5.3      | Example verification                          | API version evolution only |
+Run **5.1 General Validation** for every case; run **5.2 Case-Specific Validation** only when the case identified in [intake.md](intake.md) §2.1 matches.
 
-### 5.1: TypeSpec Validation
+| Sub-step | Action                                        | When                    |
+| -------- | --------------------------------------------- | ----------------------- |
+| 5.1.1    | `azure-sdk-mcp:azsdk_run_typespec_validation` | Always                  |
+| 5.1.2    | `tsp compile .`                               | Always                  |
+| 5.2      | Case-specific validation                      | Case matches (see §5.2) |
+
+---
+
+## 5.1 General Validation (All Cases)
+
+### 5.1.1: TypeSpec Validation
 
 Invoke `azure-sdk-mcp:azsdk_run_typespec_validation` with the project root. On failure → fix → re-run. Limit to 3 retry attempts; if still failing after 3 retries, stop and report the remaining errors to the user.
 
-### 5.2: Compile
+### 5.1.2: Compile
 
 Run `tsp compile .` from the project root. Verify `.json` output under the directory specified by the `@azure-tools/typespec-autorest` entry in the project's tspconfig.yaml. Fix compile errors if any.
 
-> 5.1 checks for errors/warnings; 5.2 generates the OpenAPI output. Both are required.
+> 5.1.1 checks for errors/warnings; 5.1.2 generates the OpenAPI output. Both are required.
 
-### 5.3: Example Verification
+---
 
-Verify `{project-root}/{version-status}/{target-version}/examples/` exists with `.json` files using the correct `api-version`. If missing, copy from the previous version's examples and update `api-version`. Skip example verification for XML-based specs, as the tooling does not support examples for XML specifications.
+## 5.2 Case-Specific Validation
 
-Verify that any example folder for an API version that no longer exists in the `Versions` enum has been deleted. For each folder under `{project-root}/{version-status}/`, check that the folder name matches an entry in the `Versions` enum. If a folder exists for a removed version, delete it.
+Run the sub-section matching the case identified in [intake.md](intake.md) §2.1. If no case matches, skip this step — 5.1 is sufficient.
+
+### Case 3 — API Versioning (ARM / Data-plane)
+
+Run after 5.1. Perform each check below and **report the result as a checklist** — one line per check marked ✅ (pass) or ❌ (fail) with a short note. If any check fails, fix the code and re-run 5.1, then continue.
+
+1. **Example verification.** Verify the new version's examples folder exists — mirroring the existing versions' examples layout observed in Step 1 (e.g. `{project-root}/examples/{target-version}/`) — with `.json` files using the correct `api-version`. If missing, copy from the latest retained version's examples and update `api-version`. Skip for XML-based specs, as the tooling does not support examples for XML specifications. Also verify that any example folder for an API version that no longer exists in the `Versions` enum has been deleted: for each versioned example folder, check that its version matches an entry in the `Versions` enum, and delete any folder for a removed version.
+2. **Enumerate versions.** List every entry in the `Versions` enum (e.g. `v2025_05_04_preview`).
+3. **Preview versioning rules.** If the new version is a preview, verify it is the final `Versions` enum value and is decorated with `@previewVersion`; verify no other version has `@previewVersion`; and verify every change from the latest stable version uses the appropriate versioning decorator with the preview version as its argument.
+4. **No dangling version references.** Every version identifier used in a versioning decorator argument (`@added`, `@removed`, `@renamedFrom`, `@typeChangedFrom`, `@madeOptional`, `@returnTypeChangedFrom`, etc.) across all `.tsp` files **must** exist in the `Versions` enum. If a decorator references a version that is no longer in the enum (because a previous version was superseded/renamed rather than kept), rebase that decorator to the correct current version or remove it — do not leave the stale reference.
+5. **Superseded version fully removed.** If a previous version was superseded/renamed (its enum entry no longer present), confirm there are **no** remaining occurrences of that old version identifier anywhere in the `.tsp` files, and that its example folder has been deleted (per check 1).
+6. **Carried-over vs. excluded features.** Confirm every feature the user chose to carry over is present in the new version **with its versioning decorators rebased onto the new version, not reverted** — e.g. a renamed property must keep its `@renamedFrom`/`@removed`/`@added` scaffolding retargeted to the new version (do not delete the decorators and restore the old shape, which would break the retained released version). Confirm every feature the user chose to exclude is not reintroduced (including any transitional decorator scaffolding — e.g. a property whose added default value was excluded must end up as a plain optional property, not a decorator-bridged rename).
+7. **Re-validate.** Re-run 5.1.1 and 5.1.2 and confirm both pass.


### PR DESCRIPTION
## Summary

- sync the `azure-typespec-author` runtime skill from Azure/azure-sdk-tools `origin/main` at `395c3989bb236c71933e406e5f15bd731a1b0fc7`
- update the skill workflow and authoring references
- apply the spec repository's Prettier formatting
- keep evaluation and skill-refinement tooling in the SDK tools repository only

## Validation

- verified the 7 runtime skill files were sourced from the SDK tools commit before repository-specific formatting
- `.github`: `npm run format:check:ci`
- `git diff --check`

Related to Azure/azure-sdk-tools#16882