### PR TITLE
Add C# provisioning emitter configuration for DNS

### DIFF
--- a/specification/dns/resource-manager/Microsoft.Network/Dns/client.tsp
+++ b/specification/dns/resource-manager/Microsoft.Network/Dns/client.tsp
@@ -11,6 +11,11 @@ using Microsoft.Network;
 
 // Add .NET SDK config
 @@scope(Microsoft.Network.Zones.listAllByDnsZone, "!csharp");
+@@alternateType(
+  Azure.ResourceManager.ProxyResource.id,
+  Azure.Core.armResourceIdentifier,
+  "csharp"
+);
 
 #suppress "@azure-tools/typespec-client-generator-core/client-option" "Customize generated C# resource names for expanded DNS record-set resources."
 #suppress "@azure-tools/typespec-client-generator-core/client-option-requires-scope" "Customize generated C# resource names for expanded DNS record-set resources."

--- a/specification/dns/resource-manager/Microsoft.Network/Dns/client.tsp
+++ b/specification/dns/resource-manager/Microsoft.Network/Dns/client.tsp
@@ -83,6 +83,7 @@ using Microsoft.Network;
 @@clientName(Zone, "DnsZone", "csharp");
 @@clientName(ZoneType, "DnsZoneType", "csharp");
 @@clientName(SigningKey, "DnsSigningKey", "csharp");
+@@clientName(SubResource, "DnsSubResourceInfo", "csharp");
 @@clientName(RecordSet, "DnsRecord", "csharp");
 @@clientName(NsRecord.nsdname, "DnsNSDomainName", "csharp");
 @@clientName(PtrRecord.ptrdname, "DnsPtrDomainName", "csharp");

--- a/specification/dns/resource-manager/Microsoft.Network/Dns/client.tsp
+++ b/specification/dns/resource-manager/Microsoft.Network/Dns/client.tsp
@@ -100,8 +100,23 @@ using Microsoft.Network;
 );
 @@clientName(ZoneProperties.numberOfRecordSets, "numberOfRecords", "csharp");
 @@clientName(
+  ZoneProperties.registrationVirtualNetworks,
+  "RegistrationVirtualNetworkReferences",
+  "csharp"
+);
+@@clientName(
+  ZoneProperties.resolutionVirtualNetworks,
+  "ResolutionVirtualNetworkReferences",
+  "csharp"
+);
+@@clientName(
   DnsResourceReferenceRequest,
   "DnsResourceReferenceContent",
+  "csharp"
+);
+@@clientName(
+  DnsResourceReferenceRequestProperties.targetResources,
+  "TargetResourceReferences",
   "csharp"
 );
 @@clientName(ARecord.ipv4Address, "IPv4Address", "csharp");

--- a/specification/dns/resource-manager/Microsoft.Network/Dns/client.tsp
+++ b/specification/dns/resource-manager/Microsoft.Network/Dns/client.tsp
@@ -100,11 +100,15 @@ using Microsoft.Network;
   "csharp"
 );
 @@clientName(ZoneProperties.numberOfRecordSets, "numberOfRecords", "csharp");
+// The .NET SDK retains RegistrationVirtualNetworks as an obsolete
+// WritableSubResource compatibility property.
 @@clientName(
   ZoneProperties.registrationVirtualNetworks,
   "RegistrationVirtualNetworkReferences",
   "csharp"
 );
+// The .NET SDK retains ResolutionVirtualNetworks as an obsolete
+// WritableSubResource compatibility property.
 @@clientName(
   ZoneProperties.resolutionVirtualNetworks,
   "ResolutionVirtualNetworkReferences",
@@ -115,6 +119,8 @@ using Microsoft.Network;
   "DnsResourceReferenceContent",
   "csharp"
 );
+// The .NET SDK retains TargetResources as an obsolete WritableSubResource
+// compatibility property.
 @@clientName(
   DnsResourceReferenceRequestProperties.targetResources,
   "TargetResourceReferences",

--- a/specification/dns/resource-manager/Microsoft.Network/Dns/client.tsp
+++ b/specification/dns/resource-manager/Microsoft.Network/Dns/client.tsp
@@ -16,6 +16,7 @@ using Microsoft.Network;
   Azure.Core.armResourceIdentifier,
   "csharp"
 );
+@@alternateType(SubResource.id, Azure.Core.armResourceIdentifier, "csharp");
 
 #suppress "@azure-tools/typespec-client-generator-core/client-option" "Customize generated C# resource names for expanded DNS record-set resources."
 #suppress "@azure-tools/typespec-client-generator-core/client-option-requires-scope" "Customize generated C# resource names for expanded DNS record-set resources."

--- a/specification/dns/resource-manager/Microsoft.Network/Dns/client.tsp
+++ b/specification/dns/resource-manager/Microsoft.Network/Dns/client.tsp
@@ -118,48 +118,5 @@ using Microsoft.Network;
 @@alternateType(DnssecConfig.etag, Azure.Core.eTag, "csharp");
 @@alternateType(RecordSet.etag, Azure.Core.eTag, "csharp");
 @@alternateType(Zone.etag, Azure.Core.eTag, "csharp");
-@@alternateType(
-  RecordSetProperties.targetResource,
-  Azure.ResourceManager.Models.WritableSubResource,
-  "csharp"
-);
-@@alternateType(
-  RecordSetProperties.trafficManagementProfile,
-  Azure.ResourceManager.Models.WritableSubResource,
-  "csharp"
-);
-@@alternateType(
-  ZoneProperties.registrationVirtualNetworks,
-  Azure.ResourceManager.Models.WritableSubResource[],
-  "csharp"
-);
-@@alternateType(
-  ZoneProperties.resolutionVirtualNetworks,
-  Azure.ResourceManager.Models.WritableSubResource[],
-  "csharp"
-);
-@@alternateType(
-  DnsResourceReferenceRequestProperties.targetResources,
-  Azure.ResourceManager.Models.WritableSubResource[],
-  "csharp"
-);
-@@alternateType(
-  DnsResourceReference.dnsResources,
-  Azure.ResourceManager.Models.WritableSubResource[],
-  "csharp"
-);
-@@alternateType(
-  DnsResourceReference.targetResource,
-  Azure.ResourceManager.Models.WritableSubResource,
-  "csharp"
-);
 @@alternateType(ARecord.ipv4Address, Azure.Core.ipV4Address, "csharp");
 @@alternateType(AaaaRecord.ipv6Address, Azure.Core.ipV6Address, "csharp");
-
-namespace Azure.ResourceManager.Models {
-  /** Represents a reference to an existing resource by its id. */
-  model WritableSubResource {
-    /** The resource id. */
-    id?: Azure.Core.armResourceIdentifier;
-  }
-}

--- a/specification/dns/resource-manager/Microsoft.Network/Dns/tspconfig.yaml
+++ b/specification/dns/resource-manager/Microsoft.Network/Dns/tspconfig.yaml
@@ -48,6 +48,10 @@ options:
     namespace: Azure.ResourceManager.Dns
     model-namespace: true
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
+  "@azure-typespec/http-client-csharp-provisioning":
+    namespace: "Azure.Provisioning.Dns"
+    emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
+    api-version: "2023-07-01-preview"
 linter:
   extends:
     - "@azure-tools/typespec-azure-rulesets/resource-manager"


### PR DESCRIPTION
## Description

Adds the C# provisioning emitter configuration for the DNS TypeSpec project so `Azure.Provisioning.Dns` can migrate to TypeSpec-based generation.

- Uses namespace `Azure.Provisioning.Dns`.
- Targets API version `2023-07-01-preview`, the only API version defined by the TypeSpec project.
- Writes generated output to the standard SDK service/namespace directory.