### PR TITLE
Fix AVS 2026-03-01 stable Swagger path

### DIFF
--- a/specification/vmware/resource-manager/Microsoft.AVS/AVS/examples/2026-03-01/LegacyWorkloadNetworks_Get.json
+++ b/specification/vmware/resource-manager/Microsoft.AVS/AVS/examples/2026-03-01/LegacyWorkloadNetworks_Get.json
@@ -1,0 +1,20 @@
+{
+  "title": "LegacyWorkloadNetworks_Get",
+  "operationId": "LegacyWorkloadNetworks_Get",
+  "parameters": {
+    "api-version": "2026-03-01",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "group1",
+    "privateCloudName": "cloud1",
+    "workloadNetworkName": "default"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.AVS/privateClouds/cloud1/workloadNetworks/default",
+        "name": "default",
+        "type": "Microsoft.AVS/privateClouds/workloadNetworks"
+      }
+    }
+  }
+}

--- a/specification/vmware/resource-manager/Microsoft.AVS/AVS/readme.md
+++ b/specification/vmware/resource-manager/Microsoft.AVS/AVS/readme.md
@@ -30,7 +30,7 @@ These settings apply only when `--tag=package-2026-03-01` is specified on the co
 
 ``` yaml $(tag) == 'package-2026-03-01'
 input-file:
-- preview/2026-03-01/vmware.json
+- stable/2026-03-01/vmware.json
 ```
 
 ### Tag: package-2025-09-01
@@ -336,6 +336,5 @@ See configuration in [readme.go.md](./readme.go.md)
 ## Java
 
 See configuration in [readme.java.md](./readme.java.md)
-
 
 

--- a/specification/vmware/resource-manager/Microsoft.AVS/AVS/stable/2026-03-01/examples/LegacyWorkloadNetworks_Get.json
+++ b/specification/vmware/resource-manager/Microsoft.AVS/AVS/stable/2026-03-01/examples/LegacyWorkloadNetworks_Get.json
@@ -1,0 +1,20 @@
+{
+  "title": "LegacyWorkloadNetworks_Get",
+  "operationId": "LegacyWorkloadNetworks_Get",
+  "parameters": {
+    "api-version": "2026-03-01",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "group1",
+    "privateCloudName": "cloud1",
+    "workloadNetworkName": "default"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.AVS/privateClouds/cloud1/workloadNetworks/default",
+        "name": "default",
+        "type": "Microsoft.AVS/privateClouds/workloadNetworks"
+      }
+    }
+  }
+}

--- a/specification/vmware/resource-manager/Microsoft.AVS/AVS/stable/2026-03-01/vmware.json
+++ b/specification/vmware/resource-manager/Microsoft.AVS/AVS/stable/2026-03-01/vmware.json
@@ -5773,6 +5773,52 @@
         }
       }
     },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AVS/privateClouds/{privateCloudName}/workloadNetworks/{workloadNetworkName}": {
+      "get": {
+        "operationId": "LegacyWorkloadNetworks_Get",
+        "description": "Get a workload network using the legacy parameterized route.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/PrivateCloudNameParameter"
+          },
+          {
+            "name": "workloadNetworkName",
+            "in": "path",
+            "description": "Name of the workload network.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/WorkloadNetwork"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "LegacyWorkloadNetworks_Get": {
+            "$ref": "./examples/LegacyWorkloadNetworks_Get.json"
+          }
+        }
+      }
+    },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AVS/privateClouds/{privateCloudName}/workloadNetworks/default": {
       "get": {
         "operationId": "WorkloadNetworks_Get",

--- a/specification/vmware/resource-manager/Microsoft.AVS/AVS/workloadNetworks.tsp
+++ b/specification/vmware/resource-manager/Microsoft.AVS/AVS/workloadNetworks.tsp
@@ -3,6 +3,7 @@ namespace Microsoft.AVS;
 using Azure.ResourceManager;
 using TypeSpec.Http;
 using TypeSpec.Rest;
+using TypeSpec.Versioning;
 
 @armResourceOperations
 interface WorkloadNetworks {
@@ -12,6 +13,26 @@ interface WorkloadNetworks {
     WorkloadNetwork,
     Response = ArmResponse<ResourceList<WorkloadNetwork>>
   >;
+}
+
+#suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-interface-requires-decorator" "Custom route retained for compatibility with API versions before the TypeSpec migration."
+@added(Versions.v2026_03_01)
+interface LegacyWorkloadNetworks {
+  #suppress "@azure-tools/typespec-azure-resource-manager/use-operation-decorator" "Custom route retained for compatibility with API versions before the TypeSpec migration."
+  #suppress "@azure-tools/typespec-azure-resource-manager/use-interface" "Custom route retained for compatibility with API versions before the TypeSpec migration."
+  @route("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AVS/privateClouds/{privateCloudName}/workloadNetworks/{workloadNetworkName}")
+  @doc("Get a workload network using the legacy parameterized route.")
+  @get
+  get(
+    ...SubscriptionIdParameter,
+    ...ResourceGroupParameter,
+    ...ApiVersionParameter,
+    ...PrivateCloudNameParameter,
+
+    @doc("Name of the workload network.")
+    @path
+    workloadNetworkName: string,
+  ): ArmResponse<WorkloadNetwork> | ErrorResponse;
 }
 
 @doc("Workload Network")


### PR DESCRIPTION
## Summary

- Corrects the AutoRest input path for `package-2026-03-01` from the nonexistent preview folder to `stable/2026-03-01/vmware.json`.
- Restores the legacy parameterized workload-network GET route alongside the newer `/default` singleton route.

## Reason

Swagger LintDiff failed because `readme.md` referenced `preview/2026-03-01/vmware.json`, while the stable API specification was generated under `stable/2026-03-01/vmware.json`.

After correcting the path, Avocado detected that the new default tag omitted the historical `/workloadNetworks/{workloadNetworkName}` API. The compatibility operation retains that route in `2026-03-01` without changing the current `/workloadNetworks/default` operation.

## Validation

- Confirmed that `stable/2026-03-01/vmware.json` exists.
- Confirmed that the package tag references the stable folder.
- TypeSpec compilation and validation pass.
- Avocado reports no missing APIs in the default tag.
