### PR TITLE
Fix data-plane review gate message to reference correct label and process

### DIFF
--- a/.github/workflows/src/summarize-checks/labelling.js
+++ b/.github/workflows/src/summarize-checks/labelling.js
@@ -856,9 +856,9 @@ const rulesPri0dataPlane = [
     anyRequiredLabels: ["data-plane-review-signoff"],
     troubleshootingGuide:
       `Your PR requires an API stewardship review as it introduces a new data-plane API version (label: <code>data-plane-review-requested</code>). ` +
-      `Email ${href("azureapirbcore@microsoft.com", "mailto:azureapirbcore@microsoft.com")} with your PR link to request an ` +
-      `${href("offline REST API review", "https://eng.ms/docs/products/azure-developer-experience/design/api-review#requesting-an-offline-rest-api-review")}. ` +
-      `A data-plane API reviewer signs off by applying the protected <code>data-plane-review-signoff</code> label.`,
+      `A data-plane API reviewer is assigned from the pool and unblocks merge by applying the protected <code>data-plane-review-signoff</code> label. ` +
+      `To request or expedite the ${href("offline REST API review", "https://eng.ms/docs/products/azure-developer-experience/design/api-review#requesting-an-offline-rest-api-review")}, ` +
+      `email ${href("azureapirbcore@microsoft.com", "mailto:azureapirbcore@microsoft.com")} with your PR link.`,
   },
 ];
 

--- a/.github/workflows/src/summarize-checks/labelling.js
+++ b/.github/workflows/src/summarize-checks/labelling.js
@@ -855,8 +855,10 @@ const rulesPri0dataPlane = [
     anyPrerequisiteLabels: ["data-plane-review-requested"],
     anyRequiredLabels: ["data-plane-review-signoff"],
     troubleshootingGuide:
-      `Your PR requires an API stewardship board review as it introduces a new API version (label: <code>new-api-version</code>). ` +
-      `Send an email to ${href("azureapirbcore@microsoft.com", "mailto:azureapirbcore@microsoft.com")} with your PR link for offline review.`,
+      `Your PR requires an API stewardship review as it introduces a new data-plane API version (label: <code>data-plane-review-requested</code>). ` +
+      `Email ${href("azureapirbcore@microsoft.com", "mailto:azureapirbcore@microsoft.com")} with your PR link to request an ` +
+      `${href("offline REST API review", "https://eng.ms/docs/products/azure-developer-experience/design/api-review#requesting-an-offline-rest-api-review")}. ` +
+      `A data-plane API reviewer signs off by applying the protected <code>data-plane-review-signoff</code> label.`,
   },
 ];
 


### PR DESCRIPTION
## What

The `Next Steps to Merge` message for the data-plane review merge gate still referenced the legacy `new-api-version` label and generic `stewardship board review` wording, even though the gate was migrated to key on `data-plane-review-requested` -> `data-plane-review-signoff`.

## Change

Updates the `troubleshootingGuide` for the data-plane review gate rule in `labelling.js` to:
- Name the correct trigger label `data-plane-review-requested` (was `new-api-version`).
- Link the current [offline REST API review](https://eng.ms/docs/products/azure-developer-experience/design/api-review#requesting-an-offline-rest-api-review) process.
- Keep the `azureapirbcore@microsoft.com` intake (confirmed correct per the stewardship board member guide).
- Describe the protected `data-plane-review-signoff` sign-off label.

## Validation

- `summarize-checks` + `labelling` tests pass (47 passed, 1 skipped).
- Prettier clean.

Draft for review of wording before marking ready.