### PR TITLE
Use ResourceIdentifier for Private DNS record IDs

### DIFF
--- a/specification/privatedns/resource-manager/Microsoft.Network/PrivateDns/client.tsp
+++ b/specification/privatedns/resource-manager/Microsoft.Network/PrivateDns/client.tsp
@@ -112,6 +112,7 @@ using Microsoft.Network;
   "csharp"
 );
 @@alternateType(RecordSet.etag, Azure.Core.eTag, "csharp");
+@@alternateType(RecordSet.id, Azure.Core.armResourceIdentifier, "csharp");
 @@alternateType(ARecord.ipv4Address, Azure.Core.ipV4Address, "csharp");
 @@alternateType(AaaaRecord.ipv6Address, Azure.Core.ipV6Address, "csharp");
 @@alternateType(

--- a/specification/privatedns/resource-manager/Microsoft.Network/PrivateDns/client.tsp
+++ b/specification/privatedns/resource-manager/Microsoft.Network/PrivateDns/client.tsp
@@ -112,7 +112,11 @@ using Microsoft.Network;
   "csharp"
 );
 @@alternateType(RecordSet.etag, Azure.Core.eTag, "csharp");
-@@alternateType(RecordSet.id, Azure.Core.armResourceIdentifier, "csharp");
+@@alternateType(
+  Azure.ResourceManager.ProxyResource.id,
+  Azure.Core.armResourceIdentifier,
+  "csharp"
+);
 @@alternateType(ARecord.ipv4Address, Azure.Core.ipV4Address, "csharp");
 @@alternateType(AaaaRecord.ipv6Address, Azure.Core.ipV6Address, "csharp");
 @@alternateType(


### PR DESCRIPTION
## Description

Maps the inherited Private DNS record-set resource ID to `Azure.Core.armResourceIdentifier` for C# generation. This preserves the existing `BicepValue<ResourceIdentifier>` provisioning API while allowing the standard resource implementation to remain generated.

## Validation

- TypeSpec project validation passes.