### PR TITLE
refactor(voice-agents): introduce conversation engine

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/examples/v1/Agents_CreateVoiceAgent_HostedAgentLatest_Gen.json
+++ b/specification/ai-foundry/data-plane/Foundry/examples/v1/Agents_CreateVoiceAgent_HostedAgentLatest_Gen.json
@@ -8,8 +8,8 @@
     "description": "A voice bridge for a hosted customer support agent.",
     "definition": {
       "kind": "voice",
-      "conversation_bridge": {
-        "type": "agent",
+      "conversation_engine": {
+        "type": "hosted_agent",
         "name": "customer-support-text-agent"
       },
       "output_modalities": [
@@ -35,8 +35,8 @@
             "created_at": 1785772800,
             "definition": {
               "kind": "voice",
-              "conversation_bridge": {
-                "type": "agent",
+              "conversation_engine": {
+                "type": "hosted_agent",
                 "name": "customer-support-text-agent"
               },
               "output_modalities": [

--- a/specification/ai-foundry/data-plane/Foundry/examples/v1/Agents_CreateVoiceAgent_HostedAgentLatest_Gen.json
+++ b/specification/ai-foundry/data-plane/Foundry/examples/v1/Agents_CreateVoiceAgent_HostedAgentLatest_Gen.json
@@ -8,7 +8,6 @@
     "description": "A voice bridge for a hosted customer support agent.",
     "definition": {
       "kind": "voice",
-      "model_type": "hosted_agent",
       "target_agent": {
         "name": "customer-support-text-agent"
       },
@@ -35,7 +34,6 @@
             "created_at": 1785772800,
             "definition": {
               "kind": "voice",
-              "model_type": "hosted_agent",
               "target_agent": {
                 "name": "customer-support-text-agent"
               },

--- a/specification/ai-foundry/data-plane/Foundry/examples/v1/Agents_CreateVoiceAgent_HostedAgentLatest_Gen.json
+++ b/specification/ai-foundry/data-plane/Foundry/examples/v1/Agents_CreateVoiceAgent_HostedAgentLatest_Gen.json
@@ -8,7 +8,8 @@
     "description": "A voice bridge for a hosted customer support agent.",
     "definition": {
       "kind": "voice",
-      "target_agent": {
+      "conversation_bridge": {
+        "type": "agent",
         "name": "customer-support-text-agent"
       },
       "output_modalities": [
@@ -34,7 +35,8 @@
             "created_at": 1785772800,
             "definition": {
               "kind": "voice",
-              "target_agent": {
+              "conversation_bridge": {
+                "type": "agent",
                 "name": "customer-support-text-agent"
               },
               "output_modalities": [

--- a/specification/ai-foundry/data-plane/Foundry/examples/v1/Agents_CreateVoiceAgent_HostedAgent_Gen.json
+++ b/specification/ai-foundry/data-plane/Foundry/examples/v1/Agents_CreateVoiceAgent_HostedAgent_Gen.json
@@ -8,8 +8,8 @@
     "description": "A voice bridge for a hosted customer support agent.",
     "definition": {
       "kind": "voice",
-      "conversation_bridge": {
-        "type": "agent",
+      "conversation_engine": {
+        "type": "hosted_agent",
         "name": "customer-support-text-agent",
         "version": "3"
       },
@@ -36,8 +36,8 @@
             "created_at": 1785772800,
             "definition": {
               "kind": "voice",
-              "conversation_bridge": {
-                "type": "agent",
+              "conversation_engine": {
+                "type": "hosted_agent",
                 "name": "customer-support-text-agent",
                 "version": "3"
               },

--- a/specification/ai-foundry/data-plane/Foundry/examples/v1/Agents_CreateVoiceAgent_HostedAgent_Gen.json
+++ b/specification/ai-foundry/data-plane/Foundry/examples/v1/Agents_CreateVoiceAgent_HostedAgent_Gen.json
@@ -8,7 +8,8 @@
     "description": "A voice bridge for a hosted customer support agent.",
     "definition": {
       "kind": "voice",
-      "target_agent": {
+      "conversation_bridge": {
+        "type": "agent",
         "name": "customer-support-text-agent",
         "version": "3"
       },
@@ -35,7 +36,8 @@
             "created_at": 1785772800,
             "definition": {
               "kind": "voice",
-              "target_agent": {
+              "conversation_bridge": {
+                "type": "agent",
                 "name": "customer-support-text-agent",
                 "version": "3"
               },

--- a/specification/ai-foundry/data-plane/Foundry/examples/v1/Agents_CreateVoiceAgent_HostedAgent_Gen.json
+++ b/specification/ai-foundry/data-plane/Foundry/examples/v1/Agents_CreateVoiceAgent_HostedAgent_Gen.json
@@ -8,7 +8,6 @@
     "description": "A voice bridge for a hosted customer support agent.",
     "definition": {
       "kind": "voice",
-      "model_type": "hosted_agent",
       "target_agent": {
         "name": "customer-support-text-agent",
         "version": "3"
@@ -36,7 +35,6 @@
             "created_at": 1785772800,
             "definition": {
               "kind": "voice",
-              "model_type": "hosted_agent",
               "target_agent": {
                 "name": "customer-support-text-agent",
                 "version": "3"

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -88770,49 +88770,6 @@
           ]
         }
       },
-      "VoiceAgentConversationBridge": {
-        "type": "object",
-        "required": [
-          "type",
-          "name"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "agent"
-            ],
-            "description": "Selects a Foundry agent as the conversation bridge."
-          },
-          "name": {
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 63,
-            "pattern": "^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$",
-            "description": "The non-empty DNS-like name of the target hosted text agent in the same project."
-          },
-          "version": {
-            "type": "string",
-            "maxLength": 25,
-            "pattern": "^(?:[1-9][0-9]{0,18}|draft-[1-9][0-9]{0,18})$",
-            "description": "The target agent version. Omit this property to select the latest version when the voice session starts. When supplied, use a positive integer or `draft-{positive-unix-timestamp}` whose numeric component fits in a signed 64-bit integer."
-          }
-        },
-        "unevaluatedProperties": {
-          "not": {}
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/VoiceConversationBridge"
-          }
-        ],
-        "description": "A closed reference to the text agent that owns conversation handling for a bridged voice agent. The target is resolved within the same project. The initial implementation requires a hosted agent that supports the `invocations_ws` protocol, Voice Live compatibility, and Bridge Protocol 1.0.",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "VoiceAgents=V1Preview"
-          ]
-        }
-      },
       "VoiceAgentDefinition": {
         "type": "object",
         "required": [
@@ -88828,15 +88785,15 @@
           },
           "model_type": {
             "$ref": "#/components/schemas/VoiceModelType",
-            "description": "How the model backing this voice agent is served. Required with `model` for a model-backed voice agent and omitted when `conversation_bridge` is provided. This is independent of the architecture (realtime or cascaded), which the service derives from the selected model."
+            "description": "How the model backing this voice agent is served. Required with `model` for a model-backed voice agent and omitted when `conversation_engine` is provided. This is independent of the architecture (realtime or cascaded), which the service derives from the selected model."
           },
           "model": {
             "type": "string",
-            "description": "The model to use for this agent. Required with `model_type` for a model-backed voice agent and omitted when `conversation_bridge` is provided. The model must support realtime or cascaded voice."
+            "description": "The model to use for this agent. Required with `model_type` for a model-backed voice agent and omitted when `conversation_engine` is provided. The model must support realtime or cascaded voice."
           },
-          "conversation_bridge": {
-            "$ref": "#/components/schemas/VoiceConversationBridge",
-            "description": "Delegates conversation handling to another backend. Exactly one of this property and the model-backed configuration (`model_type` with `model`) must be provided. When this property is provided, `model_type`, `model`, `instructions`, `tools`, and `tool_choice` must be omitted, and `greeting.tool_choice` cannot be `required`, because the bridge owns the conversation logic. The initial implementation supports an agent bridge."
+          "conversation_engine": {
+            "$ref": "#/components/schemas/VoiceConversationEngine",
+            "description": "The engine that owns conversation handling for this voice agent. Exactly one of this property and the model-backed configuration (`model_type` with `model`) must be provided. When this property is provided, `model_type`, `model`, `instructions`, `tools`, and `tool_choice` must be omitted, and `greeting.tool_choice` cannot be `required`, because the engine owns the conversation logic. The initial implementation supports a hosted-agent engine."
           },
           "instructions": {
             "type": "string",
@@ -90161,7 +90118,7 @@
           ]
         }
       },
-      "VoiceConversationBridge": {
+      "VoiceConversationEngine": {
         "type": "object",
         "required": [
           "type"
@@ -90169,16 +90126,16 @@
         "properties": {
           "type": {
             "type": "string",
-            "description": "The conversation bridge type."
+            "description": "The conversation engine type."
           }
         },
         "discriminator": {
           "propertyName": "type",
           "mapping": {
-            "agent": "#/components/schemas/VoiceAgentConversationBridge"
+            "hosted_agent": "#/components/schemas/VoiceHostedAgentConversationEngine"
           }
         },
-        "description": "A backend that owns conversation handling for a bridged voice agent.",
+        "description": "An engine that owns conversation handling for a voice agent.",
         "x-ms-foundry-meta": {
           "required_previews": [
             "VoiceAgents=V1Preview"
@@ -90258,6 +90215,49 @@
           }
         },
         "description": "Metadata for a conversation item's generated audio. For bring-your-own-storage (BYOS), the response includes\n`blob_uri`, a direct customer-storage URI without a SAS token, that the customer accesses with their own\ncredentials. For Foundry-managed storage, `blob_uri` is absent and the bytes are streamed through the item's\n`/audio/generated/content` route.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "VoiceAgents=V1Preview"
+          ]
+        }
+      },
+      "VoiceHostedAgentConversationEngine": {
+        "type": "object",
+        "required": [
+          "type",
+          "name"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "hosted_agent"
+            ],
+            "description": "Selects a hosted Foundry agent as the conversation engine."
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$",
+            "description": "The non-empty DNS-like name of the target hosted text agent in the same project."
+          },
+          "version": {
+            "type": "string",
+            "maxLength": 25,
+            "pattern": "^(?:[1-9][0-9]{0,18}|draft-[1-9][0-9]{0,18})$",
+            "description": "The target agent version. Omit this property to select the latest version when the voice session starts. When supplied, use a positive integer or `draft-{positive-unix-timestamp}` whose numeric component fits in a signed 64-bit integer."
+          }
+        },
+        "unevaluatedProperties": {
+          "not": {}
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/VoiceConversationEngine"
+          }
+        ],
+        "description": "A closed reference to the hosted text agent that owns conversation handling for a voice agent. The hosted agent is resolved within the same project and must support the `invocations_ws` protocol, Voice Live compatibility, and Bridge Protocol 1.0.",
         "x-ms-foundry-meta": {
           "required_previews": [
             "VoiceAgents=V1Preview"

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -88770,6 +88770,49 @@
           ]
         }
       },
+      "VoiceAgentConversationBridge": {
+        "type": "object",
+        "required": [
+          "type",
+          "name"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "agent"
+            ],
+            "description": "Selects a Foundry agent as the conversation bridge."
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$",
+            "description": "The non-empty DNS-like name of the target hosted text agent in the same project."
+          },
+          "version": {
+            "type": "string",
+            "maxLength": 25,
+            "pattern": "^(?:[1-9][0-9]{0,18}|draft-[1-9][0-9]{0,18})$",
+            "description": "The target agent version. Omit this property to select the latest version when the voice session starts. When supplied, use a positive integer or `draft-{positive-unix-timestamp}` whose numeric component fits in a signed 64-bit integer."
+          }
+        },
+        "unevaluatedProperties": {
+          "not": {}
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/VoiceConversationBridge"
+          }
+        ],
+        "description": "A closed reference to the text agent that owns conversation handling for a bridged voice agent. The target is resolved within the same project. The initial implementation requires a hosted agent that supports the `invocations_ws` protocol, Voice Live compatibility, and Bridge Protocol 1.0.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "VoiceAgents=V1Preview"
+          ]
+        }
+      },
       "VoiceAgentDefinition": {
         "type": "object",
         "required": [
@@ -88785,15 +88828,15 @@
           },
           "model_type": {
             "$ref": "#/components/schemas/VoiceModelType",
-            "description": "How the model backing this voice agent is served. Required with `model` for a model-backed voice agent and omitted when `target_agent` is provided. This is independent of the architecture (realtime or cascaded), which the service derives from the selected model."
+            "description": "How the model backing this voice agent is served. Required with `model` for a model-backed voice agent and omitted when `conversation_bridge` is provided. This is independent of the architecture (realtime or cascaded), which the service derives from the selected model."
           },
           "model": {
             "type": "string",
-            "description": "The model to use for this agent. Required with `model_type` for a model-backed voice agent and omitted when `target_agent` is provided. The model must support realtime or cascaded voice."
+            "description": "The model to use for this agent. Required with `model_type` for a model-backed voice agent and omitted when `conversation_bridge` is provided. The model must support realtime or cascaded voice."
           },
-          "target_agent": {
-            "$ref": "#/components/schemas/VoiceAgentTargetAgent",
-            "description": "The text agent that this voice agent fronts. Providing this property selects the agent-backed bridge path; `model_type` and `model` must be omitted. In this mode, `instructions`, `tools`, and `tool_choice` must also be omitted, and `greeting.tool_choice` cannot be `required`, because the target agent owns the conversation logic. The target must be in the same project. The initial implementation requires a hosted agent that supports the `invocations_ws` protocol, Voice Live compatibility, and Bridge Protocol 1.0."
+          "conversation_bridge": {
+            "$ref": "#/components/schemas/VoiceConversationBridge",
+            "description": "Delegates conversation handling to another backend. Exactly one of this property and the model-backed configuration (`model_type` with `model`) must be provided. When this property is provided, `model_type`, `model`, `instructions`, `tools`, and `tool_choice` must be omitted, and `greeting.tool_choice` cannot be `required`, because the bridge owns the conversation logic. The initial implementation supports an agent bridge."
           },
           "instructions": {
             "type": "string",
@@ -89775,36 +89818,6 @@
           ]
         }
       },
-      "VoiceAgentTargetAgent": {
-        "type": "object",
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 63,
-            "pattern": "^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$",
-            "description": "The non-empty DNS-like name of the target hosted text agent in the same project."
-          },
-          "version": {
-            "type": "string",
-            "maxLength": 25,
-            "pattern": "^(?:[1-9][0-9]{0,18}|draft-[1-9][0-9]{0,18})$",
-            "description": "The target agent version. Omit this property to select the latest version when the voice session starts. When supplied, use a positive integer or `draft-{positive-unix-timestamp}` whose numeric component fits in a signed 64-bit integer."
-          }
-        },
-        "unevaluatedProperties": {
-          "not": {}
-        },
-        "description": "A closed reference to the text agent that an agent-backed voice agent fronts, containing only its name and optional version. The target is resolved within the same project. The initial implementation requires the target to be a hosted agent that supports the Voice Live bridge protocol.",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "VoiceAgents=V1Preview"
-          ]
-        }
-      },
       "VoiceAgentTemplateGreetingConfig": {
         "type": "object",
         "required": [
@@ -90142,6 +90155,30 @@
           }
         },
         "description": "A persisted voice conversation. The Foundry envelope that owns a voice agent's stored\ntranscript, responses, per-turn metrics, and audio. It is the parent, retention, and delete boundary:\ndeleting it cascades to its responses, items, metrics, and audio. When finalization fails, any partial persisted\nresponses, items, and item audio remain readable.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "VoiceAgents=V1Preview"
+          ]
+        }
+      },
+      "VoiceConversationBridge": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "The conversation bridge type."
+          }
+        },
+        "discriminator": {
+          "propertyName": "type",
+          "mapping": {
+            "agent": "#/components/schemas/VoiceAgentConversationBridge"
+          }
+        },
+        "description": "A backend that owns conversation handling for a bridged voice agent.",
         "x-ms-foundry-meta": {
           "required_previews": [
             "VoiceAgents=V1Preview"

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -52169,7 +52169,7 @@
                 }
               }
             ],
-            "description": "The image(s) to edit. Must be a supported image file or an array of images.\n  For the GPT image models (`gpt-image-1`, `gpt-image-1-mini`, and `gpt-image-1.5`), each image should be a `png`, `webp`, or `jpg`\n  file less than 50MB. You can provide up to 16 images.\n  `chatgpt-image-latest` follows the same input constraints as GPT image models.\n  For `dall-e-2`, you can only provide one image, and it should be a square\n  `png` file less than 4MB."
+            "description": "The image(s) to edit. Must be a supported image file or an array of images.\n  For the GPT image models (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`, and `gpt-image-2-2026-04-21`), each image should be a `png`, `webp`, or `jpg`\n  file less than 50MB. You can provide up to 16 images.\n  `chatgpt-image-latest` follows the same input constraints as GPT image models.\n  For `dall-e-2`, you can only provide one image, and it should be a square\n  `png` file less than 4MB."
           },
           "prompt": {
             "type": "string",
@@ -52192,7 +52192,7 @@
                 "type": "null"
               }
             ],
-            "description": "Allows to set transparency for the background of the generated image(s).\n  This parameter is only supported for the GPT image models. Must be one of\n  `transparent`, `opaque` or `auto` (default value). When `auto` is used, the\n  model will automatically determine the best background for the image.\n  If `transparent`, the output format needs to support transparency, so it\n  should be set to either `png` (default value) or `webp`."
+            "description": "Set the background of the generated image(s). This parameter is only\n  supported for the GPT image models. Must be one of `transparent`, `opaque`,\n  or `auto` (default value). When `auto` is used, the model will automatically\n  determine the best background for the image.\n  Transparent backgrounds are available for supported GPT Image models. For\n  `gpt-image-2` and `gpt-image-2-2026-04-21`, this support is in preview. When\n  using `transparent`, set the output format to `png` or `webp`."
           },
           "model": {
             "anyOf": [
@@ -52203,6 +52203,8 @@
                 "type": "string",
                 "enum": [
                   "gpt-image-1.5",
+                  "gpt-image-2",
+                  "gpt-image-2-2026-04-21",
                   "dall-e-2",
                   "gpt-image-1",
                   "gpt-image-1-mini",
@@ -52213,7 +52215,7 @@
                 "type": "null"
               }
             ],
-            "description": "The model to use for image generation. Defaults to `gpt-image-1.5`.",
+            "description": "The model to use for image generation. One of `dall-e-2` or a GPT image model (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`, `gpt-image-2-2026-04-21`, or `chatgpt-image-latest`). Defaults to `gpt-image-1.5`.",
             "x-oaiTypeLabel": "string"
           },
           "n": {
@@ -52362,6 +52364,8 @@
                 "type": "string",
                 "enum": [
                   "gpt-image-1.5",
+                  "gpt-image-2",
+                  "gpt-image-2-2026-04-21",
                   "dall-e-2",
                   "dall-e-3",
                   "gpt-image-1",
@@ -52372,7 +52376,7 @@
                 "type": "null"
               }
             ],
-            "description": "The model to use for image generation. One of `dall-e-2`, `dall-e-3`, or a GPT image model (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`). Defaults to `dall-e-2` unless a parameter specific to the GPT image models is used.",
+            "description": "The model to use for image generation. One of `dall-e-2`, `dall-e-3`, or a GPT image model (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`, `gpt-image-2-2026-04-21`). Defaults to `dall-e-2` unless a parameter specific to the GPT image models is used.",
             "x-oaiTypeLabel": "string",
             "default": "dall-e-2"
           },
@@ -52524,7 +52528,7 @@
                 "type": "null"
               }
             ],
-            "description": "Allows to set transparency for the background of the generated image(s).\n  This parameter is only supported for the GPT image models. Must be one of\n  `transparent`, `opaque` or `auto` (default value). When `auto` is used, the\n  model will automatically determine the best background for the image.\n  If `transparent`, the output format needs to support transparency, so it\n  should be set to either `png` (default value) or `webp`.",
+            "description": "Set the background of the generated image(s). This parameter is only\n  supported for the GPT image models. Must be one of `transparent`, `opaque`,\n  or `auto` (default value). When `auto` is used, the model will automatically\n  determine the best background for the image.\n  Transparent backgrounds are available for supported GPT Image models. For\n  `gpt-image-2` and `gpt-image-2-2026-04-21`, this support is in preview. When\n  using `transparent`, set the output format to `png` or `webp`.",
             "default": "auto"
           },
           "style": {
@@ -55280,6 +55284,8 @@
                 "type": "string",
                 "enum": [
                   "gpt-image-1.5",
+                  "gpt-image-2",
+                  "gpt-image-2-2026-04-21",
                   "gpt-image-1",
                   "gpt-image-1-mini",
                   "chatgpt-image-latest"
@@ -55289,7 +55295,7 @@
                 "type": "null"
               }
             ],
-            "description": "The model to use for image editing.",
+            "description": "The GPT image model to use for image editing, including `gpt-image-2` and its dated snapshot `gpt-image-2-2026-04-21`.",
             "x-oaiTypeLabel": "string",
             "default": "gpt-image-1.5"
           },
@@ -55436,7 +55442,7 @@
                 "type": "null"
               }
             ],
-            "description": "Background behavior for generated image output.",
+            "description": "Set the background of the generated image output. Transparent backgrounds are available for supported GPT Image models. For `gpt-image-2` and `gpt-image-2-2026-04-21`, this support is in preview. When using `transparent`, set the output format to `png` or `webp`.",
             "default": "auto"
           },
           "stream": {
@@ -58978,7 +58984,9 @@
                 "enum": [
                   "gpt-image-1",
                   "gpt-image-1-mini",
-                  "gpt-image-1.5"
+                  "gpt-image-1.5",
+                  "gpt-image-2",
+                  "gpt-image-2-2026-04-21"
                 ]
               }
             ],
@@ -59046,7 +59054,7 @@
               "opaque",
               "auto"
             ],
-            "description": "Background type for the generated image. One of `transparent`,\n  `opaque`, or `auto`. Default: `auto`.",
+            "description": "Set the background of the generated image. One of `transparent`,\n  `opaque`, or `auto`. Transparent backgrounds are available for\n  supported GPT Image models. For `gpt-image-2` and\n  `gpt-image-2-2026-04-21`, this support is in preview. When using\n  `transparent`, set the output format to `png` or `webp`. Default: `auto`.",
             "default": "auto"
           },
           "input_fidelity": {
@@ -60116,7 +60124,7 @@
           },
           "encrypted_content": {
             "type": "string",
-            "maxLength": 10485760,
+            "maxLength": 20971520,
             "description": "The encrypted content of the compaction summary."
           }
         },
@@ -61873,7 +61881,7 @@
           },
           "encrypted_content": {
             "type": "string",
-            "maxLength": 10485760,
+            "maxLength": 20971520,
             "description": "The encrypted content of the compaction summary."
           }
         },
@@ -88765,8 +88773,7 @@
       "VoiceAgentDefinition": {
         "type": "object",
         "required": [
-          "kind",
-          "model_type"
+          "kind"
         ],
         "properties": {
           "kind": {
@@ -88778,15 +88785,15 @@
           },
           "model_type": {
             "$ref": "#/components/schemas/VoiceModelType",
-            "description": "How the voice agent obtains its conversational backend. `managed` uses the service-managed model named by `model`; `self_deployed` uses the customer's Foundry deployment named by `model`; `hosted_agent` fronts the hosted text agent referenced by `target_agent`. This is independent of the architecture (realtime or cascaded), which the service derives from the selected backend."
+            "description": "How the model backing this voice agent is served. Required with `model` for a model-backed voice agent and omitted when `target_agent` is provided. This is independent of the architecture (realtime or cascaded), which the service derives from the selected model."
           },
           "model": {
             "type": "string",
-            "description": "The model to use for this agent. Required when `model_type` is `managed` (the service-managed model name) or `self_deployed` (the customer's Foundry deployment name). Omit this property when `model_type` is `hosted_agent`; `target_agent` identifies the conversational backend. The model must support realtime or cascaded voice."
+            "description": "The model to use for this agent. Required with `model_type` for a model-backed voice agent and omitted when `target_agent` is provided. The model must support realtime or cascaded voice."
           },
           "target_agent": {
             "$ref": "#/components/schemas/VoiceAgentTargetAgent",
-            "description": "The hosted text agent that this voice agent fronts. Required when `model_type` is `hosted_agent` and not applicable otherwise. In this mode, `model`, `instructions`, `tools`, and `tool_choice` must be omitted, and `greeting.tool_choice` cannot be `required`, because the target agent owns the conversation logic. The target must be in the same project and support the `invocations_ws` protocol, Voice Live compatibility, and Bridge Protocol 1.0."
+            "description": "The text agent that this voice agent fronts. Providing this property selects the agent-backed bridge path; `model_type` and `model` must be omitted. In this mode, `instructions`, `tools`, and `tool_choice` must also be omitted, and `greeting.tool_choice` cannot be `required`, because the target agent owns the conversation logic. The target must be in the same project. The initial implementation requires a hosted agent that supports the `invocations_ws` protocol, Voice Live compatibility, and Bridge Protocol 1.0."
           },
           "instructions": {
             "type": "string",
@@ -89791,7 +89798,7 @@
         "unevaluatedProperties": {
           "not": {}
         },
-        "description": "A closed reference to the hosted text agent that a `hosted_agent` voice agent fronts, containing only its name and optional version. The target is resolved within the same project.",
+        "description": "A closed reference to the text agent that an agent-backed voice agent fronts, containing only its name and optional version. The target is resolved within the same project. The initial implementation requires the target to be a hosted agent that supports the Voice Live bridge protocol.",
         "x-ms-foundry-meta": {
           "required_previews": [
             "VoiceAgents=V1Preview"
@@ -90287,8 +90294,7 @@
             "type": "string",
             "enum": [
               "managed",
-              "self_deployed",
-              "hosted_agent"
+              "self_deployed"
             ]
           }
         ],

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -56375,7 +56375,7 @@ components:
                 contentEncoding: base64
           description: |-
             The image(s) to edit. Must be a supported image file or an array of images.
-              For the GPT image models (`gpt-image-1`, `gpt-image-1-mini`, and `gpt-image-1.5`), each image should be a `png`, `webp`, or `jpg`
+              For the GPT image models (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`, and `gpt-image-2-2026-04-21`), each image should be a `png`, `webp`, or `jpg`
               file less than 50MB. You can provide up to 16 images.
               `chatgpt-image-latest` follows the same input constraints as GPT image models.
               For `dall-e-2`, you can only provide one image, and it should be a square
@@ -56394,24 +56394,27 @@ components:
                 - auto
             - type: 'null'
           description: |-
-            Allows to set transparency for the background of the generated image(s).
-              This parameter is only supported for the GPT image models. Must be one of
-              `transparent`, `opaque` or `auto` (default value). When `auto` is used, the
-              model will automatically determine the best background for the image.
-              If `transparent`, the output format needs to support transparency, so it
-              should be set to either `png` (default value) or `webp`.
+            Set the background of the generated image(s). This parameter is only
+              supported for the GPT image models. Must be one of `transparent`, `opaque`,
+              or `auto` (default value). When `auto` is used, the model will automatically
+              determine the best background for the image.
+              Transparent backgrounds are available for supported GPT Image models. For
+              `gpt-image-2` and `gpt-image-2-2026-04-21`, this support is in preview. When
+              using `transparent`, set the output format to `png` or `webp`.
         model:
           anyOf:
             - type: string
             - type: string
               enum:
                 - gpt-image-1.5
+                - gpt-image-2
+                - gpt-image-2-2026-04-21
                 - dall-e-2
                 - gpt-image-1
                 - gpt-image-1-mini
                 - chatgpt-image-latest
             - type: 'null'
-          description: The model to use for image generation. Defaults to `gpt-image-1.5`.
+          description: The model to use for image generation. One of `dall-e-2` or a GPT image model (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`, `gpt-image-2-2026-04-21`, or `chatgpt-image-latest`). Defaults to `gpt-image-1.5`.
           x-oaiTypeLabel: string
         'n':
           anyOf:
@@ -56503,12 +56506,14 @@ components:
             - type: string
               enum:
                 - gpt-image-1.5
+                - gpt-image-2
+                - gpt-image-2-2026-04-21
                 - dall-e-2
                 - dall-e-3
                 - gpt-image-1
                 - gpt-image-1-mini
             - type: 'null'
-          description: The model to use for image generation. One of `dall-e-2`, `dall-e-3`, or a GPT image model (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`). Defaults to `dall-e-2` unless a parameter specific to the GPT image models is used.
+          description: The model to use for image generation. One of `dall-e-2`, `dall-e-3`, or a GPT image model (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`, `gpt-image-2-2026-04-21`). Defaults to `dall-e-2` unless a parameter specific to the GPT image models is used.
           x-oaiTypeLabel: string
           default: dall-e-2
         'n':
@@ -56606,12 +56611,13 @@ components:
                 - auto
             - type: 'null'
           description: |-
-            Allows to set transparency for the background of the generated image(s).
-              This parameter is only supported for the GPT image models. Must be one of
-              `transparent`, `opaque` or `auto` (default value). When `auto` is used, the
-              model will automatically determine the best background for the image.
-              If `transparent`, the output format needs to support transparency, so it
-              should be set to either `png` (default value) or `webp`.
+            Set the background of the generated image(s). This parameter is only
+              supported for the GPT image models. Must be one of `transparent`, `opaque`,
+              or `auto` (default value). When `auto` is used, the model will automatically
+              determine the best background for the image.
+              Transparent backgrounds are available for supported GPT Image models. For
+              `gpt-image-2` and `gpt-image-2-2026-04-21`, this support is in preview. When
+              using `transparent`, set the output format to `png` or `webp`.
           default: auto
         style:
           anyOf:
@@ -58536,11 +58542,13 @@ components:
             - type: string
               enum:
                 - gpt-image-1.5
+                - gpt-image-2
+                - gpt-image-2-2026-04-21
                 - gpt-image-1
                 - gpt-image-1-mini
                 - chatgpt-image-latest
             - type: 'null'
-          description: The model to use for image editing.
+          description: The GPT image model to use for image editing, including `gpt-image-2` and its dated snapshot `gpt-image-2-2026-04-21`.
           x-oaiTypeLabel: string
           default: gpt-image-1.5
         images:
@@ -58632,7 +58640,7 @@ components:
                 - opaque
                 - auto
             - type: 'null'
-          description: Background behavior for generated image output.
+          description: Set the background of the generated image output. Transparent backgrounds are available for supported GPT Image models. For `gpt-image-2` and `gpt-image-2-2026-04-21`, this support is in preview. When using `transparent`, set the output format to `png` or `webp`.
           default: auto
         stream:
           anyOf:
@@ -61188,6 +61196,8 @@ components:
                 - gpt-image-1
                 - gpt-image-1-mini
                 - gpt-image-1.5
+                - gpt-image-2
+                - gpt-image-2-2026-04-21
           default: gpt-image-1
         quality:
           type: string
@@ -61241,8 +61251,11 @@ components:
             - opaque
             - auto
           description: |-
-            Background type for the generated image. One of `transparent`,
-              `opaque`, or `auto`. Default: `auto`.
+            Set the background of the generated image. One of `transparent`,
+              `opaque`, or `auto`. Transparent backgrounds are available for
+              supported GPT Image models. For `gpt-image-2` and
+              `gpt-image-2-2026-04-21`, this support is in preview. When using
+              `transparent`, set the output format to `png` or `webp`. Default: `auto`.
           default: auto
         input_fidelity:
           anyOf:
@@ -61969,7 +61982,7 @@ components:
           default: compaction
         encrypted_content:
           type: string
-          maxLength: 10485760
+          maxLength: 20971520
           description: The encrypted content of the compaction summary.
       allOf:
         - $ref: '#/components/schemas/OpenAI.InputItem'
@@ -63113,7 +63126,7 @@ components:
           default: compaction
         encrypted_content:
           type: string
-          maxLength: 10485760
+          maxLength: 20971520
           description: The encrypted content of the compaction summary.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Item'
@@ -82860,7 +82873,6 @@ components:
       type: object
       required:
         - kind
-        - model_type
       properties:
         kind:
           type: string
@@ -82869,13 +82881,13 @@ components:
           description: The kind discriminator for a voice agent definition. Always `voice`.
         model_type:
           $ref: '#/components/schemas/VoiceModelType'
-          description: How the voice agent obtains its conversational backend. `managed` uses the service-managed model named by `model`; `self_deployed` uses the customer's Foundry deployment named by `model`; `hosted_agent` fronts the hosted text agent referenced by `target_agent`. This is independent of the architecture (realtime or cascaded), which the service derives from the selected backend.
+          description: How the model backing this voice agent is served. Required with `model` for a model-backed voice agent and omitted when `target_agent` is provided. This is independent of the architecture (realtime or cascaded), which the service derives from the selected model.
         model:
           type: string
-          description: The model to use for this agent. Required when `model_type` is `managed` (the service-managed model name) or `self_deployed` (the customer's Foundry deployment name). Omit this property when `model_type` is `hosted_agent`; `target_agent` identifies the conversational backend. The model must support realtime or cascaded voice.
+          description: The model to use for this agent. Required with `model_type` for a model-backed voice agent and omitted when `target_agent` is provided. The model must support realtime or cascaded voice.
         target_agent:
           $ref: '#/components/schemas/VoiceAgentTargetAgent'
-          description: The hosted text agent that this voice agent fronts. Required when `model_type` is `hosted_agent` and not applicable otherwise. In this mode, `model`, `instructions`, `tools`, and `tool_choice` must be omitted, and `greeting.tool_choice` cannot be `required`, because the target agent owns the conversation logic. The target must be in the same project and support the `invocations_ws` protocol, Voice Live compatibility, and Bridge Protocol 1.0.
+          description: The text agent that this voice agent fronts. Providing this property selects the agent-backed bridge path; `model_type` and `model` must be omitted. In this mode, `instructions`, `tools`, and `tool_choice` must also be omitted, and `greeting.tool_choice` cannot be `required`, because the target agent owns the conversation logic. The target must be in the same project. The initial implementation requires a hosted agent that supports the `invocations_ws` protocol, Voice Live compatibility, and Bridge Protocol 1.0.
         instructions:
           type: string
           description: A system (or developer) message inserted into the model's context. Supports template substitution via `structured_inputs`, rendered per session before the live session starts.
@@ -83578,7 +83590,7 @@ components:
           description: The target agent version. Omit this property to select the latest version when the voice session starts. When supplied, use a positive integer or `draft-{positive-unix-timestamp}` whose numeric component fits in a signed 64-bit integer.
       unevaluatedProperties:
         not: {}
-      description: A closed reference to the hosted text agent that a `hosted_agent` voice agent fronts, containing only its name and optional version. The target is resolved within the same project.
+      description: A closed reference to the text agent that an agent-backed voice agent fronts, containing only its name and optional version. The target is resolved within the same project. The initial implementation requires the target to be a hosted agent that supports the Voice Live bridge protocol.
       x-ms-foundry-meta:
         required_previews:
           - VoiceAgents=V1Preview
@@ -83924,7 +83936,6 @@ components:
           enum:
             - managed
             - self_deployed
-            - hosted_agent
       description: |-
         How the model backing a voice agent is served. This is independent of the architecture (realtime or cascaded),
         which the service derives from the selected model.

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -82869,36 +82869,6 @@ components:
       x-ms-foundry-meta:
         required_previews:
           - VoiceAgents=V1Preview
-    VoiceAgentConversationBridge:
-      type: object
-      required:
-        - type
-        - name
-      properties:
-        type:
-          type: string
-          enum:
-            - agent
-          description: Selects a Foundry agent as the conversation bridge.
-        name:
-          type: string
-          minLength: 1
-          maxLength: 63
-          pattern: ^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$
-          description: The non-empty DNS-like name of the target hosted text agent in the same project.
-        version:
-          type: string
-          maxLength: 25
-          pattern: ^(?:[1-9][0-9]{0,18}|draft-[1-9][0-9]{0,18})$
-          description: The target agent version. Omit this property to select the latest version when the voice session starts. When supplied, use a positive integer or `draft-{positive-unix-timestamp}` whose numeric component fits in a signed 64-bit integer.
-      unevaluatedProperties:
-        not: {}
-      allOf:
-        - $ref: '#/components/schemas/VoiceConversationBridge'
-      description: A closed reference to the text agent that owns conversation handling for a bridged voice agent. The target is resolved within the same project. The initial implementation requires a hosted agent that supports the `invocations_ws` protocol, Voice Live compatibility, and Bridge Protocol 1.0.
-      x-ms-foundry-meta:
-        required_previews:
-          - VoiceAgents=V1Preview
     VoiceAgentDefinition:
       type: object
       required:
@@ -82911,13 +82881,13 @@ components:
           description: The kind discriminator for a voice agent definition. Always `voice`.
         model_type:
           $ref: '#/components/schemas/VoiceModelType'
-          description: How the model backing this voice agent is served. Required with `model` for a model-backed voice agent and omitted when `conversation_bridge` is provided. This is independent of the architecture (realtime or cascaded), which the service derives from the selected model.
+          description: How the model backing this voice agent is served. Required with `model` for a model-backed voice agent and omitted when `conversation_engine` is provided. This is independent of the architecture (realtime or cascaded), which the service derives from the selected model.
         model:
           type: string
-          description: The model to use for this agent. Required with `model_type` for a model-backed voice agent and omitted when `conversation_bridge` is provided. The model must support realtime or cascaded voice.
-        conversation_bridge:
-          $ref: '#/components/schemas/VoiceConversationBridge'
-          description: Delegates conversation handling to another backend. Exactly one of this property and the model-backed configuration (`model_type` with `model`) must be provided. When this property is provided, `model_type`, `model`, `instructions`, `tools`, and `tool_choice` must be omitted, and `greeting.tool_choice` cannot be `required`, because the bridge owns the conversation logic. The initial implementation supports an agent bridge.
+          description: The model to use for this agent. Required with `model_type` for a model-backed voice agent and omitted when `conversation_engine` is provided. The model must support realtime or cascaded voice.
+        conversation_engine:
+          $ref: '#/components/schemas/VoiceConversationEngine'
+          description: The engine that owns conversation handling for this voice agent. Exactly one of this property and the model-backed configuration (`model_type` with `model`) must be provided. When this property is provided, `model_type`, `model`, `instructions`, `tools`, and `tool_choice` must be omitted, and `greeting.tool_choice` cannot be `required`, because the engine owns the conversation logic. The initial implementation supports a hosted-agent engine.
         instructions:
           type: string
           description: A system (or developer) message inserted into the model's context. Supports template substitution via `structured_inputs`, rendered per session before the live session starts.
@@ -83826,19 +83796,19 @@ components:
       x-ms-foundry-meta:
         required_previews:
           - VoiceAgents=V1Preview
-    VoiceConversationBridge:
+    VoiceConversationEngine:
       type: object
       required:
         - type
       properties:
         type:
           type: string
-          description: The conversation bridge type.
+          description: The conversation engine type.
       discriminator:
         propertyName: type
         mapping:
-          agent: '#/components/schemas/VoiceAgentConversationBridge'
-      description: A backend that owns conversation handling for a bridged voice agent.
+          hosted_agent: '#/components/schemas/VoiceHostedAgentConversationEngine'
+      description: An engine that owns conversation handling for a voice agent.
       x-ms-foundry-meta:
         required_previews:
           - VoiceAgents=V1Preview
@@ -83903,6 +83873,36 @@ components:
         `blob_uri`, a direct customer-storage URI without a SAS token, that the customer accesses with their own
         credentials. For Foundry-managed storage, `blob_uri` is absent and the bytes are streamed through the item's
         `/audio/generated/content` route.
+      x-ms-foundry-meta:
+        required_previews:
+          - VoiceAgents=V1Preview
+    VoiceHostedAgentConversationEngine:
+      type: object
+      required:
+        - type
+        - name
+      properties:
+        type:
+          type: string
+          enum:
+            - hosted_agent
+          description: Selects a hosted Foundry agent as the conversation engine.
+        name:
+          type: string
+          minLength: 1
+          maxLength: 63
+          pattern: ^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$
+          description: The non-empty DNS-like name of the target hosted text agent in the same project.
+        version:
+          type: string
+          maxLength: 25
+          pattern: ^(?:[1-9][0-9]{0,18}|draft-[1-9][0-9]{0,18})$
+          description: The target agent version. Omit this property to select the latest version when the voice session starts. When supplied, use a positive integer or `draft-{positive-unix-timestamp}` whose numeric component fits in a signed 64-bit integer.
+      unevaluatedProperties:
+        not: {}
+      allOf:
+        - $ref: '#/components/schemas/VoiceConversationEngine'
+      description: A closed reference to the hosted text agent that owns conversation handling for a voice agent. The hosted agent is resolved within the same project and must support the `invocations_ws` protocol, Voice Live compatibility, and Bridge Protocol 1.0.
       x-ms-foundry-meta:
         required_previews:
           - VoiceAgents=V1Preview

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -82869,6 +82869,36 @@ components:
       x-ms-foundry-meta:
         required_previews:
           - VoiceAgents=V1Preview
+    VoiceAgentConversationBridge:
+      type: object
+      required:
+        - type
+        - name
+      properties:
+        type:
+          type: string
+          enum:
+            - agent
+          description: Selects a Foundry agent as the conversation bridge.
+        name:
+          type: string
+          minLength: 1
+          maxLength: 63
+          pattern: ^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$
+          description: The non-empty DNS-like name of the target hosted text agent in the same project.
+        version:
+          type: string
+          maxLength: 25
+          pattern: ^(?:[1-9][0-9]{0,18}|draft-[1-9][0-9]{0,18})$
+          description: The target agent version. Omit this property to select the latest version when the voice session starts. When supplied, use a positive integer or `draft-{positive-unix-timestamp}` whose numeric component fits in a signed 64-bit integer.
+      unevaluatedProperties:
+        not: {}
+      allOf:
+        - $ref: '#/components/schemas/VoiceConversationBridge'
+      description: A closed reference to the text agent that owns conversation handling for a bridged voice agent. The target is resolved within the same project. The initial implementation requires a hosted agent that supports the `invocations_ws` protocol, Voice Live compatibility, and Bridge Protocol 1.0.
+      x-ms-foundry-meta:
+        required_previews:
+          - VoiceAgents=V1Preview
     VoiceAgentDefinition:
       type: object
       required:
@@ -82881,13 +82911,13 @@ components:
           description: The kind discriminator for a voice agent definition. Always `voice`.
         model_type:
           $ref: '#/components/schemas/VoiceModelType'
-          description: How the model backing this voice agent is served. Required with `model` for a model-backed voice agent and omitted when `target_agent` is provided. This is independent of the architecture (realtime or cascaded), which the service derives from the selected model.
+          description: How the model backing this voice agent is served. Required with `model` for a model-backed voice agent and omitted when `conversation_bridge` is provided. This is independent of the architecture (realtime or cascaded), which the service derives from the selected model.
         model:
           type: string
-          description: The model to use for this agent. Required with `model_type` for a model-backed voice agent and omitted when `target_agent` is provided. The model must support realtime or cascaded voice.
-        target_agent:
-          $ref: '#/components/schemas/VoiceAgentTargetAgent'
-          description: The text agent that this voice agent fronts. Providing this property selects the agent-backed bridge path; `model_type` and `model` must be omitted. In this mode, `instructions`, `tools`, and `tool_choice` must also be omitted, and `greeting.tool_choice` cannot be `required`, because the target agent owns the conversation logic. The target must be in the same project. The initial implementation requires a hosted agent that supports the `invocations_ws` protocol, Voice Live compatibility, and Bridge Protocol 1.0.
+          description: The model to use for this agent. Required with `model_type` for a model-backed voice agent and omitted when `conversation_bridge` is provided. The model must support realtime or cascaded voice.
+        conversation_bridge:
+          $ref: '#/components/schemas/VoiceConversationBridge'
+          description: Delegates conversation handling to another backend. Exactly one of this property and the model-backed configuration (`model_type` with `model`) must be provided. When this property is provided, `model_type`, `model`, `instructions`, `tools`, and `tool_choice` must be omitted, and `greeting.tool_choice` cannot be `required`, because the bridge owns the conversation logic. The initial implementation supports an agent bridge.
         instructions:
           type: string
           description: A system (or developer) message inserted into the model's context. Supports template substitution via `structured_inputs`, rendered per session before the live session starts.
@@ -83572,28 +83602,6 @@ components:
       x-ms-foundry-meta:
         required_previews:
           - VoiceAgents=V1Preview
-    VoiceAgentTargetAgent:
-      type: object
-      required:
-        - name
-      properties:
-        name:
-          type: string
-          minLength: 1
-          maxLength: 63
-          pattern: ^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$
-          description: The non-empty DNS-like name of the target hosted text agent in the same project.
-        version:
-          type: string
-          maxLength: 25
-          pattern: ^(?:[1-9][0-9]{0,18}|draft-[1-9][0-9]{0,18})$
-          description: The target agent version. Omit this property to select the latest version when the voice session starts. When supplied, use a positive integer or `draft-{positive-unix-timestamp}` whose numeric component fits in a signed 64-bit integer.
-      unevaluatedProperties:
-        not: {}
-      description: A closed reference to the text agent that an agent-backed voice agent fronts, containing only its name and optional version. The target is resolved within the same project. The initial implementation requires the target to be a hosted agent that supports the Voice Live bridge protocol.
-      x-ms-foundry-meta:
-        required_previews:
-          - VoiceAgents=V1Preview
     VoiceAgentTemplateGreetingConfig:
       type: object
       required:
@@ -83815,6 +83823,22 @@ components:
         transcript, responses, per-turn metrics, and audio. It is the parent, retention, and delete boundary:
         deleting it cascades to its responses, items, metrics, and audio. When finalization fails, any partial persisted
         responses, items, and item audio remain readable.
+      x-ms-foundry-meta:
+        required_previews:
+          - VoiceAgents=V1Preview
+    VoiceConversationBridge:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          description: The conversation bridge type.
+      discriminator:
+        propertyName: type
+        mapping:
+          agent: '#/components/schemas/VoiceAgentConversationBridge'
+      description: A backend that owns conversation handling for a bridged voice agent.
       x-ms-foundry-meta:
         required_previews:
           - VoiceAgents=V1Preview

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -56602,7 +56602,7 @@
                 }
               }
             ],
-            "description": "The image(s) to edit. Must be a supported image file or an array of images.\n  For the GPT image models (`gpt-image-1`, `gpt-image-1-mini`, and `gpt-image-1.5`), each image should be a `png`, `webp`, or `jpg`\n  file less than 50MB. You can provide up to 16 images.\n  `chatgpt-image-latest` follows the same input constraints as GPT image models.\n  For `dall-e-2`, you can only provide one image, and it should be a square\n  `png` file less than 4MB."
+            "description": "The image(s) to edit. Must be a supported image file or an array of images.\n  For the GPT image models (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`, and `gpt-image-2-2026-04-21`), each image should be a `png`, `webp`, or `jpg`\n  file less than 50MB. You can provide up to 16 images.\n  `chatgpt-image-latest` follows the same input constraints as GPT image models.\n  For `dall-e-2`, you can only provide one image, and it should be a square\n  `png` file less than 4MB."
           },
           "prompt": {
             "type": "string",
@@ -56625,7 +56625,7 @@
                 "type": "null"
               }
             ],
-            "description": "Allows to set transparency for the background of the generated image(s).\n  This parameter is only supported for the GPT image models. Must be one of\n  `transparent`, `opaque` or `auto` (default value). When `auto` is used, the\n  model will automatically determine the best background for the image.\n  If `transparent`, the output format needs to support transparency, so it\n  should be set to either `png` (default value) or `webp`."
+            "description": "Set the background of the generated image(s). This parameter is only\n  supported for the GPT image models. Must be one of `transparent`, `opaque`,\n  or `auto` (default value). When `auto` is used, the model will automatically\n  determine the best background for the image.\n  Transparent backgrounds are available for supported GPT Image models. For\n  `gpt-image-2` and `gpt-image-2-2026-04-21`, this support is in preview. When\n  using `transparent`, set the output format to `png` or `webp`."
           },
           "model": {
             "anyOf": [
@@ -56636,6 +56636,8 @@
                 "type": "string",
                 "enum": [
                   "gpt-image-1.5",
+                  "gpt-image-2",
+                  "gpt-image-2-2026-04-21",
                   "dall-e-2",
                   "gpt-image-1",
                   "gpt-image-1-mini",
@@ -56646,7 +56648,7 @@
                 "type": "null"
               }
             ],
-            "description": "The model to use for image generation. Defaults to `gpt-image-1.5`.",
+            "description": "The model to use for image generation. One of `dall-e-2` or a GPT image model (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`, `gpt-image-2-2026-04-21`, or `chatgpt-image-latest`). Defaults to `gpt-image-1.5`.",
             "x-oaiTypeLabel": "string"
           },
           "n": {
@@ -56795,6 +56797,8 @@
                 "type": "string",
                 "enum": [
                   "gpt-image-1.5",
+                  "gpt-image-2",
+                  "gpt-image-2-2026-04-21",
                   "dall-e-2",
                   "dall-e-3",
                   "gpt-image-1",
@@ -56805,7 +56809,7 @@
                 "type": "null"
               }
             ],
-            "description": "The model to use for image generation. One of `dall-e-2`, `dall-e-3`, or a GPT image model (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`). Defaults to `dall-e-2` unless a parameter specific to the GPT image models is used.",
+            "description": "The model to use for image generation. One of `dall-e-2`, `dall-e-3`, or a GPT image model (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`, `gpt-image-2-2026-04-21`). Defaults to `dall-e-2` unless a parameter specific to the GPT image models is used.",
             "x-oaiTypeLabel": "string",
             "default": "dall-e-2"
           },
@@ -56957,7 +56961,7 @@
                 "type": "null"
               }
             ],
-            "description": "Allows to set transparency for the background of the generated image(s).\n  This parameter is only supported for the GPT image models. Must be one of\n  `transparent`, `opaque` or `auto` (default value). When `auto` is used, the\n  model will automatically determine the best background for the image.\n  If `transparent`, the output format needs to support transparency, so it\n  should be set to either `png` (default value) or `webp`.",
+            "description": "Set the background of the generated image(s). This parameter is only\n  supported for the GPT image models. Must be one of `transparent`, `opaque`,\n  or `auto` (default value). When `auto` is used, the model will automatically\n  determine the best background for the image.\n  Transparent backgrounds are available for supported GPT Image models. For\n  `gpt-image-2` and `gpt-image-2-2026-04-21`, this support is in preview. When\n  using `transparent`, set the output format to `png` or `webp`.",
             "default": "auto"
           },
           "style": {
@@ -59713,6 +59717,8 @@
                 "type": "string",
                 "enum": [
                   "gpt-image-1.5",
+                  "gpt-image-2",
+                  "gpt-image-2-2026-04-21",
                   "gpt-image-1",
                   "gpt-image-1-mini",
                   "chatgpt-image-latest"
@@ -59722,7 +59728,7 @@
                 "type": "null"
               }
             ],
-            "description": "The model to use for image editing.",
+            "description": "The GPT image model to use for image editing, including `gpt-image-2` and its dated snapshot `gpt-image-2-2026-04-21`.",
             "x-oaiTypeLabel": "string",
             "default": "gpt-image-1.5"
           },
@@ -59869,7 +59875,7 @@
                 "type": "null"
               }
             ],
-            "description": "Background behavior for generated image output.",
+            "description": "Set the background of the generated image output. Transparent backgrounds are available for supported GPT Image models. For `gpt-image-2` and `gpt-image-2-2026-04-21`, this support is in preview. When using `transparent`, set the output format to `png` or `webp`.",
             "default": "auto"
           },
           "stream": {
@@ -63411,7 +63417,9 @@
                 "enum": [
                   "gpt-image-1",
                   "gpt-image-1-mini",
-                  "gpt-image-1.5"
+                  "gpt-image-1.5",
+                  "gpt-image-2",
+                  "gpt-image-2-2026-04-21"
                 ]
               }
             ],
@@ -63479,7 +63487,7 @@
               "opaque",
               "auto"
             ],
-            "description": "Background type for the generated image. One of `transparent`,\n  `opaque`, or `auto`. Default: `auto`.",
+            "description": "Set the background of the generated image. One of `transparent`,\n  `opaque`, or `auto`. Transparent backgrounds are available for\n  supported GPT Image models. For `gpt-image-2` and\n  `gpt-image-2-2026-04-21`, this support is in preview. When using\n  `transparent`, set the output format to `png` or `webp`. Default: `auto`.",
             "default": "auto"
           },
           "input_fidelity": {
@@ -64549,7 +64557,7 @@
           },
           "encrypted_content": {
             "type": "string",
-            "maxLength": 10485760,
+            "maxLength": 20971520,
             "description": "The encrypted content of the compaction summary."
           }
         },
@@ -66306,7 +66314,7 @@
           },
           "encrypted_content": {
             "type": "string",
-            "maxLength": 10485760,
+            "maxLength": 20971520,
             "description": "The encrypted content of the compaction summary."
           }
         },
@@ -93420,8 +93428,7 @@
       "VoiceAgentDefinition": {
         "type": "object",
         "required": [
-          "kind",
-          "model_type"
+          "kind"
         ],
         "properties": {
           "kind": {
@@ -93433,15 +93440,15 @@
           },
           "model_type": {
             "$ref": "#/components/schemas/VoiceModelType",
-            "description": "How the voice agent obtains its conversational backend. `managed` uses the service-managed model named by `model`; `self_deployed` uses the customer's Foundry deployment named by `model`; `hosted_agent` fronts the hosted text agent referenced by `target_agent`. This is independent of the architecture (realtime or cascaded), which the service derives from the selected backend."
+            "description": "How the model backing this voice agent is served. Required with `model` for a model-backed voice agent and omitted when `target_agent` is provided. This is independent of the architecture (realtime or cascaded), which the service derives from the selected model."
           },
           "model": {
             "type": "string",
-            "description": "The model to use for this agent. Required when `model_type` is `managed` (the service-managed model name) or `self_deployed` (the customer's Foundry deployment name). Omit this property when `model_type` is `hosted_agent`; `target_agent` identifies the conversational backend. The model must support realtime or cascaded voice."
+            "description": "The model to use for this agent. Required with `model_type` for a model-backed voice agent and omitted when `target_agent` is provided. The model must support realtime or cascaded voice."
           },
           "target_agent": {
             "$ref": "#/components/schemas/VoiceAgentTargetAgent",
-            "description": "The hosted text agent that this voice agent fronts. Required when `model_type` is `hosted_agent` and not applicable otherwise. In this mode, `model`, `instructions`, `tools`, and `tool_choice` must be omitted, and `greeting.tool_choice` cannot be `required`, because the target agent owns the conversation logic. The target must be in the same project and support the `invocations_ws` protocol, Voice Live compatibility, and Bridge Protocol 1.0."
+            "description": "The text agent that this voice agent fronts. Providing this property selects the agent-backed bridge path; `model_type` and `model` must be omitted. In this mode, `instructions`, `tools`, and `tool_choice` must also be omitted, and `greeting.tool_choice` cannot be `required`, because the target agent owns the conversation logic. The target must be in the same project. The initial implementation requires a hosted agent that supports the `invocations_ws` protocol, Voice Live compatibility, and Bridge Protocol 1.0."
           },
           "instructions": {
             "type": "string",
@@ -94446,7 +94453,7 @@
         "unevaluatedProperties": {
           "not": {}
         },
-        "description": "A closed reference to the hosted text agent that a `hosted_agent` voice agent fronts, containing only its name and optional version. The target is resolved within the same project.",
+        "description": "A closed reference to the text agent that an agent-backed voice agent fronts, containing only its name and optional version. The target is resolved within the same project. The initial implementation requires the target to be a hosted agent that supports the Voice Live bridge protocol.",
         "x-ms-foundry-meta": {
           "required_previews": [
             "VoiceAgents=V1Preview"
@@ -94942,8 +94949,7 @@
             "type": "string",
             "enum": [
               "managed",
-              "self_deployed",
-              "hosted_agent"
+              "self_deployed"
             ]
           }
         ],

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -93425,6 +93425,49 @@
           ]
         }
       },
+      "VoiceAgentConversationBridge": {
+        "type": "object",
+        "required": [
+          "type",
+          "name"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "agent"
+            ],
+            "description": "Selects a Foundry agent as the conversation bridge."
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$",
+            "description": "The non-empty DNS-like name of the target hosted text agent in the same project."
+          },
+          "version": {
+            "type": "string",
+            "maxLength": 25,
+            "pattern": "^(?:[1-9][0-9]{0,18}|draft-[1-9][0-9]{0,18})$",
+            "description": "The target agent version. Omit this property to select the latest version when the voice session starts. When supplied, use a positive integer or `draft-{positive-unix-timestamp}` whose numeric component fits in a signed 64-bit integer."
+          }
+        },
+        "unevaluatedProperties": {
+          "not": {}
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/VoiceConversationBridge"
+          }
+        ],
+        "description": "A closed reference to the text agent that owns conversation handling for a bridged voice agent. The target is resolved within the same project. The initial implementation requires a hosted agent that supports the `invocations_ws` protocol, Voice Live compatibility, and Bridge Protocol 1.0.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "VoiceAgents=V1Preview"
+          ]
+        }
+      },
       "VoiceAgentDefinition": {
         "type": "object",
         "required": [
@@ -93440,15 +93483,15 @@
           },
           "model_type": {
             "$ref": "#/components/schemas/VoiceModelType",
-            "description": "How the model backing this voice agent is served. Required with `model` for a model-backed voice agent and omitted when `target_agent` is provided. This is independent of the architecture (realtime or cascaded), which the service derives from the selected model."
+            "description": "How the model backing this voice agent is served. Required with `model` for a model-backed voice agent and omitted when `conversation_bridge` is provided. This is independent of the architecture (realtime or cascaded), which the service derives from the selected model."
           },
           "model": {
             "type": "string",
-            "description": "The model to use for this agent. Required with `model_type` for a model-backed voice agent and omitted when `target_agent` is provided. The model must support realtime or cascaded voice."
+            "description": "The model to use for this agent. Required with `model_type` for a model-backed voice agent and omitted when `conversation_bridge` is provided. The model must support realtime or cascaded voice."
           },
-          "target_agent": {
-            "$ref": "#/components/schemas/VoiceAgentTargetAgent",
-            "description": "The text agent that this voice agent fronts. Providing this property selects the agent-backed bridge path; `model_type` and `model` must be omitted. In this mode, `instructions`, `tools`, and `tool_choice` must also be omitted, and `greeting.tool_choice` cannot be `required`, because the target agent owns the conversation logic. The target must be in the same project. The initial implementation requires a hosted agent that supports the `invocations_ws` protocol, Voice Live compatibility, and Bridge Protocol 1.0."
+          "conversation_bridge": {
+            "$ref": "#/components/schemas/VoiceConversationBridge",
+            "description": "Delegates conversation handling to another backend. Exactly one of this property and the model-backed configuration (`model_type` with `model`) must be provided. When this property is provided, `model_type`, `model`, `instructions`, `tools`, and `tool_choice` must be omitted, and `greeting.tool_choice` cannot be `required`, because the bridge owns the conversation logic. The initial implementation supports an agent bridge."
           },
           "instructions": {
             "type": "string",
@@ -94430,36 +94473,6 @@
           ]
         }
       },
-      "VoiceAgentTargetAgent": {
-        "type": "object",
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 63,
-            "pattern": "^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$",
-            "description": "The non-empty DNS-like name of the target hosted text agent in the same project."
-          },
-          "version": {
-            "type": "string",
-            "maxLength": 25,
-            "pattern": "^(?:[1-9][0-9]{0,18}|draft-[1-9][0-9]{0,18})$",
-            "description": "The target agent version. Omit this property to select the latest version when the voice session starts. When supplied, use a positive integer or `draft-{positive-unix-timestamp}` whose numeric component fits in a signed 64-bit integer."
-          }
-        },
-        "unevaluatedProperties": {
-          "not": {}
-        },
-        "description": "A closed reference to the text agent that an agent-backed voice agent fronts, containing only its name and optional version. The target is resolved within the same project. The initial implementation requires the target to be a hosted agent that supports the Voice Live bridge protocol.",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "VoiceAgents=V1Preview"
-          ]
-        }
-      },
       "VoiceAgentTemplateGreetingConfig": {
         "type": "object",
         "required": [
@@ -94797,6 +94810,30 @@
           }
         },
         "description": "A persisted voice conversation. The Foundry envelope that owns a voice agent's stored\ntranscript, responses, per-turn metrics, and audio. It is the parent, retention, and delete boundary:\ndeleting it cascades to its responses, items, metrics, and audio. When finalization fails, any partial persisted\nresponses, items, and item audio remain readable.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "VoiceAgents=V1Preview"
+          ]
+        }
+      },
+      "VoiceConversationBridge": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "The conversation bridge type."
+          }
+        },
+        "discriminator": {
+          "propertyName": "type",
+          "mapping": {
+            "agent": "#/components/schemas/VoiceAgentConversationBridge"
+          }
+        },
+        "description": "A backend that owns conversation handling for a bridged voice agent.",
         "x-ms-foundry-meta": {
           "required_previews": [
             "VoiceAgents=V1Preview"

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -93425,49 +93425,6 @@
           ]
         }
       },
-      "VoiceAgentConversationBridge": {
-        "type": "object",
-        "required": [
-          "type",
-          "name"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "agent"
-            ],
-            "description": "Selects a Foundry agent as the conversation bridge."
-          },
-          "name": {
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 63,
-            "pattern": "^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$",
-            "description": "The non-empty DNS-like name of the target hosted text agent in the same project."
-          },
-          "version": {
-            "type": "string",
-            "maxLength": 25,
-            "pattern": "^(?:[1-9][0-9]{0,18}|draft-[1-9][0-9]{0,18})$",
-            "description": "The target agent version. Omit this property to select the latest version when the voice session starts. When supplied, use a positive integer or `draft-{positive-unix-timestamp}` whose numeric component fits in a signed 64-bit integer."
-          }
-        },
-        "unevaluatedProperties": {
-          "not": {}
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/VoiceConversationBridge"
-          }
-        ],
-        "description": "A closed reference to the text agent that owns conversation handling for a bridged voice agent. The target is resolved within the same project. The initial implementation requires a hosted agent that supports the `invocations_ws` protocol, Voice Live compatibility, and Bridge Protocol 1.0.",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "VoiceAgents=V1Preview"
-          ]
-        }
-      },
       "VoiceAgentDefinition": {
         "type": "object",
         "required": [
@@ -93483,15 +93440,15 @@
           },
           "model_type": {
             "$ref": "#/components/schemas/VoiceModelType",
-            "description": "How the model backing this voice agent is served. Required with `model` for a model-backed voice agent and omitted when `conversation_bridge` is provided. This is independent of the architecture (realtime or cascaded), which the service derives from the selected model."
+            "description": "How the model backing this voice agent is served. Required with `model` for a model-backed voice agent and omitted when `conversation_engine` is provided. This is independent of the architecture (realtime or cascaded), which the service derives from the selected model."
           },
           "model": {
             "type": "string",
-            "description": "The model to use for this agent. Required with `model_type` for a model-backed voice agent and omitted when `conversation_bridge` is provided. The model must support realtime or cascaded voice."
+            "description": "The model to use for this agent. Required with `model_type` for a model-backed voice agent and omitted when `conversation_engine` is provided. The model must support realtime or cascaded voice."
           },
-          "conversation_bridge": {
-            "$ref": "#/components/schemas/VoiceConversationBridge",
-            "description": "Delegates conversation handling to another backend. Exactly one of this property and the model-backed configuration (`model_type` with `model`) must be provided. When this property is provided, `model_type`, `model`, `instructions`, `tools`, and `tool_choice` must be omitted, and `greeting.tool_choice` cannot be `required`, because the bridge owns the conversation logic. The initial implementation supports an agent bridge."
+          "conversation_engine": {
+            "$ref": "#/components/schemas/VoiceConversationEngine",
+            "description": "The engine that owns conversation handling for this voice agent. Exactly one of this property and the model-backed configuration (`model_type` with `model`) must be provided. When this property is provided, `model_type`, `model`, `instructions`, `tools`, and `tool_choice` must be omitted, and `greeting.tool_choice` cannot be `required`, because the engine owns the conversation logic. The initial implementation supports a hosted-agent engine."
           },
           "instructions": {
             "type": "string",
@@ -94816,7 +94773,7 @@
           ]
         }
       },
-      "VoiceConversationBridge": {
+      "VoiceConversationEngine": {
         "type": "object",
         "required": [
           "type"
@@ -94824,16 +94781,16 @@
         "properties": {
           "type": {
             "type": "string",
-            "description": "The conversation bridge type."
+            "description": "The conversation engine type."
           }
         },
         "discriminator": {
           "propertyName": "type",
           "mapping": {
-            "agent": "#/components/schemas/VoiceAgentConversationBridge"
+            "hosted_agent": "#/components/schemas/VoiceHostedAgentConversationEngine"
           }
         },
-        "description": "A backend that owns conversation handling for a bridged voice agent.",
+        "description": "An engine that owns conversation handling for a voice agent.",
         "x-ms-foundry-meta": {
           "required_previews": [
             "VoiceAgents=V1Preview"
@@ -94913,6 +94870,49 @@
           }
         },
         "description": "Metadata for a conversation item's generated audio. For bring-your-own-storage (BYOS), the response includes\n`blob_uri`, a direct customer-storage URI without a SAS token, that the customer accesses with their own\ncredentials. For Foundry-managed storage, `blob_uri` is absent and the bytes are streamed through the item's\n`/audio/generated/content` route.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "VoiceAgents=V1Preview"
+          ]
+        }
+      },
+      "VoiceHostedAgentConversationEngine": {
+        "type": "object",
+        "required": [
+          "type",
+          "name"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "hosted_agent"
+            ],
+            "description": "Selects a hosted Foundry agent as the conversation engine."
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$",
+            "description": "The non-empty DNS-like name of the target hosted text agent in the same project."
+          },
+          "version": {
+            "type": "string",
+            "maxLength": 25,
+            "pattern": "^(?:[1-9][0-9]{0,18}|draft-[1-9][0-9]{0,18})$",
+            "description": "The target agent version. Omit this property to select the latest version when the voice session starts. When supplied, use a positive integer or `draft-{positive-unix-timestamp}` whose numeric component fits in a signed 64-bit integer."
+          }
+        },
+        "unevaluatedProperties": {
+          "not": {}
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/VoiceConversationEngine"
+          }
+        ],
+        "description": "A closed reference to the hosted text agent that owns conversation handling for a voice agent. The hosted agent is resolved within the same project and must support the `invocations_ws` protocol, Voice Live compatibility, and Bridge Protocol 1.0.",
         "x-ms-foundry-meta": {
           "required_previews": [
             "VoiceAgents=V1Preview"

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -59423,7 +59423,7 @@ components:
                 contentEncoding: base64
           description: |-
             The image(s) to edit. Must be a supported image file or an array of images.
-              For the GPT image models (`gpt-image-1`, `gpt-image-1-mini`, and `gpt-image-1.5`), each image should be a `png`, `webp`, or `jpg`
+              For the GPT image models (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`, and `gpt-image-2-2026-04-21`), each image should be a `png`, `webp`, or `jpg`
               file less than 50MB. You can provide up to 16 images.
               `chatgpt-image-latest` follows the same input constraints as GPT image models.
               For `dall-e-2`, you can only provide one image, and it should be a square
@@ -59442,24 +59442,27 @@ components:
                 - auto
             - type: 'null'
           description: |-
-            Allows to set transparency for the background of the generated image(s).
-              This parameter is only supported for the GPT image models. Must be one of
-              `transparent`, `opaque` or `auto` (default value). When `auto` is used, the
-              model will automatically determine the best background for the image.
-              If `transparent`, the output format needs to support transparency, so it
-              should be set to either `png` (default value) or `webp`.
+            Set the background of the generated image(s). This parameter is only
+              supported for the GPT image models. Must be one of `transparent`, `opaque`,
+              or `auto` (default value). When `auto` is used, the model will automatically
+              determine the best background for the image.
+              Transparent backgrounds are available for supported GPT Image models. For
+              `gpt-image-2` and `gpt-image-2-2026-04-21`, this support is in preview. When
+              using `transparent`, set the output format to `png` or `webp`.
         model:
           anyOf:
             - type: string
             - type: string
               enum:
                 - gpt-image-1.5
+                - gpt-image-2
+                - gpt-image-2-2026-04-21
                 - dall-e-2
                 - gpt-image-1
                 - gpt-image-1-mini
                 - chatgpt-image-latest
             - type: 'null'
-          description: The model to use for image generation. Defaults to `gpt-image-1.5`.
+          description: The model to use for image generation. One of `dall-e-2` or a GPT image model (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`, `gpt-image-2-2026-04-21`, or `chatgpt-image-latest`). Defaults to `gpt-image-1.5`.
           x-oaiTypeLabel: string
         'n':
           anyOf:
@@ -59551,12 +59554,14 @@ components:
             - type: string
               enum:
                 - gpt-image-1.5
+                - gpt-image-2
+                - gpt-image-2-2026-04-21
                 - dall-e-2
                 - dall-e-3
                 - gpt-image-1
                 - gpt-image-1-mini
             - type: 'null'
-          description: The model to use for image generation. One of `dall-e-2`, `dall-e-3`, or a GPT image model (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`). Defaults to `dall-e-2` unless a parameter specific to the GPT image models is used.
+          description: The model to use for image generation. One of `dall-e-2`, `dall-e-3`, or a GPT image model (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`, `gpt-image-2-2026-04-21`). Defaults to `dall-e-2` unless a parameter specific to the GPT image models is used.
           x-oaiTypeLabel: string
           default: dall-e-2
         'n':
@@ -59654,12 +59659,13 @@ components:
                 - auto
             - type: 'null'
           description: |-
-            Allows to set transparency for the background of the generated image(s).
-              This parameter is only supported for the GPT image models. Must be one of
-              `transparent`, `opaque` or `auto` (default value). When `auto` is used, the
-              model will automatically determine the best background for the image.
-              If `transparent`, the output format needs to support transparency, so it
-              should be set to either `png` (default value) or `webp`.
+            Set the background of the generated image(s). This parameter is only
+              supported for the GPT image models. Must be one of `transparent`, `opaque`,
+              or `auto` (default value). When `auto` is used, the model will automatically
+              determine the best background for the image.
+              Transparent backgrounds are available for supported GPT Image models. For
+              `gpt-image-2` and `gpt-image-2-2026-04-21`, this support is in preview. When
+              using `transparent`, set the output format to `png` or `webp`.
           default: auto
         style:
           anyOf:
@@ -61584,11 +61590,13 @@ components:
             - type: string
               enum:
                 - gpt-image-1.5
+                - gpt-image-2
+                - gpt-image-2-2026-04-21
                 - gpt-image-1
                 - gpt-image-1-mini
                 - chatgpt-image-latest
             - type: 'null'
-          description: The model to use for image editing.
+          description: The GPT image model to use for image editing, including `gpt-image-2` and its dated snapshot `gpt-image-2-2026-04-21`.
           x-oaiTypeLabel: string
           default: gpt-image-1.5
         images:
@@ -61680,7 +61688,7 @@ components:
                 - opaque
                 - auto
             - type: 'null'
-          description: Background behavior for generated image output.
+          description: Set the background of the generated image output. Transparent backgrounds are available for supported GPT Image models. For `gpt-image-2` and `gpt-image-2-2026-04-21`, this support is in preview. When using `transparent`, set the output format to `png` or `webp`.
           default: auto
         stream:
           anyOf:
@@ -64236,6 +64244,8 @@ components:
                 - gpt-image-1
                 - gpt-image-1-mini
                 - gpt-image-1.5
+                - gpt-image-2
+                - gpt-image-2-2026-04-21
           default: gpt-image-1
         quality:
           type: string
@@ -64289,8 +64299,11 @@ components:
             - opaque
             - auto
           description: |-
-            Background type for the generated image. One of `transparent`,
-              `opaque`, or `auto`. Default: `auto`.
+            Set the background of the generated image. One of `transparent`,
+              `opaque`, or `auto`. Transparent backgrounds are available for
+              supported GPT Image models. For `gpt-image-2` and
+              `gpt-image-2-2026-04-21`, this support is in preview. When using
+              `transparent`, set the output format to `png` or `webp`. Default: `auto`.
           default: auto
         input_fidelity:
           anyOf:
@@ -65017,7 +65030,7 @@ components:
           default: compaction
         encrypted_content:
           type: string
-          maxLength: 10485760
+          maxLength: 20971520
           description: The encrypted content of the compaction summary.
       allOf:
         - $ref: '#/components/schemas/OpenAI.InputItem'
@@ -66161,7 +66174,7 @@ components:
           default: compaction
         encrypted_content:
           type: string
-          maxLength: 10485760
+          maxLength: 20971520
           description: The encrypted content of the compaction summary.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Item'
@@ -86064,7 +86077,6 @@ components:
       type: object
       required:
         - kind
-        - model_type
       properties:
         kind:
           type: string
@@ -86073,13 +86085,13 @@ components:
           description: The kind discriminator for a voice agent definition. Always `voice`.
         model_type:
           $ref: '#/components/schemas/VoiceModelType'
-          description: How the voice agent obtains its conversational backend. `managed` uses the service-managed model named by `model`; `self_deployed` uses the customer's Foundry deployment named by `model`; `hosted_agent` fronts the hosted text agent referenced by `target_agent`. This is independent of the architecture (realtime or cascaded), which the service derives from the selected backend.
+          description: How the model backing this voice agent is served. Required with `model` for a model-backed voice agent and omitted when `target_agent` is provided. This is independent of the architecture (realtime or cascaded), which the service derives from the selected model.
         model:
           type: string
-          description: The model to use for this agent. Required when `model_type` is `managed` (the service-managed model name) or `self_deployed` (the customer's Foundry deployment name). Omit this property when `model_type` is `hosted_agent`; `target_agent` identifies the conversational backend. The model must support realtime or cascaded voice.
+          description: The model to use for this agent. Required with `model_type` for a model-backed voice agent and omitted when `target_agent` is provided. The model must support realtime or cascaded voice.
         target_agent:
           $ref: '#/components/schemas/VoiceAgentTargetAgent'
-          description: The hosted text agent that this voice agent fronts. Required when `model_type` is `hosted_agent` and not applicable otherwise. In this mode, `model`, `instructions`, `tools`, and `tool_choice` must be omitted, and `greeting.tool_choice` cannot be `required`, because the target agent owns the conversation logic. The target must be in the same project and support the `invocations_ws` protocol, Voice Live compatibility, and Bridge Protocol 1.0.
+          description: The text agent that this voice agent fronts. Providing this property selects the agent-backed bridge path; `model_type` and `model` must be omitted. In this mode, `instructions`, `tools`, and `tool_choice` must also be omitted, and `greeting.tool_choice` cannot be `required`, because the target agent owns the conversation logic. The target must be in the same project. The initial implementation requires a hosted agent that supports the `invocations_ws` protocol, Voice Live compatibility, and Bridge Protocol 1.0.
         instructions:
           type: string
           description: A system (or developer) message inserted into the model's context. Supports template substitution via `structured_inputs`, rendered per session before the live session starts.
@@ -86782,7 +86794,7 @@ components:
           description: The target agent version. Omit this property to select the latest version when the voice session starts. When supplied, use a positive integer or `draft-{positive-unix-timestamp}` whose numeric component fits in a signed 64-bit integer.
       unevaluatedProperties:
         not: {}
-      description: A closed reference to the hosted text agent that a `hosted_agent` voice agent fronts, containing only its name and optional version. The target is resolved within the same project.
+      description: A closed reference to the text agent that an agent-backed voice agent fronts, containing only its name and optional version. The target is resolved within the same project. The initial implementation requires the target to be a hosted agent that supports the Voice Live bridge protocol.
       x-ms-foundry-meta:
         required_previews:
           - VoiceAgents=V1Preview
@@ -87128,7 +87140,6 @@ components:
           enum:
             - managed
             - self_deployed
-            - hosted_agent
       description: |-
         How the model backing a voice agent is served. This is independent of the architecture (realtime or cascaded),
         which the service derives from the selected model.

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -86073,36 +86073,6 @@ components:
       x-ms-foundry-meta:
         required_previews:
           - VoiceAgents=V1Preview
-    VoiceAgentConversationBridge:
-      type: object
-      required:
-        - type
-        - name
-      properties:
-        type:
-          type: string
-          enum:
-            - agent
-          description: Selects a Foundry agent as the conversation bridge.
-        name:
-          type: string
-          minLength: 1
-          maxLength: 63
-          pattern: ^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$
-          description: The non-empty DNS-like name of the target hosted text agent in the same project.
-        version:
-          type: string
-          maxLength: 25
-          pattern: ^(?:[1-9][0-9]{0,18}|draft-[1-9][0-9]{0,18})$
-          description: The target agent version. Omit this property to select the latest version when the voice session starts. When supplied, use a positive integer or `draft-{positive-unix-timestamp}` whose numeric component fits in a signed 64-bit integer.
-      unevaluatedProperties:
-        not: {}
-      allOf:
-        - $ref: '#/components/schemas/VoiceConversationBridge'
-      description: A closed reference to the text agent that owns conversation handling for a bridged voice agent. The target is resolved within the same project. The initial implementation requires a hosted agent that supports the `invocations_ws` protocol, Voice Live compatibility, and Bridge Protocol 1.0.
-      x-ms-foundry-meta:
-        required_previews:
-          - VoiceAgents=V1Preview
     VoiceAgentDefinition:
       type: object
       required:
@@ -86115,13 +86085,13 @@ components:
           description: The kind discriminator for a voice agent definition. Always `voice`.
         model_type:
           $ref: '#/components/schemas/VoiceModelType'
-          description: How the model backing this voice agent is served. Required with `model` for a model-backed voice agent and omitted when `conversation_bridge` is provided. This is independent of the architecture (realtime or cascaded), which the service derives from the selected model.
+          description: How the model backing this voice agent is served. Required with `model` for a model-backed voice agent and omitted when `conversation_engine` is provided. This is independent of the architecture (realtime or cascaded), which the service derives from the selected model.
         model:
           type: string
-          description: The model to use for this agent. Required with `model_type` for a model-backed voice agent and omitted when `conversation_bridge` is provided. The model must support realtime or cascaded voice.
-        conversation_bridge:
-          $ref: '#/components/schemas/VoiceConversationBridge'
-          description: Delegates conversation handling to another backend. Exactly one of this property and the model-backed configuration (`model_type` with `model`) must be provided. When this property is provided, `model_type`, `model`, `instructions`, `tools`, and `tool_choice` must be omitted, and `greeting.tool_choice` cannot be `required`, because the bridge owns the conversation logic. The initial implementation supports an agent bridge.
+          description: The model to use for this agent. Required with `model_type` for a model-backed voice agent and omitted when `conversation_engine` is provided. The model must support realtime or cascaded voice.
+        conversation_engine:
+          $ref: '#/components/schemas/VoiceConversationEngine'
+          description: The engine that owns conversation handling for this voice agent. Exactly one of this property and the model-backed configuration (`model_type` with `model`) must be provided. When this property is provided, `model_type`, `model`, `instructions`, `tools`, and `tool_choice` must be omitted, and `greeting.tool_choice` cannot be `required`, because the engine owns the conversation logic. The initial implementation supports a hosted-agent engine.
         instructions:
           type: string
           description: A system (or developer) message inserted into the model's context. Supports template substitution via `structured_inputs`, rendered per session before the live session starts.
@@ -87030,19 +87000,19 @@ components:
       x-ms-foundry-meta:
         required_previews:
           - VoiceAgents=V1Preview
-    VoiceConversationBridge:
+    VoiceConversationEngine:
       type: object
       required:
         - type
       properties:
         type:
           type: string
-          description: The conversation bridge type.
+          description: The conversation engine type.
       discriminator:
         propertyName: type
         mapping:
-          agent: '#/components/schemas/VoiceAgentConversationBridge'
-      description: A backend that owns conversation handling for a bridged voice agent.
+          hosted_agent: '#/components/schemas/VoiceHostedAgentConversationEngine'
+      description: An engine that owns conversation handling for a voice agent.
       x-ms-foundry-meta:
         required_previews:
           - VoiceAgents=V1Preview
@@ -87107,6 +87077,36 @@ components:
         `blob_uri`, a direct customer-storage URI without a SAS token, that the customer accesses with their own
         credentials. For Foundry-managed storage, `blob_uri` is absent and the bytes are streamed through the item's
         `/audio/generated/content` route.
+      x-ms-foundry-meta:
+        required_previews:
+          - VoiceAgents=V1Preview
+    VoiceHostedAgentConversationEngine:
+      type: object
+      required:
+        - type
+        - name
+      properties:
+        type:
+          type: string
+          enum:
+            - hosted_agent
+          description: Selects a hosted Foundry agent as the conversation engine.
+        name:
+          type: string
+          minLength: 1
+          maxLength: 63
+          pattern: ^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$
+          description: The non-empty DNS-like name of the target hosted text agent in the same project.
+        version:
+          type: string
+          maxLength: 25
+          pattern: ^(?:[1-9][0-9]{0,18}|draft-[1-9][0-9]{0,18})$
+          description: The target agent version. Omit this property to select the latest version when the voice session starts. When supplied, use a positive integer or `draft-{positive-unix-timestamp}` whose numeric component fits in a signed 64-bit integer.
+      unevaluatedProperties:
+        not: {}
+      allOf:
+        - $ref: '#/components/schemas/VoiceConversationEngine'
+      description: A closed reference to the hosted text agent that owns conversation handling for a voice agent. The hosted agent is resolved within the same project and must support the `invocations_ws` protocol, Voice Live compatibility, and Bridge Protocol 1.0.
       x-ms-foundry-meta:
         required_previews:
           - VoiceAgents=V1Preview

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -86073,6 +86073,36 @@ components:
       x-ms-foundry-meta:
         required_previews:
           - VoiceAgents=V1Preview
+    VoiceAgentConversationBridge:
+      type: object
+      required:
+        - type
+        - name
+      properties:
+        type:
+          type: string
+          enum:
+            - agent
+          description: Selects a Foundry agent as the conversation bridge.
+        name:
+          type: string
+          minLength: 1
+          maxLength: 63
+          pattern: ^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$
+          description: The non-empty DNS-like name of the target hosted text agent in the same project.
+        version:
+          type: string
+          maxLength: 25
+          pattern: ^(?:[1-9][0-9]{0,18}|draft-[1-9][0-9]{0,18})$
+          description: The target agent version. Omit this property to select the latest version when the voice session starts. When supplied, use a positive integer or `draft-{positive-unix-timestamp}` whose numeric component fits in a signed 64-bit integer.
+      unevaluatedProperties:
+        not: {}
+      allOf:
+        - $ref: '#/components/schemas/VoiceConversationBridge'
+      description: A closed reference to the text agent that owns conversation handling for a bridged voice agent. The target is resolved within the same project. The initial implementation requires a hosted agent that supports the `invocations_ws` protocol, Voice Live compatibility, and Bridge Protocol 1.0.
+      x-ms-foundry-meta:
+        required_previews:
+          - VoiceAgents=V1Preview
     VoiceAgentDefinition:
       type: object
       required:
@@ -86085,13 +86115,13 @@ components:
           description: The kind discriminator for a voice agent definition. Always `voice`.
         model_type:
           $ref: '#/components/schemas/VoiceModelType'
-          description: How the model backing this voice agent is served. Required with `model` for a model-backed voice agent and omitted when `target_agent` is provided. This is independent of the architecture (realtime or cascaded), which the service derives from the selected model.
+          description: How the model backing this voice agent is served. Required with `model` for a model-backed voice agent and omitted when `conversation_bridge` is provided. This is independent of the architecture (realtime or cascaded), which the service derives from the selected model.
         model:
           type: string
-          description: The model to use for this agent. Required with `model_type` for a model-backed voice agent and omitted when `target_agent` is provided. The model must support realtime or cascaded voice.
-        target_agent:
-          $ref: '#/components/schemas/VoiceAgentTargetAgent'
-          description: The text agent that this voice agent fronts. Providing this property selects the agent-backed bridge path; `model_type` and `model` must be omitted. In this mode, `instructions`, `tools`, and `tool_choice` must also be omitted, and `greeting.tool_choice` cannot be `required`, because the target agent owns the conversation logic. The target must be in the same project. The initial implementation requires a hosted agent that supports the `invocations_ws` protocol, Voice Live compatibility, and Bridge Protocol 1.0.
+          description: The model to use for this agent. Required with `model_type` for a model-backed voice agent and omitted when `conversation_bridge` is provided. The model must support realtime or cascaded voice.
+        conversation_bridge:
+          $ref: '#/components/schemas/VoiceConversationBridge'
+          description: Delegates conversation handling to another backend. Exactly one of this property and the model-backed configuration (`model_type` with `model`) must be provided. When this property is provided, `model_type`, `model`, `instructions`, `tools`, and `tool_choice` must be omitted, and `greeting.tool_choice` cannot be `required`, because the bridge owns the conversation logic. The initial implementation supports an agent bridge.
         instructions:
           type: string
           description: A system (or developer) message inserted into the model's context. Supports template substitution via `structured_inputs`, rendered per session before the live session starts.
@@ -86776,28 +86806,6 @@ components:
       x-ms-foundry-meta:
         required_previews:
           - VoiceAgents=V1Preview
-    VoiceAgentTargetAgent:
-      type: object
-      required:
-        - name
-      properties:
-        name:
-          type: string
-          minLength: 1
-          maxLength: 63
-          pattern: ^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$
-          description: The non-empty DNS-like name of the target hosted text agent in the same project.
-        version:
-          type: string
-          maxLength: 25
-          pattern: ^(?:[1-9][0-9]{0,18}|draft-[1-9][0-9]{0,18})$
-          description: The target agent version. Omit this property to select the latest version when the voice session starts. When supplied, use a positive integer or `draft-{positive-unix-timestamp}` whose numeric component fits in a signed 64-bit integer.
-      unevaluatedProperties:
-        not: {}
-      description: A closed reference to the text agent that an agent-backed voice agent fronts, containing only its name and optional version. The target is resolved within the same project. The initial implementation requires the target to be a hosted agent that supports the Voice Live bridge protocol.
-      x-ms-foundry-meta:
-        required_previews:
-          - VoiceAgents=V1Preview
     VoiceAgentTemplateGreetingConfig:
       type: object
       required:
@@ -87019,6 +87027,22 @@ components:
         transcript, responses, per-turn metrics, and audio. It is the parent, retention, and delete boundary:
         deleting it cascades to its responses, items, metrics, and audio. When finalization fails, any partial persisted
         responses, items, and item audio remain readable.
+      x-ms-foundry-meta:
+        required_previews:
+          - VoiceAgents=V1Preview
+    VoiceConversationBridge:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          description: The conversation bridge type.
+      discriminator:
+        propertyName: type
+        mapping:
+          agent: '#/components/schemas/VoiceAgentConversationBridge'
+      description: A backend that owns conversation handling for a bridged voice agent.
       x-ms-foundry-meta:
         required_previews:
           - VoiceAgents=V1Preview

--- a/specification/ai-foundry/data-plane/Foundry/src/voice-agents/agents.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/voice-agents/agents.tsp
@@ -96,13 +96,13 @@ model VoiceAgentDefinition extends AgentDefinition {
   @doc("The kind discriminator for a voice agent definition. Always `voice`.")
   kind: AgentKind.voice;
 
-  @doc("How the voice agent obtains its conversational backend. `managed` uses the service-managed model named by `model`; `self_deployed` uses the customer's Foundry deployment named by `model`; `hosted_agent` fronts the hosted text agent referenced by `target_agent`. This is independent of the architecture (realtime or cascaded), which the service derives from the selected backend.")
-  model_type: VoiceModelType;
+  @doc("How the model backing this voice agent is served. Required with `model` for a model-backed voice agent and omitted when `target_agent` is provided. This is independent of the architecture (realtime or cascaded), which the service derives from the selected model.")
+  model_type?: VoiceModelType;
 
-  @doc("The model to use for this agent. Required when `model_type` is `managed` (the service-managed model name) or `self_deployed` (the customer's Foundry deployment name). Omit this property when `model_type` is `hosted_agent`; `target_agent` identifies the conversational backend. The model must support realtime or cascaded voice.")
+  @doc("The model to use for this agent. Required with `model_type` for a model-backed voice agent and omitted when `target_agent` is provided. The model must support realtime or cascaded voice.")
   `model`?: string;
 
-  @doc("The hosted text agent that this voice agent fronts. Required when `model_type` is `hosted_agent` and not applicable otherwise. In this mode, `model`, `instructions`, `tools`, and `tool_choice` must be omitted, and `greeting.tool_choice` cannot be `required`, because the target agent owns the conversation logic. The target must be in the same project and support the `invocations_ws` protocol, Voice Live compatibility, and Bridge Protocol 1.0.")
+  @doc("The text agent that this voice agent fronts. Providing this property selects the agent-backed bridge path; `model_type` and `model` must be omitted. In this mode, `instructions`, `tools`, and `tool_choice` must also be omitted, and `greeting.tool_choice` cannot be `required`, because the target agent owns the conversation logic. The target must be in the same project. The initial implementation requires a hosted agent that supports the `invocations_ws` protocol, Voice Live compatibility, and Bridge Protocol 1.0.")
   target_agent?: VoiceAgentTargetAgent;
 
   @doc("A system (or developer) message inserted into the model's context. Supports template substitution via `structured_inputs`, rendered per session before the live session starts.")
@@ -274,12 +274,9 @@ union VoiceModelType {
 
   @doc("The service uses the customer's own Foundry deployment named by `model`.")
   self_deployed: "self_deployed",
-
-  @doc("The service fronts a hosted text agent referenced by `target_agent`; `model` is not applicable in this mode.")
-  hosted_agent: "hosted_agent",
 }
 
-@doc("A closed reference to the hosted text agent that a `hosted_agent` voice agent fronts, containing only its name and optional version. The target is resolved within the same project.")
+@doc("A closed reference to the text agent that an agent-backed voice agent fronts, containing only its name and optional version. The target is resolved within the same project. The initial implementation requires the target to be a hosted agent that supports the Voice Live bridge protocol.")
 @extension("x-ms-foundry-meta", VoiceAgentRequiredPreview)
 model VoiceAgentTargetAgent {
   ...Record<never>;

--- a/specification/ai-foundry/data-plane/Foundry/src/voice-agents/agents.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/voice-agents/agents.tsp
@@ -96,14 +96,14 @@ model VoiceAgentDefinition extends AgentDefinition {
   @doc("The kind discriminator for a voice agent definition. Always `voice`.")
   kind: AgentKind.voice;
 
-  @doc("How the model backing this voice agent is served. Required with `model` for a model-backed voice agent and omitted when `target_agent` is provided. This is independent of the architecture (realtime or cascaded), which the service derives from the selected model.")
+  @doc("How the model backing this voice agent is served. Required with `model` for a model-backed voice agent and omitted when `conversation_bridge` is provided. This is independent of the architecture (realtime or cascaded), which the service derives from the selected model.")
   model_type?: VoiceModelType;
 
-  @doc("The model to use for this agent. Required with `model_type` for a model-backed voice agent and omitted when `target_agent` is provided. The model must support realtime or cascaded voice.")
+  @doc("The model to use for this agent. Required with `model_type` for a model-backed voice agent and omitted when `conversation_bridge` is provided. The model must support realtime or cascaded voice.")
   `model`?: string;
 
-  @doc("The text agent that this voice agent fronts. Providing this property selects the agent-backed bridge path; `model_type` and `model` must be omitted. In this mode, `instructions`, `tools`, and `tool_choice` must also be omitted, and `greeting.tool_choice` cannot be `required`, because the target agent owns the conversation logic. The target must be in the same project. The initial implementation requires a hosted agent that supports the `invocations_ws` protocol, Voice Live compatibility, and Bridge Protocol 1.0.")
-  target_agent?: VoiceAgentTargetAgent;
+  @doc("Delegates conversation handling to another backend. Exactly one of this property and the model-backed configuration (`model_type` with `model`) must be provided. When this property is provided, `model_type`, `model`, `instructions`, `tools`, and `tool_choice` must be omitted, and `greeting.tool_choice` cannot be `required`, because the bridge owns the conversation logic. The initial implementation supports an agent bridge.")
+  conversation_bridge?: VoiceConversationBridge;
 
   @doc("A system (or developer) message inserted into the model's context. Supports template substitution via `structured_inputs`, rendered per session before the live session starts.")
   instructions?: string;
@@ -276,10 +276,21 @@ union VoiceModelType {
   self_deployed: "self_deployed",
 }
 
-@doc("A closed reference to the text agent that an agent-backed voice agent fronts, containing only its name and optional version. The target is resolved within the same project. The initial implementation requires the target to be a hosted agent that supports the Voice Live bridge protocol.")
+@doc("A backend that owns conversation handling for a bridged voice agent.")
+@discriminator("type")
 @extension("x-ms-foundry-meta", VoiceAgentRequiredPreview)
-model VoiceAgentTargetAgent {
+model VoiceConversationBridge {
+  @doc("The conversation bridge type.")
+  type: string;
+}
+
+@doc("A closed reference to the text agent that owns conversation handling for a bridged voice agent. The target is resolved within the same project. The initial implementation requires a hosted agent that supports the `invocations_ws` protocol, Voice Live compatibility, and Bridge Protocol 1.0.")
+@extension("x-ms-foundry-meta", VoiceAgentRequiredPreview)
+model VoiceAgentConversationBridge extends VoiceConversationBridge {
   ...Record<never>;
+
+  @doc("Selects a Foundry agent as the conversation bridge.")
+  type: "agent";
 
   @doc("The non-empty DNS-like name of the target hosted text agent in the same project.")
   @minLength(1)

--- a/specification/ai-foundry/data-plane/Foundry/src/voice-agents/agents.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/voice-agents/agents.tsp
@@ -96,14 +96,14 @@ model VoiceAgentDefinition extends AgentDefinition {
   @doc("The kind discriminator for a voice agent definition. Always `voice`.")
   kind: AgentKind.voice;
 
-  @doc("How the model backing this voice agent is served. Required with `model` for a model-backed voice agent and omitted when `conversation_bridge` is provided. This is independent of the architecture (realtime or cascaded), which the service derives from the selected model.")
+  @doc("How the model backing this voice agent is served. Required with `model` for a model-backed voice agent and omitted when `conversation_engine` is provided. This is independent of the architecture (realtime or cascaded), which the service derives from the selected model.")
   model_type?: VoiceModelType;
 
-  @doc("The model to use for this agent. Required with `model_type` for a model-backed voice agent and omitted when `conversation_bridge` is provided. The model must support realtime or cascaded voice.")
+  @doc("The model to use for this agent. Required with `model_type` for a model-backed voice agent and omitted when `conversation_engine` is provided. The model must support realtime or cascaded voice.")
   `model`?: string;
 
-  @doc("Delegates conversation handling to another backend. Exactly one of this property and the model-backed configuration (`model_type` with `model`) must be provided. When this property is provided, `model_type`, `model`, `instructions`, `tools`, and `tool_choice` must be omitted, and `greeting.tool_choice` cannot be `required`, because the bridge owns the conversation logic. The initial implementation supports an agent bridge.")
-  conversation_bridge?: VoiceConversationBridge;
+  @doc("The engine that owns conversation handling for this voice agent. Exactly one of this property and the model-backed configuration (`model_type` with `model`) must be provided. When this property is provided, `model_type`, `model`, `instructions`, `tools`, and `tool_choice` must be omitted, and `greeting.tool_choice` cannot be `required`, because the engine owns the conversation logic. The initial implementation supports a hosted-agent engine.")
+  conversation_engine?: VoiceConversationEngine;
 
   @doc("A system (or developer) message inserted into the model's context. Supports template substitution via `structured_inputs`, rendered per session before the live session starts.")
   instructions?: string;
@@ -276,21 +276,21 @@ union VoiceModelType {
   self_deployed: "self_deployed",
 }
 
-@doc("A backend that owns conversation handling for a bridged voice agent.")
+@doc("An engine that owns conversation handling for a voice agent.")
 @discriminator("type")
 @extension("x-ms-foundry-meta", VoiceAgentRequiredPreview)
-model VoiceConversationBridge {
-  @doc("The conversation bridge type.")
+model VoiceConversationEngine {
+  @doc("The conversation engine type.")
   type: string;
 }
 
-@doc("A closed reference to the text agent that owns conversation handling for a bridged voice agent. The target is resolved within the same project. The initial implementation requires a hosted agent that supports the `invocations_ws` protocol, Voice Live compatibility, and Bridge Protocol 1.0.")
+@doc("A closed reference to the hosted text agent that owns conversation handling for a voice agent. The hosted agent is resolved within the same project and must support the `invocations_ws` protocol, Voice Live compatibility, and Bridge Protocol 1.0.")
 @extension("x-ms-foundry-meta", VoiceAgentRequiredPreview)
-model VoiceAgentConversationBridge extends VoiceConversationBridge {
+model VoiceHostedAgentConversationEngine extends VoiceConversationEngine {
   ...Record<never>;
 
-  @doc("Selects a Foundry agent as the conversation bridge.")
-  type: "agent";
+  @doc("Selects a hosted Foundry agent as the conversation engine.")
+  type: "hosted_agent";
 
   @doc("The non-empty DNS-like name of the target hosted text agent in the same project.")
   @minLength(1)


### PR DESCRIPTION
# Data Plane API Specification Update Pull Request

## Summary

This PR follows up on the API modeling feedback in [#45694](https://github.com/Azure/azure-rest-api-specs/pull/45852#discussion_r3908788716).

It keeps the existing top-level `model_type` and `model` properties scoped to model serving, and introduces a separate `conversation_engine` for delegating conversation handling:

```json
{
  "kind": "voice",
  "conversation_engine": {
    "type": "hosted_agent",
    "name": "my-text-agent",
    "version": "3"
  }
}
```

Existing model-backed voice agents continue to use `model_type` with `model`:

```json
{
  "kind": "voice",
  "model_type": "managed",
  "model": "gpt-realtime"
}
```

## Why this shape

A hosted agent is not a model, so representing it as `model_type: "hosted_agent"` broadened `model_type` from model-serving configuration into a general backend discriminator.

`conversation_engine` describes the component that owns conversation logic without changing the meaning or location of the published model fields. Its nested `type` discriminator identifies the engine implementation. The initial `hosted_agent` subtype carries a project-scoped agent name and optional version.

This discriminator belongs to the independent `VoiceConversationEngine` hierarchy, which is composed into `VoiceAgentDefinition` as a property. It does not add a second discriminator to the existing `AgentDefinition` hierarchy and therefore does not create a multiple-discriminator inheritance chain.

The initial implementation accepts only hosted agents because they are currently the only agent kind that implements and advertises:

- the `invocations_ws` protocol;
- Voice Live compatibility;
- Bridge Protocol 1.0.

Other conversation engine implementations can be added later as sibling `conversation_engine` subtypes with their own locator, protocol, and authentication fields after those contracts are designed.

## Contract changes

- Removes `hosted_agent` as a known value from `VoiceModelType`.
- Makes `VoiceAgentDefinition.model_type` optional because its requiredness is conditional.
- Replaces `target_agent` with the extensible `conversation_engine` property.
- Adds the `VoiceConversationEngine` base model with a `type` discriminator.
- Adds `VoiceHostedAgentConversationEngine` with `type: "hosted_agent"`, required `name`, and optional `version`.
- Documents the two mutually exclusive forms:
  - model-backed: `model_type` and `model` are required; `conversation_engine` is omitted;
  - engine-backed: `conversation_engine` is required; `model_type` and `model` are omitted.
- Preserves the existing agent name/version constraints in the hosted-agent engine subtype.
- Updates both hosted-agent examples.
- Regenerates the `v1` and `virtual-public-preview` OpenAPI JSON/YAML outputs.
- Adds no new HTTP operation paths.

The top-level TypeSpec model keeps these properties optional at schema level because their requiredness is conditional. The corresponding service validation is responsible for enforcing exactly one of the model-backed and engine-backed configurations.

## Compatibility

This is a pre-release correction to the contract introduced by [#45694](https://github.com/Azure/azure-rest-api-specs/pull/45852#discussion_r3908788716) on `feature/voice-agent-batch2`.

Existing `managed` and `self_deployed` payloads are unchanged. Making `model_type` optional widens the wire schema. Removing `hosted_agent` changes the generated known-value SDK surface of the extensible `VoiceModelType` union; the union retains its `string` base type. The bridge contract introduced by [#45694.](https://github.com/Azure/azure-rest-api-specs/pull/45852#discussion_r3908788716) is renamed and given an explicit subtype discriminator before release.

The `Swagger BreakingChange` result is therefore expected because this pre-release correction removes the newly introduced known value and replaces the newly introduced `target_agent` schema surface. These changes should be reviewed as part of the API design correction before the feature branch is released.

## API Info: The Basics

- **API Spec engagement record:** Not provided; this is a follow-up to [#45694](https://github.com/Azure/azure-rest-api-specs/pull/45852#discussion_r3908788716).
- **Release scope:** Existing feature-gated Voice Agents preview (`Foundry-Features: VoiceAgents=V1Preview`); no release-stage change.
- **API versions:** `v1` and `virtual-public-preview`.

### Change Scope

- **Design document:** [Voice Hosted-Agent design](https://msdata.visualstudio.com/Vienna/_git/vienna?path=%2Fsrc%2Fazureml-api%2Fsrc%2FAgents%2Fdocs%2Fvoice-agent%2Fvoice-hosted-agent-design.md&version=GBmaster&_a=contents)
- **Previous API change:** #45694
- **Updated TypeSpec:** `specification/ai-foundry/data-plane/Foundry/src/voice-agents/agents.tsp`
- **Updated paths:** Existing `/agents` lifecycle operations using `VoiceAgentDefinition`; no route changes.

### Viewing API changes

Refer to the URLs in the `Generated ApiView` comment on this PR to review the generated API surface and version diff.

### Regeneration note

A control compile of the unchanged base at the same SHA reproduced the unrelated OpenAI schema regeneration changes in the generated files. The authored voice change itself affects only:

- `VoiceAgentDefinition`;
- `VoiceConversationEngine`;
- `VoiceHostedAgentConversationEngine`;
- `VoiceModelType`.

The deterministic regeneration output is included so `npx tsv .` remains clean.

## Validation

- `npx tsp compile . --warn-as-error`
- `npx tsp format --check specification/ai-foundry/data-plane/Foundry/src/voice-agents/agents.tsp`
- C#, Java, and shared Python/JavaScript client TypeSpec compilation with `--no-emit --warn-as-error`
- `npx tsv .`
- v1/PuPr JSON-YAML parity and structured schema assertions
- Hosted-agent example JSON validation
- `git diff --check`

## Suppressions

No validation suppressions are added.

## Release planner

No release plan is linked by this follow-up PR. The existing Voice Agents preview release process remains unchanged.
