### PR TITLE
fix(foundry): use standard telephony time types

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/examples/v1/AgentTelephony_EndCall.json
+++ b/specification/ai-foundry/data-plane/Foundry/examples/v1/AgentTelephony_EndCall.json
@@ -22,19 +22,19 @@
         "media_connected_at": 1787500003,
         "agent_session_ready_at": 1787500004,
         "ended_at": 1787500064,
-        "duration_seconds": 62,
+        "duration_ms": 62000,
         "end_reason": "managed_hangup",
         "timing": {
-          "received_at_ms": 1787500000123,
-          "validated_at_ms": 1787500000175,
-          "admitted_at_ms": 1787500000250,
-          "answer_requested_at_ms": 1787500000300,
-          "answered_at_ms": 1787500002100,
-          "media_connected_at_ms": 1787500003200,
-          "agent_session_ready_at_ms": 1787500004100,
-          "first_caller_audio_at_ms": 1787500005200,
-          "first_agent_audio_at_ms": 1787500006800,
-          "ended_at_ms": 1787500064100,
+          "received_at": 1787500000,
+          "validated_at": 1787500000,
+          "admitted_at": 1787500000,
+          "answer_requested_at": 1787500000,
+          "answered_at": 1787500002,
+          "media_connected_at": 1787500003,
+          "agent_session_ready_at": 1787500004,
+          "first_caller_audio_at": 1787500005,
+          "first_agent_audio_at": 1787500006,
+          "ended_at": 1787500064,
           "duration_basis": "answered",
           "timestamp_source": "provider"
         },
@@ -51,7 +51,7 @@
             "name": "telephony.webhook.received",
             "source": "gateway",
             "outcome": "observed",
-            "observed_at_ms": 1787500000123,
+            "observed_at": 1787500000,
             "timestamp_source": "gateway"
           },
           {
@@ -59,7 +59,7 @@
             "name": "telephony.webhook.validation",
             "source": "twilio",
             "outcome": "succeeded",
-            "observed_at_ms": 1787500000175,
+            "observed_at": 1787500000,
             "timestamp_source": "gateway"
           },
           {
@@ -67,7 +67,7 @@
             "name": "telephony.binding.resolve",
             "source": "gateway",
             "outcome": "succeeded",
-            "observed_at_ms": 1787500000250,
+            "observed_at": 1787500000,
             "timestamp_source": "gateway"
           },
           {
@@ -75,8 +75,8 @@
             "name": "telephony.provider.answer",
             "source": "twilio",
             "outcome": "succeeded",
-            "observed_at_ms": 1787500002150,
-            "occurred_at_ms": 1787500002100,
+            "observed_at": 1787500002,
+            "occurred_at": 1787500002,
             "timestamp_source": "provider"
           },
           {
@@ -84,8 +84,8 @@
             "name": "telephony.media.connect",
             "source": "twilio",
             "outcome": "succeeded",
-            "observed_at_ms": 1787500003250,
-            "occurred_at_ms": 1787500003200,
+            "observed_at": 1787500003,
+            "occurred_at": 1787500003,
             "timestamp_source": "provider"
           },
           {
@@ -93,7 +93,7 @@
             "name": "telephony.agent_session.connect",
             "source": "voice_agent",
             "outcome": "succeeded",
-            "observed_at_ms": 1787500004100,
+            "observed_at": 1787500004,
             "timestamp_source": "gateway"
           },
           {
@@ -101,7 +101,7 @@
             "name": "telephony.call.hangup",
             "source": "gateway",
             "outcome": "succeeded",
-            "observed_at_ms": 1787500064100,
+            "observed_at": 1787500064,
             "timestamp_source": "gateway",
             "reason": "managed_hangup"
           }

--- a/specification/ai-foundry/data-plane/Foundry/examples/v1/AgentTelephony_GetCall.json
+++ b/specification/ai-foundry/data-plane/Foundry/examples/v1/AgentTelephony_GetCall.json
@@ -22,19 +22,19 @@
         "media_connected_at": 1787500003,
         "agent_session_ready_at": 1787500004,
         "ended_at": 1787500064,
-        "duration_seconds": 62,
+        "duration_ms": 62000,
         "end_reason": "caller_disconnected",
         "timing": {
-          "received_at_ms": 1787500000123,
-          "validated_at_ms": 1787500000175,
-          "admitted_at_ms": 1787500000250,
-          "answer_requested_at_ms": 1787500000300,
-          "answered_at_ms": 1787500002100,
-          "media_connected_at_ms": 1787500003200,
-          "agent_session_ready_at_ms": 1787500004100,
-          "first_caller_audio_at_ms": 1787500005200,
-          "first_agent_audio_at_ms": 1787500006800,
-          "ended_at_ms": 1787500064100,
+          "received_at": 1787500000,
+          "validated_at": 1787500000,
+          "admitted_at": 1787500000,
+          "answer_requested_at": 1787500000,
+          "answered_at": 1787500002,
+          "media_connected_at": 1787500003,
+          "agent_session_ready_at": 1787500004,
+          "first_caller_audio_at": 1787500005,
+          "first_agent_audio_at": 1787500006,
+          "ended_at": 1787500064,
           "duration_basis": "answered",
           "timestamp_source": "provider"
         },
@@ -51,7 +51,7 @@
             "name": "telephony.webhook.received",
             "source": "gateway",
             "outcome": "observed",
-            "observed_at_ms": 1787500000123,
+            "observed_at": 1787500000,
             "timestamp_source": "gateway"
           },
           {
@@ -59,7 +59,7 @@
             "name": "telephony.webhook.validation",
             "source": "twilio",
             "outcome": "succeeded",
-            "observed_at_ms": 1787500000175,
+            "observed_at": 1787500000,
             "timestamp_source": "gateway"
           },
           {
@@ -67,7 +67,7 @@
             "name": "telephony.binding.resolve",
             "source": "gateway",
             "outcome": "succeeded",
-            "observed_at_ms": 1787500000250,
+            "observed_at": 1787500000,
             "timestamp_source": "gateway"
           },
           {
@@ -75,8 +75,8 @@
             "name": "telephony.provider.answer",
             "source": "twilio",
             "outcome": "succeeded",
-            "observed_at_ms": 1787500002150,
-            "occurred_at_ms": 1787500002100,
+            "observed_at": 1787500002,
+            "occurred_at": 1787500002,
             "timestamp_source": "provider"
           },
           {
@@ -84,8 +84,8 @@
             "name": "telephony.media.connect",
             "source": "twilio",
             "outcome": "succeeded",
-            "observed_at_ms": 1787500003250,
-            "occurred_at_ms": 1787500003200,
+            "observed_at": 1787500003,
+            "occurred_at": 1787500003,
             "timestamp_source": "provider"
           },
           {
@@ -93,7 +93,7 @@
             "name": "telephony.agent_session.connect",
             "source": "voice_agent",
             "outcome": "succeeded",
-            "observed_at_ms": 1787500004100,
+            "observed_at": 1787500004,
             "timestamp_source": "gateway"
           },
           {
@@ -101,8 +101,8 @@
             "name": "telephony.call.disconnect",
             "source": "twilio",
             "outcome": "observed",
-            "observed_at_ms": 1787500064150,
-            "occurred_at_ms": 1787500064100,
+            "observed_at": 1787500064,
+            "occurred_at": 1787500064,
             "timestamp_source": "provider",
             "reason": "caller_disconnected"
           }

--- a/specification/ai-foundry/data-plane/Foundry/examples/v1/AgentTelephony_GetCallBindingNotFound.json
+++ b/specification/ai-foundry/data-plane/Foundry/examples/v1/AgentTelephony_GetCallBindingNotFound.json
@@ -19,12 +19,12 @@
         "phase": "rejected",
         "started_at": 1787500200,
         "ended_at": 1787500200,
-        "duration_seconds": 0,
+        "duration_ms": 0,
         "end_reason": "binding_not_found",
         "timing": {
-          "received_at_ms": 1787500200123,
-          "validated_at_ms": 1787500200150,
-          "ended_at_ms": 1787500200175,
+          "received_at": 1787500200,
+          "validated_at": 1787500200,
+          "ended_at": 1787500200,
           "duration_basis": "received",
           "timestamp_source": "gateway"
         },
@@ -37,7 +37,7 @@
             "name": "telephony.webhook.received",
             "source": "gateway",
             "outcome": "observed",
-            "observed_at_ms": 1787500200123,
+            "observed_at": 1787500200,
             "timestamp_source": "gateway"
           },
           {
@@ -45,7 +45,7 @@
             "name": "telephony.webhook.validation",
             "source": "teams_phone_extension",
             "outcome": "succeeded",
-            "observed_at_ms": 1787500200150,
+            "observed_at": 1787500200,
             "timestamp_source": "gateway"
           },
           {
@@ -53,7 +53,7 @@
             "name": "telephony.binding.resolve",
             "source": "gateway",
             "outcome": "rejected",
-            "observed_at_ms": 1787500200175,
+            "observed_at": 1787500200,
             "timestamp_source": "gateway",
             "reason": "binding_not_found"
           }

--- a/specification/ai-foundry/data-plane/Foundry/examples/v1/AgentTelephony_GetCallWebhookValidationFailed.json
+++ b/specification/ai-foundry/data-plane/Foundry/examples/v1/AgentTelephony_GetCallWebhookValidationFailed.json
@@ -16,12 +16,12 @@
         "phase": "rejected",
         "started_at": 1787500100,
         "ended_at": 1787500100,
-        "duration_seconds": 0,
+        "duration_ms": 0,
         "end_reason": "webhook_validation_failed",
         "timing": {
-          "received_at_ms": 1787500100123,
-          "validated_at_ms": 1787500100140,
-          "ended_at_ms": 1787500100140,
+          "received_at": 1787500100,
+          "validated_at": 1787500100,
+          "ended_at": 1787500100,
           "duration_basis": "received",
           "timestamp_source": "gateway"
         },
@@ -34,7 +34,7 @@
             "name": "telephony.webhook.received",
             "source": "gateway",
             "outcome": "observed",
-            "observed_at_ms": 1787500100123,
+            "observed_at": 1787500100,
             "timestamp_source": "gateway"
           },
           {
@@ -42,7 +42,7 @@
             "name": "telephony.webhook.validation",
             "source": "twilio",
             "outcome": "rejected",
-            "observed_at_ms": 1787500100140,
+            "observed_at": 1787500100,
             "timestamp_source": "gateway",
             "reason": "webhook_validation_failed"
           }

--- a/specification/ai-foundry/data-plane/Foundry/examples/v1/AgentTelephony_ListCalls.json
+++ b/specification/ai-foundry/data-plane/Foundry/examples/v1/AgentTelephony_ListCalls.json
@@ -28,7 +28,7 @@
             "media_connected_at": 1787500003,
             "agent_session_ready_at": 1787500004,
             "ended_at": 1787500064,
-            "duration_seconds": 62,
+            "duration_ms": 62000,
             "end_reason": "caller_disconnected"
           }
         ],

--- a/specification/ai-foundry/data-plane/Foundry/examples/v1/AgentTelephony_TransferCall.json
+++ b/specification/ai-foundry/data-plane/Foundry/examples/v1/AgentTelephony_TransferCall.json
@@ -23,15 +23,15 @@
         "media_connected_at": 1787500003,
         "agent_session_ready_at": 1787500004,
         "timing": {
-          "received_at_ms": 1787500000123,
-          "validated_at_ms": 1787500000175,
-          "admitted_at_ms": 1787500000250,
-          "answer_requested_at_ms": 1787500000300,
-          "answered_at_ms": 1787500002100,
-          "media_connected_at_ms": 1787500003200,
-          "agent_session_ready_at_ms": 1787500004100,
-          "first_caller_audio_at_ms": 1787500005200,
-          "first_agent_audio_at_ms": 1787500006800,
+          "received_at": 1787500000,
+          "validated_at": 1787500000,
+          "admitted_at": 1787500000,
+          "answer_requested_at": 1787500000,
+          "answered_at": 1787500002,
+          "media_connected_at": 1787500003,
+          "agent_session_ready_at": 1787500004,
+          "first_caller_audio_at": 1787500005,
+          "first_agent_audio_at": 1787500006,
           "duration_basis": "answered",
           "timestamp_source": "provider"
         },
@@ -48,7 +48,7 @@
             "name": "telephony.webhook.received",
             "source": "gateway",
             "outcome": "observed",
-            "observed_at_ms": 1787500000123,
+            "observed_at": 1787500000,
             "timestamp_source": "gateway"
           },
           {
@@ -56,7 +56,7 @@
             "name": "telephony.webhook.validation",
             "source": "twilio",
             "outcome": "succeeded",
-            "observed_at_ms": 1787500000175,
+            "observed_at": 1787500000,
             "timestamp_source": "gateway"
           },
           {
@@ -64,7 +64,7 @@
             "name": "telephony.binding.resolve",
             "source": "gateway",
             "outcome": "succeeded",
-            "observed_at_ms": 1787500000250,
+            "observed_at": 1787500000,
             "timestamp_source": "gateway"
           },
           {
@@ -72,8 +72,8 @@
             "name": "telephony.provider.answer",
             "source": "twilio",
             "outcome": "succeeded",
-            "observed_at_ms": 1787500002150,
-            "occurred_at_ms": 1787500002100,
+            "observed_at": 1787500002,
+            "occurred_at": 1787500002,
             "timestamp_source": "provider"
           },
           {
@@ -81,8 +81,8 @@
             "name": "telephony.media.connect",
             "source": "twilio",
             "outcome": "succeeded",
-            "observed_at_ms": 1787500003250,
-            "occurred_at_ms": 1787500003200,
+            "observed_at": 1787500003,
+            "occurred_at": 1787500003,
             "timestamp_source": "provider"
           },
           {
@@ -90,7 +90,7 @@
             "name": "telephony.agent_session.connect",
             "source": "voice_agent",
             "outcome": "succeeded",
-            "observed_at_ms": 1787500004100,
+            "observed_at": 1787500004,
             "timestamp_source": "gateway"
           },
           {
@@ -98,7 +98,7 @@
             "name": "telephony.call.transfer",
             "source": "gateway",
             "outcome": "started",
-            "observed_at_ms": 1787500010000,
+            "observed_at": 1787500010,
             "timestamp_source": "gateway"
           }
         ],

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -86277,12 +86277,11 @@
             "items": {
               "$ref": "#/components/schemas/TelephonyCallLifecycleEvent"
             },
-            "maxItems": 32,
-            "description": "The bounded lifecycle timeline."
+            "description": "The lifecycle timeline."
           },
           "events_truncated": {
             "type": "boolean",
-            "description": "Whether older lifecycle events were omitted because the bounded event limit was reached."
+            "description": "Whether older lifecycle events were omitted from the timeline."
           }
         },
         "description": "Detailed diagnostics for a durable inbound call to a voice agent.",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -85998,7 +85998,7 @@
           "name",
           "source",
           "outcome",
-          "observed_at_ms",
+          "observed_at",
           "timestamp_source"
         ],
         "properties": {
@@ -86021,17 +86021,13 @@
             "$ref": "#/components/schemas/TelephonyCallLifecycleEventOutcome",
             "description": "The outcome of the observed lifecycle operation."
           },
-          "observed_at_ms": {
-            "type": "integer",
-            "format": "int64",
-            "minimum": 0,
-            "description": "When the service observed the event, as Unix time in milliseconds."
+          "observed_at": {
+            "$ref": "#/components/schemas/FoundryTimestamp",
+            "description": "The Unix timestamp (in seconds) for when the service observed the event."
           },
-          "occurred_at_ms": {
-            "type": "integer",
-            "format": "int64",
-            "minimum": 0,
-            "description": "When the event occurred according to the provider, as Unix time in milliseconds."
+          "occurred_at": {
+            "$ref": "#/components/schemas/FoundryTimestamp",
+            "description": "The Unix timestamp (in seconds) for when the event occurred according to the provider."
           },
           "timestamp_source": {
             "$ref": "#/components/schemas/TelephonyCallTimestampSource",
@@ -86242,11 +86238,9 @@
             "$ref": "#/components/schemas/FoundryTimestamp",
             "description": "The Unix timestamp (in seconds) for when the call ended."
           },
-          "duration_seconds": {
-            "type": "integer",
-            "format": "int64",
-            "minimum": 0,
-            "description": "The call duration in seconds."
+          "duration_ms": {
+            "$ref": "#/components/schemas/FoundryDurationMilliseconds",
+            "description": "The call duration."
           },
           "end_reason": {
             "type": "string",
@@ -86380,11 +86374,9 @@
             "$ref": "#/components/schemas/FoundryTimestamp",
             "description": "The Unix timestamp (in seconds) for when the call ended."
           },
-          "duration_seconds": {
-            "type": "integer",
-            "format": "int64",
-            "minimum": 0,
-            "description": "The call duration in seconds."
+          "duration_ms": {
+            "$ref": "#/components/schemas/FoundryDurationMilliseconds",
+            "description": "The call duration."
           },
           "end_reason": {
             "type": "string",
@@ -86443,65 +86435,45 @@
           "timestamp_source"
         ],
         "properties": {
-          "received_at_ms": {
-            "type": "integer",
-            "format": "int64",
-            "minimum": 0,
-            "description": "When the provider webhook was received, as Unix time in milliseconds."
+          "received_at": {
+            "$ref": "#/components/schemas/FoundryTimestamp",
+            "description": "The Unix timestamp (in seconds) for when the provider webhook was received."
           },
-          "validated_at_ms": {
-            "type": "integer",
-            "format": "int64",
-            "minimum": 0,
-            "description": "When webhook validation completed, as Unix time in milliseconds."
+          "validated_at": {
+            "$ref": "#/components/schemas/FoundryTimestamp",
+            "description": "The Unix timestamp (in seconds) for when webhook validation completed."
           },
-          "admitted_at_ms": {
-            "type": "integer",
-            "format": "int64",
-            "minimum": 0,
-            "description": "When the call was admitted to an agent binding, as Unix time in milliseconds."
+          "admitted_at": {
+            "$ref": "#/components/schemas/FoundryTimestamp",
+            "description": "The Unix timestamp (in seconds) for when the call was admitted to an agent binding."
           },
-          "answer_requested_at_ms": {
-            "type": "integer",
-            "format": "int64",
-            "minimum": 0,
-            "description": "When the service requested that the provider answer the call, as Unix time in milliseconds."
+          "answer_requested_at": {
+            "$ref": "#/components/schemas/FoundryTimestamp",
+            "description": "The Unix timestamp (in seconds) for when the service requested that the provider answer the call."
           },
-          "answered_at_ms": {
-            "type": "integer",
-            "format": "int64",
-            "minimum": 0,
-            "description": "When the provider reported that the call was answered, as Unix time in milliseconds."
+          "answered_at": {
+            "$ref": "#/components/schemas/FoundryTimestamp",
+            "description": "The Unix timestamp (in seconds) for when the provider reported that the call was answered."
           },
-          "media_connected_at_ms": {
-            "type": "integer",
-            "format": "int64",
-            "minimum": 0,
-            "description": "When the provider media channel connected, as Unix time in milliseconds."
+          "media_connected_at": {
+            "$ref": "#/components/schemas/FoundryTimestamp",
+            "description": "The Unix timestamp (in seconds) for when the provider media channel connected."
           },
-          "agent_session_ready_at_ms": {
-            "type": "integer",
-            "format": "int64",
-            "minimum": 0,
-            "description": "When the voice-agent session became ready, as Unix time in milliseconds."
+          "agent_session_ready_at": {
+            "$ref": "#/components/schemas/FoundryTimestamp",
+            "description": "The Unix timestamp (in seconds) for when the voice-agent session became ready."
           },
-          "first_caller_audio_at_ms": {
-            "type": "integer",
-            "format": "int64",
-            "minimum": 0,
-            "description": "When caller audio was first observed, as Unix time in milliseconds."
+          "first_caller_audio_at": {
+            "$ref": "#/components/schemas/FoundryTimestamp",
+            "description": "The Unix timestamp (in seconds) for when caller audio was first observed."
           },
-          "first_agent_audio_at_ms": {
-            "type": "integer",
-            "format": "int64",
-            "minimum": 0,
-            "description": "When agent audio was first observed, as Unix time in milliseconds."
+          "first_agent_audio_at": {
+            "$ref": "#/components/schemas/FoundryTimestamp",
+            "description": "The Unix timestamp (in seconds) for when agent audio was first observed."
           },
-          "ended_at_ms": {
-            "type": "integer",
-            "format": "int64",
-            "minimum": 0,
-            "description": "When the call reached a terminal state, as Unix time in milliseconds."
+          "ended_at": {
+            "$ref": "#/components/schemas/FoundryTimestamp",
+            "description": "The Unix timestamp (in seconds) for when the call reached a terminal state."
           },
           "duration_basis": {
             "$ref": "#/components/schemas/TelephonyCallDurationBasis",
@@ -86512,7 +86484,7 @@
             "description": "The primary source of the timing milestones. Individual lifecycle events identify their own timestamp source separately."
           }
         },
-        "description": "Detailed provider-neutral timing for an inbound telephony call. Millisecond values are Unix timestamps.",
+        "description": "Detailed provider-neutral timing for an inbound telephony call.",
         "x-ms-foundry-meta": {
           "required_previews": [
             "VoiceAgents=V1Preview"

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -81112,11 +81112,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/TelephonyCallLifecycleEvent'
-          maxItems: 32
-          description: The bounded lifecycle timeline.
+          description: The lifecycle timeline.
         events_truncated:
           type: boolean
-          description: Whether older lifecycle events were omitted because the bounded event limit was reached.
+          description: Whether older lifecycle events were omitted from the timeline.
       description: Detailed diagnostics for a durable inbound call to a voice agent.
       x-ms-foundry-meta:
         required_previews:

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -80907,7 +80907,7 @@ components:
         - name
         - source
         - outcome
-        - observed_at_ms
+        - observed_at
         - timestamp_source
       properties:
         sequence:
@@ -80925,16 +80925,12 @@ components:
         outcome:
           $ref: '#/components/schemas/TelephonyCallLifecycleEventOutcome'
           description: The outcome of the observed lifecycle operation.
-        observed_at_ms:
-          type: integer
-          format: int64
-          minimum: 0
-          description: When the service observed the event, as Unix time in milliseconds.
-        occurred_at_ms:
-          type: integer
-          format: int64
-          minimum: 0
-          description: When the event occurred according to the provider, as Unix time in milliseconds.
+        observed_at:
+          $ref: '#/components/schemas/FoundryTimestamp'
+          description: The Unix timestamp (in seconds) for when the service observed the event.
+        occurred_at:
+          $ref: '#/components/schemas/FoundryTimestamp'
+          description: The Unix timestamp (in seconds) for when the event occurred according to the provider.
         timestamp_source:
           $ref: '#/components/schemas/TelephonyCallTimestampSource'
           description: The source of the event timestamp.
@@ -81085,11 +81081,9 @@ components:
         ended_at:
           $ref: '#/components/schemas/FoundryTimestamp'
           description: The Unix timestamp (in seconds) for when the call ended.
-        duration_seconds:
-          type: integer
-          format: int64
-          minimum: 0
-          description: The call duration in seconds.
+        duration_ms:
+          $ref: '#/components/schemas/FoundryDurationMilliseconds'
+          description: The call duration.
         end_reason:
           type: string
           maxLength: 128
@@ -81187,11 +81181,9 @@ components:
         ended_at:
           $ref: '#/components/schemas/FoundryTimestamp'
           description: The Unix timestamp (in seconds) for when the call ended.
-        duration_seconds:
-          type: integer
-          format: int64
-          minimum: 0
-          description: The call duration in seconds.
+        duration_ms:
+          $ref: '#/components/schemas/FoundryDurationMilliseconds'
+          description: The call duration.
         end_reason:
           type: string
           maxLength: 128
@@ -81231,63 +81223,43 @@ components:
       required:
         - timestamp_source
       properties:
-        received_at_ms:
-          type: integer
-          format: int64
-          minimum: 0
-          description: When the provider webhook was received, as Unix time in milliseconds.
-        validated_at_ms:
-          type: integer
-          format: int64
-          minimum: 0
-          description: When webhook validation completed, as Unix time in milliseconds.
-        admitted_at_ms:
-          type: integer
-          format: int64
-          minimum: 0
-          description: When the call was admitted to an agent binding, as Unix time in milliseconds.
-        answer_requested_at_ms:
-          type: integer
-          format: int64
-          minimum: 0
-          description: When the service requested that the provider answer the call, as Unix time in milliseconds.
-        answered_at_ms:
-          type: integer
-          format: int64
-          minimum: 0
-          description: When the provider reported that the call was answered, as Unix time in milliseconds.
-        media_connected_at_ms:
-          type: integer
-          format: int64
-          minimum: 0
-          description: When the provider media channel connected, as Unix time in milliseconds.
-        agent_session_ready_at_ms:
-          type: integer
-          format: int64
-          minimum: 0
-          description: When the voice-agent session became ready, as Unix time in milliseconds.
-        first_caller_audio_at_ms:
-          type: integer
-          format: int64
-          minimum: 0
-          description: When caller audio was first observed, as Unix time in milliseconds.
-        first_agent_audio_at_ms:
-          type: integer
-          format: int64
-          minimum: 0
-          description: When agent audio was first observed, as Unix time in milliseconds.
-        ended_at_ms:
-          type: integer
-          format: int64
-          minimum: 0
-          description: When the call reached a terminal state, as Unix time in milliseconds.
+        received_at:
+          $ref: '#/components/schemas/FoundryTimestamp'
+          description: The Unix timestamp (in seconds) for when the provider webhook was received.
+        validated_at:
+          $ref: '#/components/schemas/FoundryTimestamp'
+          description: The Unix timestamp (in seconds) for when webhook validation completed.
+        admitted_at:
+          $ref: '#/components/schemas/FoundryTimestamp'
+          description: The Unix timestamp (in seconds) for when the call was admitted to an agent binding.
+        answer_requested_at:
+          $ref: '#/components/schemas/FoundryTimestamp'
+          description: The Unix timestamp (in seconds) for when the service requested that the provider answer the call.
+        answered_at:
+          $ref: '#/components/schemas/FoundryTimestamp'
+          description: The Unix timestamp (in seconds) for when the provider reported that the call was answered.
+        media_connected_at:
+          $ref: '#/components/schemas/FoundryTimestamp'
+          description: The Unix timestamp (in seconds) for when the provider media channel connected.
+        agent_session_ready_at:
+          $ref: '#/components/schemas/FoundryTimestamp'
+          description: The Unix timestamp (in seconds) for when the voice-agent session became ready.
+        first_caller_audio_at:
+          $ref: '#/components/schemas/FoundryTimestamp'
+          description: The Unix timestamp (in seconds) for when caller audio was first observed.
+        first_agent_audio_at:
+          $ref: '#/components/schemas/FoundryTimestamp'
+          description: The Unix timestamp (in seconds) for when agent audio was first observed.
+        ended_at:
+          $ref: '#/components/schemas/FoundryTimestamp'
+          description: The Unix timestamp (in seconds) for when the call reached a terminal state.
         duration_basis:
           $ref: '#/components/schemas/TelephonyCallDurationBasis'
           description: The timestamp used as the basis for duration.
         timestamp_source:
           $ref: '#/components/schemas/TelephonyCallTimestampSource'
           description: The primary source of the timing milestones. Individual lifecycle events identify their own timestamp source separately.
-      description: Detailed provider-neutral timing for an inbound telephony call. Millisecond values are Unix timestamps.
+      description: Detailed provider-neutral timing for an inbound telephony call.
       x-ms-foundry-meta:
         required_previews:
           - VoiceAgents=V1Preview

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -90855,12 +90855,11 @@
             "items": {
               "$ref": "#/components/schemas/TelephonyCallLifecycleEvent"
             },
-            "maxItems": 32,
-            "description": "The bounded lifecycle timeline."
+            "description": "The lifecycle timeline."
           },
           "events_truncated": {
             "type": "boolean",
-            "description": "Whether older lifecycle events were omitted because the bounded event limit was reached."
+            "description": "Whether older lifecycle events were omitted from the timeline."
           }
         },
         "description": "Detailed diagnostics for a durable inbound call to a voice agent.",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -90576,7 +90576,7 @@
           "name",
           "source",
           "outcome",
-          "observed_at_ms",
+          "observed_at",
           "timestamp_source"
         ],
         "properties": {
@@ -90599,17 +90599,13 @@
             "$ref": "#/components/schemas/TelephonyCallLifecycleEventOutcome",
             "description": "The outcome of the observed lifecycle operation."
           },
-          "observed_at_ms": {
-            "type": "integer",
-            "format": "int64",
-            "minimum": 0,
-            "description": "When the service observed the event, as Unix time in milliseconds."
+          "observed_at": {
+            "$ref": "#/components/schemas/FoundryTimestamp",
+            "description": "The Unix timestamp (in seconds) for when the service observed the event."
           },
-          "occurred_at_ms": {
-            "type": "integer",
-            "format": "int64",
-            "minimum": 0,
-            "description": "When the event occurred according to the provider, as Unix time in milliseconds."
+          "occurred_at": {
+            "$ref": "#/components/schemas/FoundryTimestamp",
+            "description": "The Unix timestamp (in seconds) for when the event occurred according to the provider."
           },
           "timestamp_source": {
             "$ref": "#/components/schemas/TelephonyCallTimestampSource",
@@ -90820,11 +90816,9 @@
             "$ref": "#/components/schemas/FoundryTimestamp",
             "description": "The Unix timestamp (in seconds) for when the call ended."
           },
-          "duration_seconds": {
-            "type": "integer",
-            "format": "int64",
-            "minimum": 0,
-            "description": "The call duration in seconds."
+          "duration_ms": {
+            "$ref": "#/components/schemas/FoundryDurationMilliseconds",
+            "description": "The call duration."
           },
           "end_reason": {
             "type": "string",
@@ -90958,11 +90952,9 @@
             "$ref": "#/components/schemas/FoundryTimestamp",
             "description": "The Unix timestamp (in seconds) for when the call ended."
           },
-          "duration_seconds": {
-            "type": "integer",
-            "format": "int64",
-            "minimum": 0,
-            "description": "The call duration in seconds."
+          "duration_ms": {
+            "$ref": "#/components/schemas/FoundryDurationMilliseconds",
+            "description": "The call duration."
           },
           "end_reason": {
             "type": "string",
@@ -91021,65 +91013,45 @@
           "timestamp_source"
         ],
         "properties": {
-          "received_at_ms": {
-            "type": "integer",
-            "format": "int64",
-            "minimum": 0,
-            "description": "When the provider webhook was received, as Unix time in milliseconds."
+          "received_at": {
+            "$ref": "#/components/schemas/FoundryTimestamp",
+            "description": "The Unix timestamp (in seconds) for when the provider webhook was received."
           },
-          "validated_at_ms": {
-            "type": "integer",
-            "format": "int64",
-            "minimum": 0,
-            "description": "When webhook validation completed, as Unix time in milliseconds."
+          "validated_at": {
+            "$ref": "#/components/schemas/FoundryTimestamp",
+            "description": "The Unix timestamp (in seconds) for when webhook validation completed."
           },
-          "admitted_at_ms": {
-            "type": "integer",
-            "format": "int64",
-            "minimum": 0,
-            "description": "When the call was admitted to an agent binding, as Unix time in milliseconds."
+          "admitted_at": {
+            "$ref": "#/components/schemas/FoundryTimestamp",
+            "description": "The Unix timestamp (in seconds) for when the call was admitted to an agent binding."
           },
-          "answer_requested_at_ms": {
-            "type": "integer",
-            "format": "int64",
-            "minimum": 0,
-            "description": "When the service requested that the provider answer the call, as Unix time in milliseconds."
+          "answer_requested_at": {
+            "$ref": "#/components/schemas/FoundryTimestamp",
+            "description": "The Unix timestamp (in seconds) for when the service requested that the provider answer the call."
           },
-          "answered_at_ms": {
-            "type": "integer",
-            "format": "int64",
-            "minimum": 0,
-            "description": "When the provider reported that the call was answered, as Unix time in milliseconds."
+          "answered_at": {
+            "$ref": "#/components/schemas/FoundryTimestamp",
+            "description": "The Unix timestamp (in seconds) for when the provider reported that the call was answered."
           },
-          "media_connected_at_ms": {
-            "type": "integer",
-            "format": "int64",
-            "minimum": 0,
-            "description": "When the provider media channel connected, as Unix time in milliseconds."
+          "media_connected_at": {
+            "$ref": "#/components/schemas/FoundryTimestamp",
+            "description": "The Unix timestamp (in seconds) for when the provider media channel connected."
           },
-          "agent_session_ready_at_ms": {
-            "type": "integer",
-            "format": "int64",
-            "minimum": 0,
-            "description": "When the voice-agent session became ready, as Unix time in milliseconds."
+          "agent_session_ready_at": {
+            "$ref": "#/components/schemas/FoundryTimestamp",
+            "description": "The Unix timestamp (in seconds) for when the voice-agent session became ready."
           },
-          "first_caller_audio_at_ms": {
-            "type": "integer",
-            "format": "int64",
-            "minimum": 0,
-            "description": "When caller audio was first observed, as Unix time in milliseconds."
+          "first_caller_audio_at": {
+            "$ref": "#/components/schemas/FoundryTimestamp",
+            "description": "The Unix timestamp (in seconds) for when caller audio was first observed."
           },
-          "first_agent_audio_at_ms": {
-            "type": "integer",
-            "format": "int64",
-            "minimum": 0,
-            "description": "When agent audio was first observed, as Unix time in milliseconds."
+          "first_agent_audio_at": {
+            "$ref": "#/components/schemas/FoundryTimestamp",
+            "description": "The Unix timestamp (in seconds) for when agent audio was first observed."
           },
-          "ended_at_ms": {
-            "type": "integer",
-            "format": "int64",
-            "minimum": 0,
-            "description": "When the call reached a terminal state, as Unix time in milliseconds."
+          "ended_at": {
+            "$ref": "#/components/schemas/FoundryTimestamp",
+            "description": "The Unix timestamp (in seconds) for when the call reached a terminal state."
           },
           "duration_basis": {
             "$ref": "#/components/schemas/TelephonyCallDurationBasis",
@@ -91090,7 +91062,7 @@
             "description": "The primary source of the timing milestones. Individual lifecycle events identify their own timestamp source separately."
           }
         },
-        "description": "Detailed provider-neutral timing for an inbound telephony call. Millisecond values are Unix timestamps.",
+        "description": "Detailed provider-neutral timing for an inbound telephony call.",
         "x-ms-foundry-meta": {
           "required_previews": [
             "VoiceAgents=V1Preview"

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -84264,11 +84264,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/TelephonyCallLifecycleEvent'
-          maxItems: 32
-          description: The bounded lifecycle timeline.
+          description: The lifecycle timeline.
         events_truncated:
           type: boolean
-          description: Whether older lifecycle events were omitted because the bounded event limit was reached.
+          description: Whether older lifecycle events were omitted from the timeline.
       description: Detailed diagnostics for a durable inbound call to a voice agent.
       x-ms-foundry-meta:
         required_previews:

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -84059,7 +84059,7 @@ components:
         - name
         - source
         - outcome
-        - observed_at_ms
+        - observed_at
         - timestamp_source
       properties:
         sequence:
@@ -84077,16 +84077,12 @@ components:
         outcome:
           $ref: '#/components/schemas/TelephonyCallLifecycleEventOutcome'
           description: The outcome of the observed lifecycle operation.
-        observed_at_ms:
-          type: integer
-          format: int64
-          minimum: 0
-          description: When the service observed the event, as Unix time in milliseconds.
-        occurred_at_ms:
-          type: integer
-          format: int64
-          minimum: 0
-          description: When the event occurred according to the provider, as Unix time in milliseconds.
+        observed_at:
+          $ref: '#/components/schemas/FoundryTimestamp'
+          description: The Unix timestamp (in seconds) for when the service observed the event.
+        occurred_at:
+          $ref: '#/components/schemas/FoundryTimestamp'
+          description: The Unix timestamp (in seconds) for when the event occurred according to the provider.
         timestamp_source:
           $ref: '#/components/schemas/TelephonyCallTimestampSource'
           description: The source of the event timestamp.
@@ -84237,11 +84233,9 @@ components:
         ended_at:
           $ref: '#/components/schemas/FoundryTimestamp'
           description: The Unix timestamp (in seconds) for when the call ended.
-        duration_seconds:
-          type: integer
-          format: int64
-          minimum: 0
-          description: The call duration in seconds.
+        duration_ms:
+          $ref: '#/components/schemas/FoundryDurationMilliseconds'
+          description: The call duration.
         end_reason:
           type: string
           maxLength: 128
@@ -84339,11 +84333,9 @@ components:
         ended_at:
           $ref: '#/components/schemas/FoundryTimestamp'
           description: The Unix timestamp (in seconds) for when the call ended.
-        duration_seconds:
-          type: integer
-          format: int64
-          minimum: 0
-          description: The call duration in seconds.
+        duration_ms:
+          $ref: '#/components/schemas/FoundryDurationMilliseconds'
+          description: The call duration.
         end_reason:
           type: string
           maxLength: 128
@@ -84383,63 +84375,43 @@ components:
       required:
         - timestamp_source
       properties:
-        received_at_ms:
-          type: integer
-          format: int64
-          minimum: 0
-          description: When the provider webhook was received, as Unix time in milliseconds.
-        validated_at_ms:
-          type: integer
-          format: int64
-          minimum: 0
-          description: When webhook validation completed, as Unix time in milliseconds.
-        admitted_at_ms:
-          type: integer
-          format: int64
-          minimum: 0
-          description: When the call was admitted to an agent binding, as Unix time in milliseconds.
-        answer_requested_at_ms:
-          type: integer
-          format: int64
-          minimum: 0
-          description: When the service requested that the provider answer the call, as Unix time in milliseconds.
-        answered_at_ms:
-          type: integer
-          format: int64
-          minimum: 0
-          description: When the provider reported that the call was answered, as Unix time in milliseconds.
-        media_connected_at_ms:
-          type: integer
-          format: int64
-          minimum: 0
-          description: When the provider media channel connected, as Unix time in milliseconds.
-        agent_session_ready_at_ms:
-          type: integer
-          format: int64
-          minimum: 0
-          description: When the voice-agent session became ready, as Unix time in milliseconds.
-        first_caller_audio_at_ms:
-          type: integer
-          format: int64
-          minimum: 0
-          description: When caller audio was first observed, as Unix time in milliseconds.
-        first_agent_audio_at_ms:
-          type: integer
-          format: int64
-          minimum: 0
-          description: When agent audio was first observed, as Unix time in milliseconds.
-        ended_at_ms:
-          type: integer
-          format: int64
-          minimum: 0
-          description: When the call reached a terminal state, as Unix time in milliseconds.
+        received_at:
+          $ref: '#/components/schemas/FoundryTimestamp'
+          description: The Unix timestamp (in seconds) for when the provider webhook was received.
+        validated_at:
+          $ref: '#/components/schemas/FoundryTimestamp'
+          description: The Unix timestamp (in seconds) for when webhook validation completed.
+        admitted_at:
+          $ref: '#/components/schemas/FoundryTimestamp'
+          description: The Unix timestamp (in seconds) for when the call was admitted to an agent binding.
+        answer_requested_at:
+          $ref: '#/components/schemas/FoundryTimestamp'
+          description: The Unix timestamp (in seconds) for when the service requested that the provider answer the call.
+        answered_at:
+          $ref: '#/components/schemas/FoundryTimestamp'
+          description: The Unix timestamp (in seconds) for when the provider reported that the call was answered.
+        media_connected_at:
+          $ref: '#/components/schemas/FoundryTimestamp'
+          description: The Unix timestamp (in seconds) for when the provider media channel connected.
+        agent_session_ready_at:
+          $ref: '#/components/schemas/FoundryTimestamp'
+          description: The Unix timestamp (in seconds) for when the voice-agent session became ready.
+        first_caller_audio_at:
+          $ref: '#/components/schemas/FoundryTimestamp'
+          description: The Unix timestamp (in seconds) for when caller audio was first observed.
+        first_agent_audio_at:
+          $ref: '#/components/schemas/FoundryTimestamp'
+          description: The Unix timestamp (in seconds) for when agent audio was first observed.
+        ended_at:
+          $ref: '#/components/schemas/FoundryTimestamp'
+          description: The Unix timestamp (in seconds) for when the call reached a terminal state.
         duration_basis:
           $ref: '#/components/schemas/TelephonyCallDurationBasis'
           description: The timestamp used as the basis for duration.
         timestamp_source:
           $ref: '#/components/schemas/TelephonyCallTimestampSource'
           description: The primary source of the timing milestones. Individual lifecycle events identify their own timestamp source separately.
-      description: Detailed provider-neutral timing for an inbound telephony call. Millisecond values are Unix timestamps.
+      description: Detailed provider-neutral timing for an inbound telephony call.
       x-ms-foundry-meta:
         required_previews:
           - VoiceAgents=V1Preview

--- a/specification/ai-foundry/data-plane/Foundry/src/voice-agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/voice-agents/models.tsp
@@ -1115,11 +1115,10 @@ model TelephonyCallRecord {
   @doc("Correlation to the customer-facing Foundry trace.")
   trace?: TelephonyCallTrace;
 
-  @doc("The bounded lifecycle timeline.")
-  @maxItems(32)
+  @doc("The lifecycle timeline.")
   events: TelephonyCallLifecycleEvent[];
 
-  @doc("Whether older lifecycle events were omitted because the bounded event limit was reached.")
+  @doc("Whether older lifecycle events were omitted from the timeline.")
   events_truncated: boolean;
 }
 

--- a/specification/ai-foundry/data-plane/Foundry/src/voice-agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/voice-agents/models.tsp
@@ -815,48 +815,38 @@ union TelephonyCallDurationBasis {
   received: "received",
 }
 
-@doc("Detailed provider-neutral timing for an inbound telephony call. Millisecond values are Unix timestamps.")
+@doc("Detailed provider-neutral timing for an inbound telephony call.")
 @extension("x-ms-foundry-meta", VoiceAgentRequiredPreview)
 model TelephonyCallTiming {
-  @doc("When the provider webhook was received, as Unix time in milliseconds.")
-  @minValue(0)
-  received_at_ms?: int64;
+  @doc("The Unix timestamp (in seconds) for when the provider webhook was received.")
+  received_at?: FoundryTimestamp;
 
-  @doc("When webhook validation completed, as Unix time in milliseconds.")
-  @minValue(0)
-  validated_at_ms?: int64;
+  @doc("The Unix timestamp (in seconds) for when webhook validation completed.")
+  validated_at?: FoundryTimestamp;
 
-  @doc("When the call was admitted to an agent binding, as Unix time in milliseconds.")
-  @minValue(0)
-  admitted_at_ms?: int64;
+  @doc("The Unix timestamp (in seconds) for when the call was admitted to an agent binding.")
+  admitted_at?: FoundryTimestamp;
 
-  @doc("When the service requested that the provider answer the call, as Unix time in milliseconds.")
-  @minValue(0)
-  answer_requested_at_ms?: int64;
+  @doc("The Unix timestamp (in seconds) for when the service requested that the provider answer the call.")
+  answer_requested_at?: FoundryTimestamp;
 
-  @doc("When the provider reported that the call was answered, as Unix time in milliseconds.")
-  @minValue(0)
-  answered_at_ms?: int64;
+  @doc("The Unix timestamp (in seconds) for when the provider reported that the call was answered.")
+  answered_at?: FoundryTimestamp;
 
-  @doc("When the provider media channel connected, as Unix time in milliseconds.")
-  @minValue(0)
-  media_connected_at_ms?: int64;
+  @doc("The Unix timestamp (in seconds) for when the provider media channel connected.")
+  media_connected_at?: FoundryTimestamp;
 
-  @doc("When the voice-agent session became ready, as Unix time in milliseconds.")
-  @minValue(0)
-  agent_session_ready_at_ms?: int64;
+  @doc("The Unix timestamp (in seconds) for when the voice-agent session became ready.")
+  agent_session_ready_at?: FoundryTimestamp;
 
-  @doc("When caller audio was first observed, as Unix time in milliseconds.")
-  @minValue(0)
-  first_caller_audio_at_ms?: int64;
+  @doc("The Unix timestamp (in seconds) for when caller audio was first observed.")
+  first_caller_audio_at?: FoundryTimestamp;
 
-  @doc("When agent audio was first observed, as Unix time in milliseconds.")
-  @minValue(0)
-  first_agent_audio_at_ms?: int64;
+  @doc("The Unix timestamp (in seconds) for when agent audio was first observed.")
+  first_agent_audio_at?: FoundryTimestamp;
 
-  @doc("When the call reached a terminal state, as Unix time in milliseconds.")
-  @minValue(0)
-  ended_at_ms?: int64;
+  @doc("The Unix timestamp (in seconds) for when the call reached a terminal state.")
+  ended_at?: FoundryTimestamp;
 
   @doc("The timestamp used as the basis for duration.")
   duration_basis?: TelephonyCallDurationBasis;
@@ -1022,13 +1012,11 @@ model TelephonyCallLifecycleEvent {
   @doc("The outcome of the observed lifecycle operation.")
   outcome: TelephonyCallLifecycleEventOutcome;
 
-  @doc("When the service observed the event, as Unix time in milliseconds.")
-  @minValue(0)
-  observed_at_ms: int64;
+  @doc("The Unix timestamp (in seconds) for when the service observed the event.")
+  observed_at: FoundryTimestamp;
 
-  @doc("When the event occurred according to the provider, as Unix time in milliseconds.")
-  @minValue(0)
-  occurred_at_ms?: int64;
+  @doc("The Unix timestamp (in seconds) for when the event occurred according to the provider.")
+  occurred_at?: FoundryTimestamp;
 
   @doc("The source of the event timestamp.")
   timestamp_source: TelephonyCallTimestampSource;
@@ -1096,9 +1084,8 @@ model TelephonyCallSummary {
   @doc("The Unix timestamp (in seconds) for when the call ended.")
   ended_at?: FoundryTimestamp;
 
-  @doc("The call duration in seconds.")
-  @minValue(0)
-  duration_seconds?: int64;
+  @doc("The call duration.")
+  duration_ms?: FoundryDurationMilliseconds;
 
   @doc("The service-generated reason that the call ended.")
   @maxLength(128)


### PR DESCRIPTION
Updates the source branch of #45852 to use Foundry standard timestamp and duration types for Telephony. TypeSpec, examples, and generated v1/preview OpenAPI are included.