### PR TITLE
Clarify New Relic resubscribe documentation

### DIFF
--- a/specification/newrelic/resource-manager/NewRelic.Observability/NewRelicObservability/NewRelicMonitorResource.tsp
+++ b/specification/newrelic/resource-manager/NewRelic.Observability/NewRelicObservability/NewRelicMonitorResource.tsp
@@ -197,7 +197,7 @@ interface NewRelicMonitorResources {
   >;
 
   #suppress "@azure-tools/typespec-azure-resource-manager/lro-location-header" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
-  @doc("A long-running resource action.")
+  @doc("Resubscribes the New Relic organization associated with the monitor resource so that billing resumes through Azure Marketplace.")
   @Azure.Core.useFinalStateVia("azure-async-operation")
   @summary("Resubscribes the New Relic Organization of the underlying Monitor Resource to be billed by Azure Marketplace.")
   resubscribe is ArmResourceActionAsync<

--- a/specification/newrelic/resource-manager/NewRelic.Observability/NewRelicObservability/preview/2025-05-01-preview/NewRelic.json
+++ b/specification/newrelic/resource-manager/NewRelic.Observability/NewRelicObservability/preview/2025-05-01-preview/NewRelic.json
@@ -1673,7 +1673,7 @@
           "NewRelicMonitorResources"
         ],
         "summary": "Resubscribes the New Relic Organization of the underlying Monitor Resource to be billed by Azure Marketplace.",
-        "description": "A long-running resource action.",
+        "description": "Resubscribes the New Relic organization associated with the monitor resource so that billing resumes through Azure Marketplace.",
         "parameters": [
           {
             "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"

--- a/specification/newrelic/resource-manager/NewRelic.Observability/NewRelicObservability/stable/2026-06-01/NewRelic.json
+++ b/specification/newrelic/resource-manager/NewRelic.Observability/NewRelicObservability/stable/2026-06-01/NewRelic.json
@@ -1673,7 +1673,7 @@
           "NewRelicMonitorResources"
         ],
         "summary": "Resubscribes the New Relic Organization of the underlying Monitor Resource to be billed by Azure Marketplace.",
-        "description": "A long-running resource action.",
+        "description": "Resubscribes the New Relic organization associated with the monitor resource so that billing resumes through Azure Marketplace.",
         "parameters": [
           {
             "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"


### PR DESCRIPTION
## Summary
- replace the generic resubscribe operation description with a concrete New Relic billing description
- regenerate the preview and stable OpenAPI documents

This addresses the generated .NET SDK review feedback on Azure/azure-sdk-for-net#61921.

## Validation
- TypeSpec compilation completed successfully with warnings treated as errors.