### PR TITLE
Fix telephony model hierarchies for typed SDKs

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -52168,7 +52168,7 @@
                 }
               }
             ],
-            "description": "The image(s) to edit. Must be a supported image file or an array of images.\n  For the GPT image models (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`, and `gpt-image-2-2026-04-21`), each image should be a `png`, `webp`, or `jpg`\n  file less than 50MB. You can provide up to 16 images.\n  `chatgpt-image-latest` follows the same input constraints as GPT image models.\n  For `dall-e-2`, you can only provide one image, and it should be a square\n  `png` file less than 4MB."
+            "description": "The image(s) to edit. Must be a supported image file or an array of images.\n  For the GPT image models (`gpt-image-1`, `gpt-image-1-mini`, and `gpt-image-1.5`), each image should be a `png`, `webp`, or `jpg`\n  file less than 50MB. You can provide up to 16 images.\n  `chatgpt-image-latest` follows the same input constraints as GPT image models.\n  For `dall-e-2`, you can only provide one image, and it should be a square\n  `png` file less than 4MB."
           },
           "prompt": {
             "type": "string",
@@ -52191,7 +52191,7 @@
                 "type": "null"
               }
             ],
-            "description": "Set the background of the generated image(s). This parameter is only\n  supported for the GPT image models. Must be one of `transparent`, `opaque`,\n  or `auto` (default value). When `auto` is used, the model will automatically\n  determine the best background for the image.\n  Transparent backgrounds are available for supported GPT Image models. For\n  `gpt-image-2` and `gpt-image-2-2026-04-21`, this support is in preview. When\n  using `transparent`, set the output format to `png` or `webp`."
+            "description": "Allows to set transparency for the background of the generated image(s).\n  This parameter is only supported for the GPT image models. Must be one of\n  `transparent`, `opaque` or `auto` (default value). When `auto` is used, the\n  model will automatically determine the best background for the image.\n  If `transparent`, the output format needs to support transparency, so it\n  should be set to either `png` (default value) or `webp`."
           },
           "model": {
             "anyOf": [
@@ -52202,8 +52202,6 @@
                 "type": "string",
                 "enum": [
                   "gpt-image-1.5",
-                  "gpt-image-2",
-                  "gpt-image-2-2026-04-21",
                   "dall-e-2",
                   "gpt-image-1",
                   "gpt-image-1-mini",
@@ -52214,7 +52212,7 @@
                 "type": "null"
               }
             ],
-            "description": "The model to use for image generation. One of `dall-e-2` or a GPT image model (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`, `gpt-image-2-2026-04-21`, or `chatgpt-image-latest`). Defaults to `gpt-image-1.5`.",
+            "description": "The model to use for image generation. Defaults to `gpt-image-1.5`.",
             "x-oaiTypeLabel": "string"
           },
           "n": {
@@ -52363,8 +52361,6 @@
                 "type": "string",
                 "enum": [
                   "gpt-image-1.5",
-                  "gpt-image-2",
-                  "gpt-image-2-2026-04-21",
                   "dall-e-2",
                   "dall-e-3",
                   "gpt-image-1",
@@ -52375,7 +52371,7 @@
                 "type": "null"
               }
             ],
-            "description": "The model to use for image generation. One of `dall-e-2`, `dall-e-3`, or a GPT image model (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`, `gpt-image-2-2026-04-21`). Defaults to `dall-e-2` unless a parameter specific to the GPT image models is used.",
+            "description": "The model to use for image generation. One of `dall-e-2`, `dall-e-3`, or a GPT image model (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`). Defaults to `dall-e-2` unless a parameter specific to the GPT image models is used.",
             "x-oaiTypeLabel": "string",
             "default": "dall-e-2"
           },
@@ -52527,7 +52523,7 @@
                 "type": "null"
               }
             ],
-            "description": "Set the background of the generated image(s). This parameter is only\n  supported for the GPT image models. Must be one of `transparent`, `opaque`,\n  or `auto` (default value). When `auto` is used, the model will automatically\n  determine the best background for the image.\n  Transparent backgrounds are available for supported GPT Image models. For\n  `gpt-image-2` and `gpt-image-2-2026-04-21`, this support is in preview. When\n  using `transparent`, set the output format to `png` or `webp`.",
+            "description": "Allows to set transparency for the background of the generated image(s).\n  This parameter is only supported for the GPT image models. Must be one of\n  `transparent`, `opaque` or `auto` (default value). When `auto` is used, the\n  model will automatically determine the best background for the image.\n  If `transparent`, the output format needs to support transparency, so it\n  should be set to either `png` (default value) or `webp`.",
             "default": "auto"
           },
           "style": {
@@ -55283,8 +55279,6 @@
                 "type": "string",
                 "enum": [
                   "gpt-image-1.5",
-                  "gpt-image-2",
-                  "gpt-image-2-2026-04-21",
                   "gpt-image-1",
                   "gpt-image-1-mini",
                   "chatgpt-image-latest"
@@ -55294,7 +55288,7 @@
                 "type": "null"
               }
             ],
-            "description": "The GPT image model to use for image editing, including `gpt-image-2` and its dated snapshot `gpt-image-2-2026-04-21`.",
+            "description": "The model to use for image editing.",
             "x-oaiTypeLabel": "string",
             "default": "gpt-image-1.5"
           },
@@ -55441,7 +55435,7 @@
                 "type": "null"
               }
             ],
-            "description": "Set the background of the generated image output. Transparent backgrounds are available for supported GPT Image models. For `gpt-image-2` and `gpt-image-2-2026-04-21`, this support is in preview. When using `transparent`, set the output format to `png` or `webp`.",
+            "description": "Background behavior for generated image output.",
             "default": "auto"
           },
           "stream": {
@@ -58983,9 +58977,7 @@
                 "enum": [
                   "gpt-image-1",
                   "gpt-image-1-mini",
-                  "gpt-image-1.5",
-                  "gpt-image-2",
-                  "gpt-image-2-2026-04-21"
+                  "gpt-image-1.5"
                 ]
               }
             ],
@@ -59053,7 +59045,7 @@
               "opaque",
               "auto"
             ],
-            "description": "Set the background of the generated image. One of `transparent`,\n  `opaque`, or `auto`. Transparent backgrounds are available for\n  supported GPT Image models. For `gpt-image-2` and\n  `gpt-image-2-2026-04-21`, this support is in preview. When using\n  `transparent`, set the output format to `png` or `webp`. Default: `auto`.",
+            "description": "Background type for the generated image. One of `transparent`,\n  `opaque`, or `auto`. Default: `auto`.",
             "default": "auto"
           },
           "input_fidelity": {
@@ -60123,7 +60115,7 @@
           },
           "encrypted_content": {
             "type": "string",
-            "maxLength": 20971520,
+            "maxLength": 10485760,
             "description": "The encrypted content of the compaction summary."
           }
         },
@@ -61880,7 +61872,7 @@
           },
           "encrypted_content": {
             "type": "string",
-            "maxLength": 20971520,
+            "maxLength": 10485760,
             "description": "The encrypted content of the compaction summary."
           }
         },
@@ -86650,7 +86642,7 @@
         ],
         "properties": {
           "kind": {
-            "type": "string",
+            "$ref": "#/components/schemas/TelephonyTransferDestinationKind",
             "description": "The telephony transfer destination type."
           }
         },
@@ -86663,6 +86655,27 @@
           }
         },
         "description": "A destination for a telephony transfer target.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "VoiceAgents=V1Preview"
+          ]
+        }
+      },
+      "TelephonyTransferDestinationKind": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "pstn",
+              "teams",
+              "sip"
+            ]
+          }
+        ],
+        "description": "The kind of telephony transfer destination. Known values are stable; additional values may be added over time.",
         "x-ms-foundry-meta": {
           "required_previews": [
             "VoiceAgents=V1Preview"

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -37392,7 +37392,6 @@
         "type": "object",
         "required": [
           "provider",
-          "connection",
           "resource_account_object_id"
         ],
         "properties": {
@@ -37403,27 +37402,21 @@
             ],
             "description": "The Microsoft Teams Phone Extension provider."
           },
-          "connection": {
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 256,
-            "description": "The Foundry connection name for the Teams Phone Extension provider."
-          },
           "phone_number": {
             "type": "string",
             "maxLength": 64,
             "description": "The optional display phone number for the Teams resource account."
-          },
-          "label": {
-            "type": "string",
-            "maxLength": 128,
-            "description": "An optional display label for the binding."
           },
           "resource_account_object_id": {
             "$ref": "#/components/schemas/Azure.Core.uuid",
             "description": "The Microsoft Teams resource-account object identifier as a GUID."
           }
         },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/CreateTelephonyBindingRequest"
+          }
+        ],
         "description": "The request to create a Microsoft Teams Phone Extension binding.",
         "x-ms-foundry-meta": {
           "required_previews": [
@@ -37433,14 +37426,27 @@
       },
       "CreateTelephonyBindingRequest": {
         "type": "object",
-        "oneOf": [
-          {
-            "$ref": "#/components/schemas/CreateTeamsPhoneExtensionTelephonyBindingRequest"
-          },
-          {
-            "$ref": "#/components/schemas/CreateTwilioTelephonyBindingRequest"
-          }
+        "required": [
+          "provider",
+          "connection"
         ],
+        "properties": {
+          "provider": {
+            "$ref": "#/components/schemas/TelephonyProvider",
+            "description": "The telephony provider."
+          },
+          "connection": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 256,
+            "description": "The Foundry connection name for the telephony provider."
+          },
+          "label": {
+            "type": "string",
+            "maxLength": 128,
+            "description": "An optional display label for the binding."
+          }
+        },
         "discriminator": {
           "propertyName": "provider",
           "mapping": {
@@ -37459,7 +37465,6 @@
         "type": "object",
         "required": [
           "provider",
-          "connection",
           "phone_number"
         ],
         "properties": {
@@ -37470,23 +37475,17 @@
             ],
             "description": "The Twilio provider."
           },
-          "connection": {
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 256,
-            "description": "The Foundry connection name for the Twilio provider."
-          },
           "phone_number": {
             "type": "string",
             "pattern": "^\\+[1-9]\\d{6,14}$",
             "description": "The Twilio E.164 phone number."
-          },
-          "label": {
-            "type": "string",
-            "maxLength": 128,
-            "description": "An optional display label for the binding."
           }
         },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/CreateTelephonyBindingRequest"
+          }
+        ],
         "description": "The request to create a Twilio binding.",
         "x-ms-foundry-meta": {
           "required_previews": [
@@ -82628,6 +82627,11 @@
             "description": "The E.164 phone number to call."
           }
         },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/TelephonyTransferDestination"
+          }
+        ],
         "description": "A PSTN destination for a telephony transfer target.",
         "x-ms-foundry-meta": {
           "required_previews": [
@@ -85061,6 +85065,11 @@
             "description": "The SIP or SIPS URI to call."
           }
         },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/TelephonyTransferDestination"
+          }
+        ],
         "description": "A SIP destination for a telephony transfer target.",
         "x-ms-foundry-meta": {
           "required_previews": [
@@ -85616,18 +85625,10 @@
       "TeamsPhoneExtensionTelephonyBinding": {
         "type": "object",
         "required": [
-          "id",
           "provider",
-          "connection",
-          "resource_account_object_id",
-          "status",
-          "incoming_call_url"
+          "resource_account_object_id"
         ],
         "properties": {
-          "id": {
-            "$ref": "#/components/schemas/TelephonyBindingId",
-            "description": "The service-generated binding identifier."
-          },
           "provider": {
             "type": "string",
             "enum": [
@@ -85635,36 +85636,21 @@
             ],
             "description": "The Microsoft Teams Phone Extension provider."
           },
-          "connection": {
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 256,
-            "description": "The Foundry connection name for the Teams Phone Extension provider."
-          },
           "phone_number": {
             "type": "string",
             "maxLength": 64,
             "description": "The optional display phone number for the Teams resource account."
           },
-          "label": {
-            "type": "string",
-            "maxLength": 128,
-            "description": "The optional display label for the binding."
-          },
           "resource_account_object_id": {
             "$ref": "#/components/schemas/Azure.Core.uuid",
             "description": "The Microsoft Teams resource-account object identifier as a GUID."
-          },
-          "status": {
-            "$ref": "#/components/schemas/TelephonyBindingStatus",
-            "description": "The lifecycle status."
-          },
-          "incoming_call_url": {
-            "type": "string",
-            "format": "uri",
-            "description": "The service-generated webhook URL to configure with the telephony provider."
           }
         },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/TelephonyBinding"
+          }
+        ],
         "description": "A Microsoft Teams Phone Extension binding owned by a voice agent.",
         "x-ms-foundry-meta": {
           "required_previews": [
@@ -85675,19 +85661,10 @@
       "TeamsPhoneExtensionTelephonyBindingListItem": {
         "type": "object",
         "required": [
-          "id",
           "provider",
-          "connection",
-          "resource_account_object_id",
-          "status",
-          "incoming_call_url",
-          "etag"
+          "resource_account_object_id"
         ],
         "properties": {
-          "id": {
-            "$ref": "#/components/schemas/TelephonyBindingId",
-            "description": "The service-generated binding identifier."
-          },
           "provider": {
             "type": "string",
             "enum": [
@@ -85695,41 +85672,21 @@
             ],
             "description": "The Microsoft Teams Phone Extension provider."
           },
-          "connection": {
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 256,
-            "description": "The Foundry connection name for the Teams Phone Extension provider."
-          },
           "phone_number": {
             "type": "string",
             "maxLength": 64,
             "description": "The optional display phone number for the Teams resource account."
           },
-          "label": {
-            "type": "string",
-            "maxLength": 128,
-            "description": "The optional display label for the binding."
-          },
           "resource_account_object_id": {
             "$ref": "#/components/schemas/Azure.Core.uuid",
             "description": "The Microsoft Teams resource-account object identifier as a GUID."
-          },
-          "status": {
-            "$ref": "#/components/schemas/TelephonyBindingStatus",
-            "description": "The lifecycle status."
-          },
-          "incoming_call_url": {
-            "type": "string",
-            "format": "uri",
-            "description": "The service-generated webhook URL to configure with the telephony provider."
-          },
-          "etag": {
-            "$ref": "#/components/schemas/Azure.Core.eTag",
-            "description": "The entity tag to send in the `If-Match` header when updating or deleting this binding.",
-            "readOnly": true
           }
         },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/TelephonyBindingListItem"
+          }
+        ],
         "description": "A Microsoft Teams Phone Extension binding returned in a list, including its entity tag.",
         "x-ms-foundry-meta": {
           "required_previews": [
@@ -85758,6 +85715,11 @@
             "description": "The Microsoft Teams user or resource-account identifier."
           }
         },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/TelephonyTransferDestination"
+          }
+        ],
         "description": "A Microsoft Teams destination for a telephony transfer target.",
         "x-ms-foundry-meta": {
           "required_previews": [
@@ -85901,14 +85863,43 @@
       },
       "TelephonyBinding": {
         "type": "object",
-        "oneOf": [
-          {
-            "$ref": "#/components/schemas/TeamsPhoneExtensionTelephonyBinding"
-          },
-          {
-            "$ref": "#/components/schemas/TwilioTelephonyBinding"
-          }
+        "required": [
+          "id",
+          "provider",
+          "connection",
+          "status",
+          "incoming_call_url"
         ],
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/TelephonyBindingId",
+            "description": "The service-generated binding identifier."
+          },
+          "provider": {
+            "$ref": "#/components/schemas/TelephonyProvider",
+            "description": "The telephony provider."
+          },
+          "connection": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 256,
+            "description": "The Foundry connection name for the telephony provider."
+          },
+          "label": {
+            "type": "string",
+            "maxLength": 128,
+            "description": "The optional display label for the binding."
+          },
+          "status": {
+            "$ref": "#/components/schemas/TelephonyBindingStatus",
+            "description": "The lifecycle status."
+          },
+          "incoming_call_url": {
+            "type": "string",
+            "format": "uri",
+            "description": "The service-generated webhook URL to configure with the telephony provider."
+          }
+        },
         "discriminator": {
           "propertyName": "provider",
           "mapping": {
@@ -85931,14 +85922,49 @@
       },
       "TelephonyBindingListItem": {
         "type": "object",
-        "oneOf": [
-          {
-            "$ref": "#/components/schemas/TeamsPhoneExtensionTelephonyBindingListItem"
-          },
-          {
-            "$ref": "#/components/schemas/TwilioTelephonyBindingListItem"
-          }
+        "required": [
+          "id",
+          "provider",
+          "connection",
+          "status",
+          "incoming_call_url",
+          "etag"
         ],
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/TelephonyBindingId",
+            "description": "The service-generated binding identifier."
+          },
+          "provider": {
+            "$ref": "#/components/schemas/TelephonyProvider",
+            "description": "The telephony provider."
+          },
+          "connection": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 256,
+            "description": "The Foundry connection name for the telephony provider."
+          },
+          "label": {
+            "type": "string",
+            "maxLength": 128,
+            "description": "The optional display label for the binding."
+          },
+          "status": {
+            "$ref": "#/components/schemas/TelephonyBindingStatus",
+            "description": "The lifecycle status."
+          },
+          "incoming_call_url": {
+            "type": "string",
+            "format": "uri",
+            "description": "The service-generated webhook URL to configure with the telephony provider."
+          },
+          "etag": {
+            "$ref": "#/components/schemas/Azure.Core.eTag",
+            "description": "The entity tag to send in the `If-Match` header when updating or deleting this binding.",
+            "readOnly": true
+          }
+        },
         "discriminator": {
           "propertyName": "provider",
           "mapping": {
@@ -86619,17 +86645,15 @@
       },
       "TelephonyTransferDestination": {
         "type": "object",
-        "oneOf": [
-          {
-            "$ref": "#/components/schemas/PSTNTelephonyTransferDestination"
-          },
-          {
-            "$ref": "#/components/schemas/TeamsTelephonyTransferDestination"
-          },
-          {
-            "$ref": "#/components/schemas/SipTelephonyTransferDestination"
-          }
+        "required": [
+          "kind"
         ],
+        "properties": {
+          "kind": {
+            "type": "string",
+            "description": "The telephony transfer destination type."
+          }
+        },
         "discriminator": {
           "propertyName": "kind",
           "mapping": {
@@ -87615,18 +87639,10 @@
       "TwilioTelephonyBinding": {
         "type": "object",
         "required": [
-          "id",
           "provider",
-          "connection",
-          "phone_number",
-          "status",
-          "incoming_call_url"
+          "phone_number"
         ],
         "properties": {
-          "id": {
-            "$ref": "#/components/schemas/TelephonyBindingId",
-            "description": "The service-generated binding identifier."
-          },
           "provider": {
             "type": "string",
             "enum": [
@@ -87634,32 +87650,17 @@
             ],
             "description": "The Twilio provider."
           },
-          "connection": {
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 256,
-            "description": "The Foundry connection name for the Twilio provider."
-          },
           "phone_number": {
             "type": "string",
             "pattern": "^\\+[1-9]\\d{6,14}$",
             "description": "The Twilio E.164 phone number."
-          },
-          "label": {
-            "type": "string",
-            "maxLength": 128,
-            "description": "The optional display label for the binding."
-          },
-          "status": {
-            "$ref": "#/components/schemas/TelephonyBindingStatus",
-            "description": "The lifecycle status."
-          },
-          "incoming_call_url": {
-            "type": "string",
-            "format": "uri",
-            "description": "The service-generated webhook URL to configure with Twilio."
           }
         },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/TelephonyBinding"
+          }
+        ],
         "description": "A Twilio binding owned by a voice agent.",
         "x-ms-foundry-meta": {
           "required_previews": [
@@ -87670,19 +87671,10 @@
       "TwilioTelephonyBindingListItem": {
         "type": "object",
         "required": [
-          "id",
           "provider",
-          "connection",
-          "phone_number",
-          "status",
-          "incoming_call_url",
-          "etag"
+          "phone_number"
         ],
         "properties": {
-          "id": {
-            "$ref": "#/components/schemas/TelephonyBindingId",
-            "description": "The service-generated binding identifier."
-          },
           "provider": {
             "type": "string",
             "enum": [
@@ -87690,37 +87682,17 @@
             ],
             "description": "The Twilio provider."
           },
-          "connection": {
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 256,
-            "description": "The Foundry connection name for the Twilio provider."
-          },
           "phone_number": {
             "type": "string",
             "pattern": "^\\+[1-9]\\d{6,14}$",
             "description": "The Twilio E.164 phone number."
-          },
-          "label": {
-            "type": "string",
-            "maxLength": 128,
-            "description": "The optional display label for the binding."
-          },
-          "status": {
-            "$ref": "#/components/schemas/TelephonyBindingStatus",
-            "description": "The lifecycle status."
-          },
-          "incoming_call_url": {
-            "type": "string",
-            "format": "uri",
-            "description": "The service-generated webhook URL to configure with Twilio."
-          },
-          "etag": {
-            "$ref": "#/components/schemas/Azure.Core.eTag",
-            "description": "The entity tag to send in the `If-Match` header when updating or deleting this binding.",
-            "readOnly": true
           }
         },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/TelephonyBindingListItem"
+          }
+        ],
         "description": "A Twilio binding returned in a list, including its entity tag.",
         "x-ms-foundry-meta": {
           "required_previews": [

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -56372,7 +56372,7 @@ components:
                 contentEncoding: base64
           description: |-
             The image(s) to edit. Must be a supported image file or an array of images.
-              For the GPT image models (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`, and `gpt-image-2-2026-04-21`), each image should be a `png`, `webp`, or `jpg`
+              For the GPT image models (`gpt-image-1`, `gpt-image-1-mini`, and `gpt-image-1.5`), each image should be a `png`, `webp`, or `jpg`
               file less than 50MB. You can provide up to 16 images.
               `chatgpt-image-latest` follows the same input constraints as GPT image models.
               For `dall-e-2`, you can only provide one image, and it should be a square
@@ -56391,27 +56391,24 @@ components:
                 - auto
             - type: 'null'
           description: |-
-            Set the background of the generated image(s). This parameter is only
-              supported for the GPT image models. Must be one of `transparent`, `opaque`,
-              or `auto` (default value). When `auto` is used, the model will automatically
-              determine the best background for the image.
-              Transparent backgrounds are available for supported GPT Image models. For
-              `gpt-image-2` and `gpt-image-2-2026-04-21`, this support is in preview. When
-              using `transparent`, set the output format to `png` or `webp`.
+            Allows to set transparency for the background of the generated image(s).
+              This parameter is only supported for the GPT image models. Must be one of
+              `transparent`, `opaque` or `auto` (default value). When `auto` is used, the
+              model will automatically determine the best background for the image.
+              If `transparent`, the output format needs to support transparency, so it
+              should be set to either `png` (default value) or `webp`.
         model:
           anyOf:
             - type: string
             - type: string
               enum:
                 - gpt-image-1.5
-                - gpt-image-2
-                - gpt-image-2-2026-04-21
                 - dall-e-2
                 - gpt-image-1
                 - gpt-image-1-mini
                 - chatgpt-image-latest
             - type: 'null'
-          description: The model to use for image generation. One of `dall-e-2` or a GPT image model (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`, `gpt-image-2-2026-04-21`, or `chatgpt-image-latest`). Defaults to `gpt-image-1.5`.
+          description: The model to use for image generation. Defaults to `gpt-image-1.5`.
           x-oaiTypeLabel: string
         'n':
           anyOf:
@@ -56503,14 +56500,12 @@ components:
             - type: string
               enum:
                 - gpt-image-1.5
-                - gpt-image-2
-                - gpt-image-2-2026-04-21
                 - dall-e-2
                 - dall-e-3
                 - gpt-image-1
                 - gpt-image-1-mini
             - type: 'null'
-          description: The model to use for image generation. One of `dall-e-2`, `dall-e-3`, or a GPT image model (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`, `gpt-image-2-2026-04-21`). Defaults to `dall-e-2` unless a parameter specific to the GPT image models is used.
+          description: The model to use for image generation. One of `dall-e-2`, `dall-e-3`, or a GPT image model (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`). Defaults to `dall-e-2` unless a parameter specific to the GPT image models is used.
           x-oaiTypeLabel: string
           default: dall-e-2
         'n':
@@ -56608,13 +56603,12 @@ components:
                 - auto
             - type: 'null'
           description: |-
-            Set the background of the generated image(s). This parameter is only
-              supported for the GPT image models. Must be one of `transparent`, `opaque`,
-              or `auto` (default value). When `auto` is used, the model will automatically
-              determine the best background for the image.
-              Transparent backgrounds are available for supported GPT Image models. For
-              `gpt-image-2` and `gpt-image-2-2026-04-21`, this support is in preview. When
-              using `transparent`, set the output format to `png` or `webp`.
+            Allows to set transparency for the background of the generated image(s).
+              This parameter is only supported for the GPT image models. Must be one of
+              `transparent`, `opaque` or `auto` (default value). When `auto` is used, the
+              model will automatically determine the best background for the image.
+              If `transparent`, the output format needs to support transparency, so it
+              should be set to either `png` (default value) or `webp`.
           default: auto
         style:
           anyOf:
@@ -58539,13 +58533,11 @@ components:
             - type: string
               enum:
                 - gpt-image-1.5
-                - gpt-image-2
-                - gpt-image-2-2026-04-21
                 - gpt-image-1
                 - gpt-image-1-mini
                 - chatgpt-image-latest
             - type: 'null'
-          description: The GPT image model to use for image editing, including `gpt-image-2` and its dated snapshot `gpt-image-2-2026-04-21`.
+          description: The model to use for image editing.
           x-oaiTypeLabel: string
           default: gpt-image-1.5
         images:
@@ -58637,7 +58629,7 @@ components:
                 - opaque
                 - auto
             - type: 'null'
-          description: Set the background of the generated image output. Transparent backgrounds are available for supported GPT Image models. For `gpt-image-2` and `gpt-image-2-2026-04-21`, this support is in preview. When using `transparent`, set the output format to `png` or `webp`.
+          description: Background behavior for generated image output.
           default: auto
         stream:
           anyOf:
@@ -61193,8 +61185,6 @@ components:
                 - gpt-image-1
                 - gpt-image-1-mini
                 - gpt-image-1.5
-                - gpt-image-2
-                - gpt-image-2-2026-04-21
           default: gpt-image-1
         quality:
           type: string
@@ -61248,11 +61238,8 @@ components:
             - opaque
             - auto
           description: |-
-            Set the background of the generated image. One of `transparent`,
-              `opaque`, or `auto`. Transparent backgrounds are available for
-              supported GPT Image models. For `gpt-image-2` and
-              `gpt-image-2-2026-04-21`, this support is in preview. When using
-              `transparent`, set the output format to `png` or `webp`. Default: `auto`.
+            Background type for the generated image. One of `transparent`,
+              `opaque`, or `auto`. Default: `auto`.
           default: auto
         input_fidelity:
           anyOf:
@@ -61979,7 +61966,7 @@ components:
           default: compaction
         encrypted_content:
           type: string
-          maxLength: 20971520
+          maxLength: 10485760
           description: The encrypted content of the compaction summary.
       allOf:
         - $ref: '#/components/schemas/OpenAI.InputItem'
@@ -63123,7 +63110,7 @@ components:
           default: compaction
         encrypted_content:
           type: string
-          maxLength: 20971520
+          maxLength: 10485760
           description: The encrypted content of the compaction summary.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Item'
@@ -81370,7 +81357,7 @@ components:
         - kind
       properties:
         kind:
-          type: string
+          $ref: '#/components/schemas/TelephonyTransferDestinationKind'
           description: The telephony transfer destination type.
       discriminator:
         propertyName: kind
@@ -81379,6 +81366,18 @@ components:
           teams: '#/components/schemas/TeamsTelephonyTransferDestination'
           sip: '#/components/schemas/SipTelephonyTransferDestination'
       description: A destination for a telephony transfer target.
+      x-ms-foundry-meta:
+        required_previews:
+          - VoiceAgents=V1Preview
+    TelephonyTransferDestinationKind:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - pstn
+            - teams
+            - sip
+      description: The kind of telephony transfer destination. Known values are stable; additional values may be added over time.
       x-ms-foundry-meta:
         required_previews:
           - VoiceAgents=V1Preview

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -45700,7 +45700,6 @@ components:
       type: object
       required:
         - provider
-        - connection
         - resource_account_object_id
       properties:
         provider:
@@ -45708,31 +45707,37 @@ components:
           enum:
             - teams_phone_extension
           description: The Microsoft Teams Phone Extension provider.
-        connection:
-          type: string
-          minLength: 1
-          maxLength: 256
-          description: The Foundry connection name for the Teams Phone Extension provider.
         phone_number:
           type: string
           maxLength: 64
           description: The optional display phone number for the Teams resource account.
-        label:
-          type: string
-          maxLength: 128
-          description: An optional display label for the binding.
         resource_account_object_id:
           $ref: '#/components/schemas/Azure.Core.uuid'
           description: The Microsoft Teams resource-account object identifier as a GUID.
+      allOf:
+        - $ref: '#/components/schemas/CreateTelephonyBindingRequest'
       description: The request to create a Microsoft Teams Phone Extension binding.
       x-ms-foundry-meta:
         required_previews:
           - VoiceAgents=V1Preview
     CreateTelephonyBindingRequest:
       type: object
-      oneOf:
-        - $ref: '#/components/schemas/CreateTeamsPhoneExtensionTelephonyBindingRequest'
-        - $ref: '#/components/schemas/CreateTwilioTelephonyBindingRequest'
+      required:
+        - provider
+        - connection
+      properties:
+        provider:
+          $ref: '#/components/schemas/TelephonyProvider'
+          description: The telephony provider.
+        connection:
+          type: string
+          minLength: 1
+          maxLength: 256
+          description: The Foundry connection name for the telephony provider.
+        label:
+          type: string
+          maxLength: 128
+          description: An optional display label for the binding.
       discriminator:
         propertyName: provider
         mapping:
@@ -45746,7 +45751,6 @@ components:
       type: object
       required:
         - provider
-        - connection
         - phone_number
       properties:
         provider:
@@ -45754,19 +45758,12 @@ components:
           enum:
             - twilio
           description: The Twilio provider.
-        connection:
-          type: string
-          minLength: 1
-          maxLength: 256
-          description: The Foundry connection name for the Twilio provider.
         phone_number:
           type: string
           pattern: ^\+[1-9]\d{6,14}$
           description: The Twilio E.164 phone number.
-        label:
-          type: string
-          maxLength: 128
-          description: An optional display label for the binding.
+      allOf:
+        - $ref: '#/components/schemas/CreateTelephonyBindingRequest'
       description: The request to create a Twilio binding.
       x-ms-foundry-meta:
         required_previews:
@@ -78581,6 +78578,8 @@ components:
           type: string
           pattern: ^\+[1-9]\d{6,14}$
           description: The E.164 phone number to call.
+      allOf:
+        - $ref: '#/components/schemas/TelephonyTransferDestination'
       description: A PSTN destination for a telephony transfer target.
       x-ms-foundry-meta:
         required_previews:
@@ -80265,6 +80264,8 @@ components:
           type: string
           format: uri
           description: The SIP or SIPS URI to call.
+      allOf:
+        - $ref: '#/components/schemas/TelephonyTransferDestination'
       description: A SIP destination for a telephony transfer target.
       x-ms-foundry-meta:
         required_previews:
@@ -80658,44 +80659,23 @@ components:
     TeamsPhoneExtensionTelephonyBinding:
       type: object
       required:
-        - id
         - provider
-        - connection
         - resource_account_object_id
-        - status
-        - incoming_call_url
       properties:
-        id:
-          $ref: '#/components/schemas/TelephonyBindingId'
-          description: The service-generated binding identifier.
         provider:
           type: string
           enum:
             - teams_phone_extension
           description: The Microsoft Teams Phone Extension provider.
-        connection:
-          type: string
-          minLength: 1
-          maxLength: 256
-          description: The Foundry connection name for the Teams Phone Extension provider.
         phone_number:
           type: string
           maxLength: 64
           description: The optional display phone number for the Teams resource account.
-        label:
-          type: string
-          maxLength: 128
-          description: The optional display label for the binding.
         resource_account_object_id:
           $ref: '#/components/schemas/Azure.Core.uuid'
           description: The Microsoft Teams resource-account object identifier as a GUID.
-        status:
-          $ref: '#/components/schemas/TelephonyBindingStatus'
-          description: The lifecycle status.
-        incoming_call_url:
-          type: string
-          format: uri
-          description: The service-generated webhook URL to configure with the telephony provider.
+      allOf:
+        - $ref: '#/components/schemas/TelephonyBinding'
       description: A Microsoft Teams Phone Extension binding owned by a voice agent.
       x-ms-foundry-meta:
         required_previews:
@@ -80703,49 +80683,23 @@ components:
     TeamsPhoneExtensionTelephonyBindingListItem:
       type: object
       required:
-        - id
         - provider
-        - connection
         - resource_account_object_id
-        - status
-        - incoming_call_url
-        - etag
       properties:
-        id:
-          $ref: '#/components/schemas/TelephonyBindingId'
-          description: The service-generated binding identifier.
         provider:
           type: string
           enum:
             - teams_phone_extension
           description: The Microsoft Teams Phone Extension provider.
-        connection:
-          type: string
-          minLength: 1
-          maxLength: 256
-          description: The Foundry connection name for the Teams Phone Extension provider.
         phone_number:
           type: string
           maxLength: 64
           description: The optional display phone number for the Teams resource account.
-        label:
-          type: string
-          maxLength: 128
-          description: The optional display label for the binding.
         resource_account_object_id:
           $ref: '#/components/schemas/Azure.Core.uuid'
           description: The Microsoft Teams resource-account object identifier as a GUID.
-        status:
-          $ref: '#/components/schemas/TelephonyBindingStatus'
-          description: The lifecycle status.
-        incoming_call_url:
-          type: string
-          format: uri
-          description: The service-generated webhook URL to configure with the telephony provider.
-        etag:
-          $ref: '#/components/schemas/Azure.Core.eTag'
-          description: The entity tag to send in the `If-Match` header when updating or deleting this binding.
-          readOnly: true
+      allOf:
+        - $ref: '#/components/schemas/TelephonyBindingListItem'
       description: A Microsoft Teams Phone Extension binding returned in a list, including its entity tag.
       x-ms-foundry-meta:
         required_previews:
@@ -80766,6 +80720,8 @@ components:
           minLength: 1
           maxLength: 256
           description: The Microsoft Teams user or resource-account identifier.
+      allOf:
+        - $ref: '#/components/schemas/TelephonyTransferDestination'
       description: A Microsoft Teams destination for a telephony transfer target.
       x-ms-foundry-meta:
         required_previews:
@@ -80855,9 +80811,35 @@ components:
       description: The transport protocol for telemetry export.
     TelephonyBinding:
       type: object
-      oneOf:
-        - $ref: '#/components/schemas/TeamsPhoneExtensionTelephonyBinding'
-        - $ref: '#/components/schemas/TwilioTelephonyBinding'
+      required:
+        - id
+        - provider
+        - connection
+        - status
+        - incoming_call_url
+      properties:
+        id:
+          $ref: '#/components/schemas/TelephonyBindingId'
+          description: The service-generated binding identifier.
+        provider:
+          $ref: '#/components/schemas/TelephonyProvider'
+          description: The telephony provider.
+        connection:
+          type: string
+          minLength: 1
+          maxLength: 256
+          description: The Foundry connection name for the telephony provider.
+        label:
+          type: string
+          maxLength: 128
+          description: The optional display label for the binding.
+        status:
+          $ref: '#/components/schemas/TelephonyBindingStatus'
+          description: The lifecycle status.
+        incoming_call_url:
+          type: string
+          format: uri
+          description: The service-generated webhook URL to configure with the telephony provider.
       discriminator:
         propertyName: provider
         mapping:
@@ -80874,9 +80856,40 @@ components:
       description: A service-generated telephony binding identifier.
     TelephonyBindingListItem:
       type: object
-      oneOf:
-        - $ref: '#/components/schemas/TeamsPhoneExtensionTelephonyBindingListItem'
-        - $ref: '#/components/schemas/TwilioTelephonyBindingListItem'
+      required:
+        - id
+        - provider
+        - connection
+        - status
+        - incoming_call_url
+        - etag
+      properties:
+        id:
+          $ref: '#/components/schemas/TelephonyBindingId'
+          description: The service-generated binding identifier.
+        provider:
+          $ref: '#/components/schemas/TelephonyProvider'
+          description: The telephony provider.
+        connection:
+          type: string
+          minLength: 1
+          maxLength: 256
+          description: The Foundry connection name for the telephony provider.
+        label:
+          type: string
+          maxLength: 128
+          description: The optional display label for the binding.
+        status:
+          $ref: '#/components/schemas/TelephonyBindingStatus'
+          description: The lifecycle status.
+        incoming_call_url:
+          type: string
+          format: uri
+          description: The service-generated webhook URL to configure with the telephony provider.
+        etag:
+          $ref: '#/components/schemas/Azure.Core.eTag'
+          description: The entity tag to send in the `If-Match` header when updating or deleting this binding.
+          readOnly: true
       discriminator:
         propertyName: provider
         mapping:
@@ -81353,10 +81366,12 @@ components:
           - VoiceAgents=V1Preview
     TelephonyTransferDestination:
       type: object
-      oneOf:
-        - $ref: '#/components/schemas/PSTNTelephonyTransferDestination'
-        - $ref: '#/components/schemas/TeamsTelephonyTransferDestination'
-        - $ref: '#/components/schemas/SipTelephonyTransferDestination'
+      required:
+        - kind
+      properties:
+        kind:
+          type: string
+          description: The telephony transfer destination type.
       discriminator:
         propertyName: kind
         mapping:
@@ -82049,41 +82064,20 @@ components:
     TwilioTelephonyBinding:
       type: object
       required:
-        - id
         - provider
-        - connection
         - phone_number
-        - status
-        - incoming_call_url
       properties:
-        id:
-          $ref: '#/components/schemas/TelephonyBindingId'
-          description: The service-generated binding identifier.
         provider:
           type: string
           enum:
             - twilio
           description: The Twilio provider.
-        connection:
-          type: string
-          minLength: 1
-          maxLength: 256
-          description: The Foundry connection name for the Twilio provider.
         phone_number:
           type: string
           pattern: ^\+[1-9]\d{6,14}$
           description: The Twilio E.164 phone number.
-        label:
-          type: string
-          maxLength: 128
-          description: The optional display label for the binding.
-        status:
-          $ref: '#/components/schemas/TelephonyBindingStatus'
-          description: The lifecycle status.
-        incoming_call_url:
-          type: string
-          format: uri
-          description: The service-generated webhook URL to configure with Twilio.
+      allOf:
+        - $ref: '#/components/schemas/TelephonyBinding'
       description: A Twilio binding owned by a voice agent.
       x-ms-foundry-meta:
         required_previews:
@@ -82091,46 +82085,20 @@ components:
     TwilioTelephonyBindingListItem:
       type: object
       required:
-        - id
         - provider
-        - connection
         - phone_number
-        - status
-        - incoming_call_url
-        - etag
       properties:
-        id:
-          $ref: '#/components/schemas/TelephonyBindingId'
-          description: The service-generated binding identifier.
         provider:
           type: string
           enum:
             - twilio
           description: The Twilio provider.
-        connection:
-          type: string
-          minLength: 1
-          maxLength: 256
-          description: The Foundry connection name for the Twilio provider.
         phone_number:
           type: string
           pattern: ^\+[1-9]\d{6,14}$
           description: The Twilio E.164 phone number.
-        label:
-          type: string
-          maxLength: 128
-          description: The optional display label for the binding.
-        status:
-          $ref: '#/components/schemas/TelephonyBindingStatus'
-          description: The lifecycle status.
-        incoming_call_url:
-          type: string
-          format: uri
-          description: The service-generated webhook URL to configure with Twilio.
-        etag:
-          $ref: '#/components/schemas/Azure.Core.eTag'
-          description: The entity tag to send in the `If-Match` header when updating or deleting this binding.
-          readOnly: true
+      allOf:
+        - $ref: '#/components/schemas/TelephonyBindingListItem'
       description: A Twilio binding returned in a list, including its entity tag.
       x-ms-foundry-meta:
         required_previews:

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -40812,7 +40812,6 @@
         "type": "object",
         "required": [
           "provider",
-          "connection",
           "resource_account_object_id"
         ],
         "properties": {
@@ -40823,27 +40822,21 @@
             ],
             "description": "The Microsoft Teams Phone Extension provider."
           },
-          "connection": {
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 256,
-            "description": "The Foundry connection name for the Teams Phone Extension provider."
-          },
           "phone_number": {
             "type": "string",
             "maxLength": 64,
             "description": "The optional display phone number for the Teams resource account."
-          },
-          "label": {
-            "type": "string",
-            "maxLength": 128,
-            "description": "An optional display label for the binding."
           },
           "resource_account_object_id": {
             "$ref": "#/components/schemas/Azure.Core.uuid",
             "description": "The Microsoft Teams resource-account object identifier as a GUID."
           }
         },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/CreateTelephonyBindingRequest"
+          }
+        ],
         "description": "The request to create a Microsoft Teams Phone Extension binding.",
         "x-ms-foundry-meta": {
           "required_previews": [
@@ -40853,14 +40846,27 @@
       },
       "CreateTelephonyBindingRequest": {
         "type": "object",
-        "oneOf": [
-          {
-            "$ref": "#/components/schemas/CreateTeamsPhoneExtensionTelephonyBindingRequest"
-          },
-          {
-            "$ref": "#/components/schemas/CreateTwilioTelephonyBindingRequest"
-          }
+        "required": [
+          "provider",
+          "connection"
         ],
+        "properties": {
+          "provider": {
+            "$ref": "#/components/schemas/TelephonyProvider",
+            "description": "The telephony provider."
+          },
+          "connection": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 256,
+            "description": "The Foundry connection name for the telephony provider."
+          },
+          "label": {
+            "type": "string",
+            "maxLength": 128,
+            "description": "An optional display label for the binding."
+          }
+        },
         "discriminator": {
           "propertyName": "provider",
           "mapping": {
@@ -40879,7 +40885,6 @@
         "type": "object",
         "required": [
           "provider",
-          "connection",
           "phone_number"
         ],
         "properties": {
@@ -40890,23 +40895,17 @@
             ],
             "description": "The Twilio provider."
           },
-          "connection": {
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 256,
-            "description": "The Foundry connection name for the Twilio provider."
-          },
           "phone_number": {
             "type": "string",
             "pattern": "^\\+[1-9]\\d{6,14}$",
             "description": "The Twilio E.164 phone number."
-          },
-          "label": {
-            "type": "string",
-            "maxLength": 128,
-            "description": "An optional display label for the binding."
           }
         },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/CreateTelephonyBindingRequest"
+          }
+        ],
         "description": "The request to create a Twilio binding.",
         "x-ms-foundry-meta": {
           "required_previews": [
@@ -87082,6 +87081,11 @@
             "description": "The E.164 phone number to call."
           }
         },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/TelephonyTransferDestination"
+          }
+        ],
         "description": "A PSTN destination for a telephony transfer target.",
         "x-ms-foundry-meta": {
           "required_previews": [
@@ -89613,6 +89617,11 @@
             "description": "The SIP or SIPS URI to call."
           }
         },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/TelephonyTransferDestination"
+          }
+        ],
         "description": "A SIP destination for a telephony transfer target.",
         "x-ms-foundry-meta": {
           "required_previews": [
@@ -90194,18 +90203,10 @@
       "TeamsPhoneExtensionTelephonyBinding": {
         "type": "object",
         "required": [
-          "id",
           "provider",
-          "connection",
-          "resource_account_object_id",
-          "status",
-          "incoming_call_url"
+          "resource_account_object_id"
         ],
         "properties": {
-          "id": {
-            "$ref": "#/components/schemas/TelephonyBindingId",
-            "description": "The service-generated binding identifier."
-          },
           "provider": {
             "type": "string",
             "enum": [
@@ -90213,36 +90214,21 @@
             ],
             "description": "The Microsoft Teams Phone Extension provider."
           },
-          "connection": {
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 256,
-            "description": "The Foundry connection name for the Teams Phone Extension provider."
-          },
           "phone_number": {
             "type": "string",
             "maxLength": 64,
             "description": "The optional display phone number for the Teams resource account."
           },
-          "label": {
-            "type": "string",
-            "maxLength": 128,
-            "description": "The optional display label for the binding."
-          },
           "resource_account_object_id": {
             "$ref": "#/components/schemas/Azure.Core.uuid",
             "description": "The Microsoft Teams resource-account object identifier as a GUID."
-          },
-          "status": {
-            "$ref": "#/components/schemas/TelephonyBindingStatus",
-            "description": "The lifecycle status."
-          },
-          "incoming_call_url": {
-            "type": "string",
-            "format": "uri",
-            "description": "The service-generated webhook URL to configure with the telephony provider."
           }
         },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/TelephonyBinding"
+          }
+        ],
         "description": "A Microsoft Teams Phone Extension binding owned by a voice agent.",
         "x-ms-foundry-meta": {
           "required_previews": [
@@ -90253,19 +90239,10 @@
       "TeamsPhoneExtensionTelephonyBindingListItem": {
         "type": "object",
         "required": [
-          "id",
           "provider",
-          "connection",
-          "resource_account_object_id",
-          "status",
-          "incoming_call_url",
-          "etag"
+          "resource_account_object_id"
         ],
         "properties": {
-          "id": {
-            "$ref": "#/components/schemas/TelephonyBindingId",
-            "description": "The service-generated binding identifier."
-          },
           "provider": {
             "type": "string",
             "enum": [
@@ -90273,41 +90250,21 @@
             ],
             "description": "The Microsoft Teams Phone Extension provider."
           },
-          "connection": {
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 256,
-            "description": "The Foundry connection name for the Teams Phone Extension provider."
-          },
           "phone_number": {
             "type": "string",
             "maxLength": 64,
             "description": "The optional display phone number for the Teams resource account."
           },
-          "label": {
-            "type": "string",
-            "maxLength": 128,
-            "description": "The optional display label for the binding."
-          },
           "resource_account_object_id": {
             "$ref": "#/components/schemas/Azure.Core.uuid",
             "description": "The Microsoft Teams resource-account object identifier as a GUID."
-          },
-          "status": {
-            "$ref": "#/components/schemas/TelephonyBindingStatus",
-            "description": "The lifecycle status."
-          },
-          "incoming_call_url": {
-            "type": "string",
-            "format": "uri",
-            "description": "The service-generated webhook URL to configure with the telephony provider."
-          },
-          "etag": {
-            "$ref": "#/components/schemas/Azure.Core.eTag",
-            "description": "The entity tag to send in the `If-Match` header when updating or deleting this binding.",
-            "readOnly": true
           }
         },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/TelephonyBindingListItem"
+          }
+        ],
         "description": "A Microsoft Teams Phone Extension binding returned in a list, including its entity tag.",
         "x-ms-foundry-meta": {
           "required_previews": [
@@ -90336,6 +90293,11 @@
             "description": "The Microsoft Teams user or resource-account identifier."
           }
         },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/TelephonyTransferDestination"
+          }
+        ],
         "description": "A Microsoft Teams destination for a telephony transfer target.",
         "x-ms-foundry-meta": {
           "required_previews": [
@@ -90479,14 +90441,43 @@
       },
       "TelephonyBinding": {
         "type": "object",
-        "oneOf": [
-          {
-            "$ref": "#/components/schemas/TeamsPhoneExtensionTelephonyBinding"
-          },
-          {
-            "$ref": "#/components/schemas/TwilioTelephonyBinding"
-          }
+        "required": [
+          "id",
+          "provider",
+          "connection",
+          "status",
+          "incoming_call_url"
         ],
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/TelephonyBindingId",
+            "description": "The service-generated binding identifier."
+          },
+          "provider": {
+            "$ref": "#/components/schemas/TelephonyProvider",
+            "description": "The telephony provider."
+          },
+          "connection": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 256,
+            "description": "The Foundry connection name for the telephony provider."
+          },
+          "label": {
+            "type": "string",
+            "maxLength": 128,
+            "description": "The optional display label for the binding."
+          },
+          "status": {
+            "$ref": "#/components/schemas/TelephonyBindingStatus",
+            "description": "The lifecycle status."
+          },
+          "incoming_call_url": {
+            "type": "string",
+            "format": "uri",
+            "description": "The service-generated webhook URL to configure with the telephony provider."
+          }
+        },
         "discriminator": {
           "propertyName": "provider",
           "mapping": {
@@ -90509,14 +90500,49 @@
       },
       "TelephonyBindingListItem": {
         "type": "object",
-        "oneOf": [
-          {
-            "$ref": "#/components/schemas/TeamsPhoneExtensionTelephonyBindingListItem"
-          },
-          {
-            "$ref": "#/components/schemas/TwilioTelephonyBindingListItem"
-          }
+        "required": [
+          "id",
+          "provider",
+          "connection",
+          "status",
+          "incoming_call_url",
+          "etag"
         ],
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/TelephonyBindingId",
+            "description": "The service-generated binding identifier."
+          },
+          "provider": {
+            "$ref": "#/components/schemas/TelephonyProvider",
+            "description": "The telephony provider."
+          },
+          "connection": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 256,
+            "description": "The Foundry connection name for the telephony provider."
+          },
+          "label": {
+            "type": "string",
+            "maxLength": 128,
+            "description": "The optional display label for the binding."
+          },
+          "status": {
+            "$ref": "#/components/schemas/TelephonyBindingStatus",
+            "description": "The lifecycle status."
+          },
+          "incoming_call_url": {
+            "type": "string",
+            "format": "uri",
+            "description": "The service-generated webhook URL to configure with the telephony provider."
+          },
+          "etag": {
+            "$ref": "#/components/schemas/Azure.Core.eTag",
+            "description": "The entity tag to send in the `If-Match` header when updating or deleting this binding.",
+            "readOnly": true
+          }
+        },
         "discriminator": {
           "propertyName": "provider",
           "mapping": {
@@ -91197,17 +91223,15 @@
       },
       "TelephonyTransferDestination": {
         "type": "object",
-        "oneOf": [
-          {
-            "$ref": "#/components/schemas/PSTNTelephonyTransferDestination"
-          },
-          {
-            "$ref": "#/components/schemas/TeamsTelephonyTransferDestination"
-          },
-          {
-            "$ref": "#/components/schemas/SipTelephonyTransferDestination"
-          }
+        "required": [
+          "kind"
         ],
+        "properties": {
+          "kind": {
+            "type": "string",
+            "description": "The telephony transfer destination type."
+          }
+        },
         "discriminator": {
           "propertyName": "kind",
           "mapping": {
@@ -92244,18 +92268,10 @@
       "TwilioTelephonyBinding": {
         "type": "object",
         "required": [
-          "id",
           "provider",
-          "connection",
-          "phone_number",
-          "status",
-          "incoming_call_url"
+          "phone_number"
         ],
         "properties": {
-          "id": {
-            "$ref": "#/components/schemas/TelephonyBindingId",
-            "description": "The service-generated binding identifier."
-          },
           "provider": {
             "type": "string",
             "enum": [
@@ -92263,32 +92279,17 @@
             ],
             "description": "The Twilio provider."
           },
-          "connection": {
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 256,
-            "description": "The Foundry connection name for the Twilio provider."
-          },
           "phone_number": {
             "type": "string",
             "pattern": "^\\+[1-9]\\d{6,14}$",
             "description": "The Twilio E.164 phone number."
-          },
-          "label": {
-            "type": "string",
-            "maxLength": 128,
-            "description": "The optional display label for the binding."
-          },
-          "status": {
-            "$ref": "#/components/schemas/TelephonyBindingStatus",
-            "description": "The lifecycle status."
-          },
-          "incoming_call_url": {
-            "type": "string",
-            "format": "uri",
-            "description": "The service-generated webhook URL to configure with Twilio."
           }
         },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/TelephonyBinding"
+          }
+        ],
         "description": "A Twilio binding owned by a voice agent.",
         "x-ms-foundry-meta": {
           "required_previews": [
@@ -92299,19 +92300,10 @@
       "TwilioTelephonyBindingListItem": {
         "type": "object",
         "required": [
-          "id",
           "provider",
-          "connection",
-          "phone_number",
-          "status",
-          "incoming_call_url",
-          "etag"
+          "phone_number"
         ],
         "properties": {
-          "id": {
-            "$ref": "#/components/schemas/TelephonyBindingId",
-            "description": "The service-generated binding identifier."
-          },
           "provider": {
             "type": "string",
             "enum": [
@@ -92319,37 +92311,17 @@
             ],
             "description": "The Twilio provider."
           },
-          "connection": {
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 256,
-            "description": "The Foundry connection name for the Twilio provider."
-          },
           "phone_number": {
             "type": "string",
             "pattern": "^\\+[1-9]\\d{6,14}$",
             "description": "The Twilio E.164 phone number."
-          },
-          "label": {
-            "type": "string",
-            "maxLength": 128,
-            "description": "The optional display label for the binding."
-          },
-          "status": {
-            "$ref": "#/components/schemas/TelephonyBindingStatus",
-            "description": "The lifecycle status."
-          },
-          "incoming_call_url": {
-            "type": "string",
-            "format": "uri",
-            "description": "The service-generated webhook URL to configure with Twilio."
-          },
-          "etag": {
-            "$ref": "#/components/schemas/Azure.Core.eTag",
-            "description": "The entity tag to send in the `If-Match` header when updating or deleting this binding.",
-            "readOnly": true
           }
         },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/TelephonyBindingListItem"
+          }
+        ],
         "description": "A Twilio binding returned in a list, including its entity tag.",
         "x-ms-foundry-meta": {
           "required_previews": [

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -56601,7 +56601,7 @@
                 }
               }
             ],
-            "description": "The image(s) to edit. Must be a supported image file or an array of images.\n  For the GPT image models (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`, and `gpt-image-2-2026-04-21`), each image should be a `png`, `webp`, or `jpg`\n  file less than 50MB. You can provide up to 16 images.\n  `chatgpt-image-latest` follows the same input constraints as GPT image models.\n  For `dall-e-2`, you can only provide one image, and it should be a square\n  `png` file less than 4MB."
+            "description": "The image(s) to edit. Must be a supported image file or an array of images.\n  For the GPT image models (`gpt-image-1`, `gpt-image-1-mini`, and `gpt-image-1.5`), each image should be a `png`, `webp`, or `jpg`\n  file less than 50MB. You can provide up to 16 images.\n  `chatgpt-image-latest` follows the same input constraints as GPT image models.\n  For `dall-e-2`, you can only provide one image, and it should be a square\n  `png` file less than 4MB."
           },
           "prompt": {
             "type": "string",
@@ -56624,7 +56624,7 @@
                 "type": "null"
               }
             ],
-            "description": "Set the background of the generated image(s). This parameter is only\n  supported for the GPT image models. Must be one of `transparent`, `opaque`,\n  or `auto` (default value). When `auto` is used, the model will automatically\n  determine the best background for the image.\n  Transparent backgrounds are available for supported GPT Image models. For\n  `gpt-image-2` and `gpt-image-2-2026-04-21`, this support is in preview. When\n  using `transparent`, set the output format to `png` or `webp`."
+            "description": "Allows to set transparency for the background of the generated image(s).\n  This parameter is only supported for the GPT image models. Must be one of\n  `transparent`, `opaque` or `auto` (default value). When `auto` is used, the\n  model will automatically determine the best background for the image.\n  If `transparent`, the output format needs to support transparency, so it\n  should be set to either `png` (default value) or `webp`."
           },
           "model": {
             "anyOf": [
@@ -56635,8 +56635,6 @@
                 "type": "string",
                 "enum": [
                   "gpt-image-1.5",
-                  "gpt-image-2",
-                  "gpt-image-2-2026-04-21",
                   "dall-e-2",
                   "gpt-image-1",
                   "gpt-image-1-mini",
@@ -56647,7 +56645,7 @@
                 "type": "null"
               }
             ],
-            "description": "The model to use for image generation. One of `dall-e-2` or a GPT image model (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`, `gpt-image-2-2026-04-21`, or `chatgpt-image-latest`). Defaults to `gpt-image-1.5`.",
+            "description": "The model to use for image generation. Defaults to `gpt-image-1.5`.",
             "x-oaiTypeLabel": "string"
           },
           "n": {
@@ -56796,8 +56794,6 @@
                 "type": "string",
                 "enum": [
                   "gpt-image-1.5",
-                  "gpt-image-2",
-                  "gpt-image-2-2026-04-21",
                   "dall-e-2",
                   "dall-e-3",
                   "gpt-image-1",
@@ -56808,7 +56804,7 @@
                 "type": "null"
               }
             ],
-            "description": "The model to use for image generation. One of `dall-e-2`, `dall-e-3`, or a GPT image model (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`, `gpt-image-2-2026-04-21`). Defaults to `dall-e-2` unless a parameter specific to the GPT image models is used.",
+            "description": "The model to use for image generation. One of `dall-e-2`, `dall-e-3`, or a GPT image model (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`). Defaults to `dall-e-2` unless a parameter specific to the GPT image models is used.",
             "x-oaiTypeLabel": "string",
             "default": "dall-e-2"
           },
@@ -56960,7 +56956,7 @@
                 "type": "null"
               }
             ],
-            "description": "Set the background of the generated image(s). This parameter is only\n  supported for the GPT image models. Must be one of `transparent`, `opaque`,\n  or `auto` (default value). When `auto` is used, the model will automatically\n  determine the best background for the image.\n  Transparent backgrounds are available for supported GPT Image models. For\n  `gpt-image-2` and `gpt-image-2-2026-04-21`, this support is in preview. When\n  using `transparent`, set the output format to `png` or `webp`.",
+            "description": "Allows to set transparency for the background of the generated image(s).\n  This parameter is only supported for the GPT image models. Must be one of\n  `transparent`, `opaque` or `auto` (default value). When `auto` is used, the\n  model will automatically determine the best background for the image.\n  If `transparent`, the output format needs to support transparency, so it\n  should be set to either `png` (default value) or `webp`.",
             "default": "auto"
           },
           "style": {
@@ -59716,8 +59712,6 @@
                 "type": "string",
                 "enum": [
                   "gpt-image-1.5",
-                  "gpt-image-2",
-                  "gpt-image-2-2026-04-21",
                   "gpt-image-1",
                   "gpt-image-1-mini",
                   "chatgpt-image-latest"
@@ -59727,7 +59721,7 @@
                 "type": "null"
               }
             ],
-            "description": "The GPT image model to use for image editing, including `gpt-image-2` and its dated snapshot `gpt-image-2-2026-04-21`.",
+            "description": "The model to use for image editing.",
             "x-oaiTypeLabel": "string",
             "default": "gpt-image-1.5"
           },
@@ -59874,7 +59868,7 @@
                 "type": "null"
               }
             ],
-            "description": "Set the background of the generated image output. Transparent backgrounds are available for supported GPT Image models. For `gpt-image-2` and `gpt-image-2-2026-04-21`, this support is in preview. When using `transparent`, set the output format to `png` or `webp`.",
+            "description": "Background behavior for generated image output.",
             "default": "auto"
           },
           "stream": {
@@ -63416,9 +63410,7 @@
                 "enum": [
                   "gpt-image-1",
                   "gpt-image-1-mini",
-                  "gpt-image-1.5",
-                  "gpt-image-2",
-                  "gpt-image-2-2026-04-21"
+                  "gpt-image-1.5"
                 ]
               }
             ],
@@ -63486,7 +63478,7 @@
               "opaque",
               "auto"
             ],
-            "description": "Set the background of the generated image. One of `transparent`,\n  `opaque`, or `auto`. Transparent backgrounds are available for\n  supported GPT Image models. For `gpt-image-2` and\n  `gpt-image-2-2026-04-21`, this support is in preview. When using\n  `transparent`, set the output format to `png` or `webp`. Default: `auto`.",
+            "description": "Background type for the generated image. One of `transparent`,\n  `opaque`, or `auto`. Default: `auto`.",
             "default": "auto"
           },
           "input_fidelity": {
@@ -64556,7 +64548,7 @@
           },
           "encrypted_content": {
             "type": "string",
-            "maxLength": 20971520,
+            "maxLength": 10485760,
             "description": "The encrypted content of the compaction summary."
           }
         },
@@ -66313,7 +66305,7 @@
           },
           "encrypted_content": {
             "type": "string",
-            "maxLength": 20971520,
+            "maxLength": 10485760,
             "description": "The encrypted content of the compaction summary."
           }
         },
@@ -91228,7 +91220,7 @@
         ],
         "properties": {
           "kind": {
-            "type": "string",
+            "$ref": "#/components/schemas/TelephonyTransferDestinationKind",
             "description": "The telephony transfer destination type."
           }
         },
@@ -91241,6 +91233,27 @@
           }
         },
         "description": "A destination for a telephony transfer target.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "VoiceAgents=V1Preview"
+          ]
+        }
+      },
+      "TelephonyTransferDestinationKind": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "pstn",
+              "teams",
+              "sip"
+            ]
+          }
+        ],
+        "description": "The kind of telephony transfer destination. Known values are stable; additional values may be added over time.",
         "x-ms-foundry-meta": {
           "required_previews": [
             "VoiceAgents=V1Preview"

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -59420,7 +59420,7 @@ components:
                 contentEncoding: base64
           description: |-
             The image(s) to edit. Must be a supported image file or an array of images.
-              For the GPT image models (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`, and `gpt-image-2-2026-04-21`), each image should be a `png`, `webp`, or `jpg`
+              For the GPT image models (`gpt-image-1`, `gpt-image-1-mini`, and `gpt-image-1.5`), each image should be a `png`, `webp`, or `jpg`
               file less than 50MB. You can provide up to 16 images.
               `chatgpt-image-latest` follows the same input constraints as GPT image models.
               For `dall-e-2`, you can only provide one image, and it should be a square
@@ -59439,27 +59439,24 @@ components:
                 - auto
             - type: 'null'
           description: |-
-            Set the background of the generated image(s). This parameter is only
-              supported for the GPT image models. Must be one of `transparent`, `opaque`,
-              or `auto` (default value). When `auto` is used, the model will automatically
-              determine the best background for the image.
-              Transparent backgrounds are available for supported GPT Image models. For
-              `gpt-image-2` and `gpt-image-2-2026-04-21`, this support is in preview. When
-              using `transparent`, set the output format to `png` or `webp`.
+            Allows to set transparency for the background of the generated image(s).
+              This parameter is only supported for the GPT image models. Must be one of
+              `transparent`, `opaque` or `auto` (default value). When `auto` is used, the
+              model will automatically determine the best background for the image.
+              If `transparent`, the output format needs to support transparency, so it
+              should be set to either `png` (default value) or `webp`.
         model:
           anyOf:
             - type: string
             - type: string
               enum:
                 - gpt-image-1.5
-                - gpt-image-2
-                - gpt-image-2-2026-04-21
                 - dall-e-2
                 - gpt-image-1
                 - gpt-image-1-mini
                 - chatgpt-image-latest
             - type: 'null'
-          description: The model to use for image generation. One of `dall-e-2` or a GPT image model (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`, `gpt-image-2-2026-04-21`, or `chatgpt-image-latest`). Defaults to `gpt-image-1.5`.
+          description: The model to use for image generation. Defaults to `gpt-image-1.5`.
           x-oaiTypeLabel: string
         'n':
           anyOf:
@@ -59551,14 +59548,12 @@ components:
             - type: string
               enum:
                 - gpt-image-1.5
-                - gpt-image-2
-                - gpt-image-2-2026-04-21
                 - dall-e-2
                 - dall-e-3
                 - gpt-image-1
                 - gpt-image-1-mini
             - type: 'null'
-          description: The model to use for image generation. One of `dall-e-2`, `dall-e-3`, or a GPT image model (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`, `gpt-image-2-2026-04-21`). Defaults to `dall-e-2` unless a parameter specific to the GPT image models is used.
+          description: The model to use for image generation. One of `dall-e-2`, `dall-e-3`, or a GPT image model (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`). Defaults to `dall-e-2` unless a parameter specific to the GPT image models is used.
           x-oaiTypeLabel: string
           default: dall-e-2
         'n':
@@ -59656,13 +59651,12 @@ components:
                 - auto
             - type: 'null'
           description: |-
-            Set the background of the generated image(s). This parameter is only
-              supported for the GPT image models. Must be one of `transparent`, `opaque`,
-              or `auto` (default value). When `auto` is used, the model will automatically
-              determine the best background for the image.
-              Transparent backgrounds are available for supported GPT Image models. For
-              `gpt-image-2` and `gpt-image-2-2026-04-21`, this support is in preview. When
-              using `transparent`, set the output format to `png` or `webp`.
+            Allows to set transparency for the background of the generated image(s).
+              This parameter is only supported for the GPT image models. Must be one of
+              `transparent`, `opaque` or `auto` (default value). When `auto` is used, the
+              model will automatically determine the best background for the image.
+              If `transparent`, the output format needs to support transparency, so it
+              should be set to either `png` (default value) or `webp`.
           default: auto
         style:
           anyOf:
@@ -61587,13 +61581,11 @@ components:
             - type: string
               enum:
                 - gpt-image-1.5
-                - gpt-image-2
-                - gpt-image-2-2026-04-21
                 - gpt-image-1
                 - gpt-image-1-mini
                 - chatgpt-image-latest
             - type: 'null'
-          description: The GPT image model to use for image editing, including `gpt-image-2` and its dated snapshot `gpt-image-2-2026-04-21`.
+          description: The model to use for image editing.
           x-oaiTypeLabel: string
           default: gpt-image-1.5
         images:
@@ -61685,7 +61677,7 @@ components:
                 - opaque
                 - auto
             - type: 'null'
-          description: Set the background of the generated image output. Transparent backgrounds are available for supported GPT Image models. For `gpt-image-2` and `gpt-image-2-2026-04-21`, this support is in preview. When using `transparent`, set the output format to `png` or `webp`.
+          description: Background behavior for generated image output.
           default: auto
         stream:
           anyOf:
@@ -64241,8 +64233,6 @@ components:
                 - gpt-image-1
                 - gpt-image-1-mini
                 - gpt-image-1.5
-                - gpt-image-2
-                - gpt-image-2-2026-04-21
           default: gpt-image-1
         quality:
           type: string
@@ -64296,11 +64286,8 @@ components:
             - opaque
             - auto
           description: |-
-            Set the background of the generated image. One of `transparent`,
-              `opaque`, or `auto`. Transparent backgrounds are available for
-              supported GPT Image models. For `gpt-image-2` and
-              `gpt-image-2-2026-04-21`, this support is in preview. When using
-              `transparent`, set the output format to `png` or `webp`. Default: `auto`.
+            Background type for the generated image. One of `transparent`,
+              `opaque`, or `auto`. Default: `auto`.
           default: auto
         input_fidelity:
           anyOf:
@@ -65027,7 +65014,7 @@ components:
           default: compaction
         encrypted_content:
           type: string
-          maxLength: 20971520
+          maxLength: 10485760
           description: The encrypted content of the compaction summary.
       allOf:
         - $ref: '#/components/schemas/OpenAI.InputItem'
@@ -66171,7 +66158,7 @@ components:
           default: compaction
         encrypted_content:
           type: string
-          maxLength: 20971520
+          maxLength: 10485760
           description: The encrypted content of the compaction summary.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Item'
@@ -84522,7 +84509,7 @@ components:
         - kind
       properties:
         kind:
-          type: string
+          $ref: '#/components/schemas/TelephonyTransferDestinationKind'
           description: The telephony transfer destination type.
       discriminator:
         propertyName: kind
@@ -84531,6 +84518,18 @@ components:
           teams: '#/components/schemas/TeamsTelephonyTransferDestination'
           sip: '#/components/schemas/SipTelephonyTransferDestination'
       description: A destination for a telephony transfer target.
+      x-ms-foundry-meta:
+        required_previews:
+          - VoiceAgents=V1Preview
+    TelephonyTransferDestinationKind:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - pstn
+            - teams
+            - sip
+      description: The kind of telephony transfer destination. Known values are stable; additional values may be added over time.
       x-ms-foundry-meta:
         required_previews:
           - VoiceAgents=V1Preview

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -48003,7 +48003,6 @@ components:
       type: object
       required:
         - provider
-        - connection
         - resource_account_object_id
       properties:
         provider:
@@ -48011,31 +48010,37 @@ components:
           enum:
             - teams_phone_extension
           description: The Microsoft Teams Phone Extension provider.
-        connection:
-          type: string
-          minLength: 1
-          maxLength: 256
-          description: The Foundry connection name for the Teams Phone Extension provider.
         phone_number:
           type: string
           maxLength: 64
           description: The optional display phone number for the Teams resource account.
-        label:
-          type: string
-          maxLength: 128
-          description: An optional display label for the binding.
         resource_account_object_id:
           $ref: '#/components/schemas/Azure.Core.uuid'
           description: The Microsoft Teams resource-account object identifier as a GUID.
+      allOf:
+        - $ref: '#/components/schemas/CreateTelephonyBindingRequest'
       description: The request to create a Microsoft Teams Phone Extension binding.
       x-ms-foundry-meta:
         required_previews:
           - VoiceAgents=V1Preview
     CreateTelephonyBindingRequest:
       type: object
-      oneOf:
-        - $ref: '#/components/schemas/CreateTeamsPhoneExtensionTelephonyBindingRequest'
-        - $ref: '#/components/schemas/CreateTwilioTelephonyBindingRequest'
+      required:
+        - provider
+        - connection
+      properties:
+        provider:
+          $ref: '#/components/schemas/TelephonyProvider'
+          description: The telephony provider.
+        connection:
+          type: string
+          minLength: 1
+          maxLength: 256
+          description: The Foundry connection name for the telephony provider.
+        label:
+          type: string
+          maxLength: 128
+          description: An optional display label for the binding.
       discriminator:
         propertyName: provider
         mapping:
@@ -48049,7 +48054,6 @@ components:
       type: object
       required:
         - provider
-        - connection
         - phone_number
       properties:
         provider:
@@ -48057,19 +48061,12 @@ components:
           enum:
             - twilio
           description: The Twilio provider.
-        connection:
-          type: string
-          minLength: 1
-          maxLength: 256
-          description: The Foundry connection name for the Twilio provider.
         phone_number:
           type: string
           pattern: ^\+[1-9]\d{6,14}$
           description: The Twilio E.164 phone number.
-        label:
-          type: string
-          maxLength: 128
-          description: An optional display label for the binding.
+      allOf:
+        - $ref: '#/components/schemas/CreateTelephonyBindingRequest'
       description: The request to create a Twilio binding.
       x-ms-foundry-meta:
         required_previews:
@@ -81648,6 +81645,8 @@ components:
           type: string
           pattern: ^\+[1-9]\d{6,14}$
           description: The E.164 phone number to call.
+      allOf:
+        - $ref: '#/components/schemas/TelephonyTransferDestination'
       description: A PSTN destination for a telephony transfer target.
       x-ms-foundry-meta:
         required_previews:
@@ -83400,6 +83399,8 @@ components:
           type: string
           format: uri
           description: The SIP or SIPS URI to call.
+      allOf:
+        - $ref: '#/components/schemas/TelephonyTransferDestination'
       description: A SIP destination for a telephony transfer target.
       x-ms-foundry-meta:
         required_previews:
@@ -83810,44 +83811,23 @@ components:
     TeamsPhoneExtensionTelephonyBinding:
       type: object
       required:
-        - id
         - provider
-        - connection
         - resource_account_object_id
-        - status
-        - incoming_call_url
       properties:
-        id:
-          $ref: '#/components/schemas/TelephonyBindingId'
-          description: The service-generated binding identifier.
         provider:
           type: string
           enum:
             - teams_phone_extension
           description: The Microsoft Teams Phone Extension provider.
-        connection:
-          type: string
-          minLength: 1
-          maxLength: 256
-          description: The Foundry connection name for the Teams Phone Extension provider.
         phone_number:
           type: string
           maxLength: 64
           description: The optional display phone number for the Teams resource account.
-        label:
-          type: string
-          maxLength: 128
-          description: The optional display label for the binding.
         resource_account_object_id:
           $ref: '#/components/schemas/Azure.Core.uuid'
           description: The Microsoft Teams resource-account object identifier as a GUID.
-        status:
-          $ref: '#/components/schemas/TelephonyBindingStatus'
-          description: The lifecycle status.
-        incoming_call_url:
-          type: string
-          format: uri
-          description: The service-generated webhook URL to configure with the telephony provider.
+      allOf:
+        - $ref: '#/components/schemas/TelephonyBinding'
       description: A Microsoft Teams Phone Extension binding owned by a voice agent.
       x-ms-foundry-meta:
         required_previews:
@@ -83855,49 +83835,23 @@ components:
     TeamsPhoneExtensionTelephonyBindingListItem:
       type: object
       required:
-        - id
         - provider
-        - connection
         - resource_account_object_id
-        - status
-        - incoming_call_url
-        - etag
       properties:
-        id:
-          $ref: '#/components/schemas/TelephonyBindingId'
-          description: The service-generated binding identifier.
         provider:
           type: string
           enum:
             - teams_phone_extension
           description: The Microsoft Teams Phone Extension provider.
-        connection:
-          type: string
-          minLength: 1
-          maxLength: 256
-          description: The Foundry connection name for the Teams Phone Extension provider.
         phone_number:
           type: string
           maxLength: 64
           description: The optional display phone number for the Teams resource account.
-        label:
-          type: string
-          maxLength: 128
-          description: The optional display label for the binding.
         resource_account_object_id:
           $ref: '#/components/schemas/Azure.Core.uuid'
           description: The Microsoft Teams resource-account object identifier as a GUID.
-        status:
-          $ref: '#/components/schemas/TelephonyBindingStatus'
-          description: The lifecycle status.
-        incoming_call_url:
-          type: string
-          format: uri
-          description: The service-generated webhook URL to configure with the telephony provider.
-        etag:
-          $ref: '#/components/schemas/Azure.Core.eTag'
-          description: The entity tag to send in the `If-Match` header when updating or deleting this binding.
-          readOnly: true
+      allOf:
+        - $ref: '#/components/schemas/TelephonyBindingListItem'
       description: A Microsoft Teams Phone Extension binding returned in a list, including its entity tag.
       x-ms-foundry-meta:
         required_previews:
@@ -83918,6 +83872,8 @@ components:
           minLength: 1
           maxLength: 256
           description: The Microsoft Teams user or resource-account identifier.
+      allOf:
+        - $ref: '#/components/schemas/TelephonyTransferDestination'
       description: A Microsoft Teams destination for a telephony transfer target.
       x-ms-foundry-meta:
         required_previews:
@@ -84007,9 +83963,35 @@ components:
       description: The transport protocol for telemetry export.
     TelephonyBinding:
       type: object
-      oneOf:
-        - $ref: '#/components/schemas/TeamsPhoneExtensionTelephonyBinding'
-        - $ref: '#/components/schemas/TwilioTelephonyBinding'
+      required:
+        - id
+        - provider
+        - connection
+        - status
+        - incoming_call_url
+      properties:
+        id:
+          $ref: '#/components/schemas/TelephonyBindingId'
+          description: The service-generated binding identifier.
+        provider:
+          $ref: '#/components/schemas/TelephonyProvider'
+          description: The telephony provider.
+        connection:
+          type: string
+          minLength: 1
+          maxLength: 256
+          description: The Foundry connection name for the telephony provider.
+        label:
+          type: string
+          maxLength: 128
+          description: The optional display label for the binding.
+        status:
+          $ref: '#/components/schemas/TelephonyBindingStatus'
+          description: The lifecycle status.
+        incoming_call_url:
+          type: string
+          format: uri
+          description: The service-generated webhook URL to configure with the telephony provider.
       discriminator:
         propertyName: provider
         mapping:
@@ -84026,9 +84008,40 @@ components:
       description: A service-generated telephony binding identifier.
     TelephonyBindingListItem:
       type: object
-      oneOf:
-        - $ref: '#/components/schemas/TeamsPhoneExtensionTelephonyBindingListItem'
-        - $ref: '#/components/schemas/TwilioTelephonyBindingListItem'
+      required:
+        - id
+        - provider
+        - connection
+        - status
+        - incoming_call_url
+        - etag
+      properties:
+        id:
+          $ref: '#/components/schemas/TelephonyBindingId'
+          description: The service-generated binding identifier.
+        provider:
+          $ref: '#/components/schemas/TelephonyProvider'
+          description: The telephony provider.
+        connection:
+          type: string
+          minLength: 1
+          maxLength: 256
+          description: The Foundry connection name for the telephony provider.
+        label:
+          type: string
+          maxLength: 128
+          description: The optional display label for the binding.
+        status:
+          $ref: '#/components/schemas/TelephonyBindingStatus'
+          description: The lifecycle status.
+        incoming_call_url:
+          type: string
+          format: uri
+          description: The service-generated webhook URL to configure with the telephony provider.
+        etag:
+          $ref: '#/components/schemas/Azure.Core.eTag'
+          description: The entity tag to send in the `If-Match` header when updating or deleting this binding.
+          readOnly: true
       discriminator:
         propertyName: provider
         mapping:
@@ -84505,10 +84518,12 @@ components:
           - VoiceAgents=V1Preview
     TelephonyTransferDestination:
       type: object
-      oneOf:
-        - $ref: '#/components/schemas/PSTNTelephonyTransferDestination'
-        - $ref: '#/components/schemas/TeamsTelephonyTransferDestination'
-        - $ref: '#/components/schemas/SipTelephonyTransferDestination'
+      required:
+        - kind
+      properties:
+        kind:
+          type: string
+          description: The telephony transfer destination type.
       discriminator:
         propertyName: kind
         mapping:
@@ -85236,41 +85251,20 @@ components:
     TwilioTelephonyBinding:
       type: object
       required:
-        - id
         - provider
-        - connection
         - phone_number
-        - status
-        - incoming_call_url
       properties:
-        id:
-          $ref: '#/components/schemas/TelephonyBindingId'
-          description: The service-generated binding identifier.
         provider:
           type: string
           enum:
             - twilio
           description: The Twilio provider.
-        connection:
-          type: string
-          minLength: 1
-          maxLength: 256
-          description: The Foundry connection name for the Twilio provider.
         phone_number:
           type: string
           pattern: ^\+[1-9]\d{6,14}$
           description: The Twilio E.164 phone number.
-        label:
-          type: string
-          maxLength: 128
-          description: The optional display label for the binding.
-        status:
-          $ref: '#/components/schemas/TelephonyBindingStatus'
-          description: The lifecycle status.
-        incoming_call_url:
-          type: string
-          format: uri
-          description: The service-generated webhook URL to configure with Twilio.
+      allOf:
+        - $ref: '#/components/schemas/TelephonyBinding'
       description: A Twilio binding owned by a voice agent.
       x-ms-foundry-meta:
         required_previews:
@@ -85278,46 +85272,20 @@ components:
     TwilioTelephonyBindingListItem:
       type: object
       required:
-        - id
         - provider
-        - connection
         - phone_number
-        - status
-        - incoming_call_url
-        - etag
       properties:
-        id:
-          $ref: '#/components/schemas/TelephonyBindingId'
-          description: The service-generated binding identifier.
         provider:
           type: string
           enum:
             - twilio
           description: The Twilio provider.
-        connection:
-          type: string
-          minLength: 1
-          maxLength: 256
-          description: The Foundry connection name for the Twilio provider.
         phone_number:
           type: string
           pattern: ^\+[1-9]\d{6,14}$
           description: The Twilio E.164 phone number.
-        label:
-          type: string
-          maxLength: 128
-          description: The optional display label for the binding.
-        status:
-          $ref: '#/components/schemas/TelephonyBindingStatus'
-          description: The lifecycle status.
-        incoming_call_url:
-          type: string
-          format: uri
-          description: The service-generated webhook URL to configure with Twilio.
-        etag:
-          $ref: '#/components/schemas/Azure.Core.eTag'
-          description: The entity tag to send in the `If-Match` header when updating or deleting this binding.
-          readOnly: true
+      allOf:
+        - $ref: '#/components/schemas/TelephonyBindingListItem'
       description: A Twilio binding returned in a list, including its entity tag.
       x-ms-foundry-meta:
         required_previews:

--- a/specification/ai-foundry/data-plane/Foundry/src/voice-agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/voice-agents/models.tsp
@@ -465,9 +465,17 @@ union TelephonyBindingStatus {
   suspended: "suspended",
 }
 
+@doc("A destination for a telephony transfer target.")
+@discriminator("kind")
+@extension("x-ms-foundry-meta", VoiceAgentRequiredPreview)
+model TelephonyTransferDestination {
+  @doc("The telephony transfer destination type.")
+  kind: string;
+}
+
 @doc("A PSTN destination for a telephony transfer target.")
 @extension("x-ms-foundry-meta", VoiceAgentRequiredPreview)
-model PSTNTelephonyTransferDestination {
+model PSTNTelephonyTransferDestination extends TelephonyTransferDestination {
   @doc("The PSTN destination type.")
   kind: "pstn";
 
@@ -478,7 +486,7 @@ model PSTNTelephonyTransferDestination {
 
 @doc("A Microsoft Teams destination for a telephony transfer target.")
 @extension("x-ms-foundry-meta", VoiceAgentRequiredPreview)
-model TeamsTelephonyTransferDestination {
+model TeamsTelephonyTransferDestination extends TelephonyTransferDestination {
   @doc("The Microsoft Teams destination type.")
   kind: "teams";
 
@@ -490,26 +498,12 @@ model TeamsTelephonyTransferDestination {
 
 @doc("A SIP destination for a telephony transfer target.")
 @extension("x-ms-foundry-meta", VoiceAgentRequiredPreview)
-model SipTelephonyTransferDestination {
+model SipTelephonyTransferDestination extends TelephonyTransferDestination {
   @doc("The SIP destination type.")
   kind: "sip";
 
   @doc("The SIP or SIPS URI to call.")
   value: url;
-}
-
-@doc("A destination for a telephony transfer target.")
-@discriminated(#{ envelope: "none", discriminatorPropertyName: "kind" })
-@extension("x-ms-foundry-meta", VoiceAgentRequiredPreview)
-union TelephonyTransferDestination {
-  @doc("A public switched telephone network destination.")
-  pstn: PSTNTelephonyTransferDestination,
-
-  @doc("A Microsoft Teams user or resource-account destination.")
-  teams: TeamsTelephonyTransferDestination,
-
-  @doc("A Session Initiation Protocol destination.")
-  sip: SipTelephonyTransferDestination,
 }
 
 @doc("A named destination to which the voice agent may transfer a call.")
@@ -529,25 +523,35 @@ model TelephonyTransferTarget {
   destination: TelephonyTransferDestination;
 }
 
-@doc("The request to create a Microsoft Teams Phone Extension binding.")
+@doc("The request to create a telephony binding.")
+@discriminator("provider")
 @extension("x-ms-foundry-meta", VoiceAgentRequiredPreview)
-@clientName("CreateTeamsPhoneExtensionTelephonyBindingContent", "csharp")
-model CreateTeamsPhoneExtensionTelephonyBindingRequest {
-  @doc("The Microsoft Teams Phone Extension provider.")
-  provider: "teams_phone_extension";
+@clientName("CreateTelephonyBindingContent", "csharp")
+model CreateTelephonyBindingRequest {
+  @doc("The telephony provider.")
+  provider: TelephonyProvider;
 
-  @doc("The Foundry connection name for the Teams Phone Extension provider.")
+  @doc("The Foundry connection name for the telephony provider.")
   @minLength(1)
   @maxLength(256)
   connection: string;
 
-  @doc("The optional display phone number for the Teams resource account.")
-  @maxLength(64)
-  phone_number?: string;
-
   @doc("An optional display label for the binding.")
   @maxLength(128)
   label?: string;
+}
+
+@doc("The request to create a Microsoft Teams Phone Extension binding.")
+@extension("x-ms-foundry-meta", VoiceAgentRequiredPreview)
+@clientName("CreateTeamsPhoneExtensionTelephonyBindingContent", "csharp")
+model CreateTeamsPhoneExtensionTelephonyBindingRequest
+  extends CreateTelephonyBindingRequest {
+  @doc("The Microsoft Teams Phone Extension provider.")
+  provider: "teams_phone_extension";
+
+  @doc("The optional display phone number for the Teams resource account.")
+  @maxLength(64)
+  phone_number?: string;
 
   @doc("The Microsoft Teams resource-account object identifier as a GUID.")
   resource_account_object_id: Azure.Core.uuid;
@@ -556,33 +560,14 @@ model CreateTeamsPhoneExtensionTelephonyBindingRequest {
 @doc("The request to create a Twilio binding.")
 @extension("x-ms-foundry-meta", VoiceAgentRequiredPreview)
 @clientName("CreateTwilioTelephonyBindingContent", "csharp")
-model CreateTwilioTelephonyBindingRequest {
+model CreateTwilioTelephonyBindingRequest
+  extends CreateTelephonyBindingRequest {
   @doc("The Twilio provider.")
   provider: "twilio";
-
-  @doc("The Foundry connection name for the Twilio provider.")
-  @minLength(1)
-  @maxLength(256)
-  connection: string;
 
   @doc("The Twilio E.164 phone number.")
   @pattern("^\\+[1-9]\\d{6,14}$")
   phone_number: string;
-
-  @doc("An optional display label for the binding.")
-  @maxLength(128)
-  label?: string;
-}
-
-@doc("The request to create a telephony binding.")
-@discriminated(#{ envelope: "none", discriminatorPropertyName: "provider" })
-@extension("x-ms-foundry-meta", VoiceAgentRequiredPreview)
-union CreateTelephonyBindingRequest {
-  @doc("A Microsoft Teams Phone Extension binding request.")
-  teams_phone_extension: CreateTeamsPhoneExtensionTelephonyBindingRequest,
-
-  @doc("A Twilio binding request.")
-  twilio: CreateTwilioTelephonyBindingRequest,
 }
 
 @doc("The request to update an existing telephony binding. Every property is optional and the binding's provider is immutable.")
@@ -606,30 +591,24 @@ model UpdateTelephonyBindingRequest {
   phone_number?: string | null;
 }
 
-@doc("A Microsoft Teams Phone Extension binding owned by a voice agent.")
+@doc("A telephony binding owned by a voice agent.")
+@discriminator("provider")
 @extension("x-ms-foundry-meta", VoiceAgentRequiredPreview)
-model TeamsPhoneExtensionTelephonyBinding {
+model TelephonyBinding {
   @doc("The service-generated binding identifier.")
   id: TelephonyBindingId;
 
-  @doc("The Microsoft Teams Phone Extension provider.")
-  provider: "teams_phone_extension";
+  @doc("The telephony provider.")
+  provider: TelephonyProvider;
 
-  @doc("The Foundry connection name for the Teams Phone Extension provider.")
+  @doc("The Foundry connection name for the telephony provider.")
   @minLength(1)
   @maxLength(256)
   connection: string;
 
-  @doc("The optional display phone number for the Teams resource account.")
-  @maxLength(64)
-  phone_number?: string;
-
   @doc("The optional display label for the binding.")
   @maxLength(128)
   label?: string;
-
-  @doc("The Microsoft Teams resource-account object identifier as a GUID.")
-  resource_account_object_id: Azure.Core.uuid;
 
   @doc("The lifecycle status.")
   status: TelephonyBindingStatus;
@@ -638,23 +617,45 @@ model TeamsPhoneExtensionTelephonyBinding {
   incoming_call_url: url;
 }
 
+@doc("A Microsoft Teams Phone Extension binding owned by a voice agent.")
+@extension("x-ms-foundry-meta", VoiceAgentRequiredPreview)
+model TeamsPhoneExtensionTelephonyBinding extends TelephonyBinding {
+  @doc("The Microsoft Teams Phone Extension provider.")
+  provider: "teams_phone_extension";
+
+  @doc("The optional display phone number for the Teams resource account.")
+  @maxLength(64)
+  phone_number?: string;
+
+  @doc("The Microsoft Teams resource-account object identifier as a GUID.")
+  resource_account_object_id: Azure.Core.uuid;
+}
+
 @doc("A Twilio binding owned by a voice agent.")
 @extension("x-ms-foundry-meta", VoiceAgentRequiredPreview)
-model TwilioTelephonyBinding {
-  @doc("The service-generated binding identifier.")
-  id: TelephonyBindingId;
-
+model TwilioTelephonyBinding extends TelephonyBinding {
   @doc("The Twilio provider.")
   provider: "twilio";
-
-  @doc("The Foundry connection name for the Twilio provider.")
-  @minLength(1)
-  @maxLength(256)
-  connection: string;
 
   @doc("The Twilio E.164 phone number.")
   @pattern("^\\+[1-9]\\d{6,14}$")
   phone_number: string;
+}
+
+@doc("A telephony binding returned in a list, including its entity tag.")
+@discriminator("provider")
+@extension("x-ms-foundry-meta", VoiceAgentRequiredPreview)
+model TelephonyBindingListItem {
+  @doc("The service-generated binding identifier.")
+  id: TelephonyBindingId;
+
+  @doc("The telephony provider.")
+  provider: TelephonyProvider;
+
+  @doc("The Foundry connection name for the telephony provider.")
+  @minLength(1)
+  @maxLength(256)
+  connection: string;
 
   @doc("The optional display label for the binding.")
   @maxLength(128)
@@ -663,50 +664,38 @@ model TwilioTelephonyBinding {
   @doc("The lifecycle status.")
   status: TelephonyBindingStatus;
 
-  @doc("The service-generated webhook URL to configure with Twilio.")
+  @doc("The service-generated webhook URL to configure with the telephony provider.")
   incoming_call_url: url;
-}
 
-@doc("A telephony binding owned by a voice agent.")
-@discriminated(#{ envelope: "none", discriminatorPropertyName: "provider" })
-@extension("x-ms-foundry-meta", VoiceAgentRequiredPreview)
-union TelephonyBinding {
-  @doc("A Microsoft Teams Phone Extension binding.")
-  teams_phone_extension: TeamsPhoneExtensionTelephonyBinding,
-
-  @doc("A Twilio binding.")
-  twilio: TwilioTelephonyBinding,
+  @doc("The entity tag to send in the `If-Match` header when updating or deleting this binding.")
+  @visibility(Lifecycle.Read)
+  etag: Azure.Core.eTag;
 }
 
 @doc("A Microsoft Teams Phone Extension binding returned in a list, including its entity tag.")
 @extension("x-ms-foundry-meta", VoiceAgentRequiredPreview)
-model TeamsPhoneExtensionTelephonyBindingListItem {
-  ...TeamsPhoneExtensionTelephonyBinding;
+model TeamsPhoneExtensionTelephonyBindingListItem
+  extends TelephonyBindingListItem {
+  @doc("The Microsoft Teams Phone Extension provider.")
+  provider: "teams_phone_extension";
 
-  @doc("The entity tag to send in the `If-Match` header when updating or deleting this binding.")
-  @visibility(Lifecycle.Read)
-  etag: Azure.Core.eTag;
+  @doc("The optional display phone number for the Teams resource account.")
+  @maxLength(64)
+  phone_number?: string;
+
+  @doc("The Microsoft Teams resource-account object identifier as a GUID.")
+  resource_account_object_id: Azure.Core.uuid;
 }
 
 @doc("A Twilio binding returned in a list, including its entity tag.")
 @extension("x-ms-foundry-meta", VoiceAgentRequiredPreview)
-model TwilioTelephonyBindingListItem {
-  ...TwilioTelephonyBinding;
+model TwilioTelephonyBindingListItem extends TelephonyBindingListItem {
+  @doc("The Twilio provider.")
+  provider: "twilio";
 
-  @doc("The entity tag to send in the `If-Match` header when updating or deleting this binding.")
-  @visibility(Lifecycle.Read)
-  etag: Azure.Core.eTag;
-}
-
-@doc("A telephony binding returned in a list, including its entity tag.")
-@discriminated(#{ envelope: "none", discriminatorPropertyName: "provider" })
-@extension("x-ms-foundry-meta", VoiceAgentRequiredPreview)
-union TelephonyBindingListItem {
-  @doc("A Microsoft Teams Phone Extension binding list item.")
-  teams_phone_extension: TeamsPhoneExtensionTelephonyBindingListItem,
-
-  @doc("A Twilio binding list item.")
-  twilio: TwilioTelephonyBindingListItem,
+  @doc("The Twilio E.164 phone number.")
+  @pattern("^\\+[1-9]\\d{6,14}$")
+  phone_number: string;
 }
 
 /** A telephony binding response with its entity tag. */

--- a/specification/ai-foundry/data-plane/Foundry/src/voice-agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/voice-agents/models.tsp
@@ -465,12 +465,27 @@ union TelephonyBindingStatus {
   suspended: "suspended",
 }
 
+@doc("The kind of telephony transfer destination. Known values are stable; additional values may be added over time.")
+@extension("x-ms-foundry-meta", VoiceAgentRequiredPreview)
+union TelephonyTransferDestinationKind {
+  string,
+
+  @doc("A public switched telephone network destination.")
+  pstn: "pstn",
+
+  @doc("A Microsoft Teams user or resource-account destination.")
+  teams: "teams",
+
+  @doc("A Session Initiation Protocol destination.")
+  sip: "sip",
+}
+
 @doc("A destination for a telephony transfer target.")
 @discriminator("kind")
 @extension("x-ms-foundry-meta", VoiceAgentRequiredPreview)
 model TelephonyTransferDestination {
   @doc("The telephony transfer destination type.")
-  kind: string;
+  kind: TelephonyTransferDestinationKind;
 }
 
 @doc("A PSTN destination for a telephony transfer target.")


### PR DESCRIPTION
## Summary

The telephony response, request, list, and transfer-destination discriminated unions previously generated `BinaryData` in .NET. This change replaces them with explicit discriminator base-model hierarchies so .NET emits typed abstract bases and derived Teams, Twilio, PSTN, and SIP models while preserving their wire shapes.

`TelephonyTransferDestination.kind` now uses the extensible `TelephonyTransferDestinationKind` union with the known `pstn`, `teams`, and `sip` wire values, while remaining forward-compatible with additional values.

The generated `v1` and `virtual-public-preview` OpenAPI JSON/YAML artifacts are refreshed from the TypeSpec source and preserve the discriminator descriptions on derived models.

## Validation

- Azure TypeSpec validation
- `npx tsp compile . --warn-as-error`
- `npx tsv specification\ai-foundry\data-plane\Foundry`
- Deterministic regeneration check for both JSON/YAML version pairs
- Telephony discriminator mappings, required `kind`, API paths, and unchanged examples verified