### PR TITLE
[StorageCache] Customize rebalance job SDK names

### DIFF
--- a/specification/storagecache/resource-manager/Microsoft.StorageCache/StorageCache/client.tsp
+++ b/specification/storagecache/resource-manager/Microsoft.StorageCache/StorageCache/client.tsp
@@ -192,6 +192,33 @@ using Microsoft.StorageCache;
 @@clientName(ImportJobsListResult, "StorageCacheImportJobsResult", "csharp");
 @@clientName(ExpansionJob, "AmlFileSystemExpansionJob", "csharp");
 @@clientName(ExpansionJobUpdate, "AmlFileSystemExpansionJobPatch", "csharp");
+@@clientName(RebalanceJob, "StorageCacheRebalanceJob", "csharp");
+@@clientName(
+  RebalanceJobAdminStatus,
+  "StorageCacheRebalanceJobAdminStatus",
+  "csharp"
+);
+@@clientName(
+  RebalanceJobProperties,
+  "StorageCacheRebalanceJobProperties",
+  "csharp"
+);
+@@clientName(
+  RebalanceJobPropertiesProvisioningState,
+  "StorageCacheRebalanceJobPropertiesProvisioningState",
+  "csharp"
+);
+@@clientName(
+  RebalanceJobPropertiesStatus,
+  "StorageCacheRebalanceJobPropertiesStatus",
+  "csharp"
+);
+@@clientName(
+  RebalanceJobStatusType,
+  "StorageCacheRebalanceJobStatusType",
+  "csharp"
+);
+@@clientName(RebalanceJobUpdate, "StorageCacheRebalanceJobPatch", "csharp");
 @@clientName(
   KeyVaultKeyReference,
   "StorageCacheEncryptionKeyVaultKeyReference",
@@ -241,6 +268,17 @@ using Microsoft.StorageCache;
 @@clientName(ExpansionJobPropertiesStatus.startTimeUTC, "StartedOn", "csharp");
 @@clientName(
   ExpansionJobPropertiesStatus.completionTimeUTC,
+  "CompletedOn",
+  "csharp"
+);
+@@clientName(
+  ExpansionJobProperties.runRebalanceJob,
+  "ShouldRunRebalanceJob",
+  "csharp"
+);
+@@clientName(RebalanceJobPropertiesStatus.startTimeUTC, "StartedOn", "csharp");
+@@clientName(
+  RebalanceJobPropertiesStatus.completionTimeUTC,
   "CompletedOn",
   "csharp"
 );


### PR DESCRIPTION
Customizes the C# client names for Storage Cache rebalance job APIs and related properties requested in Azure/azure-sdk-for-net#62163.