### PR TITLE
Enable C# provisioning generation for WebPubSub

### DIFF
--- a/specification/webpubsub/resource-manager/Microsoft.SignalRService/SignalRService/client.tsp
+++ b/specification/webpubsub/resource-manager/Microsoft.SignalRService/SignalRService/client.tsp
@@ -95,6 +95,18 @@ using Http;
 );
 
 @@clientName(WebPubSubResource, "WebPubSub", "csharp");
+#suppress "@azure-tools/typespec-client-generator-core/client-option" "RBAC roles for provisioning"
+#suppress "@azure-tools/typespec-client-generator-core/client-option-requires-scope" "RBAC roles for provisioning"
+@@clientOption(
+  WebPubSubResource,
+  "resource-rbac-roles",
+  #{
+    WebPubSubServiceReader: "bfb1c7d2-fb1a-466b-b2ba-aee63b92deaf",
+    WebPubSubServiceOwner: "12cf5a90-567b-43ae-8102-96cf46c7d9b4",
+    WebPubSubContributor: "8cf5e20a-e4b2-4e9d-b3a1-5ceb692c2761",
+  },
+  "csharp"
+);
 @@clientName(WebPubSubProperties.disableAadAuth, "IsAadAuthDisabled", "csharp");
 @@clientName(
   WebPubSubTlsSettings.clientCertEnabled,

--- a/specification/webpubsub/resource-manager/Microsoft.SignalRService/SignalRService/client.tsp
+++ b/specification/webpubsub/resource-manager/Microsoft.SignalRService/SignalRService/client.tsp
@@ -248,9 +248,7 @@ using Http;
 @@clientName(UpstreamAuthSettings.type, "AuthType", "csharp");
 @@alternateType(SignalRServiceUsage.id, armResourceIdentifier, "csharp");
 @@clientName(LiveTraceCategory.enabled, "IsEnabled", "csharp");
-@@alternateType(LiveTraceCategory.enabled, boolean, "csharp");
 @@clientName(LiveTraceConfiguration.enabled, "IsEnabled", "csharp");
-@@alternateType(LiveTraceConfiguration.enabled, boolean, "csharp");
 @@clientName(
   WebPubSubResources.list,
   "GetWebPubSubPrivateLinkResources",

--- a/specification/webpubsub/resource-manager/Microsoft.SignalRService/SignalRService/tspconfig.yaml
+++ b/specification/webpubsub/resource-manager/Microsoft.SignalRService/SignalRService/tspconfig.yaml
@@ -34,6 +34,10 @@ options:
     namespace: "Azure.ResourceManager.WebPubSub"
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
     enable-wire-path-attribute: true
+  "@azure-typespec/http-client-csharp-provisioning":
+    namespace: "Azure.Provisioning.WebPubSub"
+    emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
+    api-version: "2025-01-01-preview"
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/webpubsub"
     emitter-output-dir: "{output-dir}/{service-dir}/armwebpubsub"

--- a/specification/webpubsub/resource-manager/Microsoft.SignalRService/SignalRService/tspconfig.yaml
+++ b/specification/webpubsub/resource-manager/Microsoft.SignalRService/SignalRService/tspconfig.yaml
@@ -34,6 +34,7 @@ options:
     namespace: "Azure.ResourceManager.WebPubSub"
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
     enable-wire-path-attribute: true
+    api-version: "2025-08-01-preview"
   "@azure-typespec/http-client-csharp-provisioning":
     namespace: "Azure.Provisioning.WebPubSub"
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"


### PR DESCRIPTION
## Summary
- enable the C# provisioning emitter for WebPubSub
- generate Azure.Provisioning.WebPubSub from API version `2025-01-01-preview`
- configure the WebPubSub resource RBAC roles

## Validation
- local TypeSpec provisioning generation succeeds
- the generated .NET package builds with ApiCompat against 1.1.0
- all 12 non-live package tests pass

## SDK
- Draft SDK PR: https://github.com/Azure/azure-sdk-for-net/pull/62633