### PR TITLE
Add StackHCIVM 2026-07-01-preview API version

### DIFF
--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/AttestationStatuses_Get.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/AttestationStatuses_Get.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceUri": "subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.AzureStackHCI/virtualMachineInstances/AttestationStatus",
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default/attestationStatus/default",
+        "properties": {
+          "attestSecureBootEnabled": "Disabled",
+          "attestationCertValidated": "Invalid",
+          "bootIntegrityValidated": "Invalid",
+          "errorMessage": "Attestation token has invalid signature",
+          "healthStatus": "Unhealthy",
+          "linuxKernelVersion": "1.0.0.0",
+          "timestamp": "2023/11/10 9:48"
+        }
+      }
+    }
+  },
+  "operationId": "AttestationStatuses_Get",
+  "title": "GetAttestationStatus"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/GalleryImages_CreateOrUpdate.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/GalleryImages_CreateOrUpdate.json
@@ -1,0 +1,100 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "galleryImageName": "test-gallery-image",
+    "resource": {
+      "extendedLocation": {
+        "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+        "type": "CustomLocation"
+      },
+      "location": "West US2",
+      "properties": {
+        "containerId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-storage-container",
+        "imagePath": "C:\\test.vhdx",
+        "osType": "Linux"
+      }
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test-gallery-image",
+        "type": "Microsoft.AzureStackHCI/galleryImages",
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/galleryImages/test-gallery-image",
+        "location": "West US2",
+        "properties": {
+          "cloudInitDataSource": "NoCloud",
+          "containerId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-storage-container",
+          "hyperVGeneration": "V2",
+          "osType": "Linux",
+          "provisioningState": "Accepted",
+          "status": {
+            "downloadStatus": {
+              "downloadSizeInMB": 9383
+            },
+            "progressPercentage": 100,
+            "provisioningStatus": {
+              "operationId": "79cfc696-44f5-4a68-a620-21850f7e9fb0",
+              "status": "Succeeded"
+            }
+          },
+          "version": {
+            "properties": {
+              "storageProfile": {
+                "osDiskImage": {
+                  "sizeInMB": 30270
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "test-gallery-image",
+        "type": "Microsoft.AzureStackHCI/galleryImages",
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/galleryImages/test-galimg3325",
+        "location": "West US2",
+        "properties": {
+          "cloudInitDataSource": "NoCloud",
+          "containerId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-storage-container",
+          "hyperVGeneration": "V2",
+          "osType": "Linux",
+          "provisioningState": "Succeeded",
+          "status": {
+            "downloadStatus": {
+              "downloadSizeInMB": 9383
+            },
+            "progressPercentage": 100,
+            "provisioningStatus": {
+              "operationId": "79cfc696-44f5-4a68-a620-21850f7e9fb0",
+              "status": "Succeeded"
+            }
+          },
+          "version": {
+            "properties": {
+              "storageProfile": {
+                "osDiskImage": {
+                  "sizeInMB": 30270
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "operationId": "GalleryImages_CreateOrUpdate",
+  "title": "PutGalleryImage"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/GalleryImages_CreateOrUpdate_FromVM.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/GalleryImages_CreateOrUpdate_FromVM.json
@@ -1,0 +1,100 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "galleryImageName": "test-gallery-image",
+    "resource": {
+      "extendedLocation": {
+        "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+        "type": "CustomLocation"
+      },
+      "location": "West US2",
+      "properties": {
+        "containerId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-storage-container",
+        "sourceVirtualMachineId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/virtualMachineInstance/test-vm",
+        "osType": "Windows"
+      }
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test-gallery-image",
+        "type": "Microsoft.AzureStackHCI/galleryImages",
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/galleryImages/test-gallery-image",
+        "location": "West US2",
+        "properties": {
+          "cloudInitDataSource": "NoCloud",
+          "containerId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-storage-container",
+          "hyperVGeneration": "V2",
+          "osType": "Linux",
+          "provisioningState": "Accepted",
+          "status": {
+            "downloadStatus": {
+              "downloadSizeInMB": 9383
+            },
+            "progressPercentage": 100,
+            "provisioningStatus": {
+              "operationId": "79cfc696-44f5-4a68-a620-21850f7e9fb0",
+              "status": "Succeeded"
+            }
+          },
+          "version": {
+            "properties": {
+              "storageProfile": {
+                "osDiskImage": {
+                  "sizeInMB": 30270
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "test-gallery-image",
+        "type": "Microsoft.AzureStackHCI/galleryImages",
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/galleryImages/test-galimg3325",
+        "location": "West US2",
+        "properties": {
+          "cloudInitDataSource": "NoCloud",
+          "containerId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-storage-container",
+          "hyperVGeneration": "V2",
+          "osType": "Linux",
+          "provisioningState": "Succeeded",
+          "status": {
+            "downloadStatus": {
+              "downloadSizeInMB": 9383
+            },
+            "progressPercentage": 100,
+            "provisioningStatus": {
+              "operationId": "79cfc696-44f5-4a68-a620-21850f7e9fb0",
+              "status": "Succeeded"
+            }
+          },
+          "version": {
+            "properties": {
+              "storageProfile": {
+                "osDiskImage": {
+                  "sizeInMB": 30270
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "operationId": "GalleryImages_CreateOrUpdate_FromVM",
+  "title": "PutGalleryImage_FromVM"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/GalleryImages_Delete.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/GalleryImages_Delete.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "galleryImageName": "test-gallery-image",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "GalleryImages_Delete",
+  "title": "DeleteGalleryImage"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/GalleryImages_Get.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/GalleryImages_Get.json
@@ -1,0 +1,56 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "galleryImageName": "test-gallery-image",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test-gallery-image",
+        "type": "Microsoft.AzureStackHCI/galleryImages",
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/galleryImages/test-gallery-image",
+        "location": "West US2",
+        "properties": {
+          "cloudInitDataSource": "NoCloud",
+          "containerId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-storage-container",
+          "hyperVGeneration": "V1",
+          "identifier": {
+            "offer": "myOfferName",
+            "publisher": "myPublisherName",
+            "sku": "mySkuName"
+          },
+          "osType": "Windows",
+          "provisioningState": "Accepted",
+          "status": {
+            "downloadStatus": {
+              "downloadSizeInMB": 9383
+            },
+            "progressPercentage": 100,
+            "provisioningStatus": {
+              "operationId": "79cfc696-44f5-4a68-a620-21850f7e9fb0",
+              "status": "Succeeded"
+            }
+          },
+          "version": {
+            "name": "1.0.0",
+            "properties": {
+              "storageProfile": {
+                "osDiskImage": {
+                  "sizeInMB": 30270
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "operationId": "GalleryImages_Get",
+  "title": "GetGalleryImage"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/GalleryImages_ListAll.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/GalleryImages_ListAll.json
@@ -1,0 +1,52 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "test-gallery-image",
+            "type": "Microsoft.AzureStackHCI/galleryImages",
+            "extendedLocation": {
+              "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+              "type": "CustomLocation"
+            },
+            "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/galleryImages/test-gallery-image",
+            "location": "West US2",
+            "properties": {
+              "cloudInitDataSource": "NoCloud",
+              "containerId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-storage-container",
+              "hyperVGeneration": "V2",
+              "osType": "Linux",
+              "provisioningState": "Accepted",
+              "status": {
+                "downloadStatus": {
+                  "downloadSizeInMB": 9383
+                },
+                "progressPercentage": 100,
+                "provisioningStatus": {
+                  "operationId": "79cfc696-44f5-4a68-a620-21850f7e9fb0",
+                  "status": "Succeeded"
+                }
+              },
+              "version": {
+                "properties": {
+                  "storageProfile": {
+                    "osDiskImage": {
+                      "sizeInMB": 30270
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "GalleryImages_ListAll",
+  "title": "ListGalleryImageBySubscription"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/GalleryImages_ListByResourceGroup.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/GalleryImages_ListByResourceGroup.json
@@ -1,0 +1,53 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "test-gallery-image",
+            "type": "Microsoft.AzureStackHCI/galleryImages",
+            "extendedLocation": {
+              "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+              "type": "CustomLocation"
+            },
+            "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/galleryImages/test-gallery-image",
+            "location": "West US2",
+            "properties": {
+              "cloudInitDataSource": "NoCloud",
+              "containerId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-storage-container",
+              "hyperVGeneration": "V2",
+              "osType": "Linux",
+              "provisioningState": "Accepted",
+              "status": {
+                "downloadStatus": {
+                  "downloadSizeInMB": 9383
+                },
+                "progressPercentage": 100,
+                "provisioningStatus": {
+                  "operationId": "79cfc696-44f5-4a68-a620-21850f7e9fb0",
+                  "status": "Succeeded"
+                }
+              },
+              "version": {
+                "properties": {
+                  "storageProfile": {
+                    "osDiskImage": {
+                      "sizeInMB": 30270
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "GalleryImages_ListByResourceGroup",
+  "title": "ListGalleryImageByResourceGroup"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/GalleryImages_Update.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/GalleryImages_Update.json
@@ -1,0 +1,63 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "galleryImageName": "test-gallery-image",
+    "properties": {
+      "tags": {
+        "additionalProperties": "sample"
+      }
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test-gallery-image",
+        "type": "Microsoft.AzureStackHCI/galleryImages",
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/galleryImages/test-galimg3325",
+        "location": "West US2",
+        "properties": {
+          "cloudInitDataSource": "NoCloud",
+          "containerId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-storage-container",
+          "hyperVGeneration": "V2",
+          "osType": "Linux",
+          "provisioningState": "Accepted",
+          "status": {
+            "downloadStatus": {
+              "downloadSizeInMB": 9383
+            },
+            "progressPercentage": 100,
+            "provisioningStatus": {
+              "operationId": "79cfc696-44f5-4a68-a620-21850f7e9fb0",
+              "status": "Succeeded"
+            }
+          },
+          "version": {
+            "properties": {
+              "storageProfile": {
+                "osDiskImage": {
+                  "sizeInMB": 30270
+                }
+              }
+            }
+          }
+        },
+        "tags": {
+          "additionalProperties": "sample"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "GalleryImages_Update",
+  "title": "UpdateGalleryImage"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/GuestAgents_Create.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/GuestAgents_Create.json
@@ -1,0 +1,43 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resource": {
+      "properties": {
+        "credentials": {
+          "password": "<password>",
+          "username": "tempuser"
+        },
+        "provisioningAction": "install"
+      }
+    },
+    "resourceUri": "subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.AzureStackHCI/virtualMachineInstances/guestAgents",
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default/guestAgents/default",
+        "properties": {
+          "provisioningAction": "install",
+          "provisioningState": "Succeeded",
+          "status": "connected"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.AzureStackHCI/virtualMachineInstances/guestAgents",
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default/guestAgents/default",
+        "properties": {
+          "provisioningAction": "install",
+          "provisioningState": "Created",
+          "status": "connected"
+        }
+      }
+    }
+  },
+  "operationId": "GuestAgents_Create",
+  "title": "CreateGuestAgent"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/GuestAgents_Delete.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/GuestAgents_Delete.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceUri": "subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "GuestAgents_Delete",
+  "title": "DeleteGuestAgent"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/GuestAgents_Get.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/GuestAgents_Get.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceUri": "subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.AzureStackHCI/virtualMachineInstances/guestAgents",
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default/guestAgents/default",
+        "properties": {
+          "provisioningAction": "install",
+          "provisioningState": "Succeeded",
+          "status": "connected"
+        }
+      }
+    }
+  },
+  "operationId": "GuestAgents_Get",
+  "title": "GetGuestAgent"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/GuestAgents_ListByVirtualMachineInstance.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/GuestAgents_ListByVirtualMachineInstance.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceUri": "subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "default",
+            "type": "Microsoft.AzureStackHCI/virtualMachineInstances/guestAgents",
+            "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default/guestAgents/default",
+            "properties": {
+              "provisioningAction": "install",
+              "provisioningState": "Succeeded",
+              "status": "connected"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "GuestAgents_ListByVirtualMachineInstance",
+  "title": "GuestAgentListByVirtualMachineInstances"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/HybridIdentityMetadataGroup_Get.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/HybridIdentityMetadataGroup_Get.json
@@ -1,0 +1,25 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceUri": "subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.AzureStackHCI/virtualMachineInstances/hybridIdentityMetadata",
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default/hybridIdentityMetadata/default",
+        "properties": {
+          "identity": {
+            "type": "SystemAssigned",
+            "principalId": "7b5129bc-8642-4a6a-95f8-63400ca6ec4d",
+            "tenantId": "ec46ca82-5d4a-4e3e-b4b7-e27f9318645d"
+          },
+          "publicKey": "8ec7d60c-9700-40b1-8e6e-e5b2f6f477f2"
+        }
+      }
+    }
+  },
+  "operationId": "HybridIdentityMetadata_Get",
+  "title": "GetHybridIdentityMetadata"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/HybridIdentityMetadata_ListByVirtualMachineInstance.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/HybridIdentityMetadata_ListByVirtualMachineInstance.json
@@ -1,0 +1,29 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceUri": "subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "default",
+            "type": "Microsoft.AzureStackHCI/virtualMachineInstances/hybridIdentityMetadata",
+            "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default/hybridIdentityMetadata/default",
+            "properties": {
+              "identity": {
+                "type": "SystemAssigned",
+                "principalId": "7b5129bc-8642-4a6a-95f8-63400ca6ec4d",
+                "tenantId": "ec46ca82-5d4a-4e3e-b4b7-e27f9318645d"
+              },
+              "publicKey": "8ec7d60c-9700-40b1-8e6e-e5b2f6f477f2"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "HybridIdentityMetadata_ListByVirtualMachineInstance",
+  "title": "HybridIdentityMetadataListByVirtualMachineInstances"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/InboundRules_CreateOrUpdate.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/InboundRules_CreateOrUpdate.json
@@ -1,0 +1,88 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "natGatewayName": "test-nat-gw",
+    "inboundRuleName": "sample-inbound-rule",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b",
+    "resource": {
+      "extendedLocation": {
+        "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+        "type": "CustomLocation"
+      },
+      "properties": {
+        "protocol": "Tcp",
+        "frontendPort": 3389,
+        "backendPort": 3389,
+        "backendIPConfiguration": {
+          "resourceId": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic/ipConfigurations/ipconfig1"
+        },
+        "publicIPAddress": {
+          "resourceId": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/publicIPAddresses/test-public-ip"
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sample-inbound-rule",
+        "type": "Microsoft.AzureStackHCI/natGateways/inboundRules",
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/natGateways/test-nat-gw/inboundRules/sample-inbound-rule",
+        "extendedLocation": {
+          "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "properties": {
+          "protocol": "Tcp",
+          "frontendPort": 3389,
+          "backendPort": 3389,
+          "backendIPConfiguration": {
+            "resourceId": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic/ipConfigurations/ipconfig1"
+          },
+          "publicIPAddress": {
+            "resourceId": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/publicIPAddresses/test-public-ip"
+          },
+          "provisioningState": "Succeeded",
+          "status": {
+            "provisioningStatus": {
+              "operationId": "12345678-1234-1234-1234-123456789012",
+              "status": "Succeeded"
+            }
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "sample-inbound-rule",
+        "type": "Microsoft.AzureStackHCI/natGateways/inboundRules",
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/natGateways/test-nat-gw/inboundRules/sample-inbound-rule",
+        "extendedLocation": {
+          "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "properties": {
+          "protocol": "Tcp",
+          "frontendPort": 3389,
+          "backendPort": 3389,
+          "backendIPConfiguration": {
+            "resourceId": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic/ipConfigurations/ipconfig1"
+          },
+          "publicIPAddress": {
+            "resourceId": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/publicIPAddresses/test-public-ip"
+          },
+          "provisioningState": "InProgress",
+          "status": {
+            "provisioningStatus": {
+              "operationId": "12345678-1234-1234-1234-123456789012",
+              "status": "InProgress"
+            }
+          }
+        }
+      }
+    }
+  },
+  "operationId": "InboundRules_CreateOrUpdate",
+  "title": "CreateOrUpdateInboundRule"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/InboundRules_Delete.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/InboundRules_Delete.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "natGatewayName": "test-nat-gw",
+    "inboundRuleName": "sample-inbound-rule",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/providers/Microsoft.AzureStackHCI/locations/westus2/operationStatuses/12345678-1234-1234-1234-123456789012?api-version=2026-07-01-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "InboundRules_Delete",
+  "title": "DeleteInboundRule"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/InboundRules_Get.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/InboundRules_Get.json
@@ -1,0 +1,42 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "natGatewayName": "test-nat-gw",
+    "inboundRuleName": "sample-inbound-rule",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sample-inbound-rule",
+        "type": "Microsoft.AzureStackHCI/natGateways/inboundRules",
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/natGateways/test-nat-gw/inboundRules/sample-inbound-rule",
+        "extendedLocation": {
+          "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "properties": {
+          "protocol": "Tcp",
+          "frontendPort": 3389,
+          "backendPort": 3389,
+          "backendIPConfiguration": {
+            "resourceId": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic/ipConfigurations/ipconfig1"
+          },
+          "publicIPAddress": {
+            "resourceId": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/publicIPAddresses/test-public-ip"
+          },
+          "provisioningState": "Succeeded",
+          "status": {
+            "provisioningStatus": {
+              "operationId": "12345678-1234-1234-1234-123456789012",
+              "status": "Succeeded"
+            }
+          }
+        }
+      }
+    }
+  },
+  "operationId": "InboundRules_Get",
+  "title": "GetInboundRule"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/InboundRules_ListByNatGateway.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/InboundRules_ListByNatGateway.json
@@ -1,0 +1,72 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "natGatewayName": "test-nat-gw",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "rdp-inbound-rule",
+            "type": "Microsoft.AzureStackHCI/natGateways/inboundRules",
+            "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/natGateways/test-nat-gw/inboundRules/rdp-inbound-rule",
+            "extendedLocation": {
+              "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+              "type": "CustomLocation"
+            },
+            "properties": {
+              "protocol": "Tcp",
+              "frontendPort": 3389,
+              "backendPort": 3389,
+              "backendIPConfiguration": {
+                "resourceId": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic/ipConfigurations/ipconfig1"
+              },
+              "publicIPAddress": {
+                "resourceId": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/publicIPAddresses/test-public-ip"
+              },
+              "provisioningState": "Succeeded",
+              "status": {
+                "provisioningStatus": {
+                  "operationId": "12345678-1234-1234-1234-123456789012",
+                  "status": "Succeeded"
+                }
+              }
+            }
+          },
+          {
+            "name": "ssh-inbound-rule",
+            "type": "Microsoft.AzureStackHCI/natGateways/inboundRules",
+            "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/natGateways/test-nat-gw/inboundRules/ssh-inbound-rule",
+            "extendedLocation": {
+              "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+              "type": "CustomLocation"
+            },
+            "properties": {
+              "protocol": "Tcp",
+              "frontendPort": 22,
+              "backendPort": 22,
+              "backendIPConfiguration": {
+                "resourceId": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic-2/ipConfigurations/ipconfig1"
+              },
+              "publicIPAddress": {
+                "resourceId": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/publicIPAddresses/test-public-ip"
+              },
+              "provisioningState": "Succeeded",
+              "status": {
+                "provisioningStatus": {
+                  "operationId": "87654321-4321-4321-4321-210987654321",
+                  "status": "Succeeded"
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "InboundRules_ListByNatGateway",
+  "title": "ListInboundRulesByNatGateway"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/LoadBalancers_CreateOrUpdate.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/LoadBalancers_CreateOrUpdate.json
@@ -1,0 +1,318 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "loadBalancerName": "test-lb",
+    "resource": {
+      "extendedLocation": {
+        "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+        "type": "CustomLocation"
+      },
+      "properties": {
+        "frontendIPConfigurations": [
+          {
+            "name": "web-frontend",
+            "properties": {
+              "publicIPAddress": {
+                "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/publicIPs/webPublicIP"
+              }
+            }
+          }
+        ],
+        "backendAddressPools": [
+          {
+            "name": "web-backend",
+            "properties": {
+              "virtualNetwork": {
+                "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/virtualNetworks/webVNet"
+              },
+              "loadBalancerBackendAddresses": [
+                {
+                  "name": "web-server-1",
+                  "properties": {
+                    "networkInterfaceIPConfiguration": {
+                      "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/networkInterfaces/web-server-1-nic/ipConfigurations/primary"
+                    },
+                    "adminState": "Up"
+                  }
+                },
+                {
+                  "name": "web-server-2",
+                  "properties": {
+                    "networkInterfaceIPConfiguration": {
+                      "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/networkInterfaces/web-server-2-nic/ipConfigurations/primary"
+                    },
+                    "adminState": "Up"
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "probes": [
+          {
+            "name": "http-probe",
+            "properties": {
+              "protocol": "Http",
+              "port": 80,
+              "requestPath": "/health",
+              "intervalInSeconds": 15,
+              "numberOfProbes": 2
+            }
+          }
+        ],
+        "loadBalancingRules": [
+          {
+            "name": "http-rule",
+            "properties": {
+              "frontendIPConfiguration": {
+                "name": "web-frontend"
+              },
+              "backendAddressPool": {
+                "name": "web-backend"
+              },
+              "probe": {
+                "name": "http-probe"
+              },
+              "protocol": "Tcp",
+              "frontendPort": 80,
+              "backendPort": 80,
+              "loadDistribution": "Default",
+              "idleTimeoutInMinutes": 4
+            }
+          },
+          {
+            "name": "https-rule",
+            "properties": {
+              "frontendIPConfiguration": {
+                "name": "web-frontend"
+              },
+              "backendAddressPool": {
+                "name": "web-backend"
+              },
+              "protocol": "Tcp",
+              "frontendPort": 443,
+              "backendPort": 443,
+              "loadDistribution": "Default",
+              "idleTimeoutInMinutes": 4
+            }
+          }
+        ]
+      },
+      "location": "West US2"
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test-lb",
+        "type": "Microsoft.AzureStackHCI/loadBalancers",
+        "extendedLocation": {
+          "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/loadBalancers/test-lb",
+        "location": "West US2",
+        "properties": {
+          "frontendIPConfigurations": [
+            {
+              "name": "web-frontend",
+              "properties": {
+                "publicIPAddress": {
+                  "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/publicIPs/webPublicIP"
+                }
+              }
+            }
+          ],
+          "backendAddressPools": [
+            {
+              "name": "web-backend",
+              "properties": {
+                "virtualNetwork": {
+                  "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/virtualNetworks/webVNet"
+                },
+                "loadBalancerBackendAddresses": [
+                  {
+                    "name": "web-server-1",
+                    "properties": {
+                      "networkInterfaceIPConfiguration": {
+                        "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/networkInterfaces/web-server-1-nic/ipConfigurations/primary"
+                      },
+                      "adminState": "Up"
+                    }
+                  },
+                  {
+                    "name": "web-server-2",
+                    "properties": {
+                      "networkInterfaceIPConfiguration": {
+                        "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/networkInterfaces/web-server-2-nic/ipConfigurations/primary"
+                      },
+                      "adminState": "Up"
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "probes": [
+            {
+              "name": "http-probe",
+              "properties": {
+                "protocol": "Http",
+                "port": 80,
+                "requestPath": "/health",
+                "intervalInSeconds": 15,
+                "numberOfProbes": 2
+              }
+            }
+          ],
+          "loadBalancingRules": [
+            {
+              "name": "http-rule",
+              "properties": {
+                "frontendIPConfiguration": {
+                  "name": "web-frontend"
+                },
+                "backendAddressPool": {
+                  "name": "web-backend"
+                },
+                "probe": {
+                  "name": "http-probe"
+                },
+                "protocol": "Tcp",
+                "frontendPort": 80,
+                "backendPort": 80,
+                "loadDistribution": "Default",
+                "idleTimeoutInMinutes": 4
+              }
+            },
+            {
+              "name": "https-rule",
+              "properties": {
+                "frontendIPConfiguration": {
+                  "name": "web-frontend"
+                },
+                "backendAddressPool": {
+                  "name": "web-backend"
+                },
+                "protocol": "Tcp",
+                "frontendPort": 443,
+                "backendPort": 443,
+                "loadDistribution": "Default",
+                "idleTimeoutInMinutes": 4
+              }
+            }
+          ],
+          "provisioningState": "Accepted"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "test-vnet",
+        "type": "Microsoft.AzureStackHCI/loadBalancers",
+        "extendedLocation": {
+          "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/loadBalancers/test-lb",
+        "location": "West US2",
+        "properties": {
+          "frontendIPConfigurations": [
+            {
+              "name": "web-frontend",
+              "properties": {
+                "publicIPAddress": {
+                  "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/publicIPs/webPublicIP"
+                }
+              }
+            }
+          ],
+          "backendAddressPools": [
+            {
+              "name": "web-backend",
+              "properties": {
+                "virtualNetwork": {
+                  "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/virtualNetworks/webVNet"
+                },
+                "loadBalancerBackendAddresses": [
+                  {
+                    "name": "web-server-1",
+                    "properties": {
+                      "networkInterfaceIPConfiguration": {
+                        "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/networkInterfaces/web-server-1-nic/ipConfigurations/primary"
+                      },
+                      "adminState": "Up"
+                    }
+                  },
+                  {
+                    "name": "web-server-2",
+                    "properties": {
+                      "networkInterfaceIPConfiguration": {
+                        "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/networkInterfaces/web-server-2-nic/ipConfigurations/primary"
+                      },
+                      "adminState": "Up"
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "probes": [
+            {
+              "name": "http-probe",
+              "properties": {
+                "protocol": "Http",
+                "port": 80,
+                "requestPath": "/health",
+                "intervalInSeconds": 15,
+                "numberOfProbes": 2
+              }
+            }
+          ],
+          "loadBalancingRules": [
+            {
+              "name": "http-rule",
+              "properties": {
+                "frontendIPConfiguration": {
+                  "name": "web-frontend"
+                },
+                "backendAddressPool": {
+                  "name": "web-backend"
+                },
+                "probe": {
+                  "name": "http-probe"
+                },
+                "protocol": "Tcp",
+                "frontendPort": 80,
+                "backendPort": 80,
+                "loadDistribution": "Default",
+                "idleTimeoutInMinutes": 4
+              }
+            },
+            {
+              "name": "https-rule",
+              "properties": {
+                "frontendIPConfiguration": {
+                  "name": "web-frontend"
+                },
+                "backendAddressPool": {
+                  "name": "web-backend"
+                },
+                "protocol": "Tcp",
+                "frontendPort": 443,
+                "backendPort": 443,
+                "loadDistribution": "Default",
+                "idleTimeoutInMinutes": 4
+              }
+            }
+          ],
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "LoadBalancers_CreateOrUpdate",
+  "title": "PutLoadBalancer"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/LoadBalancers_Delete.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/LoadBalancers_Delete.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "loadBalancerName": "test-lb",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "LoadBalancers_Delete",
+  "title": "DeleteLoadBalancers"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/LoadBalancers_Get.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/LoadBalancers_Get.json
@@ -1,0 +1,116 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "loadBalancerName": "test-lb",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test-lb",
+        "type": "Microsoft.AzureStackHCI/loadBalancers",
+        "extendedLocation": {
+          "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/loadBalancers/test-lb",
+        "location": "West US2",
+        "properties": {
+          "frontendIPConfigurations": [
+            {
+              "name": "web-frontend",
+              "properties": {
+                "publicIPAddress": {
+                  "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/publicIPs/webPublicIP"
+                }
+              }
+            }
+          ],
+          "backendAddressPools": [
+            {
+              "name": "web-backend",
+              "properties": {
+                "virtualNetwork": {
+                  "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/virtualNetworks/webVNet"
+                },
+                "loadBalancerBackendAddresses": [
+                  {
+                    "name": "web-server-1",
+                    "properties": {
+                      "networkInterfaceIPConfiguration": {
+                        "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/networkInterfaces/web-server-1-nic/ipConfigurations/primary"
+                      },
+                      "adminState": "Up"
+                    }
+                  },
+                  {
+                    "name": "web-server-2",
+                    "properties": {
+                      "networkInterfaceIPConfiguration": {
+                        "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/networkInterfaces/web-server-2-nic/ipConfigurations/primary"
+                      },
+                      "adminState": "Up"
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "probes": [
+            {
+              "name": "http-probe",
+              "properties": {
+                "protocol": "Http",
+                "port": 80,
+                "requestPath": "/health",
+                "intervalInSeconds": 15,
+                "numberOfProbes": 2
+              }
+            }
+          ],
+          "loadBalancingRules": [
+            {
+              "name": "http-rule",
+              "properties": {
+                "frontendIPConfiguration": {
+                  "name": "web-frontend"
+                },
+                "backendAddressPool": {
+                  "name": "web-backend"
+                },
+                "probe": {
+                  "name": "http-probe"
+                },
+                "protocol": "Tcp",
+                "frontendPort": 80,
+                "backendPort": 80,
+                "loadDistribution": "Default",
+                "idleTimeoutInMinutes": 4
+              }
+            },
+            {
+              "name": "https-rule",
+              "properties": {
+                "frontendIPConfiguration": {
+                  "name": "web-frontend"
+                },
+                "backendAddressPool": {
+                  "name": "web-backend"
+                },
+                "protocol": "Tcp",
+                "frontendPort": 443,
+                "backendPort": 443,
+                "loadDistribution": "Default",
+                "idleTimeoutInMinutes": 4
+              }
+            }
+          ],
+          "provisioningState": "Accepted"
+        }
+      }
+    }
+  },
+  "operationId": "LoadBalancers_Get",
+  "title": "GetLoadBalancers"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/LoadBalancers_ListAll.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/LoadBalancers_ListAll.json
@@ -1,0 +1,118 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "test-lb",
+            "type": "Microsoft.AzureStackHCI/loadBalancers",
+            "extendedLocation": {
+              "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+              "type": "CustomLocation"
+            },
+            "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/loadBalancers/test-lb",
+            "location": "West US2",
+            "properties": {
+              "frontendIPConfigurations": [
+                {
+                  "name": "web-frontend",
+                  "properties": {
+                    "publicIPAddress": {
+                      "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/publicIPs/webPublicIP"
+                    }
+                  }
+                }
+              ],
+              "backendAddressPools": [
+                {
+                  "name": "web-backend",
+                  "properties": {
+                    "virtualNetwork": {
+                      "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/virtualNetworks/webVNet"
+                    },
+                    "loadBalancerBackendAddresses": [
+                      {
+                        "name": "web-server-1",
+                        "properties": {
+                          "networkInterfaceIPConfiguration": {
+                            "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/networkInterfaces/web-server-1-nic/ipConfigurations/primary"
+                          },
+                          "adminState": "Up"
+                        }
+                      },
+                      {
+                        "name": "web-server-2",
+                        "properties": {
+                          "networkInterfaceIPConfiguration": {
+                            "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/networkInterfaces/web-server-2-nic/ipConfigurations/primary"
+                          },
+                          "adminState": "Up"
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "probes": [
+                {
+                  "name": "http-probe",
+                  "properties": {
+                    "protocol": "Http",
+                    "port": 80,
+                    "requestPath": "/health",
+                    "intervalInSeconds": 15,
+                    "numberOfProbes": 2
+                  }
+                }
+              ],
+              "loadBalancingRules": [
+                {
+                  "name": "http-rule",
+                  "properties": {
+                    "frontendIPConfiguration": {
+                      "name": "web-frontend"
+                    },
+                    "backendAddressPool": {
+                      "name": "web-backend"
+                    },
+                    "probe": {
+                      "name": "http-probe"
+                    },
+                    "protocol": "Tcp",
+                    "frontendPort": 80,
+                    "backendPort": 80,
+                    "loadDistribution": "Default",
+                    "idleTimeoutInMinutes": 4
+                  }
+                },
+                {
+                  "name": "https-rule",
+                  "properties": {
+                    "frontendIPConfiguration": {
+                      "name": "web-frontend"
+                    },
+                    "backendAddressPool": {
+                      "name": "web-backend"
+                    },
+                    "protocol": "Tcp",
+                    "frontendPort": 443,
+                    "backendPort": 443,
+                    "loadDistribution": "Default",
+                    "idleTimeoutInMinutes": 4
+                  }
+                }
+              ],
+              "provisioningState": "Accepted"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "LoadBalancers_ListAll",
+  "title": "ListLoadBalancerBySubscription"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/LoadBalancers_ListByResourceGroup.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/LoadBalancers_ListByResourceGroup.json
@@ -1,0 +1,119 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "test-lb",
+            "type": "Microsoft.AzureStackHCI/loadBalancers",
+            "extendedLocation": {
+              "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+              "type": "CustomLocation"
+            },
+            "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/loadBalancers/test-lb",
+            "location": "West US2",
+            "properties": {
+              "frontendIPConfigurations": [
+                {
+                  "name": "web-frontend",
+                  "properties": {
+                    "publicIPAddress": {
+                      "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/publicIPs/webPublicIP"
+                    }
+                  }
+                }
+              ],
+              "backendAddressPools": [
+                {
+                  "name": "web-backend",
+                  "properties": {
+                    "virtualNetwork": {
+                      "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/virtualNetworks/webVNet"
+                    },
+                    "loadBalancerBackendAddresses": [
+                      {
+                        "name": "web-server-1",
+                        "properties": {
+                          "networkInterfaceIPConfiguration": {
+                            "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/networkInterfaces/web-server-1-nic/ipConfigurations/primary"
+                          },
+                          "adminState": "Up"
+                        }
+                      },
+                      {
+                        "name": "web-server-2",
+                        "properties": {
+                          "networkInterfaceIPConfiguration": {
+                            "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/networkInterfaces/web-server-2-nic/ipConfigurations/primary"
+                          },
+                          "adminState": "Up"
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "probes": [
+                {
+                  "name": "http-probe",
+                  "properties": {
+                    "protocol": "Http",
+                    "port": 80,
+                    "requestPath": "/health",
+                    "intervalInSeconds": 15,
+                    "numberOfProbes": 2
+                  }
+                }
+              ],
+              "loadBalancingRules": [
+                {
+                  "name": "http-rule",
+                  "properties": {
+                    "frontendIPConfiguration": {
+                      "name": "web-frontend"
+                    },
+                    "backendAddressPool": {
+                      "name": "web-backend"
+                    },
+                    "probe": {
+                      "name": "http-probe"
+                    },
+                    "protocol": "Tcp",
+                    "frontendPort": 80,
+                    "backendPort": 80,
+                    "loadDistribution": "Default",
+                    "idleTimeoutInMinutes": 4
+                  }
+                },
+                {
+                  "name": "https-rule",
+                  "properties": {
+                    "frontendIPConfiguration": {
+                      "name": "web-frontend"
+                    },
+                    "backendAddressPool": {
+                      "name": "web-backend"
+                    },
+                    "protocol": "Tcp",
+                    "frontendPort": 443,
+                    "backendPort": 443,
+                    "loadDistribution": "Default",
+                    "idleTimeoutInMinutes": 4
+                  }
+                }
+              ],
+              "provisioningState": "Accepted"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "LoadBalancers_ListByResourceGroup",
+  "title": "ListLoadBalancerByResourceGroup"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/LoadBalancers_UpdateTags.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/LoadBalancers_UpdateTags.json
@@ -1,0 +1,131 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "loadBalancerName": "test-lb",
+    "properties": {
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      }
+    },
+    "resourceGroupName": "testrg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test-lb",
+        "type": "Microsoft.AzureStackHCI/loadBalancers",
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/loadBalancers/test-lb",
+        "location": "westus",
+        "extendedLocation": {
+          "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "properties": {
+          "frontendIPConfigurations": [
+            {
+              "name": "web-frontend",
+              "properties": {
+                "publicIPAddress": {
+                  "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/publicIPs/webPublicIP"
+                }
+              }
+            }
+          ],
+          "backendAddressPools": [
+            {
+              "name": "web-backend",
+              "properties": {
+                "virtualNetwork": {
+                  "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/virtualNetworks/webVNet"
+                },
+                "loadBalancerBackendAddresses": [
+                  {
+                    "name": "web-server-1",
+                    "properties": {
+                      "networkInterfaceIPConfiguration": {
+                        "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/networkInterfaces/web-server-1-nic/ipConfigurations/primary"
+                      },
+                      "adminState": "Up"
+                    }
+                  },
+                  {
+                    "name": "web-server-2",
+                    "properties": {
+                      "networkInterfaceIPConfiguration": {
+                        "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/networkInterfaces/web-server-2-nic/ipConfigurations/primary"
+                      },
+                      "adminState": "Up"
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "probes": [
+            {
+              "name": "http-probe",
+              "properties": {
+                "protocol": "Http",
+                "port": 80,
+                "requestPath": "/health",
+                "intervalInSeconds": 15,
+                "numberOfProbes": 2
+              }
+            }
+          ],
+          "loadBalancingRules": [
+            {
+              "name": "http-rule",
+              "properties": {
+                "frontendIPConfiguration": {
+                  "name": "web-frontend"
+                },
+                "backendAddressPool": {
+                  "name": "web-backend"
+                },
+                "probe": {
+                  "name": "http-probe"
+                },
+                "protocol": "Tcp",
+                "frontendPort": 80,
+                "backendPort": 80,
+                "loadDistribution": "Default",
+                "idleTimeoutInMinutes": 4
+              }
+            },
+            {
+              "name": "https-rule",
+              "properties": {
+                "frontendIPConfiguration": {
+                  "name": "web-frontend"
+                },
+                "backendAddressPool": {
+                  "name": "web-backend"
+                },
+                "protocol": "Tcp",
+                "frontendPort": 443,
+                "backendPort": 443,
+                "loadDistribution": "Default",
+                "idleTimeoutInMinutes": 4
+              }
+            }
+          ],
+          "provisioningState": "Accepted"
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "LoadBalancers_UpdateTags",
+  "title": "Update LoadBalancers tags"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/LogicalNetworks_CreateOrUpdate.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/LogicalNetworks_CreateOrUpdate.json
@@ -1,0 +1,49 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "logicalNetworkName": "test-lnet",
+    "resource": {
+      "extendedLocation": {
+        "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+        "type": "CustomLocation"
+      },
+      "location": "West US2"
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test-lnet",
+        "type": "Microsoft.AzureStackHCI/logicalNetworks",
+        "extendedLocation": {
+          "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/logicalNetworks/test-lnet",
+        "location": "West US2",
+        "properties": {
+          "provisioningState": "Accepted"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "test-lnet",
+        "type": "Microsoft.AzureStackHCI/logicalNetworks",
+        "extendedLocation": {
+          "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/logicalNetworks/test-lnet",
+        "location": "West US2",
+        "properties": {
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "LogicalNetworks_CreateOrUpdate",
+  "title": "PutLogicalNetwork"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/LogicalNetworks_Delete.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/LogicalNetworks_Delete.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "logicalNetworkName": "test-lnet",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "LogicalNetworks_Delete",
+  "title": "DeleteLogicalNetwork"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/LogicalNetworks_Get.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/LogicalNetworks_Get.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "logicalNetworkName": "test-lnet",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test-lnet",
+        "type": "Microsoft.AzureStackHCI/logicalNetworks",
+        "extendedLocation": {
+          "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/logicalNetworks/test-lnet",
+        "location": "West US2",
+        "properties": {
+          "provisioningState": "Accepted"
+        }
+      }
+    }
+  },
+  "operationId": "LogicalNetworks_Get",
+  "title": "GetLogicalNetwork"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/LogicalNetworks_ListAll.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/LogicalNetworks_ListAll.json
@@ -1,0 +1,29 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "test-lnet",
+            "type": "Microsoft.AzureStackHCI/logicalNetworks",
+            "extendedLocation": {
+              "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+              "type": "CustomLocation"
+            },
+            "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/logicalNetworks/test-lnet",
+            "location": "West US2",
+            "properties": {
+              "provisioningState": "Accepted"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "LogicalNetworks_ListAll",
+  "title": "ListLogicalNetworkBySubscription"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/LogicalNetworks_ListByResourceGroup.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/LogicalNetworks_ListByResourceGroup.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "test-lnet",
+            "type": "Microsoft.AzureStackHCI/logicalNetworks",
+            "extendedLocation": {
+              "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+              "type": "CustomLocation"
+            },
+            "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/logicalNetworks/test-lnet",
+            "location": "West US2",
+            "properties": {
+              "provisioningState": "Accepted"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "LogicalNetworks_ListByResourceGroup",
+  "title": "ListLogicalNetworkByResourceGroup"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/LogicalNetworks_Update.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/LogicalNetworks_Update.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "logicalNetworkName": "test-lnet",
+    "properties": {
+      "tags": {
+        "additionalProperties": "sample"
+      }
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test-lnet",
+        "type": "Microsoft.AzureStackHCI/logicalNetworks",
+        "extendedLocation": {
+          "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/logicalNetworks/test-lnet",
+        "location": "West US2",
+        "properties": {
+          "provisioningState": "Accepted"
+        },
+        "tags": {
+          "additionalProperties": "sample"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "LogicalNetworks_Update",
+  "title": "UpdateLogicalNetwork"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/MarketplaceGalleryImages_CreateOrUpdate.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/MarketplaceGalleryImages_CreateOrUpdate.json
@@ -1,0 +1,122 @@
+{
+  "parameters": {
+    "name": "test-marketplace-gallery-image",
+    "api-version": "2026-07-01-preview",
+    "marketplaceGalleryImageName": "test-marketplace-gallery-image",
+    "resource": {
+      "extendedLocation": {
+        "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+        "type": "CustomLocation"
+      },
+      "location": "West US2",
+      "properties": {
+        "cloudInitDataSource": "Azure",
+        "containerId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-storage-container",
+        "hyperVGeneration": "V1",
+        "identifier": {
+          "offer": "myOfferName",
+          "publisher": "myPublisherName",
+          "sku": "mySkuName"
+        },
+        "osType": "Windows",
+        "version": {
+          "name": "1.0.0"
+        }
+      }
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test-marketplace-gallery-image",
+        "type": "Microsoft.AzureStackHCI/marketplaceGalleryImages",
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/marketplaceGalleryImages/test-marketplace-gallery-image",
+        "location": "West US2",
+        "properties": {
+          "cloudInitDataSource": "Azure",
+          "containerId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-storage-container",
+          "hyperVGeneration": "V1",
+          "identifier": {
+            "offer": "myOfferName",
+            "publisher": "myPublisherName",
+            "sku": "mySkuName"
+          },
+          "osType": "Windows",
+          "provisioningState": "Accepted",
+          "status": {
+            "downloadStatus": {
+              "downloadSizeInMB": 9383
+            },
+            "progressPercentage": 0,
+            "provisioningStatus": {
+              "operationId": "79cfc696-44f5-4a68-a620-21850f7e9fb0",
+              "status": "InProgress"
+            }
+          },
+          "version": {
+            "name": "1.0.0",
+            "properties": {
+              "storageProfile": {
+                "osDiskImage": {
+                  "sizeInMB": 30270
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "test-marketplace-gallery-image",
+        "type": "Microsoft.AzureStackHCI/marketplaceGalleryImages",
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/marketplaceGalleryImages/test-marketplace-gallery-image",
+        "location": "West US2",
+        "properties": {
+          "cloudInitDataSource": "Azure",
+          "containerId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-storage-container",
+          "hyperVGeneration": "V1",
+          "identifier": {
+            "offer": "myOfferName",
+            "publisher": "myPublisherName",
+            "sku": "mySkuName"
+          },
+          "osType": "Windows",
+          "provisioningState": "Creating",
+          "status": {
+            "downloadStatus": {
+              "downloadSizeInMB": 9383
+            },
+            "progressPercentage": 100,
+            "provisioningStatus": {
+              "operationId": "79cfc696-44f5-4a68-a620-21850f7e9fb0",
+              "status": "Succeeded"
+            }
+          },
+          "version": {
+            "name": "1.0.0",
+            "properties": {
+              "storageProfile": {
+                "osDiskImage": {
+                  "sizeInMB": 30270
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "operationId": "MarketplaceGalleryImages_CreateOrUpdate",
+  "title": "PutMarketplaceGalleryImage"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/MarketplaceGalleryImages_Delete.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/MarketplaceGalleryImages_Delete.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "marketplaceGalleryImageName": "test-marketplace-gallery-image",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "MarketplaceGalleryImages_Delete",
+  "title": "DeleteMarketplaceGalleryImage"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/MarketplaceGalleryImages_Get.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/MarketplaceGalleryImages_Get.json
@@ -1,0 +1,56 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "marketplaceGalleryImageName": "test-marketplace-gallery-image",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test-marketplace-gallery-image",
+        "type": "Microsoft.AzureStackHCI/marketplaceGalleryImages",
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/marketplaceGalleryImages/test-marketplace-gallery-image",
+        "location": "West US2",
+        "properties": {
+          "cloudInitDataSource": "NoCloud",
+          "containerId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-storage-container",
+          "hyperVGeneration": "V1",
+          "identifier": {
+            "offer": "myOfferName",
+            "publisher": "myPublisherName",
+            "sku": "mySkuName"
+          },
+          "osType": "Windows",
+          "provisioningState": "Accepted",
+          "status": {
+            "downloadStatus": {
+              "downloadSizeInMB": 9383
+            },
+            "progressPercentage": 100,
+            "provisioningStatus": {
+              "operationId": "79cfc696-44f5-4a68-a620-21850f7e9fb0",
+              "status": "Succeeded"
+            }
+          },
+          "version": {
+            "name": "1.0.0",
+            "properties": {
+              "storageProfile": {
+                "osDiskImage": {
+                  "sizeInMB": 30270
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "operationId": "MarketplaceGalleryImages_Get",
+  "title": "GetMarketplaceGalleryImage"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/MarketplaceGalleryImages_ListAll.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/MarketplaceGalleryImages_ListAll.json
@@ -1,0 +1,58 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "test-marketplace-gallery-image",
+            "type": "Microsoft.AzureStackHCI/marketplaceGalleryImages",
+            "extendedLocation": {
+              "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+              "type": "CustomLocation"
+            },
+            "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/marketplaceGalleryImages/test-marketplace-gallery-image",
+            "location": "West US2",
+            "properties": {
+              "cloudInitDataSource": "Azure",
+              "containerId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-storage-container",
+              "hyperVGeneration": "V1",
+              "identifier": {
+                "offer": "myOfferName",
+                "publisher": "myPublisherName",
+                "sku": "mySkuName"
+              },
+              "osType": "Windows",
+              "provisioningState": "Accepted",
+              "status": {
+                "downloadStatus": {
+                  "downloadSizeInMB": 9383
+                },
+                "progressPercentage": 100,
+                "provisioningStatus": {
+                  "operationId": "79cfc696-44f5-4a68-a620-21850f7e9fb0",
+                  "status": "Succeeded"
+                }
+              },
+              "version": {
+                "name": "1.0.0",
+                "properties": {
+                  "storageProfile": {
+                    "osDiskImage": {
+                      "sizeInMB": 30270
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "MarketplaceGalleryImages_ListAll",
+  "title": "ListMarketplaceGalleryImageBySubscription"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/MarketplaceGalleryImages_ListByResourceGroup.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/MarketplaceGalleryImages_ListByResourceGroup.json
@@ -1,0 +1,59 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "test-marketplace-gallery-image",
+            "type": "Microsoft.AzureStackHCI/marketplaceGalleryImages",
+            "extendedLocation": {
+              "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+              "type": "CustomLocation"
+            },
+            "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/marketplaceGalleryImages/test-marketplace-gallery-image",
+            "location": "West US2",
+            "properties": {
+              "cloudInitDataSource": "Azure",
+              "containerId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-storage-container",
+              "hyperVGeneration": "V1",
+              "identifier": {
+                "offer": "myOfferName",
+                "publisher": "myPublisherName",
+                "sku": "mySkuName"
+              },
+              "osType": "Windows",
+              "provisioningState": "Accepted",
+              "status": {
+                "downloadStatus": {
+                  "downloadSizeInMB": 9383
+                },
+                "progressPercentage": 100,
+                "provisioningStatus": {
+                  "operationId": "79cfc696-44f5-4a68-a620-21850f7e9fb0",
+                  "status": "Succeeded"
+                }
+              },
+              "version": {
+                "name": "1.0.0",
+                "properties": {
+                  "storageProfile": {
+                    "osDiskImage": {
+                      "sizeInMB": 30270
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "MarketplaceGalleryImages_ListByResourceGroup",
+  "title": "ListMarketplaceGalleryImageByResourceGroup"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/MarketplaceGalleryImages_Update.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/MarketplaceGalleryImages_Update.json
@@ -1,0 +1,69 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "marketplaceGalleryImageName": "test-marketplce-gallery-image",
+    "properties": {
+      "tags": {
+        "additionalProperties": "sample"
+      }
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test-marketplace-gallery-image",
+        "type": "Microsoft.AzureStackHCI/marketplaceGalleryImages",
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/marketplaceGalleryImages/test-marketplace-gallery-image",
+        "location": "West US2",
+        "properties": {
+          "cloudInitDataSource": "Azure",
+          "containerId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-storage-container",
+          "hyperVGeneration": "V1",
+          "identifier": {
+            "offer": "myOfferName",
+            "publisher": "myPublisherName",
+            "sku": "mySkuName"
+          },
+          "osType": "Windows",
+          "provisioningState": "Accepted",
+          "status": {
+            "downloadStatus": {
+              "downloadSizeInMB": 9383
+            },
+            "progressPercentage": 0,
+            "provisioningStatus": {
+              "operationId": "79cfc696-44f5-4a68-a620-21850f7e9fb0",
+              "status": "InProgress"
+            }
+          },
+          "version": {
+            "name": "1.0.0",
+            "properties": {
+              "storageProfile": {
+                "osDiskImage": {
+                  "sizeInMB": 30270
+                }
+              }
+            }
+          }
+        },
+        "tags": {
+          "additionalProperties": "sample"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "MarketplaceGalleryImages_Update",
+  "title": "UpdateMarketplaceGalleryImage"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/NatGateways_CreateOrUpdate.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/NatGateways_CreateOrUpdate.json
@@ -1,0 +1,66 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "natGatewayName": "test-nat-gw",
+    "resource": {
+      "extendedLocation": {
+        "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+        "type": "CustomLocation"
+      },
+      "properties": {
+        "publicIPAddresses": [
+          {
+            "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/publicIPAddresses/outbound-pip"
+          }
+        ]
+      },
+      "location": "West US2"
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test-nat-gw",
+        "type": "Microsoft.AzureStackHCI/natGateways",
+        "extendedLocation": {
+          "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/natGateways/test-nat-gw",
+        "location": "West US2",
+        "properties": {
+          "publicIPAddresses": [
+            {
+              "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/publicIPAddresses/outbound-pip"
+            }
+          ],
+          "provisioningState": "Accepted"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "test-nat-gw",
+        "type": "Microsoft.AzureStackHCI/natGateways",
+        "extendedLocation": {
+          "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/natGateways/test-nat-gw",
+        "location": "West US2",
+        "properties": {
+          "publicIPAddresses": [
+            {
+              "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/publicIPAddresses/outbound-pip"
+            }
+          ],
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "NatGateways_CreateOrUpdate",
+  "title": "PutNatGateway"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/NatGateways_Delete.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/NatGateways_Delete.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "natGatewayName": "test-nat-gw",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "NatGateways_Delete",
+  "title": "DeleteNatGateway"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/NatGateways_Get.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/NatGateways_Get.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "natGatewayName": "test-nat-gw",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test-nat-gw",
+        "type": "Microsoft.AzureStackHCI/natGateways",
+        "extendedLocation": {
+          "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/natGateways/test-nat-gw",
+        "location": "West US2",
+        "properties": {
+          "publicIPAddresses": [
+            {
+              "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/publicIPAddresses/outbound-pip"
+            }
+          ],
+          "subnets": [
+            {
+              "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/virtualNetworks/main-vnet/subnets/workload-subnet"
+            }
+          ],
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "NatGateways_Get",
+  "title": "GetNatGateway"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/NatGateways_ListAll.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/NatGateways_ListAll.json
@@ -1,0 +1,39 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "testnatgw",
+            "type": "Microsoft.AzureStackHCI/natGateways",
+            "extendedLocation": {
+              "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+              "type": "CustomLocation"
+            },
+            "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/natGateways/testnatgw",
+            "location": "West US2",
+            "properties": {
+              "publicIPAddresses": [
+                {
+                  "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/publicIPAddresses/outbound-pip"
+                }
+              ],
+              "subnets": [
+                {
+                  "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/virtualNetworks/main-vnet/subnets/workload-subnet"
+                }
+              ],
+              "provisioningState": "Succeeded"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "NatGateways_ListAll",
+  "title": "ListNatGatewayBySubscription"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/NatGateways_ListByResourceGroup.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/NatGateways_ListByResourceGroup.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "testnatgw",
+            "type": "Microsoft.AzureStackHCI/natGateways",
+            "extendedLocation": {
+              "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+              "type": "CustomLocation"
+            },
+            "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/natGateways/testnatgw",
+            "location": "West US2",
+            "properties": {
+              "publicIPAddresses": [
+                {
+                  "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/publicIPAddresses/outbound-pip"
+                }
+              ],
+              "subnets": [
+                {
+                  "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/virtualNetworks/main-vnet/subnets/workload-subnet"
+                }
+              ],
+              "provisioningState": "Succeeded"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "NatGateways_ListByResourceGroup",
+  "title": "ListNatGatewayByResourceGroup"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/NatGateways_UpdateTags.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/NatGateways_UpdateTags.json
@@ -1,0 +1,52 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "natGatewayName": "testnatgw",
+    "properties": {
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      }
+    },
+    "resourceGroupName": "testrg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testnatgw",
+        "type": "Microsoft.AzureStackHCI/natGateways",
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/natGateways/testnatgw",
+        "location": "westus",
+        "extendedLocation": {
+          "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "properties": {
+          "publicIPAddresses": [
+            {
+              "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/publicIPAddresses/outbound-pip"
+            }
+          ],
+          "subnets": [
+            {
+              "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/virtualNetworks/main-vnet/subnets/workload-subnet"
+            }
+          ],
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "NatGateways_UpdateTags",
+  "title": "Update natGateway tags"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/NetworkInterfaces_CreateOrUpdate.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/NetworkInterfaces_CreateOrUpdate.json
@@ -1,0 +1,81 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "networkInterfaceName": "test-nic",
+    "resource": {
+      "extendedLocation": {
+        "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+        "type": "CustomLocation"
+      },
+      "location": "eastus",
+      "properties": {
+        "ipConfigurations": [
+          {
+            "name": "ipconfig-sample",
+            "properties": {
+              "subnet": {
+                "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/logicalNetworks/test-lnet"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test-nic",
+        "type": "Microsoft.AzureStackHCI/networkInterfaces",
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic",
+        "location": "West US2",
+        "properties": {
+          "ipConfigurations": [
+            {
+              "name": "ipconfig-sample",
+              "properties": {
+                "subnet": {
+                  "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/logicalNetworks/test-lnet"
+                }
+              }
+            }
+          ],
+          "provisioningState": "Accepted"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "test-nic",
+        "type": "Microsoft.AzureStackHCI/networkInterfaces",
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic",
+        "location": "West US2",
+        "properties": {
+          "ipConfigurations": [
+            {
+              "name": "ipconfig-sample",
+              "properties": {
+                "subnet": {
+                  "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/logicalNetworks/test-lnet"
+                }
+              }
+            }
+          ],
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "NetworkInterfaces_CreateOrUpdate",
+  "title": "PutNetworkInterface"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/NetworkInterfaces_Delete.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/NetworkInterfaces_Delete.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "networkInterfaceName": "test-nic",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "NetworkInterfaces_Delete",
+  "title": "DeleteNetworkInterface"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/NetworkInterfaces_Get.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/NetworkInterfaces_Get.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "networkInterfaceName": "test-nic",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test-nic",
+        "type": "Microsoft.AzureStackHCI/networkInterfaces",
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic",
+        "location": "West US2",
+        "properties": {
+          "ipConfigurations": [
+            {
+              "name": "ipconfig-sample",
+              "properties": {
+                "subnet": {
+                  "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/logicalNetworks/test-lnet"
+                }
+              }
+            }
+          ],
+          "provisioningState": "Accepted"
+        }
+      }
+    }
+  },
+  "operationId": "NetworkInterfaces_Get",
+  "title": "GetNetworkInterface"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/NetworkInterfaces_ListAll.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/NetworkInterfaces_ListAll.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "networkInterfaceName": "test-nic",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "test-nic",
+            "type": "Microsoft.AzureStackHCI/networkInterfaces",
+            "extendedLocation": {
+              "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+              "type": "CustomLocation"
+            },
+            "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic",
+            "location": "West US2",
+            "properties": {
+              "ipConfigurations": [
+                {
+                  "name": "ipconfig-sample",
+                  "properties": {
+                    "subnet": {
+                      "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/logicalNetworks/test-lnet"
+                    }
+                  }
+                }
+              ],
+              "provisioningState": "Accepted"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "NetworkInterfaces_ListAll",
+  "title": "ListNetworkInterfaceBySubscription"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/NetworkInterfaces_ListByResourceGroup.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/NetworkInterfaces_ListByResourceGroup.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "networkInterfaceName": "test-nic",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "test-nic",
+            "type": "Microsoft.AzureStackHCI/networkInterfaces",
+            "extendedLocation": {
+              "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+              "type": "CustomLocation"
+            },
+            "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic",
+            "location": "West US2",
+            "properties": {
+              "ipConfigurations": [
+                {
+                  "name": "ipconfig-sample",
+                  "properties": {
+                    "subnet": {
+                      "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/logicalNetworks/test-lnet"
+                    }
+                  }
+                }
+              ],
+              "provisioningState": "Accepted"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "NetworkInterfaces_ListByResourceGroup",
+  "title": "ListNetworkInterfaceByResourceGroup"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/NetworkInterfaces_Update.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/NetworkInterfaces_Update.json
@@ -1,0 +1,47 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "networkInterfaceName": "test-nic",
+    "properties": {
+      "tags": {
+        "additionalProperties": "sample"
+      }
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test-nic",
+        "type": "Microsoft.AzureStackHCI/networkInterfaces",
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic",
+        "location": "West US2",
+        "properties": {
+          "ipConfigurations": [
+            {
+              "name": "ipconfig-sample",
+              "properties": {
+                "subnet": {
+                  "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/logicalNetworks/test-lnet"
+                }
+              }
+            }
+          ],
+          "provisioningState": "Accepted"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "NetworkInterfaces_Update",
+  "title": "UpdateNetworkInterface"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/NetworkInterfaces__CreateOrUpdate_CreateFromLocal.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/NetworkInterfaces__CreateOrUpdate_CreateFromLocal.json
@@ -1,0 +1,84 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "networkInterfaceName": "test-nic",
+    "resource": {
+      "extendedLocation": {
+        "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+        "type": "CustomLocation"
+      },
+      "location": "eastus",
+      "properties": {
+        "ipConfigurations": [
+          {
+            "name": "ipconfig-sample",
+            "properties": {
+              "subnet": {
+                "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/logicalNetworks/test-lnet"
+              }
+            }
+          }
+        ],
+        "createFromLocal": true
+      }
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test-nic",
+        "type": "Microsoft.AzureStackHCI/networkInterfaces",
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic",
+        "location": "West US2",
+        "properties": {
+          "ipConfigurations": [
+            {
+              "name": "ipconfig-sample",
+              "properties": {
+                "subnet": {
+                  "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/logicalNetworks/test-lnet"
+                }
+              }
+            }
+          ],
+          "createFromLocal": true,
+          "provisioningState": "Accepted"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "test-nic",
+        "type": "Microsoft.AzureStackHCI/networkInterfaces",
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic",
+        "location": "West US2",
+        "properties": {
+          "ipConfigurations": [
+            {
+              "name": "ipconfig-sample",
+              "properties": {
+                "subnet": {
+                  "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/logicalNetworks/test-lnet"
+                }
+              }
+            }
+          ],
+          "createFromLocal": true,
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "NetworkInterfaces_CreateOrUpdate",
+  "title": "CreateNetworkInterfaceFromLocal"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/NetworkSecurityGroups_CreateOrUpdate.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/NetworkSecurityGroups_CreateOrUpdate.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "networkSecurityGroupName": "testnsg",
+    "resource": {
+      "location": "eastus"
+    },
+    "resourceGroupName": "testrg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testnsg",
+        "type": "Microsoft.AzureStackHCI/networkSecurityGroups",
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/networkSecurityGroups/testnsg",
+        "location": "eastus",
+        "properties": {
+          "provisioningState": "Succeeded"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "testnsg",
+        "type": "Microsoft.AzureStackHCI/networkSecurityGroups",
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/networkSecurityGroups/testnsg",
+        "location": "eastus",
+        "properties": {
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "NetworkSecurityGroups_CreateOrUpdate",
+  "title": "CreateNetworkSecurityGroup"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/NetworkSecurityGroups_Delete.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/NetworkSecurityGroups_Delete.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "networkSecurityGroupName": "testnsg",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {
+      "headers": {
+        "Azure-AsyncOperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "NetworkSecurityGroups_Delete",
+  "title": "Delete network security group"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/NetworkSecurityGroups_Get.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/NetworkSecurityGroups_Get.json
@@ -1,0 +1,23 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "networkSecurityGroupName": "testnsg",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testnsg",
+        "type": "Microsoft.AzureStackHCI/networkSecurityGroups",
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/rg1/providers/Microsoft.AzureStackHCI/networkSecurityGroups/testnsg",
+        "location": "westus",
+        "properties": {
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "NetworkSecurityGroups_Get",
+  "title": "Get network security group"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/NetworkSecurityGroups_ListAll.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/NetworkSecurityGroups_ListAll.json
@@ -1,0 +1,34 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "nsg1",
+            "type": "Microsoft.AzureStackHCI/networkSecurityGroups",
+            "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/networkSecurityGroups/nsg1",
+            "location": "westus",
+            "properties": {
+              "provisioningState": "Succeeded"
+            }
+          },
+          {
+            "name": "nsg2",
+            "type": "Microsoft.AzureStackHCI/networkSecurityGroups",
+            "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/rg2/providers/Microsoft.AzureStackHCI/networkSecurityGroups/nsg2",
+            "location": "westus",
+            "properties": {
+              "provisioningState": "Succeeded"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "NetworkSecurityGroups_ListAll",
+  "title": "List all network security groups"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/NetworkSecurityGroups_ListByResourceGroup.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/NetworkSecurityGroups_ListByResourceGroup.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceGroupName": "testrg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "nsg1",
+            "type": "Microsoft.AzureStackHCI/networkSecurityGroups",
+            "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/networkSecurityGroups/nsg1",
+            "location": "westus",
+            "properties": {
+              "provisioningState": "Succeeded"
+            }
+          },
+          {
+            "name": "nsg3",
+            "type": "Microsoft.AzureStackHCI/networkSecurityGroups",
+            "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/networkSecurityGroups/nsg3",
+            "location": "westus",
+            "properties": {
+              "provisioningState": "Succeeded"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "NetworkSecurityGroups_ListByResourceGroup",
+  "title": "List network security groups in resource group"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/NetworkSecurityGroups_UpdateTags.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/NetworkSecurityGroups_UpdateTags.json
@@ -1,0 +1,38 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "networkSecurityGroupName": "testnsg",
+    "properties": {
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      }
+    },
+    "resourceGroupName": "testrg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testnsg",
+        "type": "Microsoft.AzureStackHCI/networkSecurityGroups",
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/networkSecurityGroups/testnsg",
+        "location": "westus",
+        "properties": {
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "NetworkSecurityGroups_UpdateTags",
+  "title": "Update network security group tags"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/Operations_List.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/Operations_List.json
@@ -1,0 +1,335 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Microsoft.AzureStackHCI/VirtualHardDisks/Delete",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft.AzureStackHCI",
+              "resource": "VirtualHardDisks",
+              "operation": "Deletes virtual hard disk resource",
+              "description": "Deletes virtual hard disk resource"
+            }
+          },
+          {
+            "name": "Microsoft.AzureStackHCI/VirtualHardDisks/Write",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft.AzureStackHCI",
+              "resource": "VirtualHardDisks",
+              "operation": "Creates/Updates virtual hard disk resource",
+              "description": "Creates/Updates virtual hard disk resource"
+            }
+          },
+          {
+            "name": "Microsoft.AzureStackHCI/VirtualHardDisks/Read",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft.AzureStackHCI",
+              "resource": "VirtualHardDisks",
+              "operation": "Gets/Lists virtual hard disk resource",
+              "description": "Gets/Lists virtual hard disk resource"
+            }
+          },
+          {
+            "name": "Microsoft.AzureStackHCI/Snapshots/Delete",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft.AzureStackHCI",
+              "resource": "Snapshots",
+              "operation": "Deletes snapshot resource",
+              "description": "Deletes snapshot resource"
+            }
+          },
+          {
+            "name": "Microsoft.AzureStackHCI/Snapshots/Write",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft.AzureStackHCI",
+              "resource": "Snapshots",
+              "operation": "Creates/Updates snapshot resource",
+              "description": "Creates/Updates snapshot resource"
+            }
+          },
+          {
+            "name": "Microsoft.AzureStackHCI/Snapshots/Read",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft.AzureStackHCI",
+              "resource": "Snapshots",
+              "operation": "Gets/Lists snapshot resource",
+              "description": "Gets/Lists snapshot resource"
+            }
+          },
+          {
+            "name": "Microsoft.AzureStackHCI/NetworkInterfaces/Delete",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft.AzureStackHCI",
+              "resource": "NetworkInterfaces",
+              "operation": "Deletes network interfaces resource",
+              "description": "Deletes network interfaces resource"
+            }
+          },
+          {
+            "name": "Microsoft.AzureStackHCI/NetworkInterfaces/Write",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft.AzureStackHCI",
+              "resource": "NetworkInterfaces",
+              "operation": "Creates/Updates network interfaces resource",
+              "description": "Creates/Updates network interfaces resource"
+            }
+          },
+          {
+            "name": "Microsoft.AzureStackHCI/NetworkInterfaces/Read",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft.AzureStackHCI",
+              "resource": "NetworkInterfaces",
+              "operation": "Gets/Lists network interfaces resource",
+              "description": "Gets/Lists network interfaces resource"
+            }
+          },
+          {
+            "name": "Microsoft.AzureStackHCI/GalleryImages/Delete",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft.AzureStackHCI",
+              "resource": "GalleryImages",
+              "operation": "Deletes gallery images resource",
+              "description": "Deletes gallery images resource"
+            }
+          },
+          {
+            "name": "Microsoft.AzureStackHCI/GalleryImages/Write",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft.AzureStackHCI",
+              "resource": "GalleryImages",
+              "operation": "Creates/Updates gallery images resource",
+              "description": "Creates/Updates gallery images resource"
+            }
+          },
+          {
+            "name": "Microsoft.AzureStackHCI/GalleryImages/Read",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft.AzureStackHCI",
+              "resource": "GalleryImages",
+              "operation": "Gets/Lists gallery images resource",
+              "description": "Gets/Lists gallery images resource"
+            }
+          },
+          {
+            "name": "Microsoft.AzureStackHCI/VirtualMachineInstances/HybridIdentityMetadata/Read",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft.AzureStackHCI",
+              "resource": "VirtualMachineInstances/HybridIdentityMetadata",
+              "operation": "Gets/Lists virtual machine instance hybrid identity metadata proxy resource",
+              "description": "Gets/Lists virtual machine instance hybrid identity metadata proxy resource"
+            }
+          },
+          {
+            "name": "Microsoft.AzureStackHCI/VirtualMachineInstances/attestationStatus/read",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft.AzureStackHCI",
+              "resource": "VirtualMachineInstances/attestationStatus",
+              "operation": "Gets/Lists virtual machine instance's attestation status",
+              "description": "Gets/Lists virtual machine instance's attestation status"
+            }
+          },
+          {
+            "name": "Microsoft.AzureStackHCI/LogicalNetworks/Delete",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft.AzureStackHCI",
+              "resource": "LogicalNetworks",
+              "operation": "Deletes logical networks resource",
+              "description": "Deletes logical networks resource"
+            }
+          },
+          {
+            "name": "Microsoft.AzureStackHCI/LogicalNetworks/Write",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft.AzureStackHCI",
+              "resource": "LogicalNetworks",
+              "operation": "Creates/Updates logical networks resource",
+              "description": "Creates/Updates logical networks resource"
+            }
+          },
+          {
+            "name": "Microsoft.AzureStackHCI/LogicalNetworks/Read",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft.AzureStackHCI",
+              "resource": "LogicalNetworks",
+              "operation": "Gets/Lists logical networks resource",
+              "description": "Gets/Lists logical networks resource"
+            }
+          },
+          {
+            "name": "Microsoft.AzureStackHCI/LogicalNetworks/join/action",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft.AzureStackHCI",
+              "resource": "LogicalNetworks",
+              "operation": "Joins logical networks resource",
+              "description": "Joins logical networks resource"
+            }
+          },
+          {
+            "name": "Microsoft.AzureStackHCI/VirtualMachineInstances/Restart/Action",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft.AzureStackHCI",
+              "resource": "VirtualMachineInstances",
+              "operation": "Restarts virtual machine instance resource",
+              "description": "Restarts virtual machine instance resource"
+            }
+          },
+          {
+            "name": "Microsoft.AzureStackHCI/VirtualMachineInstances/Start/Action",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft.AzureStackHCI",
+              "resource": "VirtualMachineInstances",
+              "operation": "Starts virtual machine instance resource",
+              "description": "Starts virtual machine instance resource"
+            }
+          },
+          {
+            "name": "Microsoft.AzureStackHCI/VirtualMachineInstances/Stop/Action",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft.AzureStackHCI",
+              "resource": "VirtualMachineInstances",
+              "operation": "Stops virtual machine instance resource",
+              "description": "Stops virtual machine instance resource"
+            }
+          },
+          {
+            "name": "Microsoft.AzureStackHCI/VirtualMachineInstances/Delete",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft.AzureStackHCI",
+              "resource": "VirtualMachineInstances",
+              "operation": "Deletes virtual machine instance resource",
+              "description": "Deletes virtual machine instance resource"
+            }
+          },
+          {
+            "name": "Microsoft.AzureStackHCI/VirtualMachineInstances/Write",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft.AzureStackHCI",
+              "resource": "VirtualMachineInstances",
+              "operation": "Creates/Updates virtual machine instance resource",
+              "description": "Creates/Updates virtual machine instance resource"
+            }
+          },
+          {
+            "name": "Microsoft.AzureStackHCI/VirtualMachineInstances/Read",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft.AzureStackHCI",
+              "resource": "VirtualMachineInstances",
+              "operation": "Gets/Lists virtual machine instance resource",
+              "description": "Gets/Lists virtual machine instance resource"
+            }
+          },
+          {
+            "name": "Microsoft.AzureStackHCI/StorageContainers/Delete",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft.AzureStackHCI",
+              "resource": "StorageContainers",
+              "operation": "Deletes storage containers resource",
+              "description": "Deletes storage containers resource"
+            }
+          },
+          {
+            "name": "Microsoft.AzureStackHCI/StorageContainers/Write",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft.AzureStackHCI",
+              "resource": "StorageContainers",
+              "operation": "Creates/Updates storage containers resource",
+              "description": "Creates/Updates storage containers resource"
+            }
+          },
+          {
+            "name": "Microsoft.AzureStackHCI/StorageContainers/Read",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft.AzureStackHCI",
+              "resource": "StorageContainers",
+              "operation": "Gets/Lists storage containers resource",
+              "description": "Gets/Lists storage containers resource"
+            }
+          },
+          {
+            "name": "Microsoft.AzureStackHCI/StorageContainers/deploy/action",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft.AzureStackHCI",
+              "resource": "StorageContainers",
+              "operation": "Deploys storage containers resource",
+              "description": "Deploys storage containers resource"
+            }
+          },
+          {
+            "name": "Microsoft.AzureStackHCI/MarketPlaceGalleryImages/Delete",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft.AzureStackHCI",
+              "resource": "MarketPlaceGalleryImages",
+              "operation": "Deletes market place gallery images resource",
+              "description": "Deletes market place gallery images resource"
+            }
+          },
+          {
+            "name": "Microsoft.AzureStackHCI/MarketPlaceGalleryImages/Write",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft.AzureStackHCI",
+              "resource": "MarketPlaceGalleryImages",
+              "operation": "Creates/Updates market place gallery images resource",
+              "description": "Creates/Updates market place gallery images resource"
+            }
+          },
+          {
+            "name": "Microsoft.AzureStackHCI/MarketPlaceGalleryImages/Read",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft.AzureStackHCI",
+              "resource": "MarketPlaceGalleryImages",
+              "operation": "Gets/Lists market place gallery images resource",
+              "description": "Gets/Lists market place gallery images resource"
+            }
+          },
+          {
+            "name": "Microsoft.AzureStackHCI/MarketPlaceGalleryImages/deploy/action",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft.AzureStackHCI",
+              "resource": "MarketPlaceGalleryImages",
+              "operation": "Deploys market place gallery images resource",
+              "description": "Deploys market place gallery images resource"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Operations_List",
+  "title": "List the operations for the provider."
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/PublicIPAddresses_CreateOrUpdate.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/PublicIPAddresses_CreateOrUpdate.json
@@ -1,0 +1,56 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "publicIPAddressName": "public-ip1",
+    "resource": {
+      "location": "eastus",
+      "properties": {
+        "publicIPAddressVersion": "IPv4",
+        "ipAddress": "10.100.100.4",
+        "ipAllocationScope": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/logicalNetworks/lnet1"
+      }
+    },
+    "resourceGroupName": "testrg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "public-ip1",
+        "type": "Microsoft.AzureStackHCI/publicIPAddresses",
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/publicIPAddresses/public-ip1",
+        "location": "eastus",
+        "extendedLocation": {
+          "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "properties": {
+          "publicIPAddressVersion": "IPv4",
+          "ipAddress": "10.100.100.4",
+          "ipAllocationScope": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/logicalNetworks/lnet1",
+          "provisioningState": "Succeeded"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "public-ip1",
+        "type": "Microsoft.AzureStackHCI/publicIPAddresses",
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/publicIPAddresses/public-ip1",
+        "location": "eastus",
+        "extendedLocation": {
+          "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "properties": {
+          "publicIPAddressVersion": "IPv4",
+          "ipAddress": "10.100.100.4",
+          "ipAllocationScope": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/logicalNetworks/lnet1",
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "PublicIPAddresses_CreateOrUpdate",
+  "title": "CreatePublicIPAddress"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/PublicIPAddresses_Delete.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/PublicIPAddresses_Delete.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "publicIPAddressName": "test-ip",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {
+      "headers": {
+        "Azure-AsyncOperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "PublicIPAddresses_Delete",
+  "title": "Delete public IP address"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/PublicIPAddresses_Get.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/PublicIPAddresses_Get.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "publicIPAddressName": "testip",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testip",
+        "type": "Microsoft.AzureStackHCI/publicIPAddresses",
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/rg1/providers/Microsoft.AzureStackHCI/publicIPAddresses/testip",
+        "location": "westus",
+        "extendedLocation": {
+          "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "properties": {
+          "publicIPAddressVersion": "IPv4",
+          "ipAddress": "10.100.100.4",
+          "ipAllocationScope": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/logicalNetworks/lnet1",
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "PublicIPAddresses_Get",
+  "title": "Get public IP address"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/PublicIPAddresses_ListALL.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/PublicIPAddresses_ListALL.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "publicip1",
+            "type": "Microsoft.AzureStackHCI/publicIPAddresses",
+            "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/publicIPAddresses/publicip1",
+            "location": "westus",
+            "extendedLocation": {
+              "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+              "type": "CustomLocation"
+            },
+            "properties": {
+              "publicIPAddressVersion": "IPv4",
+              "ipAddress": "10.100.100.4",
+              "ipAllocationScope": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/logicalNetworks/lnet1",
+              "provisioningState": "Succeeded"
+            }
+          },
+          {
+            "name": "publicip2",
+            "type": "Microsoft.AzureStackHCI/publicIPAddresses",
+            "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/rg2/providers/Microsoft.AzureStackHCI/publicIPAddresses/publicip2",
+            "location": "westus",
+            "extendedLocation": {
+              "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+              "type": "CustomLocation"
+            },
+            "properties": {
+              "publicIPAddressVersion": "IPv4",
+              "ipAddress": "10.100.100.5",
+              "ipAllocationScope": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/logicalNetworks/lnet1",
+              "provisioningState": "Succeeded"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "PublicIPAddresses_ListAll",
+  "title": "List all public IP addresses"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/PublicIPAddresses_ListByResourceGroup.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/PublicIPAddresses_ListByResourceGroup.json
@@ -1,0 +1,49 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceGroupName": "testrg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "publicip1",
+            "type": "Microsoft.AzureStackHCI/publicIPAddresses",
+            "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/publicIPAddresses/publicip1",
+            "location": "westus",
+            "extendedLocation": {
+              "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+              "type": "CustomLocation"
+            },
+            "properties": {
+              "publicIPAddressVersion": "IPv4",
+              "ipAddress": "10.100.100.4",
+              "ipAllocationScope": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/logicalNetworks/lnet1",
+              "provisioningState": "Succeeded"
+            }
+          },
+          {
+            "name": "publicip3",
+            "type": "Microsoft.AzureStackHCI/publicIPAddresses",
+            "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/publicIPAddresses/publicip3",
+            "location": "westus",
+            "extendedLocation": {
+              "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+              "type": "CustomLocation"
+            },
+            "properties": {
+              "publicIPAddressVersion": "IPv4",
+              "ipAddress": "10.100.100.5",
+              "ipAllocationScope": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/logicalNetworks/lnet1",
+              "provisioningState": "Succeeded"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "PublicIPAddresses_ListByResourceGroup",
+  "title": "List public IPs in resource group"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/PublicIPAddresses_UpdateTags.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/PublicIPAddresses_UpdateTags.json
@@ -1,0 +1,45 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "publicIPAddressName": "publicip",
+    "properties": {
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      }
+    },
+    "resourceGroupName": "testrg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "publicip",
+        "type": "Microsoft.AzureStackHCI/publicIPAddresses",
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/publicIPAddresses/publicip",
+        "location": "westus",
+        "extendedLocation": {
+          "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "properties": {
+          "publicIPAddressVersion": "IPv4",
+          "ipAddress": "10.100.100.4",
+          "ipAllocationScope": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/logicalNetworks/lnet1",
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "PublicIPAddresses_UpdateTags",
+  "title": "Update public IP addresses tags"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/SecurityRules_CreateOrUpdate.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/SecurityRules_CreateOrUpdate.json
@@ -1,0 +1,85 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "networkSecurityGroupName": "testnsg",
+    "securityRuleName": "rule1",
+    "resource": {
+      "extendedLocation": {
+        "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+        "type": "CustomLocation"
+      },
+      "properties": {
+        "access": "Allow",
+        "destinationAddressPrefixes": [
+          "*"
+        ],
+        "destinationPortRanges": [
+          "80"
+        ],
+        "direction": "Inbound",
+        "priority": 130,
+        "sourceAddressPrefixes": [
+          "*"
+        ],
+        "sourcePortRanges": [
+          "*"
+        ],
+        "protocol": "*"
+      }
+    },
+    "resourceGroupName": "testrg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "rule1",
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/networkSecurityGroups/testnsg/securityRule/rule1",
+        "properties": {
+          "access": "Allow",
+          "destinationAddressPrefixes": [
+            "*"
+          ],
+          "destinationPortRanges": [
+            "80"
+          ],
+          "direction": "Inbound",
+          "priority": 130,
+          "sourceAddressPrefixes": [
+            "*"
+          ],
+          "sourcePortRanges": [
+            "*"
+          ],
+          "protocol": "*"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "rule1",
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/networkSecurityGroups/testnsg/securityRule/rule1",
+        "properties": {
+          "access": "Allow",
+          "destinationAddressPrefixes": [
+            "*"
+          ],
+          "destinationPortRanges": [
+            "80"
+          ],
+          "direction": "Inbound",
+          "priority": 130,
+          "sourceAddressPrefixes": [
+            "*"
+          ],
+          "sourcePortRanges": [
+            "*"
+          ],
+          "protocol": "*"
+        }
+      }
+    }
+  },
+  "operationId": "SecurityRules_CreateOrUpdate",
+  "title": "SecurityRulesCreateOrUpdate"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/SecurityRules_Delete.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/SecurityRules_Delete.json
@@ -1,0 +1,23 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "networkSecurityGroupName": "testnsg",
+    "resourceGroupName": "testrg",
+    "securityRuleName": "rule1",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {
+      "headers": {
+        "Azure-AsyncOperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "SecurityRules_Delete",
+  "title": "SecurityRulesDelete"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/SecurityRules_Get.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/SecurityRules_Get.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "networkSecurityGroupName": "testnsg",
+    "resourceGroupName": "testrg",
+    "securityRuleName": "rule1",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "rule1",
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/networkSecurityGroups/testnsg/securityRule/rule1",
+        "properties": {
+          "access": "Allow",
+          "destinationAddressPrefixes": [
+            "*"
+          ],
+          "destinationPortRanges": [
+            "80"
+          ],
+          "direction": "Inbound",
+          "priority": 130,
+          "sourceAddressPrefixes": [
+            "*"
+          ],
+          "sourcePortRanges": [
+            "*"
+          ],
+          "protocol": "*"
+        }
+      }
+    }
+  },
+  "operationId": "SecurityRules_Get",
+  "title": "Get network security rule in network security group"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/SecurityRules_ListByNetworkSecurityGroup.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/SecurityRules_ListByNetworkSecurityGroup.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "networkSecurityGroupName": "testnsg",
+    "resourceGroupName": "testrg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "rule1",
+            "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/networkSecurityGroups/testnsg/securityRule/rule1",
+            "properties": {
+              "access": "Allow",
+              "destinationAddressPrefixes": [
+                "*"
+              ],
+              "destinationPortRanges": [
+                "80"
+              ],
+              "direction": "Inbound",
+              "priority": 130,
+              "sourceAddressPrefixes": [
+                "*"
+              ],
+              "sourcePortRanges": [
+                "*"
+              ],
+              "protocol": "*"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "SecurityRules_ListByNetworkSecurityGroup",
+  "title": "List network security rules in network security group"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/Snapshots_CreateOrUpdate.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/Snapshots_CreateOrUpdate.json
@@ -1,0 +1,86 @@
+{
+  "operationId": "Snapshots_CreateOrUpdate",
+  "title": "Create or update a snapshot",
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b",
+    "snapshotName": "test-snapshot",
+    "resource": {
+      "extendedLocation": {
+        "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+        "type": "CustomLocation"
+      },
+      "location": "West US2",
+      "tags": {
+        "environment": "test"
+      },
+      "properties": {
+        "creationData": {
+          "createOption": "Copy",
+          "sourceResourceId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/virtualHardDisks/source-vhd"
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test-snapshot",
+        "type": "Microsoft.AzureStackHCI/snapshots",
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/snapshots/test-snapshot",
+        "location": "West US2",
+        "tags": {
+          "environment": "test"
+        },
+        "properties": {
+          "creationData": {
+            "createOption": "Copy",
+            "sourceResourceId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/virtualHardDisks/source-vhd",
+            "sourceUniqueId": "b99c94ca-e43d-4282-9c78-84d58e5ce81a"
+          },
+          "provisioningState": "Succeeded",
+          "timeCreated": "2023-11-15T10:30:00Z",
+          "diskSizeBytes": 68719476736,
+          "uniqueId": "f9e8d7c6-b5a4-9382-7160-5948372615a3",
+          "status": {
+            "provisioningStatus": {
+              "status": "Succeeded"
+            }
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "test-snapshot",
+        "type": "Microsoft.AzureStackHCI/snapshots",
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/snapshots/test-snapshot",
+        "location": "West US2",
+        "tags": {
+          "environment": "test"
+        },
+        "properties": {
+          "creationData": {
+            "createOption": "Copy",
+            "sourceResourceId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/virtualHardDisks/source-vhd"
+          },
+          "provisioningState": "Accepted",
+          "status": {
+            "provisioningStatus": {
+              "status": "InProgress"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/Snapshots_Delete.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/Snapshots_Delete.json
@@ -1,0 +1,18 @@
+{
+  "operationId": "Snapshots_Delete",
+  "title": "Delete a snapshot",
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b",
+    "snapshotName": "test-snapshot"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/providers/Microsoft.AzureStackHCI/locations/West US2/operationStatuses/01234567-abcd-ef12-3456-7890abcdef12*87654321-dcba-fe21-6543-1098765432ba"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/Snapshots_Get.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/Snapshots_Get.json
@@ -1,0 +1,43 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b",
+    "snapshotName": "test-snapshot"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test-snapshot",
+        "type": "Microsoft.AzureStackHCI/snapshots",
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/snapshots/test-snapshot",
+        "location": "West US2",
+        "tags": {
+          "environment": "test"
+        },
+        "properties": {
+          "creationData": {
+            "createOption": "Copy",
+            "sourceResourceId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/virtualHardDisks/source-vhd",
+            "sourceUniqueId": "b99c94ca-e43d-4282-9c78-84d58e5ce81a"
+          },
+          "provisioningState": "Succeeded",
+          "timeCreated": "2023-11-15T10:30:00Z",
+          "diskSizeBytes": 68719476736,
+          "uniqueId": "f9e8d7c6-b5a4-9382-7160-5948372615a3",
+          "status": {
+            "provisioningStatus": {
+              "status": "Succeeded"
+            }
+          }
+        }
+      }
+    }
+  },
+  "operationId": "Snapshots_Get",
+  "title": "Get a snapshot"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/Snapshots_ListAll.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/Snapshots_ListAll.json
@@ -1,0 +1,71 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "test-snapshot-1",
+            "type": "Microsoft.AzureStackHCI/snapshots",
+            "extendedLocation": {
+              "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+              "type": "CustomLocation"
+            },
+            "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/snapshots/test-snapshot-1",
+            "location": "West US2",
+            "tags": {
+              "environment": "test"
+            },
+            "properties": {
+              "creationData": {
+                "createOption": "Copy",
+                "sourceResourceId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/virtualHardDisks/source-vhd",
+                "sourceUniqueId": "b99c94ca-e43d-4282-9c78-84d58e5ce81a"
+              },
+              "provisioningState": "Succeeded",
+              "timeCreated": "2023-11-15T10:30:00Z",
+              "diskSizeBytes": 68719476736,
+              "uniqueId": "f9e8d7c6-b5a4-9382-7160-5948372615a3",
+              "status": {
+                "provisioningStatus": {
+                  "status": "Succeeded"
+                }
+              }
+            }
+          },
+          {
+            "name": "test-snapshot-2",
+            "type": "Microsoft.AzureStackHCI/snapshots",
+            "extendedLocation": {
+              "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+              "type": "CustomLocation"
+            },
+            "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/other-rg/providers/Microsoft.AzureStackHCI/snapshots/test-snapshot-2",
+            "location": "East US",
+            "properties": {
+              "creationData": {
+                "createOption": "Copy",
+                "sourceResourceId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/other-rg/providers/Microsoft.AzureStackHCI/virtualHardDisks/another-vhd",
+                "sourceUniqueId": "c11a94ca-e43d-4282-9c78-84d58e5ce81b"
+              },
+              "provisioningState": "Succeeded",
+              "timeCreated": "2023-11-16T08:30:00Z",
+              "diskSizeBytes": 137438953472,
+              "uniqueId": "a1b2c3d4-e5f6-7890-1234-567890abcdef",
+              "status": {
+                "provisioningStatus": {
+                  "status": "Succeeded"
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Snapshots_ListAll",
+  "title": "List all snapshots in a subscription"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/Snapshots_ListByResourceGroup.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/Snapshots_ListByResourceGroup.json
@@ -1,0 +1,46 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "test-snapshot-1",
+            "type": "Microsoft.AzureStackHCI/snapshots",
+            "extendedLocation": {
+              "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+              "type": "CustomLocation"
+            },
+            "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/snapshots/test-snapshot-1",
+            "location": "West US2",
+            "tags": {
+              "environment": "test"
+            },
+            "properties": {
+              "creationData": {
+                "createOption": "Copy",
+                "sourceResourceId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/virtualHardDisks/source-vhd",
+                "sourceUniqueId": "b99c94ca-e43d-4282-9c78-84d58e5ce81a"
+              },
+              "provisioningState": "Succeeded",
+              "timeCreated": "2023-11-15T10:30:00Z",
+              "diskSizeBytes": 68719476736,
+              "uniqueId": "f9e8d7c6-b5a4-9382-7160-5948372615a3",
+              "status": {
+                "provisioningStatus": {
+                  "status": "Succeeded"
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Snapshots_ListByResourceGroup",
+  "title": "List snapshots by resource group"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/Snapshots_Update.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/Snapshots_Update.json
@@ -1,0 +1,55 @@
+{
+  "operationId": "Snapshots_Update",
+  "title": "Update a snapshot",
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b",
+    "snapshotName": "test-snapshot",
+    "properties": {
+      "tags": {
+        "environment": "production",
+        "tier": "standard"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test-snapshot",
+        "type": "Microsoft.AzureStackHCI/snapshots",
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/snapshots/test-snapshot",
+        "location": "West US2",
+        "tags": {
+          "environment": "production",
+          "tier": "standard"
+        },
+        "properties": {
+          "creationData": {
+            "createOption": "Copy",
+            "sourceResourceId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/virtualHardDisks/source-vhd",
+            "sourceUniqueId": "b99c94ca-e43d-4282-9c78-84d58e5ce81a"
+          },
+          "provisioningState": "Succeeded",
+          "timeCreated": "2023-11-15T10:30:00Z",
+          "diskSizeBytes": 68719476736,
+          "uniqueId": "f9e8d7c6-b5a4-9382-7160-5948372615a3",
+          "status": {
+            "provisioningStatus": {
+              "status": "Succeeded"
+            }
+          }
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/providers/Microsoft.AzureStackHCI/locations/West US2/operationStatuses/01234567-abcd-ef12-3456-7890abcdef12*87654321-dcba-fe21-6543-1098765432ba"
+      }
+    }
+  }
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/StorageContainers_CreateOrUpdate.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/StorageContainers_CreateOrUpdate.json
@@ -1,0 +1,54 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceGroupName": "test-rg",
+    "storageContainerName": "Default_Container",
+    "resource": {
+      "extendedLocation": {
+        "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+        "type": "CustomLocation"
+      },
+      "location": "West US2",
+      "properties": {
+        "path": "C:\\container_storage"
+      }
+    },
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "Default_Container",
+        "type": "Microsoft.AzureStackHCI/storageContainers",
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-galimg3325",
+        "location": "West US2",
+        "properties": {
+          "path": "C:\\container_storage",
+          "provisioningState": "Accepted"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "Default_Container",
+        "type": "Microsoft.AzureStackHCI/storageContainers",
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-galimg3325",
+        "location": "West US2",
+        "properties": {
+          "path": "C:\\container_storage",
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "StorageContainers_CreateOrUpdate",
+  "title": "PutStorageContainer"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/StorageContainers_Delete.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/StorageContainers_Delete.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceGroupName": "test-rg",
+    "storageContainerName": "Default_Container",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "StorageContainers_Delete",
+  "title": "DeleteStorageContainer"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/StorageContainers_Get.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/StorageContainers_Get.json
@@ -1,0 +1,28 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceGroupName": "test-rg",
+    "storageContainerName": "Default_Container",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "Default_Container",
+        "type": "Microsoft.AzureStackHCI/storageContainers",
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/Default_Container",
+        "location": "West US2",
+        "properties": {
+          "path": "C:\\container_storage",
+          "provisioningState": "Accepted"
+        }
+      }
+    }
+  },
+  "operationId": "StorageContainers_Get",
+  "title": "GetStorageContainer"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/StorageContainers_ListAll.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/StorageContainers_ListAll.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Default_Container",
+            "type": "Microsoft.AzureStackHCI/storageContainers",
+            "extendedLocation": {
+              "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+              "type": "CustomLocation"
+            },
+            "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/Default_Container",
+            "location": "West US2",
+            "properties": {
+              "path": "C:\\container_storage",
+              "provisioningState": "Accepted"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "StorageContainers_ListAll",
+  "title": "ListStorageContainerBySubscription"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/StorageContainers_ListByResourceGroup.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/StorageContainers_ListByResourceGroup.json
@@ -1,0 +1,31 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Default_Container",
+            "type": "Microsoft.AzureStackHCI/storageContainers",
+            "extendedLocation": {
+              "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+              "type": "CustomLocation"
+            },
+            "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/Default_Container",
+            "location": "West US2",
+            "properties": {
+              "path": "C:\\container_storage",
+              "provisioningState": "Accepted"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "StorageContainers_ListByResourceGroup",
+  "title": "ListStorageContainerByResourceGroup"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/StorageContainers_Update.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/StorageContainers_Update.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceGroupName": "test-rg",
+    "storageContainerName": "Default_Container",
+    "properties": {
+      "tags": {
+        "additionalProperties": "sample"
+      }
+    },
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "Default_Container",
+        "type": "Microsoft.AzureStackHCI/storageContainers",
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-galimg3325",
+        "location": "West US2",
+        "properties": {
+          "path": "C:\\container_storage",
+          "provisioningState": "Accepted"
+        },
+        "tags": {
+          "additionalProperties": "sample"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "StorageContainers_Update",
+  "title": "UpdateStorageContainer"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualHardDisks_CreateOrUpdate.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualHardDisks_CreateOrUpdate.json
@@ -1,0 +1,66 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b",
+    "virtualHardDiskName": "test-vhd",
+    "resource": {
+      "extendedLocation": {
+        "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+        "type": "CustomLocation"
+      },
+      "location": "West US2",
+      "properties": {
+        "diskSizeGB": 32
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test-vhd",
+        "type": "Microsoft.AzureStackHCI/virtualHardDisks",
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/virtualHardDisks/test-vhd",
+        "location": "West US2",
+        "properties": {
+          "blockSizeBytes": 0,
+          "diskFileFormat": "vhdx",
+          "diskSizeGB": 32,
+          "dynamic": true,
+          "hyperVGeneration": "V2",
+          "logicalSectorBytes": 512,
+          "physicalSectorBytes": 512,
+          "provisioningState": "Accepted"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "test-vhd",
+        "type": "Microsoft.AzureStackHCI/virtualHardDisks",
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/virtualHardDisks/test-vhd",
+        "location": "West US2",
+        "properties": {
+          "blockSizeBytes": 0,
+          "diskFileFormat": "vhdx",
+          "diskSizeGB": 32,
+          "dynamic": true,
+          "hyperVGeneration": "V2",
+          "logicalSectorBytes": 512,
+          "physicalSectorBytes": 512,
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "VirtualHardDisks_CreateOrUpdate",
+  "title": "PutVirtualHardDisk"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualHardDisks_Delete.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualHardDisks_Delete.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b",
+    "virtualHardDiskName": "test-vhd"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "VirtualHardDisks_Delete",
+  "title": "DeleteVirtualHardDisk"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualHardDisks_Download.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualHardDisks_Download.json
@@ -1,0 +1,66 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b",
+    "virtualHardDiskName": "test-vhd",
+    "resource": {
+      "extendedLocation": {
+        "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+        "type": "CustomLocation"
+      },
+      "location": "West US2",
+      "properties": {
+        "downloadUrl": "https://YourStorageAccountName.blob.core.windows.net/YourContainerName/YourVHDBlobName.vhd?<sas-token>"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test-vhd",
+        "type": "Microsoft.AzureStackHCI/virtualHardDisks",
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/virtualHardDisks/test-vhd",
+        "location": "West US2",
+        "properties": {
+          "blockSizeBytes": 0,
+          "diskFileFormat": "vhdx",
+          "diskSizeGB": 32,
+          "dynamic": true,
+          "hyperVGeneration": "V2",
+          "logicalSectorBytes": 512,
+          "physicalSectorBytes": 512,
+          "provisioningState": "Accepted"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "test-vhd",
+        "type": "Microsoft.AzureStackHCI/virtualHardDisks",
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/virtualHardDisks/test-vhd",
+        "location": "West US2",
+        "properties": {
+          "blockSizeBytes": 0,
+          "diskFileFormat": "vhdx",
+          "diskSizeGB": 32,
+          "dynamic": true,
+          "hyperVGeneration": "V2",
+          "logicalSectorBytes": 512,
+          "physicalSectorBytes": 512,
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "VirtualHardDisks_Download",
+  "title": "DownloadVirtualHardDisk"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualHardDisks_Get.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualHardDisks_Get.json
@@ -1,0 +1,46 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b",
+    "virtualHardDiskName": "test-vhd"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test-vhd",
+        "type": "Microsoft.AzureStackHCI/virtualHardDisks",
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/virtualHardDisks/test-vhd",
+        "location": "West US2",
+        "properties": {
+          "blockSizeBytes": 0,
+          "diskFileFormat": "vhdx",
+          "diskSizeGB": 32,
+          "dynamic": true,
+          "hyperVGeneration": "V2",
+          "logicalSectorBytes": 512,
+          "physicalSectorBytes": 512,
+          "provisioningState": "Accepted",
+          "status": {
+            "uploadStatus": {
+              "uploadedSizeInMB": 10240,
+              "progressPercentage": 55,
+              "status": "InProgress"
+            },
+            "downloadStatus": {
+              "downloadedSizeInMB": 10240,
+              "progressPercentage": 100,
+              "status": "Succeeded"
+            }
+          }
+        }
+      }
+    }
+  },
+  "operationId": "VirtualHardDisks_Get",
+  "title": "GetVirtualHardDisk"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualHardDisks_ListAll.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualHardDisks_ListAll.json
@@ -1,0 +1,36 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "test-vhd",
+            "type": "Microsoft.AzureStackHCI/virtualHardDisks",
+            "extendedLocation": {
+              "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+              "type": "CustomLocation"
+            },
+            "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/virtualHardDisks/test-vhd",
+            "location": "West US2",
+            "properties": {
+              "blockSizeBytes": 0,
+              "diskFileFormat": "vhdx",
+              "diskSizeGB": 32,
+              "dynamic": true,
+              "hyperVGeneration": "V2",
+              "logicalSectorBytes": 512,
+              "physicalSectorBytes": 512,
+              "provisioningState": "Accepted"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "VirtualHardDisks_ListAll",
+  "title": "ListVirtualHardDiskBySubscription"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualHardDisks_ListByResourceGroup.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualHardDisks_ListByResourceGroup.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "test-vhd",
+            "type": "Microsoft.AzureStackHCI/virtualHardDisks",
+            "extendedLocation": {
+              "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+              "type": "CustomLocation"
+            },
+            "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/virtualHardDisks/test-vhd",
+            "location": "West US2",
+            "properties": {
+              "blockSizeBytes": 0,
+              "diskFileFormat": "vhdx",
+              "diskSizeGB": 32,
+              "dynamic": true,
+              "hyperVGeneration": "V2",
+              "logicalSectorBytes": 512,
+              "physicalSectorBytes": 512,
+              "provisioningState": "Accepted"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "VirtualHardDisks_ListByResourceGroup",
+  "title": "ListVirtualHardDiskByResourceGroup"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualHardDisks_Update.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualHardDisks_Update.json
@@ -1,0 +1,47 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b",
+    "virtualHardDiskName": "test-vhd",
+    "properties": {
+      "tags": {
+        "additionalProperties": "sample"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test-vhd",
+        "type": "Microsoft.AzureStackHCI/virtualHardDisks",
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/virtualHardDisks/test-vhd",
+        "location": "West US2",
+        "properties": {
+          "blockSizeBytes": 0,
+          "diskFileFormat": "vhdx",
+          "diskSizeGB": 32,
+          "dynamic": true,
+          "hyperVGeneration": "V2",
+          "logicalSectorBytes": 512,
+          "physicalSectorBytes": 512,
+          "provisioningState": "Accepted"
+        },
+        "tags": {
+          "additionalProperties": "sample"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "VirtualHardDisks_Update",
+  "title": "UpdateVirtualHardDisk"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualHardDisks_Upload.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualHardDisks_Upload.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b",
+    "virtualHardDiskName": "test-vhd",
+    "body": {
+      "azureManagedDiskUploadUrl": "https://YourStorageAccountName.blob.core.windows.net/YourContainerName/YourVHDBlobName.vhd?<sas-token>"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "virtualHardDiskId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/virtualHardDisks/test-vhd",
+        "uploadStatus": {
+          "uploadedSizeInMB": 10240,
+          "progressPercentage": 55,
+          "status": "InProgress"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "location": "https://contoso.com/operationstatus"
+      }
+    }
+  },
+  "operationId": "VirtualHardDisks_Upload",
+  "title": "UploadVirtualHardDisk"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualHardDisks__CreateOrUpdate_CreateFromLocal.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualHardDisks__CreateOrUpdate_CreateFromLocal.json
@@ -1,0 +1,71 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b",
+    "virtualHardDiskName": "rehome-datadisk-1",
+    "resource": {
+      "extendedLocation": {
+        "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+        "type": "CustomLocation"
+      },
+      "location": "West US2",
+      "properties": {
+        "createFromLocal": true,
+        "localVhdPath": "C:\\ClusterStorage\\UserStorage_2\\e35803d0bd82d61\\rehome555-dd1-a95612cb-f1fa-4daa-a4fd-272844fa512c-dogfoodarc.vhdx"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "rehome-datadisk-1",
+        "type": "Microsoft.AzureStackHCI/virtualHardDisks",
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/virtualHardDisks/rehome-datadisk-1",
+        "location": "West US2",
+        "properties": {
+          "blockSizeBytes": 0,
+          "diskFileFormat": "vhdx",
+          "diskSizeGB": 32,
+          "dynamic": true,
+          "hyperVGeneration": "V2",
+          "logicalSectorBytes": 512,
+          "physicalSectorBytes": 512,
+          "createFromLocal": true,
+          "containerId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/UserStorage_2",
+          "provisioningState": "Accepted"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "rehome-datadisk-1",
+        "type": "Microsoft.AzureStackHCI/virtualHardDisks",
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/virtualHardDisks/rehome-datadisk-1",
+        "location": "West US2",
+        "properties": {
+          "blockSizeBytes": 0,
+          "diskFileFormat": "vhdx",
+          "diskSizeGB": 32,
+          "dynamic": true,
+          "hyperVGeneration": "V2",
+          "logicalSectorBytes": 512,
+          "physicalSectorBytes": 512,
+          "createFromLocal": true,
+          "containerId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/UserStorage_2",
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "VirtualHardDisks_CreateOrUpdate",
+  "title": "CreateVirtualHardDiskFromLocal"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualMachineInstances_CreateOrUpdate_Put_Virtual_Machine_Instance_With_Gallery_Image.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualMachineInstances_CreateOrUpdate_Put_Virtual_Machine_Instance_With_Gallery_Image.json
@@ -1,0 +1,115 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceUri": "subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM",
+    "resource": {
+      "extendedLocation": {
+        "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+        "type": "CustomLocation"
+      },
+      "properties": {
+        "hardwareProfile": {
+          "vmSize": "Default"
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic"
+            }
+          ]
+        },
+        "osProfile": {
+          "adminPassword": "password",
+          "adminUsername": "localadmin",
+          "computerName": "luamaster"
+        },
+        "securityProfile": {
+          "enableTPM": true,
+          "uefiSettings": {
+            "secureBootEnabled": true
+          }
+        },
+        "storageProfile": {
+          "imageReference": {
+            "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/galleryImages/test-gallery-image"
+          },
+          "vmConfigStoragePathId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-container"
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default",
+        "properties": {
+          "hardwareProfile": {
+            "vmSize": "Default"
+          },
+          "networkProfile": {
+            "networkInterfaces": [
+              {
+                "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic"
+              }
+            ]
+          },
+          "osProfile": {
+            "adminUsername": "localadmin",
+            "computerName": "luamaster"
+          },
+          "provisioningState": "Accepted",
+          "securityProfile": {
+            "enableTPM": true,
+            "uefiSettings": {
+              "secureBootEnabled": true
+            }
+          },
+          "storageProfile": {
+            "imageReference": {
+              "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/galleryImages/test-gallery-image"
+            },
+            "vmConfigStoragePathId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-container"
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default",
+        "properties": {
+          "hardwareProfile": {
+            "vmSize": "Default"
+          },
+          "networkProfile": {
+            "networkInterfaces": [
+              {
+                "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic"
+              }
+            ]
+          },
+          "osProfile": {
+            "adminUsername": "localadmin",
+            "computerName": "luamaster"
+          },
+          "provisioningState": "Succeeded",
+          "storageProfile": {
+            "imageReference": {
+              "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/galleryImages/test-gallery-image"
+            },
+            "vmConfigStoragePathId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-container"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "VirtualMachineInstances_CreateOrUpdate",
+  "title": "PutVirtualMachineInstanceWithGalleryImage"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualMachineInstances_CreateOrUpdate_Put_Virtual_Machine_Instance_With_Gpu.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualMachineInstances_CreateOrUpdate_Put_Virtual_Machine_Instance_With_Gpu.json
@@ -1,0 +1,133 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceUri": "subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM",
+    "resource": {
+      "extendedLocation": {
+        "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+        "type": "CustomLocation"
+      },
+      "properties": {
+        "hardwareProfile": {
+          "vmSize": "Default",
+          "virtualMachineGPUs": [
+            {
+              "assignmentType": "GpuDDA",
+              "partitionSizeMB": 0
+            }
+          ]
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic"
+            }
+          ]
+        },
+        "osProfile": {
+          "adminPassword": "password",
+          "adminUsername": "localadmin",
+          "computerName": "luamaster"
+        },
+        "securityProfile": {
+          "enableTPM": true,
+          "uefiSettings": {
+            "secureBootEnabled": true
+          }
+        },
+        "storageProfile": {
+          "imageReference": {
+            "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/galleryImages/test-gallery-image"
+          },
+          "vmConfigStoragePathId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-container"
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default",
+        "properties": {
+          "hardwareProfile": {
+            "vmSize": "Default",
+            "virtualMachineGPUs": [
+              {
+                "assignmentType": "GpuDDA",
+                "partitionSizeMB": 0
+              }
+            ]
+          },
+          "networkProfile": {
+            "networkInterfaces": [
+              {
+                "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic"
+              }
+            ]
+          },
+          "osProfile": {
+            "adminUsername": "localadmin",
+            "computerName": "luamaster"
+          },
+          "provisioningState": "Accepted",
+          "securityProfile": {
+            "enableTPM": true,
+            "uefiSettings": {
+              "secureBootEnabled": true
+            }
+          },
+          "storageProfile": {
+            "imageReference": {
+              "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/galleryImages/test-gallery-image"
+            },
+            "vmConfigStoragePathId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-container"
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default",
+        "properties": {
+          "hardwareProfile": {
+            "vmSize": "Default",
+            "virtualMachineGPUs": [
+              {
+                "assignmentType": "GpuDDA",
+                "partitionSizeMB": 0
+              }
+            ]
+          },
+          "networkProfile": {
+            "networkInterfaces": [
+              {
+                "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic"
+              }
+            ]
+          },
+          "osProfile": {
+            "adminUsername": "localadmin",
+            "computerName": "luamaster"
+          },
+          "provisioningState": "Succeeded",
+          "storageProfile": {
+            "imageReference": {
+              "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/galleryImages/test-gallery-image"
+            },
+            "vmConfigStoragePathId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-container"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "VirtualMachineInstances_CreateOrUpdate",
+  "title": "PutVirtualMachineInstanceWithGpu"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualMachineInstances_CreateOrUpdate_Put_Virtual_Machine_Instance_With_Marketplace_Gallery_Image.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualMachineInstances_CreateOrUpdate_Put_Virtual_Machine_Instance_With_Marketplace_Gallery_Image.json
@@ -1,0 +1,115 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceUri": "subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM",
+    "resource": {
+      "extendedLocation": {
+        "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+        "type": "CustomLocation"
+      },
+      "properties": {
+        "hardwareProfile": {
+          "vmSize": "Default"
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic"
+            }
+          ]
+        },
+        "osProfile": {
+          "adminPassword": "password",
+          "adminUsername": "localadmin",
+          "computerName": "luamaster"
+        },
+        "securityProfile": {
+          "enableTPM": true,
+          "uefiSettings": {
+            "secureBootEnabled": true
+          }
+        },
+        "storageProfile": {
+          "imageReference": {
+            "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/marketplaceGalleryImages/test-marketplace-gallery-image"
+          },
+          "vmConfigStoragePathId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-container"
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default",
+        "properties": {
+          "hardwareProfile": {
+            "vmSize": "Default"
+          },
+          "networkProfile": {
+            "networkInterfaces": [
+              {
+                "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic"
+              }
+            ]
+          },
+          "osProfile": {
+            "adminUsername": "localadmin",
+            "computerName": "luamaster"
+          },
+          "provisioningState": "Accepted",
+          "securityProfile": {
+            "enableTPM": true,
+            "uefiSettings": {
+              "secureBootEnabled": true
+            }
+          },
+          "storageProfile": {
+            "imageReference": {
+              "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/marketplaceGalleryImages/test-marketplace-gallery-image"
+            },
+            "vmConfigStoragePathId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-container"
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default",
+        "properties": {
+          "hardwareProfile": {
+            "vmSize": "Default"
+          },
+          "networkProfile": {
+            "networkInterfaces": [
+              {
+                "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic"
+              }
+            ]
+          },
+          "osProfile": {
+            "adminUsername": "localadmin",
+            "computerName": "luamaster"
+          },
+          "provisioningState": "Succeeded",
+          "storageProfile": {
+            "imageReference": {
+              "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/marketplaceGalleryImages/test-marketplace-gallery-image"
+            },
+            "vmConfigStoragePathId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-container"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "VirtualMachineInstances_CreateOrUpdate",
+  "title": "PutVirtualMachineInstanceWithMarketplaceGalleryImage"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualMachineInstances_CreateOrUpdate_Put_Virtual_Machine_Instance_With_Os_Disk.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualMachineInstances_CreateOrUpdate_Put_Virtual_Machine_Instance_With_Os_Disk.json
@@ -1,0 +1,102 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceUri": "subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM",
+    "resource": {
+      "extendedLocation": {
+        "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+        "type": "CustomLocation"
+      },
+      "properties": {
+        "hardwareProfile": {
+          "vmSize": "Default"
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic"
+            }
+          ]
+        },
+        "securityProfile": {
+          "enableTPM": true,
+          "uefiSettings": {
+            "secureBootEnabled": true
+          }
+        },
+        "storageProfile": {
+          "osDisk": {
+            "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/virtualHardDisks/test-vhd"
+          },
+          "vmConfigStoragePathId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-container"
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default",
+        "properties": {
+          "hardwareProfile": {
+            "vmSize": "Default"
+          },
+          "networkProfile": {
+            "networkInterfaces": [
+              {
+                "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic"
+              }
+            ]
+          },
+          "provisioningState": "Accepted",
+          "securityProfile": {
+            "enableTPM": true,
+            "uefiSettings": {
+              "secureBootEnabled": true
+            }
+          },
+          "storageProfile": {
+            "osDisk": {
+              "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/virtualHardDisks/test-vhd"
+            },
+            "vmConfigStoragePathId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-container"
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default",
+        "properties": {
+          "hardwareProfile": {
+            "vmSize": "Default"
+          },
+          "networkProfile": {
+            "networkInterfaces": [
+              {
+                "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic"
+              }
+            ]
+          },
+          "provisioningState": "Succeeded",
+          "storageProfile": {
+            "osDisk": {
+              "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/virtualHardDisks/test-vhd"
+            },
+            "vmConfigStoragePathId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-container"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "VirtualMachineInstances_CreateOrUpdate",
+  "title": "PutVirtualMachineInstanceWithOsDisk"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualMachineInstances_CreateOrUpdate_Put_Virtual_Machine_Instance_With_Vm_Config_Agent.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualMachineInstances_CreateOrUpdate_Put_Virtual_Machine_Instance_With_Vm_Config_Agent.json
@@ -1,0 +1,146 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceUri": "subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM",
+    "resource": {
+      "extendedLocation": {
+        "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+        "type": "CustomLocation"
+      },
+      "properties": {
+        "hardwareProfile": {
+          "vmSize": "Default"
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic"
+            }
+          ]
+        },
+        "osProfile": {
+          "adminPassword": "password",
+          "adminUsername": "localadmin",
+          "computerName": "luamaster",
+          "windowsConfiguration": {
+            "provisionVMConfigAgent": true
+          }
+        },
+        "securityProfile": {
+          "enableTPM": true,
+          "uefiSettings": {
+            "secureBootEnabled": true
+          }
+        },
+        "storageProfile": {
+          "imageReference": {
+            "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/galleryImages/test-gallery-image"
+          },
+          "vmConfigStoragePathId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-container"
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default",
+        "properties": {
+          "hardwareProfile": {
+            "vmSize": "Default"
+          },
+          "instanceView": {
+            "vmAgent": {
+              "statuses": [
+                {
+                  "code": "Ok",
+                  "displayStatus": "Ok",
+                  "level": "Info",
+                  "message": "The agent is healthy",
+                  "time": "2009-06-15T13:45:30"
+                }
+              ],
+              "vmConfigAgentVersion": "1.0.0"
+            }
+          },
+          "networkProfile": {
+            "networkInterfaces": [
+              {
+                "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic"
+              }
+            ]
+          },
+          "osProfile": {
+            "adminUsername": "localadmin",
+            "computerName": "luamaster"
+          },
+          "provisioningState": "Accepted",
+          "securityProfile": {
+            "enableTPM": true,
+            "uefiSettings": {
+              "secureBootEnabled": true
+            }
+          },
+          "storageProfile": {
+            "imageReference": {
+              "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/galleryImages/test-gallery-image"
+            },
+            "vmConfigStoragePathId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-container"
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default",
+        "properties": {
+          "hardwareProfile": {
+            "vmSize": "Default"
+          },
+          "instanceView": {
+            "vmAgent": {
+              "statuses": [
+                {
+                  "code": "Ok",
+                  "displayStatus": "Ok",
+                  "level": "Info",
+                  "message": "The agent is healthy",
+                  "time": "2009-06-15T13:45:30"
+                }
+              ],
+              "vmConfigAgentVersion": "1.0.0"
+            }
+          },
+          "networkProfile": {
+            "networkInterfaces": [
+              {
+                "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic"
+              }
+            ]
+          },
+          "osProfile": {
+            "adminUsername": "localadmin",
+            "computerName": "luamaster"
+          },
+          "provisioningState": "Succeeded",
+          "storageProfile": {
+            "imageReference": {
+              "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/galleryImages/test-gallery-image"
+            },
+            "vmConfigStoragePathId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-container"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "VirtualMachineInstances_CreateOrUpdate",
+  "title": "PutVirtualMachineInstanceWithVMConfigAgent"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualMachineInstances_Delete.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualMachineInstances_Delete.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceUri": "subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "VirtualMachineInstances_Delete",
+  "title": "DeleteVirtualMachine"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualMachineInstances_Get.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualMachineInstances_Get.json
@@ -1,0 +1,44 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceUri": "subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.AzureStackHCI/virtualMachineInstances",
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default",
+        "properties": {
+          "hardwareProfile": {
+            "vmSize": "Default"
+          },
+          "networkProfile": {
+            "networkInterfaces": [
+              {
+                "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic"
+              }
+            ]
+          },
+          "osProfile": {
+            "adminUsername": "localadmin",
+            "computerName": "luamaster"
+          },
+          "provisioningState": "Accepted",
+          "storageProfile": {
+            "imageReference": {
+              "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/galleryImages/test-gallery-image"
+            },
+            "vmConfigStoragePathId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-container"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "VirtualMachineInstances_Get",
+  "title": "GetVirtualMachineInstance"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualMachineInstances_List.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualMachineInstances_List.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceUri": "subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "default",
+            "type": "Microsoft.AzureStackHCI/virtualMachineInstances",
+            "extendedLocation": {
+              "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+              "type": "CustomLocation"
+            },
+            "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default",
+            "properties": {
+              "hardwareProfile": {
+                "vmSize": "Default"
+              },
+              "networkProfile": {
+                "networkInterfaces": [
+                  {
+                    "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic"
+                  }
+                ]
+              },
+              "osProfile": {
+                "adminUsername": "localadmin",
+                "computerName": "luamaster"
+              },
+              "provisioningState": "Accepted",
+              "storageProfile": {
+                "imageReference": {
+                  "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/galleryImages/test-gallery-image"
+                },
+                "vmConfigStoragePathId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-container"
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "VirtualMachineInstances_List",
+  "title": "ListVirtualMachineInstances"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualMachineInstances_Pause.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualMachineInstances_Pause.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceUri": "subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/Microsoft.HybridCompute/machines/DemoVM/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "VirtualMachineInstances_Pause",
+  "title": "PauseVirtualMachine"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualMachineInstances_PowerOff.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualMachineInstances_PowerOff.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceUri": "subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default",
+    "body": {
+      "skipShutdown": false
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default/operations/poweroff",
+        "name": "poweroff",
+        "status": "Succeeded",
+        "startTime": "2026-01-20T00:00:00Z",
+        "endTime": "2026-01-20T00:01:00Z"
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "VirtualMachineInstances_PowerOff",
+  "title": "PowerOffVirtualMachine"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualMachineInstances_Restart.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualMachineInstances_Restart.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceUri": "subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "VirtualMachineInstances_Restart",
+  "title": "RestartVirtualMachine"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualMachineInstances_Save.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualMachineInstances_Save.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceUri": "subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/Microsoft.HybridCompute/machines/DemoVM/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "VirtualMachineInstances_Save",
+  "title": "SaveVirtualMachine"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualMachineInstances_Start.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualMachineInstances_Start.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceUri": "subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "VirtualMachineInstances_Start",
+  "title": "StartVirtualMachine"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualMachineInstances_Stop.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualMachineInstances_Stop.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceUri": "subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "VirtualMachineInstances_Stop",
+  "title": "StopVirtualMachine"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualMachineInstances_Update.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualMachineInstances_Update.json
@@ -1,0 +1,64 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceUri": "subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM",
+    "properties": {
+      "properties": {
+        "storageProfile": {
+          "dataDisks": [
+            {
+              "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/virtualHardDisks/test-vhd"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.AzureStackHCI/virtualMachineInstances",
+        "extendedLocation": {
+          "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default",
+        "properties": {
+          "hardwareProfile": {
+            "vmSize": "Default"
+          },
+          "networkProfile": {
+            "networkInterfaces": [
+              {
+                "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic"
+              }
+            ]
+          },
+          "osProfile": {
+            "adminUsername": "localadmin",
+            "computerName": "luamaster"
+          },
+          "provisioningState": "Accepted",
+          "storageProfile": {
+            "dataDisks": [
+              {
+                "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/virtualHardDisks/test-vhd"
+              }
+            ],
+            "imageReference": {
+              "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/galleryImages/test-gallery-image"
+            }
+          }
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "VirtualMachineInstances_Update",
+  "title": "UpdateVirtualMachine"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualMachineInstances_Update_DynamicMemory.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualMachineInstances_Update_DynamicMemory.json
@@ -1,0 +1,61 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceUri": "subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM",
+    "properties": {
+      "properties": {
+        "hardwareProfile": {
+          "dynamicMemoryConfig": {
+            "enabled": true,
+            "minimumMemoryMB": 2048,
+            "maximumMemoryMB": 8192,
+            "targetMemoryBuffer": 20
+          }
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.AzureStackHCI/virtualMachineInstances",
+        "extendedLocation": {
+          "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default",
+        "properties": {
+          "hardwareProfile": {
+            "vmSize": "Default",
+            "dynamicMemoryConfig": {
+              "enabled": true,
+              "minimumMemoryMB": 2048,
+              "maximumMemoryMB": 8192,
+              "targetMemoryBuffer": 20
+            }
+          },
+          "networkProfile": {
+            "networkInterfaces": [
+              {
+                "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic"
+              }
+            ]
+          },
+          "osProfile": {
+            "adminUsername": "localadmin",
+            "computerName": "luamaster"
+          },
+          "provisioningState": "Accepted"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "VirtualMachineInstances_Update",
+  "title": "UpdateVirtualMachineDynamicMemory"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualMachineInstances__CreateOrUpdate_CreateFromLocal.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualMachineInstances__CreateOrUpdate_CreateFromLocal.json
@@ -1,0 +1,108 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceUri": "subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM",
+    "resource": {
+      "extendedLocation": {
+        "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+        "type": "CustomLocation"
+      },
+      "properties": {
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic"
+            }
+          ]
+        },
+        "storageProfile": {
+          "dataDisks": [
+            {
+              "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/virtualHardDisks/test-vhd"
+            }
+          ]
+        },
+        "createFromLocal": true,
+        "localVmName": "DemoVM_restored"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default",
+        "properties": {
+          "hardwareProfile": {
+            "vmSize": "Default"
+          },
+          "networkProfile": {
+            "networkInterfaces": [
+              {
+                "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic"
+              }
+            ]
+          },
+          "osProfile": {
+            "adminUsername": "localadmin",
+            "computerName": "luamaster"
+          },
+          "provisioningState": "Accepted",
+          "securityProfile": {
+            "enableTPM": true,
+            "uefiSettings": {
+              "secureBootEnabled": true
+            }
+          },
+          "storageProfile": {
+            "imageReference": {
+              "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/galleryImages/test-gallery-image"
+            },
+            "vmConfigStoragePathId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-container"
+          },
+          "createFromLocal": true,
+          "localVmName": "DemoVM_restored"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default",
+        "properties": {
+          "hardwareProfile": {
+            "vmSize": "Default"
+          },
+          "networkProfile": {
+            "networkInterfaces": [
+              {
+                "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic"
+              }
+            ]
+          },
+          "osProfile": {
+            "adminUsername": "localadmin",
+            "computerName": "luamaster"
+          },
+          "provisioningState": "Succeeded",
+          "storageProfile": {
+            "imageReference": {
+              "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/galleryImages/test-gallery-image"
+            },
+            "vmConfigStoragePathId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-container"
+          },
+          "createFromLocal": true,
+          "localVmName": "DemoVM_restored"
+        }
+      }
+    }
+  },
+  "operationId": "VirtualMachineInstances_CreateOrUpdate",
+  "title": "CreateVirtualMachineInstanceFromLocal"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualNetworkSubnets_CreateOrUpdate.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualNetworkSubnets_CreateOrUpdate.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "virtualNetworkName": "test-vnet",
+    "subnetName": "subnet1",
+    "resource": {
+      "properties": {
+        "addressPrefix": "10.0.0.0/28"
+      }
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "subnet",
+        "type": "Microsoft.AzureStackHCI/virtualNetworks/subnets",
+        "extendedLocation": {
+          "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/virtualNetworks/test-vnet/subnets/subnet1",
+        "properties": {
+          "addressPrefix": "10.0.0.0/28",
+          "provisioningState": "Accepted"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "test-vnet",
+        "type": "Microsoft.AzureStackHCI/virtualNetworks",
+        "extendedLocation": {
+          "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/virtualNetworks/test-vnet/subnets/subnet1",
+        "properties": {
+          "addressPrefix": "10.0.0.0/28",
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "VirtualNetworkSubnets_CreateOrUpdate",
+  "title": "PutVirtualNetworkSubnet"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualNetworkSubnets_Delete.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualNetworkSubnets_Delete.json
@@ -1,0 +1,23 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "virtualNetworkName": "test-vnet",
+    "resourceGroupName": "test-rg",
+    "subnetName": "subnet1",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "VirtualNetworkSubnets_Delete",
+  "title": "DeleteVirtualNetworkSubnet"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualNetworkSubnets_Get.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualNetworkSubnets_Get.json
@@ -1,0 +1,28 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "virtualNetworkName": "test-vnet",
+    "subnetName": "subnet1",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "subnet1",
+        "type": "Microsoft.AzureStackHCI/virtualNetworks/subnets",
+        "extendedLocation": {
+          "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/virtualNetworks/test-vnet/subnets/subnet1",
+        "properties": {
+          "addressPrefix": "10.0.0.0/28",
+          "provisioningState": "Accepted"
+        }
+      }
+    }
+  },
+  "operationId": "VirtualNetworkSubnets_Get",
+  "title": "GetVirtualNetworkSubnet"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualNetworkSubnets_ListByVirtualNetwork.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualNetworkSubnets_ListByVirtualNetwork.json
@@ -1,0 +1,31 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "virtualNetworkName": "test-vnet",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "subnet1",
+            "type": "Microsoft.AzureStackHCI/virtualNetworks/subnets",
+            "extendedLocation": {
+              "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+              "type": "CustomLocation"
+            },
+            "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/virtualNetworks/test-vnet/subnets/subnet1",
+            "properties": {
+              "addressPrefix": "10.0.0.0/28",
+              "provisioningState": "Accepted"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "VirtualNetworkSubnets_ListByVirtualNetwork",
+  "title": "ListVirtualNetworkSubnetsByVirtualNetwork"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualNetworkSubnets_Update.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualNetworkSubnets_Update.json
@@ -1,0 +1,43 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "virtualNetworkName": "test-vnet",
+    "subnetName": "subnet1",
+    "properties": {
+      "properties": {
+        "networkSecurityGroup": {
+          "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/networkSecurityGroups/testnsg"
+        }
+      }
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "subnet1",
+        "type": "Microsoft.AzureStackHCI/virtualNetworks/subnets",
+        "extendedLocation": {
+          "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/virtualNetworks/test-vnet/subnets/subnet1",
+        "properties": {
+          "provisioningState": "Accepted",
+          "addressPrefix": "10.0.0.0/28",
+          "networkSecurityGroup": {
+            "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/networkSecurityGroups/testnsg"
+          }
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "VirtualNetworkSubnets_Update",
+  "title": "UpdateVirtualNetworkUpdates"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualNetworks_CreateOrUpdate.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualNetworks_CreateOrUpdate.json
@@ -1,0 +1,75 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "virtualNetworkName": "test-vnet",
+    "resource": {
+      "extendedLocation": {
+        "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+        "type": "CustomLocation"
+      },
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "10.0.0.0/24"
+          ]
+        },
+        "dhcpOptions": {
+          "dnsServers": []
+        }
+      },
+      "location": "West US2"
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test-vnet",
+        "type": "Microsoft.AzureStackHCI/virtualNetworks",
+        "extendedLocation": {
+          "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/virtualNetworks/test-vnet",
+        "location": "West US2",
+        "properties": {
+          "addressSpace": {
+            "addressPrefixes": [
+              "10.0.0.0/24"
+            ]
+          },
+          "dhcpOptions": {
+            "dnsServers": []
+          },
+          "provisioningState": "Accepted"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "test-vnet",
+        "type": "Microsoft.AzureStackHCI/virtualNetworks",
+        "extendedLocation": {
+          "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/virtualNetworks/test-vnet",
+        "location": "West US2",
+        "properties": {
+          "addressSpace": {
+            "addressPrefixes": [
+              "10.0.0.0/24"
+            ]
+          },
+          "dhcpOptions": {
+            "dnsServers": []
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "VirtualNetworks_CreateOrUpdate",
+  "title": "PutVirtualNetwork"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualNetworks_Delete.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualNetworks_Delete.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "virtualNetworkName": "test-vnet",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "VirtualNetworks_Delete",
+  "title": "DeleteVirtualNetwork"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualNetworks_Get.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualNetworks_Get.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "virtualNetworkName": "test-vnet",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test-vnet",
+        "type": "Microsoft.AzureStackHCI/virtualNetworks",
+        "extendedLocation": {
+          "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/virtualNetworks/test-vnet",
+        "location": "West US2",
+        "properties": {
+          "addressSpace": {
+            "addressPrefixes": [
+              "10.0.0.0/24"
+            ]
+          },
+          "dhcpOptions": {
+            "dnsServers": []
+          },
+          "provisioningState": "Accepted"
+        }
+      }
+    }
+  },
+  "operationId": "VirtualNetworks_Get",
+  "title": "GetVirtualNetwork"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualNetworks_ListAll.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualNetworks_ListAll.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "test-vnet",
+            "type": "Microsoft.AzureStackHCI/virtualNetworks",
+            "extendedLocation": {
+              "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+              "type": "CustomLocation"
+            },
+            "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/virtualNetworks/test-vnet",
+            "location": "West US2",
+            "properties": {
+              "addressSpace": {
+                "addressPrefixes": [
+                  "10.0.0.0/24"
+                ]
+              },
+              "dhcpOptions": {
+                "dnsServers": []
+              },
+              "provisioningState": "Accepted"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "VirtualNetworks_ListAll",
+  "title": "ListVirtualNetworkBySubscription"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualNetworks_ListByResourceGroup.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualNetworks_ListByResourceGroup.json
@@ -1,0 +1,38 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "test-vnet",
+            "type": "Microsoft.AzureStackHCI/virtualNetworks",
+            "extendedLocation": {
+              "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+              "type": "CustomLocation"
+            },
+            "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/virtualNetworks/test-vnet",
+            "location": "West US2",
+            "properties": {
+              "addressSpace": {
+                "addressPrefixes": [
+                  "10.0.0.0/24"
+                ]
+              },
+              "dhcpOptions": {
+                "dnsServers": []
+              },
+              "provisioningState": "Accepted"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "VirtualNetworks_ListByResourceGroup",
+  "title": "ListVirtualNetworkByResourceGroup"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualNetworks_Update.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualNetworks_Update.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "virtualNetworkName": "test-vnet",
+    "properties": {
+      "tags": {
+        "additionalProperties": "sample"
+      }
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test-vnet",
+        "type": "Microsoft.AzureStackHCI/virtualNetworks",
+        "extendedLocation": {
+          "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/virtualNetworks/test-vnet",
+        "location": "West US2",
+        "properties": {
+          "addressSpace": {
+            "addressPrefixes": [
+              "10.0.0.0/24"
+            ]
+          },
+          "dhcpOptions": {
+            "dnsServers": []
+          },
+          "provisioningState": "Accepted"
+        },
+        "tags": {
+          "additionalProperties": "sample"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "VirtualNetworks_Update",
+  "title": "UpdateVirtualNetwork"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualNetworks_UpdateTags.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/examples/2026-07-01-preview/VirtualNetworks_UpdateTags.json
@@ -1,0 +1,50 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "virtualNetworkName": "testvnet",
+    "properties": {
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      }
+    },
+    "resourceGroupName": "testrg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testvnet",
+        "type": "Microsoft.AzureStackHCI/virtualNetworks",
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/virtualNetworks/testvnet",
+        "location": "westus",
+        "extendedLocation": {
+          "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "properties": {
+          "addressSpace": {
+            "addressPrefixes": [
+              "10.0.0.0/24"
+            ]
+          },
+          "dhcpOptions": {
+            "dnsServers": []
+          },
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "VirtualNetworks_UpdateTags",
+  "title": "Update virtual Network tags"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/main.tsp
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/main.tsp
@@ -96,4 +96,9 @@ enum Versions {
    * The 2026-04-01-preview API version.
    */
   v2026_04_01_preview: "2026-04-01-preview",
+
+  /**
+   * The 2026-07-01-preview API version.
+   */
+  v2026_07_01_preview: "2026-07-01-preview",
 }

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/models.tsp
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/models.tsp
@@ -2377,6 +2377,10 @@ model VirtualMachineInstancePropertiesHardwareProfileDynamicMemoryConfig {
 
   @doc("Defines the amount of extra memory that should be reserved for a virtual machine instance at runtime, as a percentage of the total memory that the virtual machine instance is thought to need. This only applies to virtual systems with dynamic memory enabled. This property can be in the range of 5 to 2000.")
   targetMemoryBuffer?: int32;
+
+  @added(Versions.v2026_07_01_preview)
+  @doc("Specifies whether dynamic memory is enabled for the virtual machine instance. When omitted, dynamic memory remains enabled; setting this to false converts the virtual machine instance to static memory.")
+  enabled?: boolean;
 }
 
 #suppress "@azure-tools/typespec-azure-core/casing-style" "GPU is a short form. It is the correct case."
@@ -2697,6 +2701,10 @@ model HardwareProfileUpdate {
   @doc("virtualMachineGPUs - updated list of GPUs on the virtual machine instance")
   @Azure.ResourceManager.identifiers(#[])
   virtualMachineGPUs?: VirtualMachineInstancePropertiesHardwareProfileVirtualMachineGPU[];
+
+  @added(Versions.v2026_07_01_preview)
+  @doc("Dynamic memory config for day-2 updates and static-to-dynamic conversion of the virtual machine instance.")
+  dynamicMemoryConfig?: VirtualMachineInstancePropertiesHardwareProfileDynamicMemoryConfig;
 }
 
 @doc("Storage profile update")

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/AttestationStatuses_Get.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/AttestationStatuses_Get.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceUri": "subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.AzureStackHCI/virtualMachineInstances/AttestationStatus",
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default/attestationStatus/default",
+        "properties": {
+          "attestSecureBootEnabled": "Disabled",
+          "attestationCertValidated": "Invalid",
+          "bootIntegrityValidated": "Invalid",
+          "errorMessage": "Attestation token has invalid signature",
+          "healthStatus": "Unhealthy",
+          "linuxKernelVersion": "1.0.0.0",
+          "timestamp": "2023/11/10 9:48"
+        }
+      }
+    }
+  },
+  "operationId": "AttestationStatuses_Get",
+  "title": "GetAttestationStatus"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/GalleryImages_CreateOrUpdate.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/GalleryImages_CreateOrUpdate.json
@@ -1,0 +1,100 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "galleryImageName": "test-gallery-image",
+    "resource": {
+      "extendedLocation": {
+        "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+        "type": "CustomLocation"
+      },
+      "location": "West US2",
+      "properties": {
+        "containerId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-storage-container",
+        "imagePath": "C:\\test.vhdx",
+        "osType": "Linux"
+      }
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test-gallery-image",
+        "type": "Microsoft.AzureStackHCI/galleryImages",
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/galleryImages/test-gallery-image",
+        "location": "West US2",
+        "properties": {
+          "cloudInitDataSource": "NoCloud",
+          "containerId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-storage-container",
+          "hyperVGeneration": "V2",
+          "osType": "Linux",
+          "provisioningState": "Accepted",
+          "status": {
+            "downloadStatus": {
+              "downloadSizeInMB": 9383
+            },
+            "progressPercentage": 100,
+            "provisioningStatus": {
+              "operationId": "79cfc696-44f5-4a68-a620-21850f7e9fb0",
+              "status": "Succeeded"
+            }
+          },
+          "version": {
+            "properties": {
+              "storageProfile": {
+                "osDiskImage": {
+                  "sizeInMB": 30270
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "test-gallery-image",
+        "type": "Microsoft.AzureStackHCI/galleryImages",
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/galleryImages/test-galimg3325",
+        "location": "West US2",
+        "properties": {
+          "cloudInitDataSource": "NoCloud",
+          "containerId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-storage-container",
+          "hyperVGeneration": "V2",
+          "osType": "Linux",
+          "provisioningState": "Succeeded",
+          "status": {
+            "downloadStatus": {
+              "downloadSizeInMB": 9383
+            },
+            "progressPercentage": 100,
+            "provisioningStatus": {
+              "operationId": "79cfc696-44f5-4a68-a620-21850f7e9fb0",
+              "status": "Succeeded"
+            }
+          },
+          "version": {
+            "properties": {
+              "storageProfile": {
+                "osDiskImage": {
+                  "sizeInMB": 30270
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "operationId": "GalleryImages_CreateOrUpdate",
+  "title": "PutGalleryImage"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/GalleryImages_Delete.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/GalleryImages_Delete.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "galleryImageName": "test-gallery-image",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "GalleryImages_Delete",
+  "title": "DeleteGalleryImage"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/GalleryImages_Get.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/GalleryImages_Get.json
@@ -1,0 +1,56 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "galleryImageName": "test-gallery-image",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test-gallery-image",
+        "type": "Microsoft.AzureStackHCI/galleryImages",
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/galleryImages/test-gallery-image",
+        "location": "West US2",
+        "properties": {
+          "cloudInitDataSource": "NoCloud",
+          "containerId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-storage-container",
+          "hyperVGeneration": "V1",
+          "identifier": {
+            "offer": "myOfferName",
+            "publisher": "myPublisherName",
+            "sku": "mySkuName"
+          },
+          "osType": "Windows",
+          "provisioningState": "Accepted",
+          "status": {
+            "downloadStatus": {
+              "downloadSizeInMB": 9383
+            },
+            "progressPercentage": 100,
+            "provisioningStatus": {
+              "operationId": "79cfc696-44f5-4a68-a620-21850f7e9fb0",
+              "status": "Succeeded"
+            }
+          },
+          "version": {
+            "name": "1.0.0",
+            "properties": {
+              "storageProfile": {
+                "osDiskImage": {
+                  "sizeInMB": 30270
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "operationId": "GalleryImages_Get",
+  "title": "GetGalleryImage"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/GalleryImages_ListAll.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/GalleryImages_ListAll.json
@@ -1,0 +1,52 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "test-gallery-image",
+            "type": "Microsoft.AzureStackHCI/galleryImages",
+            "extendedLocation": {
+              "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+              "type": "CustomLocation"
+            },
+            "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/galleryImages/test-gallery-image",
+            "location": "West US2",
+            "properties": {
+              "cloudInitDataSource": "NoCloud",
+              "containerId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-storage-container",
+              "hyperVGeneration": "V2",
+              "osType": "Linux",
+              "provisioningState": "Accepted",
+              "status": {
+                "downloadStatus": {
+                  "downloadSizeInMB": 9383
+                },
+                "progressPercentage": 100,
+                "provisioningStatus": {
+                  "operationId": "79cfc696-44f5-4a68-a620-21850f7e9fb0",
+                  "status": "Succeeded"
+                }
+              },
+              "version": {
+                "properties": {
+                  "storageProfile": {
+                    "osDiskImage": {
+                      "sizeInMB": 30270
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "GalleryImages_ListAll",
+  "title": "ListGalleryImageBySubscription"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/GalleryImages_ListByResourceGroup.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/GalleryImages_ListByResourceGroup.json
@@ -1,0 +1,53 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "test-gallery-image",
+            "type": "Microsoft.AzureStackHCI/galleryImages",
+            "extendedLocation": {
+              "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+              "type": "CustomLocation"
+            },
+            "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/galleryImages/test-gallery-image",
+            "location": "West US2",
+            "properties": {
+              "cloudInitDataSource": "NoCloud",
+              "containerId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-storage-container",
+              "hyperVGeneration": "V2",
+              "osType": "Linux",
+              "provisioningState": "Accepted",
+              "status": {
+                "downloadStatus": {
+                  "downloadSizeInMB": 9383
+                },
+                "progressPercentage": 100,
+                "provisioningStatus": {
+                  "operationId": "79cfc696-44f5-4a68-a620-21850f7e9fb0",
+                  "status": "Succeeded"
+                }
+              },
+              "version": {
+                "properties": {
+                  "storageProfile": {
+                    "osDiskImage": {
+                      "sizeInMB": 30270
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "GalleryImages_ListByResourceGroup",
+  "title": "ListGalleryImageByResourceGroup"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/GalleryImages_Update.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/GalleryImages_Update.json
@@ -1,0 +1,63 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "galleryImageName": "test-gallery-image",
+    "properties": {
+      "tags": {
+        "additionalProperties": "sample"
+      }
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test-gallery-image",
+        "type": "Microsoft.AzureStackHCI/galleryImages",
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/galleryImages/test-galimg3325",
+        "location": "West US2",
+        "properties": {
+          "cloudInitDataSource": "NoCloud",
+          "containerId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-storage-container",
+          "hyperVGeneration": "V2",
+          "osType": "Linux",
+          "provisioningState": "Accepted",
+          "status": {
+            "downloadStatus": {
+              "downloadSizeInMB": 9383
+            },
+            "progressPercentage": 100,
+            "provisioningStatus": {
+              "operationId": "79cfc696-44f5-4a68-a620-21850f7e9fb0",
+              "status": "Succeeded"
+            }
+          },
+          "version": {
+            "properties": {
+              "storageProfile": {
+                "osDiskImage": {
+                  "sizeInMB": 30270
+                }
+              }
+            }
+          }
+        },
+        "tags": {
+          "additionalProperties": "sample"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "GalleryImages_Update",
+  "title": "UpdateGalleryImage"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/GuestAgents_Create.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/GuestAgents_Create.json
@@ -1,0 +1,43 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resource": {
+      "properties": {
+        "credentials": {
+          "password": "<password>",
+          "username": "tempuser"
+        },
+        "provisioningAction": "install"
+      }
+    },
+    "resourceUri": "subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.AzureStackHCI/virtualMachineInstances/guestAgents",
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default/guestAgents/default",
+        "properties": {
+          "provisioningAction": "install",
+          "provisioningState": "Succeeded",
+          "status": "connected"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.AzureStackHCI/virtualMachineInstances/guestAgents",
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default/guestAgents/default",
+        "properties": {
+          "provisioningAction": "install",
+          "provisioningState": "Created",
+          "status": "connected"
+        }
+      }
+    }
+  },
+  "operationId": "GuestAgents_Create",
+  "title": "CreateGuestAgent"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/GuestAgents_Delete.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/GuestAgents_Delete.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceUri": "subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "GuestAgents_Delete",
+  "title": "DeleteGuestAgent"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/GuestAgents_Get.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/GuestAgents_Get.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceUri": "subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.AzureStackHCI/virtualMachineInstances/guestAgents",
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default/guestAgents/default",
+        "properties": {
+          "provisioningAction": "install",
+          "provisioningState": "Succeeded",
+          "status": "connected"
+        }
+      }
+    }
+  },
+  "operationId": "GuestAgents_Get",
+  "title": "GetGuestAgent"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/GuestAgents_ListByVirtualMachineInstance.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/GuestAgents_ListByVirtualMachineInstance.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceUri": "subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "default",
+            "type": "Microsoft.AzureStackHCI/virtualMachineInstances/guestAgents",
+            "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default/guestAgents/default",
+            "properties": {
+              "provisioningAction": "install",
+              "provisioningState": "Succeeded",
+              "status": "connected"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "GuestAgents_ListByVirtualMachineInstance",
+  "title": "GuestAgentListByVirtualMachineInstances"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/HybridIdentityMetadataGroup_Get.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/HybridIdentityMetadataGroup_Get.json
@@ -1,0 +1,25 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceUri": "subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.AzureStackHCI/virtualMachineInstances/hybridIdentityMetadata",
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default/hybridIdentityMetadata/default",
+        "properties": {
+          "identity": {
+            "type": "SystemAssigned",
+            "principalId": "7b5129bc-8642-4a6a-95f8-63400ca6ec4d",
+            "tenantId": "ec46ca82-5d4a-4e3e-b4b7-e27f9318645d"
+          },
+          "publicKey": "8ec7d60c-9700-40b1-8e6e-e5b2f6f477f2"
+        }
+      }
+    }
+  },
+  "operationId": "HybridIdentityMetadata_Get",
+  "title": "GetHybridIdentityMetadata"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/HybridIdentityMetadata_ListByVirtualMachineInstance.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/HybridIdentityMetadata_ListByVirtualMachineInstance.json
@@ -1,0 +1,29 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceUri": "subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "default",
+            "type": "Microsoft.AzureStackHCI/virtualMachineInstances/hybridIdentityMetadata",
+            "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default/hybridIdentityMetadata/default",
+            "properties": {
+              "identity": {
+                "type": "SystemAssigned",
+                "principalId": "7b5129bc-8642-4a6a-95f8-63400ca6ec4d",
+                "tenantId": "ec46ca82-5d4a-4e3e-b4b7-e27f9318645d"
+              },
+              "publicKey": "8ec7d60c-9700-40b1-8e6e-e5b2f6f477f2"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "HybridIdentityMetadata_ListByVirtualMachineInstance",
+  "title": "HybridIdentityMetadataListByVirtualMachineInstances"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/InboundRules_CreateOrUpdate.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/InboundRules_CreateOrUpdate.json
@@ -1,0 +1,88 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "natGatewayName": "test-nat-gw",
+    "inboundRuleName": "sample-inbound-rule",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b",
+    "resource": {
+      "extendedLocation": {
+        "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+        "type": "CustomLocation"
+      },
+      "properties": {
+        "protocol": "Tcp",
+        "frontendPort": 3389,
+        "backendPort": 3389,
+        "backendIPConfiguration": {
+          "resourceId": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic/ipConfigurations/ipconfig1"
+        },
+        "publicIPAddress": {
+          "resourceId": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/publicIPAddresses/test-public-ip"
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sample-inbound-rule",
+        "type": "Microsoft.AzureStackHCI/natGateways/inboundRules",
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/natGateways/test-nat-gw/inboundRules/sample-inbound-rule",
+        "extendedLocation": {
+          "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "properties": {
+          "protocol": "Tcp",
+          "frontendPort": 3389,
+          "backendPort": 3389,
+          "backendIPConfiguration": {
+            "resourceId": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic/ipConfigurations/ipconfig1"
+          },
+          "publicIPAddress": {
+            "resourceId": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/publicIPAddresses/test-public-ip"
+          },
+          "provisioningState": "Succeeded",
+          "status": {
+            "provisioningStatus": {
+              "operationId": "12345678-1234-1234-1234-123456789012",
+              "status": "Succeeded"
+            }
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "sample-inbound-rule",
+        "type": "Microsoft.AzureStackHCI/natGateways/inboundRules",
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/natGateways/test-nat-gw/inboundRules/sample-inbound-rule",
+        "extendedLocation": {
+          "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "properties": {
+          "protocol": "Tcp",
+          "frontendPort": 3389,
+          "backendPort": 3389,
+          "backendIPConfiguration": {
+            "resourceId": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic/ipConfigurations/ipconfig1"
+          },
+          "publicIPAddress": {
+            "resourceId": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/publicIPAddresses/test-public-ip"
+          },
+          "provisioningState": "InProgress",
+          "status": {
+            "provisioningStatus": {
+              "operationId": "12345678-1234-1234-1234-123456789012",
+              "status": "InProgress"
+            }
+          }
+        }
+      }
+    }
+  },
+  "operationId": "InboundRules_CreateOrUpdate",
+  "title": "CreateOrUpdateInboundRule"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/InboundRules_Delete.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/InboundRules_Delete.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "natGatewayName": "test-nat-gw",
+    "inboundRuleName": "sample-inbound-rule",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/providers/Microsoft.AzureStackHCI/locations/westus2/operationStatuses/12345678-1234-1234-1234-123456789012?api-version=2026-07-01-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "InboundRules_Delete",
+  "title": "DeleteInboundRule"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/InboundRules_Get.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/InboundRules_Get.json
@@ -1,0 +1,42 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "natGatewayName": "test-nat-gw",
+    "inboundRuleName": "sample-inbound-rule",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sample-inbound-rule",
+        "type": "Microsoft.AzureStackHCI/natGateways/inboundRules",
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/natGateways/test-nat-gw/inboundRules/sample-inbound-rule",
+        "extendedLocation": {
+          "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "properties": {
+          "protocol": "Tcp",
+          "frontendPort": 3389,
+          "backendPort": 3389,
+          "backendIPConfiguration": {
+            "resourceId": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic/ipConfigurations/ipconfig1"
+          },
+          "publicIPAddress": {
+            "resourceId": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/publicIPAddresses/test-public-ip"
+          },
+          "provisioningState": "Succeeded",
+          "status": {
+            "provisioningStatus": {
+              "operationId": "12345678-1234-1234-1234-123456789012",
+              "status": "Succeeded"
+            }
+          }
+        }
+      }
+    }
+  },
+  "operationId": "InboundRules_Get",
+  "title": "GetInboundRule"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/InboundRules_ListByNatGateway.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/InboundRules_ListByNatGateway.json
@@ -1,0 +1,72 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "natGatewayName": "test-nat-gw",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "rdp-inbound-rule",
+            "type": "Microsoft.AzureStackHCI/natGateways/inboundRules",
+            "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/natGateways/test-nat-gw/inboundRules/rdp-inbound-rule",
+            "extendedLocation": {
+              "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+              "type": "CustomLocation"
+            },
+            "properties": {
+              "protocol": "Tcp",
+              "frontendPort": 3389,
+              "backendPort": 3389,
+              "backendIPConfiguration": {
+                "resourceId": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic/ipConfigurations/ipconfig1"
+              },
+              "publicIPAddress": {
+                "resourceId": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/publicIPAddresses/test-public-ip"
+              },
+              "provisioningState": "Succeeded",
+              "status": {
+                "provisioningStatus": {
+                  "operationId": "12345678-1234-1234-1234-123456789012",
+                  "status": "Succeeded"
+                }
+              }
+            }
+          },
+          {
+            "name": "ssh-inbound-rule",
+            "type": "Microsoft.AzureStackHCI/natGateways/inboundRules",
+            "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/natGateways/test-nat-gw/inboundRules/ssh-inbound-rule",
+            "extendedLocation": {
+              "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+              "type": "CustomLocation"
+            },
+            "properties": {
+              "protocol": "Tcp",
+              "frontendPort": 22,
+              "backendPort": 22,
+              "backendIPConfiguration": {
+                "resourceId": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic-2/ipConfigurations/ipconfig1"
+              },
+              "publicIPAddress": {
+                "resourceId": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/publicIPAddresses/test-public-ip"
+              },
+              "provisioningState": "Succeeded",
+              "status": {
+                "provisioningStatus": {
+                  "operationId": "87654321-4321-4321-4321-210987654321",
+                  "status": "Succeeded"
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "InboundRules_ListByNatGateway",
+  "title": "ListInboundRulesByNatGateway"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/LoadBalancers_CreateOrUpdate.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/LoadBalancers_CreateOrUpdate.json
@@ -1,0 +1,318 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "loadBalancerName": "test-lb",
+    "resource": {
+      "extendedLocation": {
+        "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+        "type": "CustomLocation"
+      },
+      "properties": {
+        "frontendIPConfigurations": [
+          {
+            "name": "web-frontend",
+            "properties": {
+              "publicIPAddress": {
+                "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/publicIPs/webPublicIP"
+              }
+            }
+          }
+        ],
+        "backendAddressPools": [
+          {
+            "name": "web-backend",
+            "properties": {
+              "virtualNetwork": {
+                "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/virtualNetworks/webVNet"
+              },
+              "loadBalancerBackendAddresses": [
+                {
+                  "name": "web-server-1",
+                  "properties": {
+                    "networkInterfaceIPConfiguration": {
+                      "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/networkInterfaces/web-server-1-nic/ipConfigurations/primary"
+                    },
+                    "adminState": "Up"
+                  }
+                },
+                {
+                  "name": "web-server-2",
+                  "properties": {
+                    "networkInterfaceIPConfiguration": {
+                      "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/networkInterfaces/web-server-2-nic/ipConfigurations/primary"
+                    },
+                    "adminState": "Up"
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "probes": [
+          {
+            "name": "http-probe",
+            "properties": {
+              "protocol": "Http",
+              "port": 80,
+              "requestPath": "/health",
+              "intervalInSeconds": 15,
+              "numberOfProbes": 2
+            }
+          }
+        ],
+        "loadBalancingRules": [
+          {
+            "name": "http-rule",
+            "properties": {
+              "frontendIPConfiguration": {
+                "name": "web-frontend"
+              },
+              "backendAddressPool": {
+                "name": "web-backend"
+              },
+              "probe": {
+                "name": "http-probe"
+              },
+              "protocol": "Tcp",
+              "frontendPort": 80,
+              "backendPort": 80,
+              "loadDistribution": "Default",
+              "idleTimeoutInMinutes": 4
+            }
+          },
+          {
+            "name": "https-rule",
+            "properties": {
+              "frontendIPConfiguration": {
+                "name": "web-frontend"
+              },
+              "backendAddressPool": {
+                "name": "web-backend"
+              },
+              "protocol": "Tcp",
+              "frontendPort": 443,
+              "backendPort": 443,
+              "loadDistribution": "Default",
+              "idleTimeoutInMinutes": 4
+            }
+          }
+        ]
+      },
+      "location": "West US2"
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test-lb",
+        "type": "Microsoft.AzureStackHCI/loadBalancers",
+        "extendedLocation": {
+          "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/loadBalancers/test-lb",
+        "location": "West US2",
+        "properties": {
+          "frontendIPConfigurations": [
+            {
+              "name": "web-frontend",
+              "properties": {
+                "publicIPAddress": {
+                  "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/publicIPs/webPublicIP"
+                }
+              }
+            }
+          ],
+          "backendAddressPools": [
+            {
+              "name": "web-backend",
+              "properties": {
+                "virtualNetwork": {
+                  "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/virtualNetworks/webVNet"
+                },
+                "loadBalancerBackendAddresses": [
+                  {
+                    "name": "web-server-1",
+                    "properties": {
+                      "networkInterfaceIPConfiguration": {
+                        "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/networkInterfaces/web-server-1-nic/ipConfigurations/primary"
+                      },
+                      "adminState": "Up"
+                    }
+                  },
+                  {
+                    "name": "web-server-2",
+                    "properties": {
+                      "networkInterfaceIPConfiguration": {
+                        "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/networkInterfaces/web-server-2-nic/ipConfigurations/primary"
+                      },
+                      "adminState": "Up"
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "probes": [
+            {
+              "name": "http-probe",
+              "properties": {
+                "protocol": "Http",
+                "port": 80,
+                "requestPath": "/health",
+                "intervalInSeconds": 15,
+                "numberOfProbes": 2
+              }
+            }
+          ],
+          "loadBalancingRules": [
+            {
+              "name": "http-rule",
+              "properties": {
+                "frontendIPConfiguration": {
+                  "name": "web-frontend"
+                },
+                "backendAddressPool": {
+                  "name": "web-backend"
+                },
+                "probe": {
+                  "name": "http-probe"
+                },
+                "protocol": "Tcp",
+                "frontendPort": 80,
+                "backendPort": 80,
+                "loadDistribution": "Default",
+                "idleTimeoutInMinutes": 4
+              }
+            },
+            {
+              "name": "https-rule",
+              "properties": {
+                "frontendIPConfiguration": {
+                  "name": "web-frontend"
+                },
+                "backendAddressPool": {
+                  "name": "web-backend"
+                },
+                "protocol": "Tcp",
+                "frontendPort": 443,
+                "backendPort": 443,
+                "loadDistribution": "Default",
+                "idleTimeoutInMinutes": 4
+              }
+            }
+          ],
+          "provisioningState": "Accepted"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "test-vnet",
+        "type": "Microsoft.AzureStackHCI/loadBalancers",
+        "extendedLocation": {
+          "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/loadBalancers/test-lb",
+        "location": "West US2",
+        "properties": {
+          "frontendIPConfigurations": [
+            {
+              "name": "web-frontend",
+              "properties": {
+                "publicIPAddress": {
+                  "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/publicIPs/webPublicIP"
+                }
+              }
+            }
+          ],
+          "backendAddressPools": [
+            {
+              "name": "web-backend",
+              "properties": {
+                "virtualNetwork": {
+                  "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/virtualNetworks/webVNet"
+                },
+                "loadBalancerBackendAddresses": [
+                  {
+                    "name": "web-server-1",
+                    "properties": {
+                      "networkInterfaceIPConfiguration": {
+                        "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/networkInterfaces/web-server-1-nic/ipConfigurations/primary"
+                      },
+                      "adminState": "Up"
+                    }
+                  },
+                  {
+                    "name": "web-server-2",
+                    "properties": {
+                      "networkInterfaceIPConfiguration": {
+                        "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/networkInterfaces/web-server-2-nic/ipConfigurations/primary"
+                      },
+                      "adminState": "Up"
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "probes": [
+            {
+              "name": "http-probe",
+              "properties": {
+                "protocol": "Http",
+                "port": 80,
+                "requestPath": "/health",
+                "intervalInSeconds": 15,
+                "numberOfProbes": 2
+              }
+            }
+          ],
+          "loadBalancingRules": [
+            {
+              "name": "http-rule",
+              "properties": {
+                "frontendIPConfiguration": {
+                  "name": "web-frontend"
+                },
+                "backendAddressPool": {
+                  "name": "web-backend"
+                },
+                "probe": {
+                  "name": "http-probe"
+                },
+                "protocol": "Tcp",
+                "frontendPort": 80,
+                "backendPort": 80,
+                "loadDistribution": "Default",
+                "idleTimeoutInMinutes": 4
+              }
+            },
+            {
+              "name": "https-rule",
+              "properties": {
+                "frontendIPConfiguration": {
+                  "name": "web-frontend"
+                },
+                "backendAddressPool": {
+                  "name": "web-backend"
+                },
+                "protocol": "Tcp",
+                "frontendPort": 443,
+                "backendPort": 443,
+                "loadDistribution": "Default",
+                "idleTimeoutInMinutes": 4
+              }
+            }
+          ],
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "LoadBalancers_CreateOrUpdate",
+  "title": "PutLoadBalancer"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/LoadBalancers_Delete.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/LoadBalancers_Delete.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "loadBalancerName": "test-lb",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "LoadBalancers_Delete",
+  "title": "DeleteLoadBalancers"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/LoadBalancers_Get.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/LoadBalancers_Get.json
@@ -1,0 +1,116 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "loadBalancerName": "test-lb",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test-lb",
+        "type": "Microsoft.AzureStackHCI/loadBalancers",
+        "extendedLocation": {
+          "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/loadBalancers/test-lb",
+        "location": "West US2",
+        "properties": {
+          "frontendIPConfigurations": [
+            {
+              "name": "web-frontend",
+              "properties": {
+                "publicIPAddress": {
+                  "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/publicIPs/webPublicIP"
+                }
+              }
+            }
+          ],
+          "backendAddressPools": [
+            {
+              "name": "web-backend",
+              "properties": {
+                "virtualNetwork": {
+                  "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/virtualNetworks/webVNet"
+                },
+                "loadBalancerBackendAddresses": [
+                  {
+                    "name": "web-server-1",
+                    "properties": {
+                      "networkInterfaceIPConfiguration": {
+                        "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/networkInterfaces/web-server-1-nic/ipConfigurations/primary"
+                      },
+                      "adminState": "Up"
+                    }
+                  },
+                  {
+                    "name": "web-server-2",
+                    "properties": {
+                      "networkInterfaceIPConfiguration": {
+                        "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/networkInterfaces/web-server-2-nic/ipConfigurations/primary"
+                      },
+                      "adminState": "Up"
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "probes": [
+            {
+              "name": "http-probe",
+              "properties": {
+                "protocol": "Http",
+                "port": 80,
+                "requestPath": "/health",
+                "intervalInSeconds": 15,
+                "numberOfProbes": 2
+              }
+            }
+          ],
+          "loadBalancingRules": [
+            {
+              "name": "http-rule",
+              "properties": {
+                "frontendIPConfiguration": {
+                  "name": "web-frontend"
+                },
+                "backendAddressPool": {
+                  "name": "web-backend"
+                },
+                "probe": {
+                  "name": "http-probe"
+                },
+                "protocol": "Tcp",
+                "frontendPort": 80,
+                "backendPort": 80,
+                "loadDistribution": "Default",
+                "idleTimeoutInMinutes": 4
+              }
+            },
+            {
+              "name": "https-rule",
+              "properties": {
+                "frontendIPConfiguration": {
+                  "name": "web-frontend"
+                },
+                "backendAddressPool": {
+                  "name": "web-backend"
+                },
+                "protocol": "Tcp",
+                "frontendPort": 443,
+                "backendPort": 443,
+                "loadDistribution": "Default",
+                "idleTimeoutInMinutes": 4
+              }
+            }
+          ],
+          "provisioningState": "Accepted"
+        }
+      }
+    }
+  },
+  "operationId": "LoadBalancers_Get",
+  "title": "GetLoadBalancers"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/LoadBalancers_ListAll.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/LoadBalancers_ListAll.json
@@ -1,0 +1,118 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "test-lb",
+            "type": "Microsoft.AzureStackHCI/loadBalancers",
+            "extendedLocation": {
+              "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+              "type": "CustomLocation"
+            },
+            "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/loadBalancers/test-lb",
+            "location": "West US2",
+            "properties": {
+              "frontendIPConfigurations": [
+                {
+                  "name": "web-frontend",
+                  "properties": {
+                    "publicIPAddress": {
+                      "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/publicIPs/webPublicIP"
+                    }
+                  }
+                }
+              ],
+              "backendAddressPools": [
+                {
+                  "name": "web-backend",
+                  "properties": {
+                    "virtualNetwork": {
+                      "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/virtualNetworks/webVNet"
+                    },
+                    "loadBalancerBackendAddresses": [
+                      {
+                        "name": "web-server-1",
+                        "properties": {
+                          "networkInterfaceIPConfiguration": {
+                            "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/networkInterfaces/web-server-1-nic/ipConfigurations/primary"
+                          },
+                          "adminState": "Up"
+                        }
+                      },
+                      {
+                        "name": "web-server-2",
+                        "properties": {
+                          "networkInterfaceIPConfiguration": {
+                            "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/networkInterfaces/web-server-2-nic/ipConfigurations/primary"
+                          },
+                          "adminState": "Up"
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "probes": [
+                {
+                  "name": "http-probe",
+                  "properties": {
+                    "protocol": "Http",
+                    "port": 80,
+                    "requestPath": "/health",
+                    "intervalInSeconds": 15,
+                    "numberOfProbes": 2
+                  }
+                }
+              ],
+              "loadBalancingRules": [
+                {
+                  "name": "http-rule",
+                  "properties": {
+                    "frontendIPConfiguration": {
+                      "name": "web-frontend"
+                    },
+                    "backendAddressPool": {
+                      "name": "web-backend"
+                    },
+                    "probe": {
+                      "name": "http-probe"
+                    },
+                    "protocol": "Tcp",
+                    "frontendPort": 80,
+                    "backendPort": 80,
+                    "loadDistribution": "Default",
+                    "idleTimeoutInMinutes": 4
+                  }
+                },
+                {
+                  "name": "https-rule",
+                  "properties": {
+                    "frontendIPConfiguration": {
+                      "name": "web-frontend"
+                    },
+                    "backendAddressPool": {
+                      "name": "web-backend"
+                    },
+                    "protocol": "Tcp",
+                    "frontendPort": 443,
+                    "backendPort": 443,
+                    "loadDistribution": "Default",
+                    "idleTimeoutInMinutes": 4
+                  }
+                }
+              ],
+              "provisioningState": "Accepted"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "LoadBalancers_ListAll",
+  "title": "ListLoadBalancerBySubscription"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/LoadBalancers_ListByResourceGroup.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/LoadBalancers_ListByResourceGroup.json
@@ -1,0 +1,119 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "test-lb",
+            "type": "Microsoft.AzureStackHCI/loadBalancers",
+            "extendedLocation": {
+              "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+              "type": "CustomLocation"
+            },
+            "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/loadBalancers/test-lb",
+            "location": "West US2",
+            "properties": {
+              "frontendIPConfigurations": [
+                {
+                  "name": "web-frontend",
+                  "properties": {
+                    "publicIPAddress": {
+                      "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/publicIPs/webPublicIP"
+                    }
+                  }
+                }
+              ],
+              "backendAddressPools": [
+                {
+                  "name": "web-backend",
+                  "properties": {
+                    "virtualNetwork": {
+                      "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/virtualNetworks/webVNet"
+                    },
+                    "loadBalancerBackendAddresses": [
+                      {
+                        "name": "web-server-1",
+                        "properties": {
+                          "networkInterfaceIPConfiguration": {
+                            "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/networkInterfaces/web-server-1-nic/ipConfigurations/primary"
+                          },
+                          "adminState": "Up"
+                        }
+                      },
+                      {
+                        "name": "web-server-2",
+                        "properties": {
+                          "networkInterfaceIPConfiguration": {
+                            "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/networkInterfaces/web-server-2-nic/ipConfigurations/primary"
+                          },
+                          "adminState": "Up"
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "probes": [
+                {
+                  "name": "http-probe",
+                  "properties": {
+                    "protocol": "Http",
+                    "port": 80,
+                    "requestPath": "/health",
+                    "intervalInSeconds": 15,
+                    "numberOfProbes": 2
+                  }
+                }
+              ],
+              "loadBalancingRules": [
+                {
+                  "name": "http-rule",
+                  "properties": {
+                    "frontendIPConfiguration": {
+                      "name": "web-frontend"
+                    },
+                    "backendAddressPool": {
+                      "name": "web-backend"
+                    },
+                    "probe": {
+                      "name": "http-probe"
+                    },
+                    "protocol": "Tcp",
+                    "frontendPort": 80,
+                    "backendPort": 80,
+                    "loadDistribution": "Default",
+                    "idleTimeoutInMinutes": 4
+                  }
+                },
+                {
+                  "name": "https-rule",
+                  "properties": {
+                    "frontendIPConfiguration": {
+                      "name": "web-frontend"
+                    },
+                    "backendAddressPool": {
+                      "name": "web-backend"
+                    },
+                    "protocol": "Tcp",
+                    "frontendPort": 443,
+                    "backendPort": 443,
+                    "loadDistribution": "Default",
+                    "idleTimeoutInMinutes": 4
+                  }
+                }
+              ],
+              "provisioningState": "Accepted"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "LoadBalancers_ListByResourceGroup",
+  "title": "ListLoadBalancerByResourceGroup"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/LoadBalancers_UpdateTags.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/LoadBalancers_UpdateTags.json
@@ -1,0 +1,131 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "loadBalancerName": "test-lb",
+    "properties": {
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      }
+    },
+    "resourceGroupName": "testrg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test-lb",
+        "type": "Microsoft.AzureStackHCI/loadBalancers",
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/loadBalancers/test-lb",
+        "location": "westus",
+        "extendedLocation": {
+          "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "properties": {
+          "frontendIPConfigurations": [
+            {
+              "name": "web-frontend",
+              "properties": {
+                "publicIPAddress": {
+                  "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/publicIPs/webPublicIP"
+                }
+              }
+            }
+          ],
+          "backendAddressPools": [
+            {
+              "name": "web-backend",
+              "properties": {
+                "virtualNetwork": {
+                  "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/virtualNetworks/webVNet"
+                },
+                "loadBalancerBackendAddresses": [
+                  {
+                    "name": "web-server-1",
+                    "properties": {
+                      "networkInterfaceIPConfiguration": {
+                        "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/networkInterfaces/web-server-1-nic/ipConfigurations/primary"
+                      },
+                      "adminState": "Up"
+                    }
+                  },
+                  {
+                    "name": "web-server-2",
+                    "properties": {
+                      "networkInterfaceIPConfiguration": {
+                        "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/networkInterfaces/web-server-2-nic/ipConfigurations/primary"
+                      },
+                      "adminState": "Up"
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "probes": [
+            {
+              "name": "http-probe",
+              "properties": {
+                "protocol": "Http",
+                "port": 80,
+                "requestPath": "/health",
+                "intervalInSeconds": 15,
+                "numberOfProbes": 2
+              }
+            }
+          ],
+          "loadBalancingRules": [
+            {
+              "name": "http-rule",
+              "properties": {
+                "frontendIPConfiguration": {
+                  "name": "web-frontend"
+                },
+                "backendAddressPool": {
+                  "name": "web-backend"
+                },
+                "probe": {
+                  "name": "http-probe"
+                },
+                "protocol": "Tcp",
+                "frontendPort": 80,
+                "backendPort": 80,
+                "loadDistribution": "Default",
+                "idleTimeoutInMinutes": 4
+              }
+            },
+            {
+              "name": "https-rule",
+              "properties": {
+                "frontendIPConfiguration": {
+                  "name": "web-frontend"
+                },
+                "backendAddressPool": {
+                  "name": "web-backend"
+                },
+                "protocol": "Tcp",
+                "frontendPort": 443,
+                "backendPort": 443,
+                "loadDistribution": "Default",
+                "idleTimeoutInMinutes": 4
+              }
+            }
+          ],
+          "provisioningState": "Accepted"
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "LoadBalancers_UpdateTags",
+  "title": "Update LoadBalancers tags"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/LogicalNetworks_CreateOrUpdate.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/LogicalNetworks_CreateOrUpdate.json
@@ -1,0 +1,49 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "logicalNetworkName": "test-lnet",
+    "resource": {
+      "extendedLocation": {
+        "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+        "type": "CustomLocation"
+      },
+      "location": "West US2"
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test-lnet",
+        "type": "Microsoft.AzureStackHCI/logicalNetworks",
+        "extendedLocation": {
+          "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/logicalNetworks/test-lnet",
+        "location": "West US2",
+        "properties": {
+          "provisioningState": "Accepted"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "test-lnet",
+        "type": "Microsoft.AzureStackHCI/logicalNetworks",
+        "extendedLocation": {
+          "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/logicalNetworks/test-lnet",
+        "location": "West US2",
+        "properties": {
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "LogicalNetworks_CreateOrUpdate",
+  "title": "PutLogicalNetwork"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/LogicalNetworks_Delete.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/LogicalNetworks_Delete.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "logicalNetworkName": "test-lnet",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "LogicalNetworks_Delete",
+  "title": "DeleteLogicalNetwork"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/LogicalNetworks_Get.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/LogicalNetworks_Get.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "logicalNetworkName": "test-lnet",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test-lnet",
+        "type": "Microsoft.AzureStackHCI/logicalNetworks",
+        "extendedLocation": {
+          "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/logicalNetworks/test-lnet",
+        "location": "West US2",
+        "properties": {
+          "provisioningState": "Accepted"
+        }
+      }
+    }
+  },
+  "operationId": "LogicalNetworks_Get",
+  "title": "GetLogicalNetwork"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/LogicalNetworks_ListAll.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/LogicalNetworks_ListAll.json
@@ -1,0 +1,29 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "test-lnet",
+            "type": "Microsoft.AzureStackHCI/logicalNetworks",
+            "extendedLocation": {
+              "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+              "type": "CustomLocation"
+            },
+            "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/logicalNetworks/test-lnet",
+            "location": "West US2",
+            "properties": {
+              "provisioningState": "Accepted"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "LogicalNetworks_ListAll",
+  "title": "ListLogicalNetworkBySubscription"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/LogicalNetworks_ListByResourceGroup.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/LogicalNetworks_ListByResourceGroup.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "test-lnet",
+            "type": "Microsoft.AzureStackHCI/logicalNetworks",
+            "extendedLocation": {
+              "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+              "type": "CustomLocation"
+            },
+            "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/logicalNetworks/test-lnet",
+            "location": "West US2",
+            "properties": {
+              "provisioningState": "Accepted"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "LogicalNetworks_ListByResourceGroup",
+  "title": "ListLogicalNetworkByResourceGroup"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/LogicalNetworks_Update.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/LogicalNetworks_Update.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "logicalNetworkName": "test-lnet",
+    "properties": {
+      "tags": {
+        "additionalProperties": "sample"
+      }
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test-lnet",
+        "type": "Microsoft.AzureStackHCI/logicalNetworks",
+        "extendedLocation": {
+          "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/logicalNetworks/test-lnet",
+        "location": "West US2",
+        "properties": {
+          "provisioningState": "Accepted"
+        },
+        "tags": {
+          "additionalProperties": "sample"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "LogicalNetworks_Update",
+  "title": "UpdateLogicalNetwork"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/MarketplaceGalleryImages_CreateOrUpdate.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/MarketplaceGalleryImages_CreateOrUpdate.json
@@ -1,0 +1,122 @@
+{
+  "parameters": {
+    "name": "test-marketplace-gallery-image",
+    "api-version": "2026-07-01-preview",
+    "marketplaceGalleryImageName": "test-marketplace-gallery-image",
+    "resource": {
+      "extendedLocation": {
+        "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+        "type": "CustomLocation"
+      },
+      "location": "West US2",
+      "properties": {
+        "cloudInitDataSource": "Azure",
+        "containerId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-storage-container",
+        "hyperVGeneration": "V1",
+        "identifier": {
+          "offer": "myOfferName",
+          "publisher": "myPublisherName",
+          "sku": "mySkuName"
+        },
+        "osType": "Windows",
+        "version": {
+          "name": "1.0.0"
+        }
+      }
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test-marketplace-gallery-image",
+        "type": "Microsoft.AzureStackHCI/marketplaceGalleryImages",
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/marketplaceGalleryImages/test-marketplace-gallery-image",
+        "location": "West US2",
+        "properties": {
+          "cloudInitDataSource": "Azure",
+          "containerId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-storage-container",
+          "hyperVGeneration": "V1",
+          "identifier": {
+            "offer": "myOfferName",
+            "publisher": "myPublisherName",
+            "sku": "mySkuName"
+          },
+          "osType": "Windows",
+          "provisioningState": "Accepted",
+          "status": {
+            "downloadStatus": {
+              "downloadSizeInMB": 9383
+            },
+            "progressPercentage": 0,
+            "provisioningStatus": {
+              "operationId": "79cfc696-44f5-4a68-a620-21850f7e9fb0",
+              "status": "InProgress"
+            }
+          },
+          "version": {
+            "name": "1.0.0",
+            "properties": {
+              "storageProfile": {
+                "osDiskImage": {
+                  "sizeInMB": 30270
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "test-marketplace-gallery-image",
+        "type": "Microsoft.AzureStackHCI/marketplaceGalleryImages",
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/marketplaceGalleryImages/test-marketplace-gallery-image",
+        "location": "West US2",
+        "properties": {
+          "cloudInitDataSource": "Azure",
+          "containerId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-storage-container",
+          "hyperVGeneration": "V1",
+          "identifier": {
+            "offer": "myOfferName",
+            "publisher": "myPublisherName",
+            "sku": "mySkuName"
+          },
+          "osType": "Windows",
+          "provisioningState": "Creating",
+          "status": {
+            "downloadStatus": {
+              "downloadSizeInMB": 9383
+            },
+            "progressPercentage": 100,
+            "provisioningStatus": {
+              "operationId": "79cfc696-44f5-4a68-a620-21850f7e9fb0",
+              "status": "Succeeded"
+            }
+          },
+          "version": {
+            "name": "1.0.0",
+            "properties": {
+              "storageProfile": {
+                "osDiskImage": {
+                  "sizeInMB": 30270
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "operationId": "MarketplaceGalleryImages_CreateOrUpdate",
+  "title": "PutMarketplaceGalleryImage"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/MarketplaceGalleryImages_Delete.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/MarketplaceGalleryImages_Delete.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "marketplaceGalleryImageName": "test-marketplace-gallery-image",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "MarketplaceGalleryImages_Delete",
+  "title": "DeleteMarketplaceGalleryImage"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/MarketplaceGalleryImages_Get.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/MarketplaceGalleryImages_Get.json
@@ -1,0 +1,56 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "marketplaceGalleryImageName": "test-marketplace-gallery-image",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test-marketplace-gallery-image",
+        "type": "Microsoft.AzureStackHCI/marketplaceGalleryImages",
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/marketplaceGalleryImages/test-marketplace-gallery-image",
+        "location": "West US2",
+        "properties": {
+          "cloudInitDataSource": "NoCloud",
+          "containerId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-storage-container",
+          "hyperVGeneration": "V1",
+          "identifier": {
+            "offer": "myOfferName",
+            "publisher": "myPublisherName",
+            "sku": "mySkuName"
+          },
+          "osType": "Windows",
+          "provisioningState": "Accepted",
+          "status": {
+            "downloadStatus": {
+              "downloadSizeInMB": 9383
+            },
+            "progressPercentage": 100,
+            "provisioningStatus": {
+              "operationId": "79cfc696-44f5-4a68-a620-21850f7e9fb0",
+              "status": "Succeeded"
+            }
+          },
+          "version": {
+            "name": "1.0.0",
+            "properties": {
+              "storageProfile": {
+                "osDiskImage": {
+                  "sizeInMB": 30270
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "operationId": "MarketplaceGalleryImages_Get",
+  "title": "GetMarketplaceGalleryImage"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/MarketplaceGalleryImages_ListAll.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/MarketplaceGalleryImages_ListAll.json
@@ -1,0 +1,58 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "test-marketplace-gallery-image",
+            "type": "Microsoft.AzureStackHCI/marketplaceGalleryImages",
+            "extendedLocation": {
+              "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+              "type": "CustomLocation"
+            },
+            "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/marketplaceGalleryImages/test-marketplace-gallery-image",
+            "location": "West US2",
+            "properties": {
+              "cloudInitDataSource": "Azure",
+              "containerId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-storage-container",
+              "hyperVGeneration": "V1",
+              "identifier": {
+                "offer": "myOfferName",
+                "publisher": "myPublisherName",
+                "sku": "mySkuName"
+              },
+              "osType": "Windows",
+              "provisioningState": "Accepted",
+              "status": {
+                "downloadStatus": {
+                  "downloadSizeInMB": 9383
+                },
+                "progressPercentage": 100,
+                "provisioningStatus": {
+                  "operationId": "79cfc696-44f5-4a68-a620-21850f7e9fb0",
+                  "status": "Succeeded"
+                }
+              },
+              "version": {
+                "name": "1.0.0",
+                "properties": {
+                  "storageProfile": {
+                    "osDiskImage": {
+                      "sizeInMB": 30270
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "MarketplaceGalleryImages_ListAll",
+  "title": "ListMarketplaceGalleryImageBySubscription"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/MarketplaceGalleryImages_ListByResourceGroup.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/MarketplaceGalleryImages_ListByResourceGroup.json
@@ -1,0 +1,59 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "test-marketplace-gallery-image",
+            "type": "Microsoft.AzureStackHCI/marketplaceGalleryImages",
+            "extendedLocation": {
+              "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+              "type": "CustomLocation"
+            },
+            "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/marketplaceGalleryImages/test-marketplace-gallery-image",
+            "location": "West US2",
+            "properties": {
+              "cloudInitDataSource": "Azure",
+              "containerId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-storage-container",
+              "hyperVGeneration": "V1",
+              "identifier": {
+                "offer": "myOfferName",
+                "publisher": "myPublisherName",
+                "sku": "mySkuName"
+              },
+              "osType": "Windows",
+              "provisioningState": "Accepted",
+              "status": {
+                "downloadStatus": {
+                  "downloadSizeInMB": 9383
+                },
+                "progressPercentage": 100,
+                "provisioningStatus": {
+                  "operationId": "79cfc696-44f5-4a68-a620-21850f7e9fb0",
+                  "status": "Succeeded"
+                }
+              },
+              "version": {
+                "name": "1.0.0",
+                "properties": {
+                  "storageProfile": {
+                    "osDiskImage": {
+                      "sizeInMB": 30270
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "MarketplaceGalleryImages_ListByResourceGroup",
+  "title": "ListMarketplaceGalleryImageByResourceGroup"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/MarketplaceGalleryImages_Update.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/MarketplaceGalleryImages_Update.json
@@ -1,0 +1,69 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "marketplaceGalleryImageName": "test-marketplce-gallery-image",
+    "properties": {
+      "tags": {
+        "additionalProperties": "sample"
+      }
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test-marketplace-gallery-image",
+        "type": "Microsoft.AzureStackHCI/marketplaceGalleryImages",
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/marketplaceGalleryImages/test-marketplace-gallery-image",
+        "location": "West US2",
+        "properties": {
+          "cloudInitDataSource": "Azure",
+          "containerId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-storage-container",
+          "hyperVGeneration": "V1",
+          "identifier": {
+            "offer": "myOfferName",
+            "publisher": "myPublisherName",
+            "sku": "mySkuName"
+          },
+          "osType": "Windows",
+          "provisioningState": "Accepted",
+          "status": {
+            "downloadStatus": {
+              "downloadSizeInMB": 9383
+            },
+            "progressPercentage": 0,
+            "provisioningStatus": {
+              "operationId": "79cfc696-44f5-4a68-a620-21850f7e9fb0",
+              "status": "InProgress"
+            }
+          },
+          "version": {
+            "name": "1.0.0",
+            "properties": {
+              "storageProfile": {
+                "osDiskImage": {
+                  "sizeInMB": 30270
+                }
+              }
+            }
+          }
+        },
+        "tags": {
+          "additionalProperties": "sample"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "MarketplaceGalleryImages_Update",
+  "title": "UpdateMarketplaceGalleryImage"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/NatGateways_CreateOrUpdate.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/NatGateways_CreateOrUpdate.json
@@ -1,0 +1,66 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "natGatewayName": "test-nat-gw",
+    "resource": {
+      "extendedLocation": {
+        "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+        "type": "CustomLocation"
+      },
+      "properties": {
+        "publicIPAddresses": [
+          {
+            "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/publicIPAddresses/outbound-pip"
+          }
+        ]
+      },
+      "location": "West US2"
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test-nat-gw",
+        "type": "Microsoft.AzureStackHCI/natGateways",
+        "extendedLocation": {
+          "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/natGateways/test-nat-gw",
+        "location": "West US2",
+        "properties": {
+          "publicIPAddresses": [
+            {
+              "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/publicIPAddresses/outbound-pip"
+            }
+          ],
+          "provisioningState": "Accepted"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "test-nat-gw",
+        "type": "Microsoft.AzureStackHCI/natGateways",
+        "extendedLocation": {
+          "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/natGateways/test-nat-gw",
+        "location": "West US2",
+        "properties": {
+          "publicIPAddresses": [
+            {
+              "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/publicIPAddresses/outbound-pip"
+            }
+          ],
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "NatGateways_CreateOrUpdate",
+  "title": "PutNatGateway"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/NatGateways_Delete.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/NatGateways_Delete.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "natGatewayName": "test-nat-gw",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "NatGateways_Delete",
+  "title": "DeleteNatGateway"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/NatGateways_Get.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/NatGateways_Get.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "natGatewayName": "test-nat-gw",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test-nat-gw",
+        "type": "Microsoft.AzureStackHCI/natGateways",
+        "extendedLocation": {
+          "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/natGateways/test-nat-gw",
+        "location": "West US2",
+        "properties": {
+          "publicIPAddresses": [
+            {
+              "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/publicIPAddresses/outbound-pip"
+            }
+          ],
+          "subnets": [
+            {
+              "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/virtualNetworks/main-vnet/subnets/workload-subnet"
+            }
+          ],
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "NatGateways_Get",
+  "title": "GetNatGateway"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/NatGateways_ListAll.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/NatGateways_ListAll.json
@@ -1,0 +1,39 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "testnatgw",
+            "type": "Microsoft.AzureStackHCI/natGateways",
+            "extendedLocation": {
+              "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+              "type": "CustomLocation"
+            },
+            "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/natGateways/testnatgw",
+            "location": "West US2",
+            "properties": {
+              "publicIPAddresses": [
+                {
+                  "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/publicIPAddresses/outbound-pip"
+                }
+              ],
+              "subnets": [
+                {
+                  "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/virtualNetworks/main-vnet/subnets/workload-subnet"
+                }
+              ],
+              "provisioningState": "Succeeded"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "NatGateways_ListAll",
+  "title": "ListNatGatewayBySubscription"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/NatGateways_ListByResourceGroup.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/NatGateways_ListByResourceGroup.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "testnatgw",
+            "type": "Microsoft.AzureStackHCI/natGateways",
+            "extendedLocation": {
+              "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+              "type": "CustomLocation"
+            },
+            "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/natGateways/testnatgw",
+            "location": "West US2",
+            "properties": {
+              "publicIPAddresses": [
+                {
+                  "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/publicIPAddresses/outbound-pip"
+                }
+              ],
+              "subnets": [
+                {
+                  "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/virtualNetworks/main-vnet/subnets/workload-subnet"
+                }
+              ],
+              "provisioningState": "Succeeded"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "NatGateways_ListByResourceGroup",
+  "title": "ListNatGatewayByResourceGroup"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/NatGateways_UpdateTags.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/NatGateways_UpdateTags.json
@@ -1,0 +1,52 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "natGatewayName": "testnatgw",
+    "properties": {
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      }
+    },
+    "resourceGroupName": "testrg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testnatgw",
+        "type": "Microsoft.AzureStackHCI/natGateways",
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/natGateways/testnatgw",
+        "location": "westus",
+        "extendedLocation": {
+          "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "properties": {
+          "publicIPAddresses": [
+            {
+              "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/publicIPAddresses/outbound-pip"
+            }
+          ],
+          "subnets": [
+            {
+              "resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/azure-local-rg/providers/Microsoft.AzureStackHCI/virtualNetworks/main-vnet/subnets/workload-subnet"
+            }
+          ],
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "NatGateways_UpdateTags",
+  "title": "Update natGateway tags"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/NetworkInterfaces_CreateOrUpdate.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/NetworkInterfaces_CreateOrUpdate.json
@@ -1,0 +1,81 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "networkInterfaceName": "test-nic",
+    "resource": {
+      "extendedLocation": {
+        "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+        "type": "CustomLocation"
+      },
+      "location": "eastus",
+      "properties": {
+        "ipConfigurations": [
+          {
+            "name": "ipconfig-sample",
+            "properties": {
+              "subnet": {
+                "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/logicalNetworks/test-lnet"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test-nic",
+        "type": "Microsoft.AzureStackHCI/networkInterfaces",
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic",
+        "location": "West US2",
+        "properties": {
+          "ipConfigurations": [
+            {
+              "name": "ipconfig-sample",
+              "properties": {
+                "subnet": {
+                  "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/logicalNetworks/test-lnet"
+                }
+              }
+            }
+          ],
+          "provisioningState": "Accepted"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "test-nic",
+        "type": "Microsoft.AzureStackHCI/networkInterfaces",
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic",
+        "location": "West US2",
+        "properties": {
+          "ipConfigurations": [
+            {
+              "name": "ipconfig-sample",
+              "properties": {
+                "subnet": {
+                  "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/logicalNetworks/test-lnet"
+                }
+              }
+            }
+          ],
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "NetworkInterfaces_CreateOrUpdate",
+  "title": "PutNetworkInterface"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/NetworkInterfaces_Delete.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/NetworkInterfaces_Delete.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "networkInterfaceName": "test-nic",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "NetworkInterfaces_Delete",
+  "title": "DeleteNetworkInterface"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/NetworkInterfaces_Get.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/NetworkInterfaces_Get.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "networkInterfaceName": "test-nic",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test-nic",
+        "type": "Microsoft.AzureStackHCI/networkInterfaces",
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic",
+        "location": "West US2",
+        "properties": {
+          "ipConfigurations": [
+            {
+              "name": "ipconfig-sample",
+              "properties": {
+                "subnet": {
+                  "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/logicalNetworks/test-lnet"
+                }
+              }
+            }
+          ],
+          "provisioningState": "Accepted"
+        }
+      }
+    }
+  },
+  "operationId": "NetworkInterfaces_Get",
+  "title": "GetNetworkInterface"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/NetworkInterfaces_ListAll.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/NetworkInterfaces_ListAll.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "networkInterfaceName": "test-nic",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "test-nic",
+            "type": "Microsoft.AzureStackHCI/networkInterfaces",
+            "extendedLocation": {
+              "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+              "type": "CustomLocation"
+            },
+            "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic",
+            "location": "West US2",
+            "properties": {
+              "ipConfigurations": [
+                {
+                  "name": "ipconfig-sample",
+                  "properties": {
+                    "subnet": {
+                      "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/logicalNetworks/test-lnet"
+                    }
+                  }
+                }
+              ],
+              "provisioningState": "Accepted"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "NetworkInterfaces_ListAll",
+  "title": "ListNetworkInterfaceBySubscription"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/NetworkInterfaces_ListByResourceGroup.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/NetworkInterfaces_ListByResourceGroup.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "networkInterfaceName": "test-nic",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "test-nic",
+            "type": "Microsoft.AzureStackHCI/networkInterfaces",
+            "extendedLocation": {
+              "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+              "type": "CustomLocation"
+            },
+            "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic",
+            "location": "West US2",
+            "properties": {
+              "ipConfigurations": [
+                {
+                  "name": "ipconfig-sample",
+                  "properties": {
+                    "subnet": {
+                      "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/logicalNetworks/test-lnet"
+                    }
+                  }
+                }
+              ],
+              "provisioningState": "Accepted"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "NetworkInterfaces_ListByResourceGroup",
+  "title": "ListNetworkInterfaceByResourceGroup"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/NetworkInterfaces_Update.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/NetworkInterfaces_Update.json
@@ -1,0 +1,47 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "networkInterfaceName": "test-nic",
+    "properties": {
+      "tags": {
+        "additionalProperties": "sample"
+      }
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test-nic",
+        "type": "Microsoft.AzureStackHCI/networkInterfaces",
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic",
+        "location": "West US2",
+        "properties": {
+          "ipConfigurations": [
+            {
+              "name": "ipconfig-sample",
+              "properties": {
+                "subnet": {
+                  "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/logicalNetworks/test-lnet"
+                }
+              }
+            }
+          ],
+          "provisioningState": "Accepted"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "NetworkInterfaces_Update",
+  "title": "UpdateNetworkInterface"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/NetworkInterfaces__CreateOrUpdate_CreateFromLocal.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/NetworkInterfaces__CreateOrUpdate_CreateFromLocal.json
@@ -1,0 +1,84 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "networkInterfaceName": "test-nic",
+    "resource": {
+      "extendedLocation": {
+        "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+        "type": "CustomLocation"
+      },
+      "location": "eastus",
+      "properties": {
+        "ipConfigurations": [
+          {
+            "name": "ipconfig-sample",
+            "properties": {
+              "subnet": {
+                "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/logicalNetworks/test-lnet"
+              }
+            }
+          }
+        ],
+        "createFromLocal": true
+      }
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test-nic",
+        "type": "Microsoft.AzureStackHCI/networkInterfaces",
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic",
+        "location": "West US2",
+        "properties": {
+          "ipConfigurations": [
+            {
+              "name": "ipconfig-sample",
+              "properties": {
+                "subnet": {
+                  "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/logicalNetworks/test-lnet"
+                }
+              }
+            }
+          ],
+          "createFromLocal": true,
+          "provisioningState": "Accepted"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "test-nic",
+        "type": "Microsoft.AzureStackHCI/networkInterfaces",
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic",
+        "location": "West US2",
+        "properties": {
+          "ipConfigurations": [
+            {
+              "name": "ipconfig-sample",
+              "properties": {
+                "subnet": {
+                  "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/logicalNetworks/test-lnet"
+                }
+              }
+            }
+          ],
+          "createFromLocal": true,
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "NetworkInterfaces_CreateOrUpdate",
+  "title": "CreateNetworkInterfaceFromLocal"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/NetworkSecurityGroups_CreateOrUpdate.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/NetworkSecurityGroups_CreateOrUpdate.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "networkSecurityGroupName": "testnsg",
+    "resource": {
+      "location": "eastus"
+    },
+    "resourceGroupName": "testrg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testnsg",
+        "type": "Microsoft.AzureStackHCI/networkSecurityGroups",
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/networkSecurityGroups/testnsg",
+        "location": "eastus",
+        "properties": {
+          "provisioningState": "Succeeded"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "testnsg",
+        "type": "Microsoft.AzureStackHCI/networkSecurityGroups",
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/networkSecurityGroups/testnsg",
+        "location": "eastus",
+        "properties": {
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "NetworkSecurityGroups_CreateOrUpdate",
+  "title": "CreateNetworkSecurityGroup"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/NetworkSecurityGroups_Delete.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/NetworkSecurityGroups_Delete.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "networkSecurityGroupName": "testnsg",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {
+      "headers": {
+        "Azure-AsyncOperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "NetworkSecurityGroups_Delete",
+  "title": "Delete network security group"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/NetworkSecurityGroups_Get.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/NetworkSecurityGroups_Get.json
@@ -1,0 +1,23 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "networkSecurityGroupName": "testnsg",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testnsg",
+        "type": "Microsoft.AzureStackHCI/networkSecurityGroups",
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/rg1/providers/Microsoft.AzureStackHCI/networkSecurityGroups/testnsg",
+        "location": "westus",
+        "properties": {
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "NetworkSecurityGroups_Get",
+  "title": "Get network security group"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/NetworkSecurityGroups_ListAll.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/NetworkSecurityGroups_ListAll.json
@@ -1,0 +1,34 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "nsg1",
+            "type": "Microsoft.AzureStackHCI/networkSecurityGroups",
+            "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/networkSecurityGroups/nsg1",
+            "location": "westus",
+            "properties": {
+              "provisioningState": "Succeeded"
+            }
+          },
+          {
+            "name": "nsg2",
+            "type": "Microsoft.AzureStackHCI/networkSecurityGroups",
+            "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/rg2/providers/Microsoft.AzureStackHCI/networkSecurityGroups/nsg2",
+            "location": "westus",
+            "properties": {
+              "provisioningState": "Succeeded"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "NetworkSecurityGroups_ListAll",
+  "title": "List all network security groups"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/NetworkSecurityGroups_ListByResourceGroup.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/NetworkSecurityGroups_ListByResourceGroup.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceGroupName": "testrg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "nsg1",
+            "type": "Microsoft.AzureStackHCI/networkSecurityGroups",
+            "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/networkSecurityGroups/nsg1",
+            "location": "westus",
+            "properties": {
+              "provisioningState": "Succeeded"
+            }
+          },
+          {
+            "name": "nsg3",
+            "type": "Microsoft.AzureStackHCI/networkSecurityGroups",
+            "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/networkSecurityGroups/nsg3",
+            "location": "westus",
+            "properties": {
+              "provisioningState": "Succeeded"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "NetworkSecurityGroups_ListByResourceGroup",
+  "title": "List network security groups in resource group"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/NetworkSecurityGroups_UpdateTags.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/NetworkSecurityGroups_UpdateTags.json
@@ -1,0 +1,38 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "networkSecurityGroupName": "testnsg",
+    "properties": {
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      }
+    },
+    "resourceGroupName": "testrg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testnsg",
+        "type": "Microsoft.AzureStackHCI/networkSecurityGroups",
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/networkSecurityGroups/testnsg",
+        "location": "westus",
+        "properties": {
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "NetworkSecurityGroups_UpdateTags",
+  "title": "Update network security group tags"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/Operations_List.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/Operations_List.json
@@ -1,0 +1,335 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Microsoft.AzureStackHCI/VirtualHardDisks/Delete",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft.AzureStackHCI",
+              "resource": "VirtualHardDisks",
+              "operation": "Deletes virtual hard disk resource",
+              "description": "Deletes virtual hard disk resource"
+            }
+          },
+          {
+            "name": "Microsoft.AzureStackHCI/VirtualHardDisks/Write",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft.AzureStackHCI",
+              "resource": "VirtualHardDisks",
+              "operation": "Creates/Updates virtual hard disk resource",
+              "description": "Creates/Updates virtual hard disk resource"
+            }
+          },
+          {
+            "name": "Microsoft.AzureStackHCI/VirtualHardDisks/Read",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft.AzureStackHCI",
+              "resource": "VirtualHardDisks",
+              "operation": "Gets/Lists virtual hard disk resource",
+              "description": "Gets/Lists virtual hard disk resource"
+            }
+          },
+          {
+            "name": "Microsoft.AzureStackHCI/Snapshots/Delete",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft.AzureStackHCI",
+              "resource": "Snapshots",
+              "operation": "Deletes snapshot resource",
+              "description": "Deletes snapshot resource"
+            }
+          },
+          {
+            "name": "Microsoft.AzureStackHCI/Snapshots/Write",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft.AzureStackHCI",
+              "resource": "Snapshots",
+              "operation": "Creates/Updates snapshot resource",
+              "description": "Creates/Updates snapshot resource"
+            }
+          },
+          {
+            "name": "Microsoft.AzureStackHCI/Snapshots/Read",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft.AzureStackHCI",
+              "resource": "Snapshots",
+              "operation": "Gets/Lists snapshot resource",
+              "description": "Gets/Lists snapshot resource"
+            }
+          },
+          {
+            "name": "Microsoft.AzureStackHCI/NetworkInterfaces/Delete",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft.AzureStackHCI",
+              "resource": "NetworkInterfaces",
+              "operation": "Deletes network interfaces resource",
+              "description": "Deletes network interfaces resource"
+            }
+          },
+          {
+            "name": "Microsoft.AzureStackHCI/NetworkInterfaces/Write",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft.AzureStackHCI",
+              "resource": "NetworkInterfaces",
+              "operation": "Creates/Updates network interfaces resource",
+              "description": "Creates/Updates network interfaces resource"
+            }
+          },
+          {
+            "name": "Microsoft.AzureStackHCI/NetworkInterfaces/Read",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft.AzureStackHCI",
+              "resource": "NetworkInterfaces",
+              "operation": "Gets/Lists network interfaces resource",
+              "description": "Gets/Lists network interfaces resource"
+            }
+          },
+          {
+            "name": "Microsoft.AzureStackHCI/GalleryImages/Delete",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft.AzureStackHCI",
+              "resource": "GalleryImages",
+              "operation": "Deletes gallery images resource",
+              "description": "Deletes gallery images resource"
+            }
+          },
+          {
+            "name": "Microsoft.AzureStackHCI/GalleryImages/Write",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft.AzureStackHCI",
+              "resource": "GalleryImages",
+              "operation": "Creates/Updates gallery images resource",
+              "description": "Creates/Updates gallery images resource"
+            }
+          },
+          {
+            "name": "Microsoft.AzureStackHCI/GalleryImages/Read",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft.AzureStackHCI",
+              "resource": "GalleryImages",
+              "operation": "Gets/Lists gallery images resource",
+              "description": "Gets/Lists gallery images resource"
+            }
+          },
+          {
+            "name": "Microsoft.AzureStackHCI/VirtualMachineInstances/HybridIdentityMetadata/Read",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft.AzureStackHCI",
+              "resource": "VirtualMachineInstances/HybridIdentityMetadata",
+              "operation": "Gets/Lists virtual machine instance hybrid identity metadata proxy resource",
+              "description": "Gets/Lists virtual machine instance hybrid identity metadata proxy resource"
+            }
+          },
+          {
+            "name": "Microsoft.AzureStackHCI/VirtualMachineInstances/attestationStatus/read",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft.AzureStackHCI",
+              "resource": "VirtualMachineInstances/attestationStatus",
+              "operation": "Gets/Lists virtual machine instance's attestation status",
+              "description": "Gets/Lists virtual machine instance's attestation status"
+            }
+          },
+          {
+            "name": "Microsoft.AzureStackHCI/LogicalNetworks/Delete",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft.AzureStackHCI",
+              "resource": "LogicalNetworks",
+              "operation": "Deletes logical networks resource",
+              "description": "Deletes logical networks resource"
+            }
+          },
+          {
+            "name": "Microsoft.AzureStackHCI/LogicalNetworks/Write",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft.AzureStackHCI",
+              "resource": "LogicalNetworks",
+              "operation": "Creates/Updates logical networks resource",
+              "description": "Creates/Updates logical networks resource"
+            }
+          },
+          {
+            "name": "Microsoft.AzureStackHCI/LogicalNetworks/Read",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft.AzureStackHCI",
+              "resource": "LogicalNetworks",
+              "operation": "Gets/Lists logical networks resource",
+              "description": "Gets/Lists logical networks resource"
+            }
+          },
+          {
+            "name": "Microsoft.AzureStackHCI/LogicalNetworks/join/action",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft.AzureStackHCI",
+              "resource": "LogicalNetworks",
+              "operation": "Joins logical networks resource",
+              "description": "Joins logical networks resource"
+            }
+          },
+          {
+            "name": "Microsoft.AzureStackHCI/VirtualMachineInstances/Restart/Action",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft.AzureStackHCI",
+              "resource": "VirtualMachineInstances",
+              "operation": "Restarts virtual machine instance resource",
+              "description": "Restarts virtual machine instance resource"
+            }
+          },
+          {
+            "name": "Microsoft.AzureStackHCI/VirtualMachineInstances/Start/Action",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft.AzureStackHCI",
+              "resource": "VirtualMachineInstances",
+              "operation": "Starts virtual machine instance resource",
+              "description": "Starts virtual machine instance resource"
+            }
+          },
+          {
+            "name": "Microsoft.AzureStackHCI/VirtualMachineInstances/Stop/Action",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft.AzureStackHCI",
+              "resource": "VirtualMachineInstances",
+              "operation": "Stops virtual machine instance resource",
+              "description": "Stops virtual machine instance resource"
+            }
+          },
+          {
+            "name": "Microsoft.AzureStackHCI/VirtualMachineInstances/Delete",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft.AzureStackHCI",
+              "resource": "VirtualMachineInstances",
+              "operation": "Deletes virtual machine instance resource",
+              "description": "Deletes virtual machine instance resource"
+            }
+          },
+          {
+            "name": "Microsoft.AzureStackHCI/VirtualMachineInstances/Write",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft.AzureStackHCI",
+              "resource": "VirtualMachineInstances",
+              "operation": "Creates/Updates virtual machine instance resource",
+              "description": "Creates/Updates virtual machine instance resource"
+            }
+          },
+          {
+            "name": "Microsoft.AzureStackHCI/VirtualMachineInstances/Read",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft.AzureStackHCI",
+              "resource": "VirtualMachineInstances",
+              "operation": "Gets/Lists virtual machine instance resource",
+              "description": "Gets/Lists virtual machine instance resource"
+            }
+          },
+          {
+            "name": "Microsoft.AzureStackHCI/StorageContainers/Delete",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft.AzureStackHCI",
+              "resource": "StorageContainers",
+              "operation": "Deletes storage containers resource",
+              "description": "Deletes storage containers resource"
+            }
+          },
+          {
+            "name": "Microsoft.AzureStackHCI/StorageContainers/Write",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft.AzureStackHCI",
+              "resource": "StorageContainers",
+              "operation": "Creates/Updates storage containers resource",
+              "description": "Creates/Updates storage containers resource"
+            }
+          },
+          {
+            "name": "Microsoft.AzureStackHCI/StorageContainers/Read",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft.AzureStackHCI",
+              "resource": "StorageContainers",
+              "operation": "Gets/Lists storage containers resource",
+              "description": "Gets/Lists storage containers resource"
+            }
+          },
+          {
+            "name": "Microsoft.AzureStackHCI/StorageContainers/deploy/action",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft.AzureStackHCI",
+              "resource": "StorageContainers",
+              "operation": "Deploys storage containers resource",
+              "description": "Deploys storage containers resource"
+            }
+          },
+          {
+            "name": "Microsoft.AzureStackHCI/MarketPlaceGalleryImages/Delete",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft.AzureStackHCI",
+              "resource": "MarketPlaceGalleryImages",
+              "operation": "Deletes market place gallery images resource",
+              "description": "Deletes market place gallery images resource"
+            }
+          },
+          {
+            "name": "Microsoft.AzureStackHCI/MarketPlaceGalleryImages/Write",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft.AzureStackHCI",
+              "resource": "MarketPlaceGalleryImages",
+              "operation": "Creates/Updates market place gallery images resource",
+              "description": "Creates/Updates market place gallery images resource"
+            }
+          },
+          {
+            "name": "Microsoft.AzureStackHCI/MarketPlaceGalleryImages/Read",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft.AzureStackHCI",
+              "resource": "MarketPlaceGalleryImages",
+              "operation": "Gets/Lists market place gallery images resource",
+              "description": "Gets/Lists market place gallery images resource"
+            }
+          },
+          {
+            "name": "Microsoft.AzureStackHCI/MarketPlaceGalleryImages/deploy/action",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft.AzureStackHCI",
+              "resource": "MarketPlaceGalleryImages",
+              "operation": "Deploys market place gallery images resource",
+              "description": "Deploys market place gallery images resource"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Operations_List",
+  "title": "List the operations for the provider."
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/PublicIPAddresses_CreateOrUpdate.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/PublicIPAddresses_CreateOrUpdate.json
@@ -1,0 +1,56 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "publicIPAddressName": "public-ip1",
+    "resource": {
+      "location": "eastus",
+      "properties": {
+        "publicIPAddressVersion": "IPv4",
+        "ipAddress": "10.100.100.4",
+        "ipAllocationScope": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/logicalNetworks/lnet1"
+      }
+    },
+    "resourceGroupName": "testrg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "public-ip1",
+        "type": "Microsoft.AzureStackHCI/publicIPAddresses",
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/publicIPAddresses/public-ip1",
+        "location": "eastus",
+        "extendedLocation": {
+          "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "properties": {
+          "publicIPAddressVersion": "IPv4",
+          "ipAddress": "10.100.100.4",
+          "ipAllocationScope": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/logicalNetworks/lnet1",
+          "provisioningState": "Succeeded"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "public-ip1",
+        "type": "Microsoft.AzureStackHCI/publicIPAddresses",
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/publicIPAddresses/public-ip1",
+        "location": "eastus",
+        "extendedLocation": {
+          "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "properties": {
+          "publicIPAddressVersion": "IPv4",
+          "ipAddress": "10.100.100.4",
+          "ipAllocationScope": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/logicalNetworks/lnet1",
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "PublicIPAddresses_CreateOrUpdate",
+  "title": "CreatePublicIPAddress"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/PublicIPAddresses_Delete.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/PublicIPAddresses_Delete.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "publicIPAddressName": "test-ip",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {
+      "headers": {
+        "Azure-AsyncOperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "PublicIPAddresses_Delete",
+  "title": "Delete public IP address"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/PublicIPAddresses_Get.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/PublicIPAddresses_Get.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "publicIPAddressName": "testip",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testip",
+        "type": "Microsoft.AzureStackHCI/publicIPAddresses",
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/rg1/providers/Microsoft.AzureStackHCI/publicIPAddresses/testip",
+        "location": "westus",
+        "extendedLocation": {
+          "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "properties": {
+          "publicIPAddressVersion": "IPv4",
+          "ipAddress": "10.100.100.4",
+          "ipAllocationScope": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/logicalNetworks/lnet1",
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "PublicIPAddresses_Get",
+  "title": "Get public IP address"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/PublicIPAddresses_ListALL.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/PublicIPAddresses_ListALL.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "publicip1",
+            "type": "Microsoft.AzureStackHCI/publicIPAddresses",
+            "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/publicIPAddresses/publicip1",
+            "location": "westus",
+            "extendedLocation": {
+              "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+              "type": "CustomLocation"
+            },
+            "properties": {
+              "publicIPAddressVersion": "IPv4",
+              "ipAddress": "10.100.100.4",
+              "ipAllocationScope": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/logicalNetworks/lnet1",
+              "provisioningState": "Succeeded"
+            }
+          },
+          {
+            "name": "publicip2",
+            "type": "Microsoft.AzureStackHCI/publicIPAddresses",
+            "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/rg2/providers/Microsoft.AzureStackHCI/publicIPAddresses/publicip2",
+            "location": "westus",
+            "extendedLocation": {
+              "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+              "type": "CustomLocation"
+            },
+            "properties": {
+              "publicIPAddressVersion": "IPv4",
+              "ipAddress": "10.100.100.5",
+              "ipAllocationScope": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/logicalNetworks/lnet1",
+              "provisioningState": "Succeeded"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "PublicIPAddresses_ListAll",
+  "title": "List all public IP addresses"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/PublicIPAddresses_ListByResourceGroup.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/PublicIPAddresses_ListByResourceGroup.json
@@ -1,0 +1,49 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceGroupName": "testrg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "publicip1",
+            "type": "Microsoft.AzureStackHCI/publicIPAddresses",
+            "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/publicIPAddresses/publicip1",
+            "location": "westus",
+            "extendedLocation": {
+              "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+              "type": "CustomLocation"
+            },
+            "properties": {
+              "publicIPAddressVersion": "IPv4",
+              "ipAddress": "10.100.100.4",
+              "ipAllocationScope": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/logicalNetworks/lnet1",
+              "provisioningState": "Succeeded"
+            }
+          },
+          {
+            "name": "publicip3",
+            "type": "Microsoft.AzureStackHCI/publicIPAddresses",
+            "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/publicIPAddresses/publicip3",
+            "location": "westus",
+            "extendedLocation": {
+              "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+              "type": "CustomLocation"
+            },
+            "properties": {
+              "publicIPAddressVersion": "IPv4",
+              "ipAddress": "10.100.100.5",
+              "ipAllocationScope": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/logicalNetworks/lnet1",
+              "provisioningState": "Succeeded"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "PublicIPAddresses_ListByResourceGroup",
+  "title": "List public IPs in resource group"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/PublicIPAddresses_UpdateTags.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/PublicIPAddresses_UpdateTags.json
@@ -1,0 +1,45 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "publicIPAddressName": "publicip",
+    "properties": {
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      }
+    },
+    "resourceGroupName": "testrg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "publicip",
+        "type": "Microsoft.AzureStackHCI/publicIPAddresses",
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/publicIPAddresses/publicip",
+        "location": "westus",
+        "extendedLocation": {
+          "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "properties": {
+          "publicIPAddressVersion": "IPv4",
+          "ipAddress": "10.100.100.4",
+          "ipAllocationScope": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/logicalNetworks/lnet1",
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "PublicIPAddresses_UpdateTags",
+  "title": "Update public IP addresses tags"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/SecurityRules_CreateOrUpdate.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/SecurityRules_CreateOrUpdate.json
@@ -1,0 +1,85 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "networkSecurityGroupName": "testnsg",
+    "securityRuleName": "rule1",
+    "resource": {
+      "extendedLocation": {
+        "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+        "type": "CustomLocation"
+      },
+      "properties": {
+        "access": "Allow",
+        "destinationAddressPrefixes": [
+          "*"
+        ],
+        "destinationPortRanges": [
+          "80"
+        ],
+        "direction": "Inbound",
+        "priority": 130,
+        "sourceAddressPrefixes": [
+          "*"
+        ],
+        "sourcePortRanges": [
+          "*"
+        ],
+        "protocol": "*"
+      }
+    },
+    "resourceGroupName": "testrg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "rule1",
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/networkSecurityGroups/testnsg/securityRule/rule1",
+        "properties": {
+          "access": "Allow",
+          "destinationAddressPrefixes": [
+            "*"
+          ],
+          "destinationPortRanges": [
+            "80"
+          ],
+          "direction": "Inbound",
+          "priority": 130,
+          "sourceAddressPrefixes": [
+            "*"
+          ],
+          "sourcePortRanges": [
+            "*"
+          ],
+          "protocol": "*"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "rule1",
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/networkSecurityGroups/testnsg/securityRule/rule1",
+        "properties": {
+          "access": "Allow",
+          "destinationAddressPrefixes": [
+            "*"
+          ],
+          "destinationPortRanges": [
+            "80"
+          ],
+          "direction": "Inbound",
+          "priority": 130,
+          "sourceAddressPrefixes": [
+            "*"
+          ],
+          "sourcePortRanges": [
+            "*"
+          ],
+          "protocol": "*"
+        }
+      }
+    }
+  },
+  "operationId": "SecurityRules_CreateOrUpdate",
+  "title": "SecurityRulesCreateOrUpdate"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/SecurityRules_Delete.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/SecurityRules_Delete.json
@@ -1,0 +1,23 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "networkSecurityGroupName": "testnsg",
+    "resourceGroupName": "testrg",
+    "securityRuleName": "rule1",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {
+      "headers": {
+        "Azure-AsyncOperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "SecurityRules_Delete",
+  "title": "SecurityRulesDelete"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/SecurityRules_Get.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/SecurityRules_Get.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "networkSecurityGroupName": "testnsg",
+    "resourceGroupName": "testrg",
+    "securityRuleName": "rule1",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "rule1",
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/networkSecurityGroups/testnsg/securityRule/rule1",
+        "properties": {
+          "access": "Allow",
+          "destinationAddressPrefixes": [
+            "*"
+          ],
+          "destinationPortRanges": [
+            "80"
+          ],
+          "direction": "Inbound",
+          "priority": 130,
+          "sourceAddressPrefixes": [
+            "*"
+          ],
+          "sourcePortRanges": [
+            "*"
+          ],
+          "protocol": "*"
+        }
+      }
+    }
+  },
+  "operationId": "SecurityRules_Get",
+  "title": "Get network security rule in network security group"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/SecurityRules_ListByNetworkSecurityGroup.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/SecurityRules_ListByNetworkSecurityGroup.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "networkSecurityGroupName": "testnsg",
+    "resourceGroupName": "testrg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "rule1",
+            "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/networkSecurityGroups/testnsg/securityRule/rule1",
+            "properties": {
+              "access": "Allow",
+              "destinationAddressPrefixes": [
+                "*"
+              ],
+              "destinationPortRanges": [
+                "80"
+              ],
+              "direction": "Inbound",
+              "priority": 130,
+              "sourceAddressPrefixes": [
+                "*"
+              ],
+              "sourcePortRanges": [
+                "*"
+              ],
+              "protocol": "*"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "SecurityRules_ListByNetworkSecurityGroup",
+  "title": "List network security rules in network security group"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/Snapshots_CreateOrUpdate.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/Snapshots_CreateOrUpdate.json
@@ -1,0 +1,86 @@
+{
+  "operationId": "Snapshots_CreateOrUpdate",
+  "title": "Create or update a snapshot",
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b",
+    "snapshotName": "test-snapshot",
+    "resource": {
+      "extendedLocation": {
+        "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+        "type": "CustomLocation"
+      },
+      "location": "West US2",
+      "tags": {
+        "environment": "test"
+      },
+      "properties": {
+        "creationData": {
+          "createOption": "Copy",
+          "sourceResourceId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/virtualHardDisks/source-vhd"
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test-snapshot",
+        "type": "Microsoft.AzureStackHCI/snapshots",
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/snapshots/test-snapshot",
+        "location": "West US2",
+        "tags": {
+          "environment": "test"
+        },
+        "properties": {
+          "creationData": {
+            "createOption": "Copy",
+            "sourceResourceId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/virtualHardDisks/source-vhd",
+            "sourceUniqueId": "b99c94ca-e43d-4282-9c78-84d58e5ce81a"
+          },
+          "provisioningState": "Succeeded",
+          "timeCreated": "2023-11-15T10:30:00Z",
+          "diskSizeBytes": 68719476736,
+          "uniqueId": "f9e8d7c6-b5a4-9382-7160-5948372615a3",
+          "status": {
+            "provisioningStatus": {
+              "status": "Succeeded"
+            }
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "test-snapshot",
+        "type": "Microsoft.AzureStackHCI/snapshots",
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/snapshots/test-snapshot",
+        "location": "West US2",
+        "tags": {
+          "environment": "test"
+        },
+        "properties": {
+          "creationData": {
+            "createOption": "Copy",
+            "sourceResourceId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/virtualHardDisks/source-vhd"
+          },
+          "provisioningState": "Accepted",
+          "status": {
+            "provisioningStatus": {
+              "status": "InProgress"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/Snapshots_Delete.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/Snapshots_Delete.json
@@ -1,0 +1,18 @@
+{
+  "operationId": "Snapshots_Delete",
+  "title": "Delete a snapshot",
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b",
+    "snapshotName": "test-snapshot"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/providers/Microsoft.AzureStackHCI/locations/West US2/operationStatuses/01234567-abcd-ef12-3456-7890abcdef12*87654321-dcba-fe21-6543-1098765432ba"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/Snapshots_Get.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/Snapshots_Get.json
@@ -1,0 +1,43 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b",
+    "snapshotName": "test-snapshot"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test-snapshot",
+        "type": "Microsoft.AzureStackHCI/snapshots",
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/snapshots/test-snapshot",
+        "location": "West US2",
+        "tags": {
+          "environment": "test"
+        },
+        "properties": {
+          "creationData": {
+            "createOption": "Copy",
+            "sourceResourceId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/virtualHardDisks/source-vhd",
+            "sourceUniqueId": "b99c94ca-e43d-4282-9c78-84d58e5ce81a"
+          },
+          "provisioningState": "Succeeded",
+          "timeCreated": "2023-11-15T10:30:00Z",
+          "diskSizeBytes": 68719476736,
+          "uniqueId": "f9e8d7c6-b5a4-9382-7160-5948372615a3",
+          "status": {
+            "provisioningStatus": {
+              "status": "Succeeded"
+            }
+          }
+        }
+      }
+    }
+  },
+  "operationId": "Snapshots_Get",
+  "title": "Get a snapshot"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/Snapshots_ListAll.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/Snapshots_ListAll.json
@@ -1,0 +1,71 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "test-snapshot-1",
+            "type": "Microsoft.AzureStackHCI/snapshots",
+            "extendedLocation": {
+              "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+              "type": "CustomLocation"
+            },
+            "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/snapshots/test-snapshot-1",
+            "location": "West US2",
+            "tags": {
+              "environment": "test"
+            },
+            "properties": {
+              "creationData": {
+                "createOption": "Copy",
+                "sourceResourceId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/virtualHardDisks/source-vhd",
+                "sourceUniqueId": "b99c94ca-e43d-4282-9c78-84d58e5ce81a"
+              },
+              "provisioningState": "Succeeded",
+              "timeCreated": "2023-11-15T10:30:00Z",
+              "diskSizeBytes": 68719476736,
+              "uniqueId": "f9e8d7c6-b5a4-9382-7160-5948372615a3",
+              "status": {
+                "provisioningStatus": {
+                  "status": "Succeeded"
+                }
+              }
+            }
+          },
+          {
+            "name": "test-snapshot-2",
+            "type": "Microsoft.AzureStackHCI/snapshots",
+            "extendedLocation": {
+              "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+              "type": "CustomLocation"
+            },
+            "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/other-rg/providers/Microsoft.AzureStackHCI/snapshots/test-snapshot-2",
+            "location": "East US",
+            "properties": {
+              "creationData": {
+                "createOption": "Copy",
+                "sourceResourceId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/other-rg/providers/Microsoft.AzureStackHCI/virtualHardDisks/another-vhd",
+                "sourceUniqueId": "c11a94ca-e43d-4282-9c78-84d58e5ce81b"
+              },
+              "provisioningState": "Succeeded",
+              "timeCreated": "2023-11-16T08:30:00Z",
+              "diskSizeBytes": 137438953472,
+              "uniqueId": "a1b2c3d4-e5f6-7890-1234-567890abcdef",
+              "status": {
+                "provisioningStatus": {
+                  "status": "Succeeded"
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Snapshots_ListAll",
+  "title": "List all snapshots in a subscription"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/Snapshots_ListByResourceGroup.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/Snapshots_ListByResourceGroup.json
@@ -1,0 +1,46 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "test-snapshot-1",
+            "type": "Microsoft.AzureStackHCI/snapshots",
+            "extendedLocation": {
+              "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+              "type": "CustomLocation"
+            },
+            "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/snapshots/test-snapshot-1",
+            "location": "West US2",
+            "tags": {
+              "environment": "test"
+            },
+            "properties": {
+              "creationData": {
+                "createOption": "Copy",
+                "sourceResourceId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/virtualHardDisks/source-vhd",
+                "sourceUniqueId": "b99c94ca-e43d-4282-9c78-84d58e5ce81a"
+              },
+              "provisioningState": "Succeeded",
+              "timeCreated": "2023-11-15T10:30:00Z",
+              "diskSizeBytes": 68719476736,
+              "uniqueId": "f9e8d7c6-b5a4-9382-7160-5948372615a3",
+              "status": {
+                "provisioningStatus": {
+                  "status": "Succeeded"
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Snapshots_ListByResourceGroup",
+  "title": "List snapshots by resource group"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/Snapshots_Update.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/Snapshots_Update.json
@@ -1,0 +1,55 @@
+{
+  "operationId": "Snapshots_Update",
+  "title": "Update a snapshot",
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b",
+    "snapshotName": "test-snapshot",
+    "properties": {
+      "tags": {
+        "environment": "production",
+        "tier": "standard"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test-snapshot",
+        "type": "Microsoft.AzureStackHCI/snapshots",
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/snapshots/test-snapshot",
+        "location": "West US2",
+        "tags": {
+          "environment": "production",
+          "tier": "standard"
+        },
+        "properties": {
+          "creationData": {
+            "createOption": "Copy",
+            "sourceResourceId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/virtualHardDisks/source-vhd",
+            "sourceUniqueId": "b99c94ca-e43d-4282-9c78-84d58e5ce81a"
+          },
+          "provisioningState": "Succeeded",
+          "timeCreated": "2023-11-15T10:30:00Z",
+          "diskSizeBytes": 68719476736,
+          "uniqueId": "f9e8d7c6-b5a4-9382-7160-5948372615a3",
+          "status": {
+            "provisioningStatus": {
+              "status": "Succeeded"
+            }
+          }
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/providers/Microsoft.AzureStackHCI/locations/West US2/operationStatuses/01234567-abcd-ef12-3456-7890abcdef12*87654321-dcba-fe21-6543-1098765432ba"
+      }
+    }
+  }
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/StorageContainers_CreateOrUpdate.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/StorageContainers_CreateOrUpdate.json
@@ -1,0 +1,54 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceGroupName": "test-rg",
+    "storageContainerName": "Default_Container",
+    "resource": {
+      "extendedLocation": {
+        "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+        "type": "CustomLocation"
+      },
+      "location": "West US2",
+      "properties": {
+        "path": "C:\\container_storage"
+      }
+    },
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "Default_Container",
+        "type": "Microsoft.AzureStackHCI/storageContainers",
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-galimg3325",
+        "location": "West US2",
+        "properties": {
+          "path": "C:\\container_storage",
+          "provisioningState": "Accepted"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "Default_Container",
+        "type": "Microsoft.AzureStackHCI/storageContainers",
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-galimg3325",
+        "location": "West US2",
+        "properties": {
+          "path": "C:\\container_storage",
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "StorageContainers_CreateOrUpdate",
+  "title": "PutStorageContainer"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/StorageContainers_Delete.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/StorageContainers_Delete.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceGroupName": "test-rg",
+    "storageContainerName": "Default_Container",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "StorageContainers_Delete",
+  "title": "DeleteStorageContainer"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/StorageContainers_Get.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/StorageContainers_Get.json
@@ -1,0 +1,28 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceGroupName": "test-rg",
+    "storageContainerName": "Default_Container",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "Default_Container",
+        "type": "Microsoft.AzureStackHCI/storageContainers",
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/Default_Container",
+        "location": "West US2",
+        "properties": {
+          "path": "C:\\container_storage",
+          "provisioningState": "Accepted"
+        }
+      }
+    }
+  },
+  "operationId": "StorageContainers_Get",
+  "title": "GetStorageContainer"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/StorageContainers_ListAll.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/StorageContainers_ListAll.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Default_Container",
+            "type": "Microsoft.AzureStackHCI/storageContainers",
+            "extendedLocation": {
+              "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+              "type": "CustomLocation"
+            },
+            "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/Default_Container",
+            "location": "West US2",
+            "properties": {
+              "path": "C:\\container_storage",
+              "provisioningState": "Accepted"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "StorageContainers_ListAll",
+  "title": "ListStorageContainerBySubscription"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/StorageContainers_ListByResourceGroup.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/StorageContainers_ListByResourceGroup.json
@@ -1,0 +1,31 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Default_Container",
+            "type": "Microsoft.AzureStackHCI/storageContainers",
+            "extendedLocation": {
+              "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+              "type": "CustomLocation"
+            },
+            "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/Default_Container",
+            "location": "West US2",
+            "properties": {
+              "path": "C:\\container_storage",
+              "provisioningState": "Accepted"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "StorageContainers_ListByResourceGroup",
+  "title": "ListStorageContainerByResourceGroup"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/StorageContainers_Update.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/StorageContainers_Update.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceGroupName": "test-rg",
+    "storageContainerName": "Default_Container",
+    "properties": {
+      "tags": {
+        "additionalProperties": "sample"
+      }
+    },
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "Default_Container",
+        "type": "Microsoft.AzureStackHCI/storageContainers",
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-galimg3325",
+        "location": "West US2",
+        "properties": {
+          "path": "C:\\container_storage",
+          "provisioningState": "Accepted"
+        },
+        "tags": {
+          "additionalProperties": "sample"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "StorageContainers_Update",
+  "title": "UpdateStorageContainer"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualHardDisks_CreateOrUpdate.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualHardDisks_CreateOrUpdate.json
@@ -1,0 +1,66 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b",
+    "virtualHardDiskName": "test-vhd",
+    "resource": {
+      "extendedLocation": {
+        "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+        "type": "CustomLocation"
+      },
+      "location": "West US2",
+      "properties": {
+        "diskSizeGB": 32
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test-vhd",
+        "type": "Microsoft.AzureStackHCI/virtualHardDisks",
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/virtualHardDisks/test-vhd",
+        "location": "West US2",
+        "properties": {
+          "blockSizeBytes": 0,
+          "diskFileFormat": "vhdx",
+          "diskSizeGB": 32,
+          "dynamic": true,
+          "hyperVGeneration": "V2",
+          "logicalSectorBytes": 512,
+          "physicalSectorBytes": 512,
+          "provisioningState": "Accepted"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "test-vhd",
+        "type": "Microsoft.AzureStackHCI/virtualHardDisks",
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/virtualHardDisks/test-vhd",
+        "location": "West US2",
+        "properties": {
+          "blockSizeBytes": 0,
+          "diskFileFormat": "vhdx",
+          "diskSizeGB": 32,
+          "dynamic": true,
+          "hyperVGeneration": "V2",
+          "logicalSectorBytes": 512,
+          "physicalSectorBytes": 512,
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "VirtualHardDisks_CreateOrUpdate",
+  "title": "PutVirtualHardDisk"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualHardDisks_Delete.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualHardDisks_Delete.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b",
+    "virtualHardDiskName": "test-vhd"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "VirtualHardDisks_Delete",
+  "title": "DeleteVirtualHardDisk"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualHardDisks_Get.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualHardDisks_Get.json
@@ -1,0 +1,46 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b",
+    "virtualHardDiskName": "test-vhd"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test-vhd",
+        "type": "Microsoft.AzureStackHCI/virtualHardDisks",
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/virtualHardDisks/test-vhd",
+        "location": "West US2",
+        "properties": {
+          "blockSizeBytes": 0,
+          "diskFileFormat": "vhdx",
+          "diskSizeGB": 32,
+          "dynamic": true,
+          "hyperVGeneration": "V2",
+          "logicalSectorBytes": 512,
+          "physicalSectorBytes": 512,
+          "provisioningState": "Accepted",
+          "status": {
+            "uploadStatus": {
+              "uploadedSizeInMB": 10240,
+              "progressPercentage": 55,
+              "status": "InProgress"
+            },
+            "downloadStatus": {
+              "downloadedSizeInMB": 10240,
+              "progressPercentage": 100,
+              "status": "Succeeded"
+            }
+          }
+        }
+      }
+    }
+  },
+  "operationId": "VirtualHardDisks_Get",
+  "title": "GetVirtualHardDisk"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualHardDisks_ListAll.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualHardDisks_ListAll.json
@@ -1,0 +1,36 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "test-vhd",
+            "type": "Microsoft.AzureStackHCI/virtualHardDisks",
+            "extendedLocation": {
+              "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+              "type": "CustomLocation"
+            },
+            "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/virtualHardDisks/test-vhd",
+            "location": "West US2",
+            "properties": {
+              "blockSizeBytes": 0,
+              "diskFileFormat": "vhdx",
+              "diskSizeGB": 32,
+              "dynamic": true,
+              "hyperVGeneration": "V2",
+              "logicalSectorBytes": 512,
+              "physicalSectorBytes": 512,
+              "provisioningState": "Accepted"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "VirtualHardDisks_ListAll",
+  "title": "ListVirtualHardDiskBySubscription"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualHardDisks_ListByResourceGroup.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualHardDisks_ListByResourceGroup.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "test-vhd",
+            "type": "Microsoft.AzureStackHCI/virtualHardDisks",
+            "extendedLocation": {
+              "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+              "type": "CustomLocation"
+            },
+            "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/virtualHardDisks/test-vhd",
+            "location": "West US2",
+            "properties": {
+              "blockSizeBytes": 0,
+              "diskFileFormat": "vhdx",
+              "diskSizeGB": 32,
+              "dynamic": true,
+              "hyperVGeneration": "V2",
+              "logicalSectorBytes": 512,
+              "physicalSectorBytes": 512,
+              "provisioningState": "Accepted"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "VirtualHardDisks_ListByResourceGroup",
+  "title": "ListVirtualHardDiskByResourceGroup"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualHardDisks_Update.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualHardDisks_Update.json
@@ -1,0 +1,47 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b",
+    "virtualHardDiskName": "test-vhd",
+    "properties": {
+      "tags": {
+        "additionalProperties": "sample"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test-vhd",
+        "type": "Microsoft.AzureStackHCI/virtualHardDisks",
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/virtualHardDisks/test-vhd",
+        "location": "West US2",
+        "properties": {
+          "blockSizeBytes": 0,
+          "diskFileFormat": "vhdx",
+          "diskSizeGB": 32,
+          "dynamic": true,
+          "hyperVGeneration": "V2",
+          "logicalSectorBytes": 512,
+          "physicalSectorBytes": 512,
+          "provisioningState": "Accepted"
+        },
+        "tags": {
+          "additionalProperties": "sample"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "VirtualHardDisks_Update",
+  "title": "UpdateVirtualHardDisk"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualHardDisks_Upload.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualHardDisks_Upload.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b",
+    "virtualHardDiskName": "test-vhd",
+    "body": {
+      "azureManagedDiskUploadUrl": "https://YourStorageAccountName.blob.core.windows.net/YourContainerName/YourVHDBlobName.vhd?<sas-token>"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "virtualHardDiskId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/virtualHardDisks/test-vhd",
+        "uploadStatus": {
+          "uploadedSizeInMB": 10240,
+          "progressPercentage": 55,
+          "status": "InProgress"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "location": "https://contoso.com/operationstatus"
+      }
+    }
+  },
+  "operationId": "VirtualHardDisks_Upload",
+  "title": "UploadVirtualHardDisk"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualHardDisks__CreateOrUpdate_CreateFromLocal.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualHardDisks__CreateOrUpdate_CreateFromLocal.json
@@ -1,0 +1,71 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b",
+    "virtualHardDiskName": "rehome-datadisk-1",
+    "resource": {
+      "extendedLocation": {
+        "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+        "type": "CustomLocation"
+      },
+      "location": "West US2",
+      "properties": {
+        "createFromLocal": true,
+        "localVhdPath": "C:\\ClusterStorage\\UserStorage_2\\e35803d0bd82d61\\rehome555-dd1-a95612cb-f1fa-4daa-a4fd-272844fa512c-dogfoodarc.vhdx"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "rehome-datadisk-1",
+        "type": "Microsoft.AzureStackHCI/virtualHardDisks",
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/virtualHardDisks/rehome-datadisk-1",
+        "location": "West US2",
+        "properties": {
+          "blockSizeBytes": 0,
+          "diskFileFormat": "vhdx",
+          "diskSizeGB": 32,
+          "dynamic": true,
+          "hyperVGeneration": "V2",
+          "logicalSectorBytes": 512,
+          "physicalSectorBytes": 512,
+          "createFromLocal": true,
+          "containerId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/UserStorage_2",
+          "provisioningState": "Accepted"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "rehome-datadisk-1",
+        "type": "Microsoft.AzureStackHCI/virtualHardDisks",
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/virtualHardDisks/rehome-datadisk-1",
+        "location": "West US2",
+        "properties": {
+          "blockSizeBytes": 0,
+          "diskFileFormat": "vhdx",
+          "diskSizeGB": 32,
+          "dynamic": true,
+          "hyperVGeneration": "V2",
+          "logicalSectorBytes": 512,
+          "physicalSectorBytes": 512,
+          "createFromLocal": true,
+          "containerId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/UserStorage_2",
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "VirtualHardDisks_CreateOrUpdate",
+  "title": "CreateVirtualHardDiskFromLocal"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualMachineInstances_CreateOrUpdate_Put_Virtual_Machine_Instance_With_Gallery_Image.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualMachineInstances_CreateOrUpdate_Put_Virtual_Machine_Instance_With_Gallery_Image.json
@@ -1,0 +1,115 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceUri": "subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM",
+    "resource": {
+      "extendedLocation": {
+        "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+        "type": "CustomLocation"
+      },
+      "properties": {
+        "hardwareProfile": {
+          "vmSize": "Default"
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic"
+            }
+          ]
+        },
+        "osProfile": {
+          "adminPassword": "password",
+          "adminUsername": "localadmin",
+          "computerName": "luamaster"
+        },
+        "securityProfile": {
+          "enableTPM": true,
+          "uefiSettings": {
+            "secureBootEnabled": true
+          }
+        },
+        "storageProfile": {
+          "imageReference": {
+            "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/galleryImages/test-gallery-image"
+          },
+          "vmConfigStoragePathId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-container"
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default",
+        "properties": {
+          "hardwareProfile": {
+            "vmSize": "Default"
+          },
+          "networkProfile": {
+            "networkInterfaces": [
+              {
+                "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic"
+              }
+            ]
+          },
+          "osProfile": {
+            "adminUsername": "localadmin",
+            "computerName": "luamaster"
+          },
+          "provisioningState": "Accepted",
+          "securityProfile": {
+            "enableTPM": true,
+            "uefiSettings": {
+              "secureBootEnabled": true
+            }
+          },
+          "storageProfile": {
+            "imageReference": {
+              "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/galleryImages/test-gallery-image"
+            },
+            "vmConfigStoragePathId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-container"
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default",
+        "properties": {
+          "hardwareProfile": {
+            "vmSize": "Default"
+          },
+          "networkProfile": {
+            "networkInterfaces": [
+              {
+                "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic"
+              }
+            ]
+          },
+          "osProfile": {
+            "adminUsername": "localadmin",
+            "computerName": "luamaster"
+          },
+          "provisioningState": "Succeeded",
+          "storageProfile": {
+            "imageReference": {
+              "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/galleryImages/test-gallery-image"
+            },
+            "vmConfigStoragePathId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-container"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "VirtualMachineInstances_CreateOrUpdate",
+  "title": "PutVirtualMachineInstanceWithGalleryImage"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualMachineInstances_CreateOrUpdate_Put_Virtual_Machine_Instance_With_Gpu.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualMachineInstances_CreateOrUpdate_Put_Virtual_Machine_Instance_With_Gpu.json
@@ -1,0 +1,133 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceUri": "subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM",
+    "resource": {
+      "extendedLocation": {
+        "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+        "type": "CustomLocation"
+      },
+      "properties": {
+        "hardwareProfile": {
+          "vmSize": "Default",
+          "virtualMachineGPUs": [
+            {
+              "assignmentType": "GpuDDA",
+              "partitionSizeMB": 0
+            }
+          ]
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic"
+            }
+          ]
+        },
+        "osProfile": {
+          "adminPassword": "password",
+          "adminUsername": "localadmin",
+          "computerName": "luamaster"
+        },
+        "securityProfile": {
+          "enableTPM": true,
+          "uefiSettings": {
+            "secureBootEnabled": true
+          }
+        },
+        "storageProfile": {
+          "imageReference": {
+            "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/galleryImages/test-gallery-image"
+          },
+          "vmConfigStoragePathId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-container"
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default",
+        "properties": {
+          "hardwareProfile": {
+            "vmSize": "Default",
+            "virtualMachineGPUs": [
+              {
+                "assignmentType": "GpuDDA",
+                "partitionSizeMB": 0
+              }
+            ]
+          },
+          "networkProfile": {
+            "networkInterfaces": [
+              {
+                "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic"
+              }
+            ]
+          },
+          "osProfile": {
+            "adminUsername": "localadmin",
+            "computerName": "luamaster"
+          },
+          "provisioningState": "Accepted",
+          "securityProfile": {
+            "enableTPM": true,
+            "uefiSettings": {
+              "secureBootEnabled": true
+            }
+          },
+          "storageProfile": {
+            "imageReference": {
+              "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/galleryImages/test-gallery-image"
+            },
+            "vmConfigStoragePathId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-container"
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default",
+        "properties": {
+          "hardwareProfile": {
+            "vmSize": "Default",
+            "virtualMachineGPUs": [
+              {
+                "assignmentType": "GpuDDA",
+                "partitionSizeMB": 0
+              }
+            ]
+          },
+          "networkProfile": {
+            "networkInterfaces": [
+              {
+                "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic"
+              }
+            ]
+          },
+          "osProfile": {
+            "adminUsername": "localadmin",
+            "computerName": "luamaster"
+          },
+          "provisioningState": "Succeeded",
+          "storageProfile": {
+            "imageReference": {
+              "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/galleryImages/test-gallery-image"
+            },
+            "vmConfigStoragePathId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-container"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "VirtualMachineInstances_CreateOrUpdate",
+  "title": "PutVirtualMachineInstanceWithGpu"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualMachineInstances_CreateOrUpdate_Put_Virtual_Machine_Instance_With_Marketplace_Gallery_Image.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualMachineInstances_CreateOrUpdate_Put_Virtual_Machine_Instance_With_Marketplace_Gallery_Image.json
@@ -1,0 +1,115 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceUri": "subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM",
+    "resource": {
+      "extendedLocation": {
+        "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+        "type": "CustomLocation"
+      },
+      "properties": {
+        "hardwareProfile": {
+          "vmSize": "Default"
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic"
+            }
+          ]
+        },
+        "osProfile": {
+          "adminPassword": "password",
+          "adminUsername": "localadmin",
+          "computerName": "luamaster"
+        },
+        "securityProfile": {
+          "enableTPM": true,
+          "uefiSettings": {
+            "secureBootEnabled": true
+          }
+        },
+        "storageProfile": {
+          "imageReference": {
+            "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/marketplaceGalleryImages/test-marketplace-gallery-image"
+          },
+          "vmConfigStoragePathId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-container"
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default",
+        "properties": {
+          "hardwareProfile": {
+            "vmSize": "Default"
+          },
+          "networkProfile": {
+            "networkInterfaces": [
+              {
+                "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic"
+              }
+            ]
+          },
+          "osProfile": {
+            "adminUsername": "localadmin",
+            "computerName": "luamaster"
+          },
+          "provisioningState": "Accepted",
+          "securityProfile": {
+            "enableTPM": true,
+            "uefiSettings": {
+              "secureBootEnabled": true
+            }
+          },
+          "storageProfile": {
+            "imageReference": {
+              "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/marketplaceGalleryImages/test-marketplace-gallery-image"
+            },
+            "vmConfigStoragePathId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-container"
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default",
+        "properties": {
+          "hardwareProfile": {
+            "vmSize": "Default"
+          },
+          "networkProfile": {
+            "networkInterfaces": [
+              {
+                "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic"
+              }
+            ]
+          },
+          "osProfile": {
+            "adminUsername": "localadmin",
+            "computerName": "luamaster"
+          },
+          "provisioningState": "Succeeded",
+          "storageProfile": {
+            "imageReference": {
+              "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/marketplaceGalleryImages/test-marketplace-gallery-image"
+            },
+            "vmConfigStoragePathId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-container"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "VirtualMachineInstances_CreateOrUpdate",
+  "title": "PutVirtualMachineInstanceWithMarketplaceGalleryImage"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualMachineInstances_CreateOrUpdate_Put_Virtual_Machine_Instance_With_Os_Disk.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualMachineInstances_CreateOrUpdate_Put_Virtual_Machine_Instance_With_Os_Disk.json
@@ -1,0 +1,102 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceUri": "subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM",
+    "resource": {
+      "extendedLocation": {
+        "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+        "type": "CustomLocation"
+      },
+      "properties": {
+        "hardwareProfile": {
+          "vmSize": "Default"
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic"
+            }
+          ]
+        },
+        "securityProfile": {
+          "enableTPM": true,
+          "uefiSettings": {
+            "secureBootEnabled": true
+          }
+        },
+        "storageProfile": {
+          "osDisk": {
+            "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/virtualHardDisks/test-vhd"
+          },
+          "vmConfigStoragePathId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-container"
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default",
+        "properties": {
+          "hardwareProfile": {
+            "vmSize": "Default"
+          },
+          "networkProfile": {
+            "networkInterfaces": [
+              {
+                "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic"
+              }
+            ]
+          },
+          "provisioningState": "Accepted",
+          "securityProfile": {
+            "enableTPM": true,
+            "uefiSettings": {
+              "secureBootEnabled": true
+            }
+          },
+          "storageProfile": {
+            "osDisk": {
+              "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/virtualHardDisks/test-vhd"
+            },
+            "vmConfigStoragePathId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-container"
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default",
+        "properties": {
+          "hardwareProfile": {
+            "vmSize": "Default"
+          },
+          "networkProfile": {
+            "networkInterfaces": [
+              {
+                "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic"
+              }
+            ]
+          },
+          "provisioningState": "Succeeded",
+          "storageProfile": {
+            "osDisk": {
+              "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/virtualHardDisks/test-vhd"
+            },
+            "vmConfigStoragePathId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-container"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "VirtualMachineInstances_CreateOrUpdate",
+  "title": "PutVirtualMachineInstanceWithOsDisk"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualMachineInstances_CreateOrUpdate_Put_Virtual_Machine_Instance_With_Vm_Config_Agent.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualMachineInstances_CreateOrUpdate_Put_Virtual_Machine_Instance_With_Vm_Config_Agent.json
@@ -1,0 +1,146 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceUri": "subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM",
+    "resource": {
+      "extendedLocation": {
+        "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+        "type": "CustomLocation"
+      },
+      "properties": {
+        "hardwareProfile": {
+          "vmSize": "Default"
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic"
+            }
+          ]
+        },
+        "osProfile": {
+          "adminPassword": "password",
+          "adminUsername": "localadmin",
+          "computerName": "luamaster",
+          "windowsConfiguration": {
+            "provisionVMConfigAgent": true
+          }
+        },
+        "securityProfile": {
+          "enableTPM": true,
+          "uefiSettings": {
+            "secureBootEnabled": true
+          }
+        },
+        "storageProfile": {
+          "imageReference": {
+            "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/galleryImages/test-gallery-image"
+          },
+          "vmConfigStoragePathId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-container"
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default",
+        "properties": {
+          "hardwareProfile": {
+            "vmSize": "Default"
+          },
+          "instanceView": {
+            "vmAgent": {
+              "statuses": [
+                {
+                  "code": "Ok",
+                  "displayStatus": "Ok",
+                  "level": "Info",
+                  "message": "The agent is healthy",
+                  "time": "2009-06-15T13:45:30"
+                }
+              ],
+              "vmConfigAgentVersion": "1.0.0"
+            }
+          },
+          "networkProfile": {
+            "networkInterfaces": [
+              {
+                "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic"
+              }
+            ]
+          },
+          "osProfile": {
+            "adminUsername": "localadmin",
+            "computerName": "luamaster"
+          },
+          "provisioningState": "Accepted",
+          "securityProfile": {
+            "enableTPM": true,
+            "uefiSettings": {
+              "secureBootEnabled": true
+            }
+          },
+          "storageProfile": {
+            "imageReference": {
+              "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/galleryImages/test-gallery-image"
+            },
+            "vmConfigStoragePathId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-container"
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default",
+        "properties": {
+          "hardwareProfile": {
+            "vmSize": "Default"
+          },
+          "instanceView": {
+            "vmAgent": {
+              "statuses": [
+                {
+                  "code": "Ok",
+                  "displayStatus": "Ok",
+                  "level": "Info",
+                  "message": "The agent is healthy",
+                  "time": "2009-06-15T13:45:30"
+                }
+              ],
+              "vmConfigAgentVersion": "1.0.0"
+            }
+          },
+          "networkProfile": {
+            "networkInterfaces": [
+              {
+                "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic"
+              }
+            ]
+          },
+          "osProfile": {
+            "adminUsername": "localadmin",
+            "computerName": "luamaster"
+          },
+          "provisioningState": "Succeeded",
+          "storageProfile": {
+            "imageReference": {
+              "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/galleryImages/test-gallery-image"
+            },
+            "vmConfigStoragePathId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-container"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "VirtualMachineInstances_CreateOrUpdate",
+  "title": "PutVirtualMachineInstanceWithVMConfigAgent"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualMachineInstances_Delete.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualMachineInstances_Delete.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceUri": "subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "VirtualMachineInstances_Delete",
+  "title": "DeleteVirtualMachine"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualMachineInstances_Get.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualMachineInstances_Get.json
@@ -1,0 +1,44 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceUri": "subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.AzureStackHCI/virtualMachineInstances",
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default",
+        "properties": {
+          "hardwareProfile": {
+            "vmSize": "Default"
+          },
+          "networkProfile": {
+            "networkInterfaces": [
+              {
+                "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic"
+              }
+            ]
+          },
+          "osProfile": {
+            "adminUsername": "localadmin",
+            "computerName": "luamaster"
+          },
+          "provisioningState": "Accepted",
+          "storageProfile": {
+            "imageReference": {
+              "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/galleryImages/test-gallery-image"
+            },
+            "vmConfigStoragePathId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-container"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "VirtualMachineInstances_Get",
+  "title": "GetVirtualMachineInstance"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualMachineInstances_List.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualMachineInstances_List.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceUri": "subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "default",
+            "type": "Microsoft.AzureStackHCI/virtualMachineInstances",
+            "extendedLocation": {
+              "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+              "type": "CustomLocation"
+            },
+            "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default",
+            "properties": {
+              "hardwareProfile": {
+                "vmSize": "Default"
+              },
+              "networkProfile": {
+                "networkInterfaces": [
+                  {
+                    "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic"
+                  }
+                ]
+              },
+              "osProfile": {
+                "adminUsername": "localadmin",
+                "computerName": "luamaster"
+              },
+              "provisioningState": "Accepted",
+              "storageProfile": {
+                "imageReference": {
+                  "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/galleryImages/test-gallery-image"
+                },
+                "vmConfigStoragePathId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-container"
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "VirtualMachineInstances_List",
+  "title": "ListVirtualMachineInstances"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualMachineInstances_Pause.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualMachineInstances_Pause.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceUri": "subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/Microsoft.HybridCompute/machines/DemoVM/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "VirtualMachineInstances_Pause",
+  "title": "PauseVirtualMachine"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualMachineInstances_PowerOff.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualMachineInstances_PowerOff.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceUri": "subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default",
+    "body": {
+      "skipShutdown": false
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default/operations/poweroff",
+        "name": "poweroff",
+        "status": "Succeeded",
+        "startTime": "2026-01-20T00:00:00Z",
+        "endTime": "2026-01-20T00:01:00Z"
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "VirtualMachineInstances_PowerOff",
+  "title": "PowerOffVirtualMachine"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualMachineInstances_Restart.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualMachineInstances_Restart.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceUri": "subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "VirtualMachineInstances_Restart",
+  "title": "RestartVirtualMachine"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualMachineInstances_Save.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualMachineInstances_Save.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceUri": "subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/Microsoft.HybridCompute/machines/DemoVM/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "VirtualMachineInstances_Save",
+  "title": "SaveVirtualMachine"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualMachineInstances_Start.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualMachineInstances_Start.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceUri": "subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "VirtualMachineInstances_Start",
+  "title": "StartVirtualMachine"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualMachineInstances_Stop.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualMachineInstances_Stop.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceUri": "subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "VirtualMachineInstances_Stop",
+  "title": "StopVirtualMachine"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualMachineInstances_Update.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualMachineInstances_Update.json
@@ -1,0 +1,64 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceUri": "subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM",
+    "properties": {
+      "properties": {
+        "storageProfile": {
+          "dataDisks": [
+            {
+              "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/virtualHardDisks/test-vhd"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.AzureStackHCI/virtualMachineInstances",
+        "extendedLocation": {
+          "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default",
+        "properties": {
+          "hardwareProfile": {
+            "vmSize": "Default"
+          },
+          "networkProfile": {
+            "networkInterfaces": [
+              {
+                "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic"
+              }
+            ]
+          },
+          "osProfile": {
+            "adminUsername": "localadmin",
+            "computerName": "luamaster"
+          },
+          "provisioningState": "Accepted",
+          "storageProfile": {
+            "dataDisks": [
+              {
+                "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/virtualHardDisks/test-vhd"
+              }
+            ],
+            "imageReference": {
+              "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/galleryImages/test-gallery-image"
+            }
+          }
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "VirtualMachineInstances_Update",
+  "title": "UpdateVirtualMachine"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualMachineInstances_Update_DynamicMemory.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualMachineInstances_Update_DynamicMemory.json
@@ -1,0 +1,61 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceUri": "subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM",
+    "properties": {
+      "properties": {
+        "hardwareProfile": {
+          "dynamicMemoryConfig": {
+            "enabled": true,
+            "minimumMemoryMB": 2048,
+            "maximumMemoryMB": 8192,
+            "targetMemoryBuffer": 20
+          }
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.AzureStackHCI/virtualMachineInstances",
+        "extendedLocation": {
+          "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default",
+        "properties": {
+          "hardwareProfile": {
+            "vmSize": "Default",
+            "dynamicMemoryConfig": {
+              "enabled": true,
+              "minimumMemoryMB": 2048,
+              "maximumMemoryMB": 8192,
+              "targetMemoryBuffer": 20
+            }
+          },
+          "networkProfile": {
+            "networkInterfaces": [
+              {
+                "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic"
+              }
+            ]
+          },
+          "osProfile": {
+            "adminUsername": "localadmin",
+            "computerName": "luamaster"
+          },
+          "provisioningState": "Accepted"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "VirtualMachineInstances_Update",
+  "title": "UpdateVirtualMachineDynamicMemory"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualMachineInstances__CreateOrUpdate_CreateFromLocal.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualMachineInstances__CreateOrUpdate_CreateFromLocal.json
@@ -1,0 +1,108 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceUri": "subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM",
+    "resource": {
+      "extendedLocation": {
+        "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+        "type": "CustomLocation"
+      },
+      "properties": {
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic"
+            }
+          ]
+        },
+        "storageProfile": {
+          "dataDisks": [
+            {
+              "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/virtualHardDisks/test-vhd"
+            }
+          ]
+        },
+        "createFromLocal": true,
+        "localVmName": "DemoVM_restored"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default",
+        "properties": {
+          "hardwareProfile": {
+            "vmSize": "Default"
+          },
+          "networkProfile": {
+            "networkInterfaces": [
+              {
+                "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic"
+              }
+            ]
+          },
+          "osProfile": {
+            "adminUsername": "localadmin",
+            "computerName": "luamaster"
+          },
+          "provisioningState": "Accepted",
+          "securityProfile": {
+            "enableTPM": true,
+            "uefiSettings": {
+              "secureBootEnabled": true
+            }
+          },
+          "storageProfile": {
+            "imageReference": {
+              "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/galleryImages/test-gallery-image"
+            },
+            "vmConfigStoragePathId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-container"
+          },
+          "createFromLocal": true,
+          "localVmName": "DemoVM_restored"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "extendedLocation": {
+          "name": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.HybridCompute/machines/DemoVM/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default",
+        "properties": {
+          "hardwareProfile": {
+            "vmSize": "Default"
+          },
+          "networkProfile": {
+            "networkInterfaces": [
+              {
+                "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/networkInterfaces/test-nic"
+              }
+            ]
+          },
+          "osProfile": {
+            "adminUsername": "localadmin",
+            "computerName": "luamaster"
+          },
+          "provisioningState": "Succeeded",
+          "storageProfile": {
+            "imageReference": {
+              "id": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/galleryImages/test-gallery-image"
+            },
+            "vmConfigStoragePathId": "/subscriptions/a95612cb-f1fa-4daa-a4fd-272844fa512c/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/storageContainers/test-container"
+          },
+          "createFromLocal": true,
+          "localVmName": "DemoVM_restored"
+        }
+      }
+    }
+  },
+  "operationId": "VirtualMachineInstances_CreateOrUpdate",
+  "title": "CreateVirtualMachineInstanceFromLocal"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualNetworkSubnets_CreateOrUpdate.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualNetworkSubnets_CreateOrUpdate.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "virtualNetworkName": "test-vnet",
+    "subnetName": "subnet1",
+    "resource": {
+      "properties": {
+        "addressPrefix": "10.0.0.0/28"
+      }
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "subnet",
+        "type": "Microsoft.AzureStackHCI/virtualNetworks/subnets",
+        "extendedLocation": {
+          "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/virtualNetworks/test-vnet/subnets/subnet1",
+        "properties": {
+          "addressPrefix": "10.0.0.0/28",
+          "provisioningState": "Accepted"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "test-vnet",
+        "type": "Microsoft.AzureStackHCI/virtualNetworks",
+        "extendedLocation": {
+          "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/virtualNetworks/test-vnet/subnets/subnet1",
+        "properties": {
+          "addressPrefix": "10.0.0.0/28",
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "VirtualNetworkSubnets_CreateOrUpdate",
+  "title": "PutVirtualNetworkSubnet"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualNetworkSubnets_Delete.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualNetworkSubnets_Delete.json
@@ -1,0 +1,23 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "virtualNetworkName": "test-vnet",
+    "resourceGroupName": "test-rg",
+    "subnetName": "subnet1",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "VirtualNetworkSubnets_Delete",
+  "title": "DeleteVirtualNetworkSubnet"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualNetworkSubnets_Get.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualNetworkSubnets_Get.json
@@ -1,0 +1,28 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "virtualNetworkName": "test-vnet",
+    "subnetName": "subnet1",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "subnet1",
+        "type": "Microsoft.AzureStackHCI/virtualNetworks/subnets",
+        "extendedLocation": {
+          "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/virtualNetworks/test-vnet/subnets/subnet1",
+        "properties": {
+          "addressPrefix": "10.0.0.0/28",
+          "provisioningState": "Accepted"
+        }
+      }
+    }
+  },
+  "operationId": "VirtualNetworkSubnets_Get",
+  "title": "GetVirtualNetworkSubnet"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualNetworkSubnets_ListByVirtualNetwork.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualNetworkSubnets_ListByVirtualNetwork.json
@@ -1,0 +1,31 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "virtualNetworkName": "test-vnet",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "subnet1",
+            "type": "Microsoft.AzureStackHCI/virtualNetworks/subnets",
+            "extendedLocation": {
+              "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+              "type": "CustomLocation"
+            },
+            "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/virtualNetworks/test-vnet/subnets/subnet1",
+            "properties": {
+              "addressPrefix": "10.0.0.0/28",
+              "provisioningState": "Accepted"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "VirtualNetworkSubnets_ListByVirtualNetwork",
+  "title": "ListVirtualNetworkSubnetsByVirtualNetwork"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualNetworkSubnets_Update.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualNetworkSubnets_Update.json
@@ -1,0 +1,43 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "virtualNetworkName": "test-vnet",
+    "subnetName": "subnet1",
+    "properties": {
+      "properties": {
+        "networkSecurityGroup": {
+          "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/networkSecurityGroups/testnsg"
+        }
+      }
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "subnet1",
+        "type": "Microsoft.AzureStackHCI/virtualNetworks/subnets",
+        "extendedLocation": {
+          "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/virtualNetworks/test-vnet/subnets/subnet1",
+        "properties": {
+          "provisioningState": "Accepted",
+          "addressPrefix": "10.0.0.0/28",
+          "networkSecurityGroup": {
+            "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/networkSecurityGroups/testnsg"
+          }
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "VirtualNetworkSubnets_Update",
+  "title": "UpdateVirtualNetworkUpdates"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualNetworks_CreateOrUpdate.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualNetworks_CreateOrUpdate.json
@@ -1,0 +1,75 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "virtualNetworkName": "test-vnet",
+    "resource": {
+      "extendedLocation": {
+        "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+        "type": "CustomLocation"
+      },
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "10.0.0.0/24"
+          ]
+        },
+        "dhcpOptions": {
+          "dnsServers": []
+        }
+      },
+      "location": "West US2"
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test-vnet",
+        "type": "Microsoft.AzureStackHCI/virtualNetworks",
+        "extendedLocation": {
+          "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/virtualNetworks/test-vnet",
+        "location": "West US2",
+        "properties": {
+          "addressSpace": {
+            "addressPrefixes": [
+              "10.0.0.0/24"
+            ]
+          },
+          "dhcpOptions": {
+            "dnsServers": []
+          },
+          "provisioningState": "Accepted"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "test-vnet",
+        "type": "Microsoft.AzureStackHCI/virtualNetworks",
+        "extendedLocation": {
+          "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/virtualNetworks/test-vnet",
+        "location": "West US2",
+        "properties": {
+          "addressSpace": {
+            "addressPrefixes": [
+              "10.0.0.0/24"
+            ]
+          },
+          "dhcpOptions": {
+            "dnsServers": []
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "VirtualNetworks_CreateOrUpdate",
+  "title": "PutVirtualNetwork"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualNetworks_Delete.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualNetworks_Delete.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "virtualNetworkName": "test-vnet",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "VirtualNetworks_Delete",
+  "title": "DeleteVirtualNetwork"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualNetworks_Get.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualNetworks_Get.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "virtualNetworkName": "test-vnet",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test-vnet",
+        "type": "Microsoft.AzureStackHCI/virtualNetworks",
+        "extendedLocation": {
+          "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/virtualNetworks/test-vnet",
+        "location": "West US2",
+        "properties": {
+          "addressSpace": {
+            "addressPrefixes": [
+              "10.0.0.0/24"
+            ]
+          },
+          "dhcpOptions": {
+            "dnsServers": []
+          },
+          "provisioningState": "Accepted"
+        }
+      }
+    }
+  },
+  "operationId": "VirtualNetworks_Get",
+  "title": "GetVirtualNetwork"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualNetworks_ListAll.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualNetworks_ListAll.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "test-vnet",
+            "type": "Microsoft.AzureStackHCI/virtualNetworks",
+            "extendedLocation": {
+              "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+              "type": "CustomLocation"
+            },
+            "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.AzureStackHCI/virtualNetworks/test-vnet",
+            "location": "West US2",
+            "properties": {
+              "addressSpace": {
+                "addressPrefixes": [
+                  "10.0.0.0/24"
+                ]
+              },
+              "dhcpOptions": {
+                "dnsServers": []
+              },
+              "provisioningState": "Accepted"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "VirtualNetworks_ListAll",
+  "title": "ListVirtualNetworkBySubscription"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualNetworks_ListByResourceGroup.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualNetworks_ListByResourceGroup.json
@@ -1,0 +1,38 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "test-vnet",
+            "type": "Microsoft.AzureStackHCI/virtualNetworks",
+            "extendedLocation": {
+              "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+              "type": "CustomLocation"
+            },
+            "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/virtualNetworks/test-vnet",
+            "location": "West US2",
+            "properties": {
+              "addressSpace": {
+                "addressPrefixes": [
+                  "10.0.0.0/24"
+                ]
+              },
+              "dhcpOptions": {
+                "dnsServers": []
+              },
+              "provisioningState": "Accepted"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "VirtualNetworks_ListByResourceGroup",
+  "title": "ListVirtualNetworkByResourceGroup"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualNetworks_UpdateTags.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/examples/VirtualNetworks_UpdateTags.json
@@ -1,0 +1,50 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01-preview",
+    "virtualNetworkName": "testvnet",
+    "properties": {
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      }
+    },
+    "resourceGroupName": "testrg",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testvnet",
+        "type": "Microsoft.AzureStackHCI/virtualNetworks",
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/testrg/providers/Microsoft.AzureStackHCI/virtualNetworks/testvnet",
+        "location": "westus",
+        "extendedLocation": {
+          "name": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/dogfoodarc/providers/Microsoft.ExtendedLocation/customLocations/dogfood-location",
+          "type": "CustomLocation"
+        },
+        "properties": {
+          "addressSpace": {
+            "addressPrefixes": [
+              "10.0.0.0/24"
+            ]
+          },
+          "dhcpOptions": {
+            "dnsServers": []
+          },
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  },
+  "operationId": "VirtualNetworks_UpdateTags",
+  "title": "Update virtual Network tags"
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/stackhcivm.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/preview/2026-07-01-preview/stackhcivm.json
@@ -1,0 +1,11713 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Microsoft.AzureStackHCI",
+    "version": "2026-07-01-preview",
+    "description": "Azure Stack HCI management service",
+    "x-typespec-generated": [
+      {
+        "emitter": "@azure-tools/typespec-autorest"
+      }
+    ]
+  },
+  "schemes": [
+    "https"
+  ],
+  "host": "management.azure.com",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "GalleryImages"
+    },
+    {
+      "name": "LogicalNetworks"
+    },
+    {
+      "name": "MarketplaceGalleryImages"
+    },
+    {
+      "name": "NetworkInterfaces"
+    },
+    {
+      "name": "NetworkSecurityGroups"
+    },
+    {
+      "name": "SecurityRules"
+    },
+    {
+      "name": "Snapshots"
+    },
+    {
+      "name": "StorageContainers"
+    },
+    {
+      "name": "VirtualHardDisks"
+    },
+    {
+      "name": "VirtualMachineInstances"
+    },
+    {
+      "name": "HybridIdentityMetadataGroup"
+    },
+    {
+      "name": "AttestationStatuses"
+    },
+    {
+      "name": "GuestAgents"
+    },
+    {
+      "name": "VirtualNetworks"
+    },
+    {
+      "name": "VirtualNetworkSubnets"
+    },
+    {
+      "name": "PublicIPAddresses"
+    },
+    {
+      "name": "NatGateways"
+    },
+    {
+      "name": "InboundRules"
+    },
+    {
+      "name": "LoadBalancers"
+    },
+    {
+      "name": "Operations"
+    }
+  ],
+  "paths": {
+    "/{resourceUri}/providers/Microsoft.AzureStackHCI/virtualMachineInstances": {
+      "get": {
+        "operationId": "VirtualMachineInstances_List",
+        "tags": [
+          "VirtualMachineInstances"
+        ],
+        "description": "Lists all of the virtual machine instances within the specified parent resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/Azure.ResourceManager.ResourceUriParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VirtualMachineInstanceListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ListVirtualMachineInstances": {
+            "$ref": "./examples/VirtualMachineInstances_List.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/{resourceUri}/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default": {
+      "get": {
+        "operationId": "VirtualMachineInstances_Get",
+        "tags": [
+          "VirtualMachineInstances"
+        ],
+        "description": "Gets a virtual machine instance",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/Azure.ResourceManager.ResourceUriParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VirtualMachineInstance"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "GetVirtualMachineInstance": {
+            "$ref": "./examples/VirtualMachineInstances_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "VirtualMachineInstances_CreateOrUpdate",
+        "tags": [
+          "VirtualMachineInstances"
+        ],
+        "description": "The operation to create or update a virtual machine instance. Please note some properties can be set only during virtual machine instance creation.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/Azure.ResourceManager.ResourceUriParameter"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Resource create parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/VirtualMachineInstance"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'VirtualMachineInstance' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/VirtualMachineInstance"
+            }
+          },
+          "201": {
+            "description": "Resource 'VirtualMachineInstance' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/VirtualMachineInstance"
+            },
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "CreateVirtualMachineInstanceFromLocal": {
+            "$ref": "./examples/VirtualMachineInstances__CreateOrUpdate_CreateFromLocal.json"
+          },
+          "PutVirtualMachineInstanceWithGalleryImage": {
+            "$ref": "./examples/VirtualMachineInstances_CreateOrUpdate_Put_Virtual_Machine_Instance_With_Gallery_Image.json"
+          },
+          "PutVirtualMachineInstanceWithGpu": {
+            "$ref": "./examples/VirtualMachineInstances_CreateOrUpdate_Put_Virtual_Machine_Instance_With_Gpu.json"
+          },
+          "PutVirtualMachineInstanceWithMarketplaceGalleryImage": {
+            "$ref": "./examples/VirtualMachineInstances_CreateOrUpdate_Put_Virtual_Machine_Instance_With_Marketplace_Gallery_Image.json"
+          },
+          "PutVirtualMachineInstanceWithOsDisk": {
+            "$ref": "./examples/VirtualMachineInstances_CreateOrUpdate_Put_Virtual_Machine_Instance_With_Os_Disk.json"
+          },
+          "PutVirtualMachineInstanceWithVMConfigAgent": {
+            "$ref": "./examples/VirtualMachineInstances_CreateOrUpdate_Put_Virtual_Machine_Instance_With_Vm_Config_Agent.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "VirtualMachineInstances_Update",
+        "tags": [
+          "VirtualMachineInstances"
+        ],
+        "description": "The operation to update a virtual machine instance.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/Azure.ResourceManager.ResourceUriParameter"
+          },
+          {
+            "name": "properties",
+            "in": "body",
+            "description": "The resource properties to be updated.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/VirtualMachineInstanceUpdateRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VirtualMachineInstance"
+            }
+          },
+          "202": {
+            "description": "Resource update request accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "UpdateVirtualMachine": {
+            "$ref": "./examples/VirtualMachineInstances_Update.json"
+          },
+          "UpdateVirtualMachineDynamicMemory": {
+            "$ref": "./examples/VirtualMachineInstances_Update_DynamicMemory.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "VirtualMachineInstances_Delete",
+        "tags": [
+          "VirtualMachineInstances"
+        ],
+        "description": "The operation to delete a virtual machine instance.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/Azure.ResourceManager.ResourceUriParameter"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DeleteVirtualMachine": {
+            "$ref": "./examples/VirtualMachineInstances_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/{resourceUri}/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default/attestationStatus/default": {
+      "get": {
+        "operationId": "AttestationStatuses_Get",
+        "tags": [
+          "AttestationStatuses"
+        ],
+        "description": "Implements AttestationStatus GET method.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/Azure.ResourceManager.ResourceUriParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AttestationStatus"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "GetAttestationStatus": {
+            "$ref": "./examples/AttestationStatuses_Get.json"
+          }
+        }
+      }
+    },
+    "/{resourceUri}/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default/guestAgents": {
+      "get": {
+        "operationId": "GuestAgents_ListByVirtualMachineInstance",
+        "tags": [
+          "GuestAgents"
+        ],
+        "description": "Returns the list of GuestAgent of the given vm.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/Azure.ResourceManager.ResourceUriParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/GuestAgentListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "GuestAgentListByVirtualMachineInstances": {
+            "$ref": "./examples/GuestAgents_ListByVirtualMachineInstance.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/{resourceUri}/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default/guestAgents/default": {
+      "get": {
+        "operationId": "GuestAgents_Get",
+        "tags": [
+          "GuestAgents"
+        ],
+        "description": "Implements GuestAgent GET method.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/Azure.ResourceManager.ResourceUriParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/GuestAgent"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "GetGuestAgent": {
+            "$ref": "./examples/GuestAgents_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "GuestAgents_Create",
+        "tags": [
+          "GuestAgents"
+        ],
+        "description": "Create Or Update GuestAgent.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/Azure.ResourceManager.ResourceUriParameter"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Resource create parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/GuestAgent"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'GuestAgent' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/GuestAgent"
+            }
+          },
+          "201": {
+            "description": "Resource 'GuestAgent' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/GuestAgent"
+            },
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "CreateGuestAgent": {
+            "$ref": "./examples/GuestAgents_Create.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "GuestAgents_Delete",
+        "tags": [
+          "GuestAgents"
+        ],
+        "description": "Implements GuestAgent DELETE method.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/Azure.ResourceManager.ResourceUriParameter"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DeleteGuestAgent": {
+            "$ref": "./examples/GuestAgents_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/{resourceUri}/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default/hybridIdentityMetadata": {
+      "get": {
+        "operationId": "HybridIdentityMetadata_ListByVirtualMachineInstance",
+        "tags": [
+          "HybridIdentityMetadataGroup"
+        ],
+        "description": "Returns the list of HybridIdentityMetadata of the given vm.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/Azure.ResourceManager.ResourceUriParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/HybridIdentityMetadataListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "HybridIdentityMetadataListByVirtualMachineInstances": {
+            "$ref": "./examples/HybridIdentityMetadata_ListByVirtualMachineInstance.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/{resourceUri}/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default/hybridIdentityMetadata/default": {
+      "get": {
+        "operationId": "HybridIdentityMetadata_Get",
+        "tags": [
+          "HybridIdentityMetadataGroup"
+        ],
+        "description": "Implements HybridIdentityMetadata GET method.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/Azure.ResourceManager.ResourceUriParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/HybridIdentityMetadata"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "GetHybridIdentityMetadata": {
+            "$ref": "./examples/HybridIdentityMetadataGroup_Get.json"
+          }
+        }
+      }
+    },
+    "/{resourceUri}/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default/pause": {
+      "post": {
+        "operationId": "VirtualMachineInstances_Pause",
+        "tags": [
+          "VirtualMachineInstances"
+        ],
+        "description": "The operation to pause a virtual machine instance.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/Azure.ResourceManager.ResourceUriParameter"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PauseVirtualMachine": {
+            "$ref": "./examples/VirtualMachineInstances_Pause.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/{resourceUri}/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default/powerOff": {
+      "post": {
+        "operationId": "VirtualMachineInstances_PowerOff",
+        "tags": [
+          "VirtualMachineInstances"
+        ],
+        "description": "The operation to power off a virtual machine instance.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/Azure.ResourceManager.ResourceUriParameter"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "The content of the action request",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PowerOffVirtualMachineOptions"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/OperationStatusResult"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PowerOffVirtualMachine": {
+            "$ref": "./examples/VirtualMachineInstances_PowerOff.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/{resourceUri}/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default/restart": {
+      "post": {
+        "operationId": "VirtualMachineInstances_Restart",
+        "tags": [
+          "VirtualMachineInstances"
+        ],
+        "description": "The operation to restart a virtual machine instance.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/Azure.ResourceManager.ResourceUriParameter"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RestartVirtualMachine": {
+            "$ref": "./examples/VirtualMachineInstances_Restart.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/{resourceUri}/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default/save": {
+      "post": {
+        "operationId": "VirtualMachineInstances_Save",
+        "tags": [
+          "VirtualMachineInstances"
+        ],
+        "description": "The operation to save a virtual machine instance.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/Azure.ResourceManager.ResourceUriParameter"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "SaveVirtualMachine": {
+            "$ref": "./examples/VirtualMachineInstances_Save.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/{resourceUri}/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default/start": {
+      "post": {
+        "operationId": "VirtualMachineInstances_Start",
+        "tags": [
+          "VirtualMachineInstances"
+        ],
+        "description": "The operation to start a virtual machine instance.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/Azure.ResourceManager.ResourceUriParameter"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "StartVirtualMachine": {
+            "$ref": "./examples/VirtualMachineInstances_Start.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/{resourceUri}/providers/Microsoft.AzureStackHCI/virtualMachineInstances/default/stop": {
+      "post": {
+        "operationId": "VirtualMachineInstances_Stop",
+        "tags": [
+          "VirtualMachineInstances"
+        ],
+        "description": "The operation to stop a virtual machine instance.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/Azure.ResourceManager.ResourceUriParameter"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "StopVirtualMachine": {
+            "$ref": "./examples/VirtualMachineInstances_Stop.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/providers/Microsoft.AzureStackHCI/operations": {
+      "get": {
+        "operationId": "Operations_List",
+        "tags": [
+          "Operations"
+        ],
+        "description": "List the operations for the provider",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/OperationListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List the operations for the provider.": {
+            "$ref": "./examples/Operations_List.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.AzureStackHCI/galleryImages": {
+      "get": {
+        "operationId": "GalleryImages_ListAll",
+        "tags": [
+          "GalleryImages"
+        ],
+        "description": "Lists all of the gallery images in the specified subscription. Use the nextLink property in the response to get the next page of gallery images.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/GalleryImageListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ListGalleryImageBySubscription": {
+            "$ref": "./examples/GalleryImages_ListAll.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.AzureStackHCI/loadBalancers": {
+      "get": {
+        "operationId": "LoadBalancers_ListAll",
+        "tags": [
+          "LoadBalancers"
+        ],
+        "description": "Lists all of the loadBalancers in the specified subscription. Use the nextLink property in the response to get the next page of LoadBalancer.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/LoadBalancerListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ListLoadBalancerBySubscription": {
+            "$ref": "./examples/LoadBalancers_ListAll.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.AzureStackHCI/logicalNetworks": {
+      "get": {
+        "operationId": "LogicalNetworks_ListAll",
+        "tags": [
+          "LogicalNetworks"
+        ],
+        "description": "Lists all of the logical networks in the specified subscription. Use the nextLink property in the response to get the next page of logical networks.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/LogicalNetworkListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ListLogicalNetworkBySubscription": {
+            "$ref": "./examples/LogicalNetworks_ListAll.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.AzureStackHCI/marketplaceGalleryImages": {
+      "get": {
+        "operationId": "MarketplaceGalleryImages_ListAll",
+        "tags": [
+          "MarketplaceGalleryImages"
+        ],
+        "description": "Lists all of the marketplace gallery images in the specified subscription. Use the nextLink property in the response to get the next page of marketplace gallery images.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/MarketplaceGalleryImageListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ListMarketplaceGalleryImageBySubscription": {
+            "$ref": "./examples/MarketplaceGalleryImages_ListAll.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.AzureStackHCI/natGateways": {
+      "get": {
+        "operationId": "NatGateways_ListAll",
+        "tags": [
+          "NatGateways"
+        ],
+        "description": "Lists all of the natGateways in the specified subscription. Use the nextLink property in the response to get the next page of NatGateway.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NatGatewayListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ListNatGatewayBySubscription": {
+            "$ref": "./examples/NatGateways_ListAll.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.AzureStackHCI/networkInterfaces": {
+      "get": {
+        "operationId": "NetworkInterfaces_ListAll",
+        "tags": [
+          "NetworkInterfaces"
+        ],
+        "description": "Lists all of the network interfaces in the specified subscription. Use the nextLink property in the response to get the next page of network interfaces.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkInterfaceListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ListNetworkInterfaceBySubscription": {
+            "$ref": "./examples/NetworkInterfaces_ListAll.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.AzureStackHCI/networkSecurityGroups": {
+      "get": {
+        "operationId": "NetworkSecurityGroups_ListAll",
+        "tags": [
+          "NetworkSecurityGroups"
+        ],
+        "description": "Gets all network security groups in a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkSecurityGroupListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List all network security groups": {
+            "$ref": "./examples/NetworkSecurityGroups_ListAll.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.AzureStackHCI/publicIPAddresses": {
+      "get": {
+        "operationId": "PublicIPAddresses_ListAll",
+        "tags": [
+          "PublicIPAddresses"
+        ],
+        "description": "Lists all of the publicIPAddresses in the specified subscription. Use the nextLink property in the response to get the next page of PublicIP.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PublicIPAddressListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List all public IP addresses": {
+            "$ref": "./examples/PublicIPAddresses_ListALL.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.AzureStackHCI/snapshots": {
+      "get": {
+        "operationId": "Snapshots_ListAll",
+        "tags": [
+          "Snapshots"
+        ],
+        "description": "Lists all of the snapshots in the specified subscription. Use the nextLink property in the response to get the next page of snapshots.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SnapshotListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List all snapshots in a subscription": {
+            "$ref": "./examples/Snapshots_ListAll.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.AzureStackHCI/storageContainers": {
+      "get": {
+        "operationId": "StorageContainers_ListAll",
+        "tags": [
+          "StorageContainers"
+        ],
+        "description": "Lists all of the storage containers in the specified subscription. Use the nextLink property in the response to get the next page of storage containers.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/StorageContainerListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ListStorageContainerBySubscription": {
+            "$ref": "./examples/StorageContainers_ListAll.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.AzureStackHCI/virtualHardDisks": {
+      "get": {
+        "operationId": "VirtualHardDisks_ListAll",
+        "tags": [
+          "VirtualHardDisks"
+        ],
+        "description": "Lists all of the virtual hard disks in the specified subscription. Use the nextLink property in the response to get the next page of virtual hard disks.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VirtualHardDiskListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ListVirtualHardDiskBySubscription": {
+            "$ref": "./examples/VirtualHardDisks_ListAll.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.AzureStackHCI/virtualNetworks": {
+      "get": {
+        "operationId": "VirtualNetworks_ListAll",
+        "tags": [
+          "VirtualNetworks"
+        ],
+        "description": "Lists all of the virtual networks in the specified subscription. Use the nextLink property in the response to get the next page of virtualNetwork networks.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ListVirtualNetworkBySubscription": {
+            "$ref": "./examples/VirtualNetworks_ListAll.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/galleryImages": {
+      "get": {
+        "operationId": "GalleryImages_ListByResourceGroup",
+        "tags": [
+          "GalleryImages"
+        ],
+        "description": "Lists all of the gallery images in the specified resource group. Use the nextLink property in the response to get the next page of gallery images.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/GalleryImageListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ListGalleryImageByResourceGroup": {
+            "$ref": "./examples/GalleryImages_ListByResourceGroup.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/galleryImages/{galleryImageName}": {
+      "get": {
+        "operationId": "GalleryImages_Get",
+        "tags": [
+          "GalleryImages"
+        ],
+        "description": "Gets a gallery image",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "galleryImageName",
+            "in": "path",
+            "description": "Name of the gallery image",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/GalleryImage"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "GetGalleryImage": {
+            "$ref": "./examples/GalleryImages_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "GalleryImages_CreateOrUpdate",
+        "tags": [
+          "GalleryImages"
+        ],
+        "description": "The operation to create or update a gallery image. Please note some properties can be set only during gallery image creation.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "galleryImageName",
+            "in": "path",
+            "description": "Name of the gallery image",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Resource create parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/GalleryImage"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'GalleryImage' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/GalleryImage"
+            }
+          },
+          "201": {
+            "description": "Resource 'GalleryImage' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/GalleryImage"
+            },
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PutGalleryImage": {
+            "$ref": "./examples/GalleryImages_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "GalleryImages_Update",
+        "tags": [
+          "GalleryImages"
+        ],
+        "description": "The operation to update a gallery image.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "galleryImageName",
+            "in": "path",
+            "description": "Name of the gallery image",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "properties",
+            "in": "body",
+            "description": "The resource properties to be updated.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/GalleryImageTagsUpdate"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/GalleryImage"
+            }
+          },
+          "202": {
+            "description": "Resource update request accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "UpdateGalleryImage": {
+            "$ref": "./examples/GalleryImages_Update.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "GalleryImages_Delete",
+        "tags": [
+          "GalleryImages"
+        ],
+        "description": "The operation to delete a gallery image.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "galleryImageName",
+            "in": "path",
+            "description": "Name of the gallery image",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DeleteGalleryImage": {
+            "$ref": "./examples/GalleryImages_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/loadBalancers": {
+      "get": {
+        "operationId": "LoadBalancers_ListByResourceGroup",
+        "tags": [
+          "LoadBalancers"
+        ],
+        "description": "Lists all of the loadBalancers in the specified resource group. Use the nextLink property in the response to get the next page of LoadBalancer.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/LoadBalancerListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ListLoadBalancerByResourceGroup": {
+            "$ref": "./examples/LoadBalancers_ListByResourceGroup.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/loadBalancers/{loadBalancerName}": {
+      "get": {
+        "operationId": "LoadBalancers_Get",
+        "tags": [
+          "LoadBalancers"
+        ],
+        "description": "The operation to get a loadBalancer.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "loadBalancerName",
+            "in": "path",
+            "description": "Name of the load balancer",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/LoadBalancer"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "GetLoadBalancers": {
+            "$ref": "./examples/LoadBalancers_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "LoadBalancers_CreateOrUpdate",
+        "tags": [
+          "LoadBalancers"
+        ],
+        "description": "The operation to create or update a loadBalancer. Please note some properties can be set only during LoadBalancer creation.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "loadBalancerName",
+            "in": "path",
+            "description": "Name of the load balancer",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Resource create parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/LoadBalancer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'LoadBalancer' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/LoadBalancer"
+            }
+          },
+          "201": {
+            "description": "Resource 'LoadBalancer' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/LoadBalancer"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PutLoadBalancer": {
+            "$ref": "./examples/LoadBalancers_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "LoadBalancers_UpdateTags",
+        "tags": [
+          "LoadBalancers"
+        ],
+        "description": "Updates a loadBalancer tags.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "loadBalancerName",
+            "in": "path",
+            "description": "Name of the load balancer",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "properties",
+            "in": "body",
+            "description": "The resource properties to be updated.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/LoadBalancerTagsUpdate"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/LoadBalancer"
+            }
+          },
+          "202": {
+            "description": "Resource update request accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Update LoadBalancers tags": {
+            "$ref": "./examples/LoadBalancers_UpdateTags.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "LoadBalancers_Delete",
+        "tags": [
+          "LoadBalancers"
+        ],
+        "description": "The operation to delete a loadBalancer.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "loadBalancerName",
+            "in": "path",
+            "description": "Name of the load balancer",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DeleteLoadBalancers": {
+            "$ref": "./examples/LoadBalancers_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/logicalNetworks": {
+      "get": {
+        "operationId": "LogicalNetworks_ListByResourceGroup",
+        "tags": [
+          "LogicalNetworks"
+        ],
+        "description": "Lists all of the logical networks in the specified resource group. Use the nextLink property in the response to get the next page of logical networks.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/LogicalNetworkListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ListLogicalNetworkByResourceGroup": {
+            "$ref": "./examples/LogicalNetworks_ListByResourceGroup.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/logicalNetworks/{logicalNetworkName}": {
+      "get": {
+        "operationId": "LogicalNetworks_Get",
+        "tags": [
+          "LogicalNetworks"
+        ],
+        "description": "The operation to get a logical network.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "logicalNetworkName",
+            "in": "path",
+            "description": "Name of the logical network",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/LogicalNetwork"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "GetLogicalNetwork": {
+            "$ref": "./examples/LogicalNetworks_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "LogicalNetworks_CreateOrUpdate",
+        "tags": [
+          "LogicalNetworks"
+        ],
+        "description": "The operation to create or update a logical network. Please note some properties can be set only during logical network creation.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "logicalNetworkName",
+            "in": "path",
+            "description": "Name of the logical network",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Resource create parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/LogicalNetwork"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'LogicalNetwork' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/LogicalNetwork"
+            }
+          },
+          "201": {
+            "description": "Resource 'LogicalNetwork' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/LogicalNetwork"
+            },
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PutLogicalNetwork": {
+            "$ref": "./examples/LogicalNetworks_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "LogicalNetworks_Update",
+        "tags": [
+          "LogicalNetworks"
+        ],
+        "description": "The operation to update a logical network.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "logicalNetworkName",
+            "in": "path",
+            "description": "Name of the logical network",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "properties",
+            "in": "body",
+            "description": "The resource properties to be updated.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/LogicalNetworksUpdateRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/LogicalNetwork"
+            }
+          },
+          "202": {
+            "description": "Resource update request accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "UpdateLogicalNetwork": {
+            "$ref": "./examples/LogicalNetworks_Update.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "LogicalNetworks_Delete",
+        "tags": [
+          "LogicalNetworks"
+        ],
+        "description": "The operation to delete a logical network.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "logicalNetworkName",
+            "in": "path",
+            "description": "Name of the logical network",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DeleteLogicalNetwork": {
+            "$ref": "./examples/LogicalNetworks_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/marketplaceGalleryImages": {
+      "get": {
+        "operationId": "MarketplaceGalleryImages_ListByResourceGroup",
+        "tags": [
+          "MarketplaceGalleryImages"
+        ],
+        "description": "Lists all of the marketplace gallery images in the specified resource group. Use the nextLink property in the response to get the next page of marketplace gallery images.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/MarketplaceGalleryImageListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ListMarketplaceGalleryImageByResourceGroup": {
+            "$ref": "./examples/MarketplaceGalleryImages_ListByResourceGroup.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/marketplaceGalleryImages/{marketplaceGalleryImageName}": {
+      "get": {
+        "operationId": "MarketplaceGalleryImages_Get",
+        "tags": [
+          "MarketplaceGalleryImages"
+        ],
+        "description": "Gets a marketplace gallery image",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "marketplaceGalleryImageName",
+            "in": "path",
+            "description": "Name of the marketplace gallery image",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/MarketplaceGalleryImage"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "GetMarketplaceGalleryImage": {
+            "$ref": "./examples/MarketplaceGalleryImages_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "MarketplaceGalleryImages_CreateOrUpdate",
+        "tags": [
+          "MarketplaceGalleryImages"
+        ],
+        "description": "The operation to create or update a marketplace gallery image. Please note some properties can be set only during marketplace gallery image creation.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "marketplaceGalleryImageName",
+            "in": "path",
+            "description": "Name of the marketplace gallery image",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Resource create parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/MarketplaceGalleryImage"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'MarketplaceGalleryImage' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/MarketplaceGalleryImage"
+            }
+          },
+          "201": {
+            "description": "Resource 'MarketplaceGalleryImage' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/MarketplaceGalleryImage"
+            },
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PutMarketplaceGalleryImage": {
+            "$ref": "./examples/MarketplaceGalleryImages_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "MarketplaceGalleryImages_Update",
+        "tags": [
+          "MarketplaceGalleryImages"
+        ],
+        "description": "The operation to update a marketplace gallery image.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "marketplaceGalleryImageName",
+            "in": "path",
+            "description": "Name of the marketplace gallery image",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "properties",
+            "in": "body",
+            "description": "The resource properties to be updated.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/MarketplaceGalleryImageTagsUpdate"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/MarketplaceGalleryImage"
+            }
+          },
+          "202": {
+            "description": "Resource update request accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "UpdateMarketplaceGalleryImage": {
+            "$ref": "./examples/MarketplaceGalleryImages_Update.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "MarketplaceGalleryImages_Delete",
+        "tags": [
+          "MarketplaceGalleryImages"
+        ],
+        "description": "The operation to delete a marketplace gallery image.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "marketplaceGalleryImageName",
+            "in": "path",
+            "description": "Name of the marketplace gallery image",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DeleteMarketplaceGalleryImage": {
+            "$ref": "./examples/MarketplaceGalleryImages_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/natGateways": {
+      "get": {
+        "operationId": "NatGateways_ListByResourceGroup",
+        "tags": [
+          "NatGateways"
+        ],
+        "description": "Lists all of the natGateways in the specified resource group. Use the nextLink property in the response to get the next page of NatGateway.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NatGatewayListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ListNatGatewayByResourceGroup": {
+            "$ref": "./examples/NatGateways_ListByResourceGroup.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/natGateways/{natGatewayName}": {
+      "get": {
+        "operationId": "NatGateways_Get",
+        "tags": [
+          "NatGateways"
+        ],
+        "description": "The operation to get a natGateway.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "natGatewayName",
+            "in": "path",
+            "description": "Name of the nat gateway",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NatGateway"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "GetNatGateway": {
+            "$ref": "./examples/NatGateways_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "NatGateways_CreateOrUpdate",
+        "tags": [
+          "NatGateways"
+        ],
+        "description": "The operation to create or update a natGateway. Please note some properties can be set only during NatGateway creation.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "natGatewayName",
+            "in": "path",
+            "description": "Name of the nat gateway",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Resource create parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/NatGateway"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'NatGateway' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/NatGateway"
+            }
+          },
+          "201": {
+            "description": "Resource 'NatGateway' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/NatGateway"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PutNatGateway": {
+            "$ref": "./examples/NatGateways_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "NatGateways_UpdateTags",
+        "tags": [
+          "NatGateways"
+        ],
+        "description": "Updates a natGateway tags.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "natGatewayName",
+            "in": "path",
+            "description": "Name of the nat gateway",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "properties",
+            "in": "body",
+            "description": "The resource properties to be updated.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/NatGatewayTagsUpdate"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NatGateway"
+            }
+          },
+          "202": {
+            "description": "Resource update request accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Update natGateway tags": {
+            "$ref": "./examples/NatGateways_UpdateTags.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "NatGateways_Delete",
+        "tags": [
+          "NatGateways"
+        ],
+        "description": "The operation to delete a natGateway.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "natGatewayName",
+            "in": "path",
+            "description": "Name of the nat gateway",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DeleteNatGateway": {
+            "$ref": "./examples/NatGateways_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/natGateways/{natGatewayName}/inboundRules": {
+      "get": {
+        "operationId": "InboundRules_ListByNatGateway",
+        "tags": [
+          "InboundRules"
+        ],
+        "description": "Lists all of the inbound rules in the specified NAT gateway. Use the nextLink property in the response to get the next page of inbound rules.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "natGatewayName",
+            "in": "path",
+            "description": "Name of the nat gateway",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/InboundRuleListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ListInboundRulesByNatGateway": {
+            "$ref": "./examples/InboundRules_ListByNatGateway.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/natGateways/{natGatewayName}/inboundRules/{inboundRuleName}": {
+      "get": {
+        "operationId": "InboundRules_Get",
+        "tags": [
+          "InboundRules"
+        ],
+        "description": "The operation to get an inbound rule.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "natGatewayName",
+            "in": "path",
+            "description": "Name of the nat gateway",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "inboundRuleName",
+            "in": "path",
+            "description": "Name of the inbound rule",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/InboundRule"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "GetInboundRule": {
+            "$ref": "./examples/InboundRules_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "InboundRules_CreateOrUpdate",
+        "tags": [
+          "InboundRules"
+        ],
+        "description": "The operation to create or update an inbound rule. Please note some properties can be set only during inbound rule creation.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "natGatewayName",
+            "in": "path",
+            "description": "Name of the nat gateway",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "inboundRuleName",
+            "in": "path",
+            "description": "Name of the inbound rule",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Resource create parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/InboundRule"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'InboundRule' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/InboundRule"
+            }
+          },
+          "201": {
+            "description": "Resource 'InboundRule' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/InboundRule"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "CreateOrUpdateInboundRule": {
+            "$ref": "./examples/InboundRules_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "InboundRules_Delete",
+        "tags": [
+          "InboundRules"
+        ],
+        "description": "The operation to delete an inbound rule.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "natGatewayName",
+            "in": "path",
+            "description": "Name of the nat gateway",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "inboundRuleName",
+            "in": "path",
+            "description": "Name of the inbound rule",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DeleteInboundRule": {
+            "$ref": "./examples/InboundRules_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/networkInterfaces": {
+      "get": {
+        "operationId": "NetworkInterfaces_ListByResourceGroup",
+        "tags": [
+          "NetworkInterfaces"
+        ],
+        "description": "Lists all of the network interfaces in the specified resource group. Use the nextLink property in the response to get the next page of network interfaces.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkInterfaceListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ListNetworkInterfaceByResourceGroup": {
+            "$ref": "./examples/NetworkInterfaces_ListByResourceGroup.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/networkInterfaces/{networkInterfaceName}": {
+      "get": {
+        "operationId": "NetworkInterfaces_Get",
+        "tags": [
+          "NetworkInterfaces"
+        ],
+        "description": "Gets a network interface",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkInterfaceName",
+            "in": "path",
+            "description": "Name of the network interface",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkInterface"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "GetNetworkInterface": {
+            "$ref": "./examples/NetworkInterfaces_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "NetworkInterfaces_CreateOrUpdate",
+        "tags": [
+          "NetworkInterfaces"
+        ],
+        "description": "The operation to create or update a network interface. Please note some properties can be set only during network interface creation.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkInterfaceName",
+            "in": "path",
+            "description": "Name of the network interface",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Resource create parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/NetworkInterface"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'NetworkInterface' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/NetworkInterface"
+            }
+          },
+          "201": {
+            "description": "Resource 'NetworkInterface' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/NetworkInterface"
+            },
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "CreateNetworkInterfaceFromLocal": {
+            "$ref": "./examples/NetworkInterfaces__CreateOrUpdate_CreateFromLocal.json"
+          },
+          "PutNetworkInterface": {
+            "$ref": "./examples/NetworkInterfaces_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "NetworkInterfaces_Update",
+        "tags": [
+          "NetworkInterfaces"
+        ],
+        "description": "The operation to update a network interface.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkInterfaceName",
+            "in": "path",
+            "description": "Name of the network interface",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "properties",
+            "in": "body",
+            "description": "The resource properties to be updated.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/NetworkInterfacesUpdateRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkInterface"
+            }
+          },
+          "202": {
+            "description": "Resource update request accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "UpdateNetworkInterface": {
+            "$ref": "./examples/NetworkInterfaces_Update.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "NetworkInterfaces_Delete",
+        "tags": [
+          "NetworkInterfaces"
+        ],
+        "description": "The operation to delete a network interface.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkInterfaceName",
+            "in": "path",
+            "description": "Name of the network interface",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DeleteNetworkInterface": {
+            "$ref": "./examples/NetworkInterfaces_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/networkSecurityGroups": {
+      "get": {
+        "operationId": "NetworkSecurityGroups_ListByResourceGroup",
+        "tags": [
+          "NetworkSecurityGroups"
+        ],
+        "description": "Gets all network security groups in a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkSecurityGroupListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List network security groups in resource group": {
+            "$ref": "./examples/NetworkSecurityGroups_ListByResourceGroup.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/networkSecurityGroups/{networkSecurityGroupName}": {
+      "get": {
+        "operationId": "NetworkSecurityGroups_Get",
+        "tags": [
+          "NetworkSecurityGroups"
+        ],
+        "description": "Gets the specified network security group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkSecurityGroupName",
+            "in": "path",
+            "description": "Name of the network security group",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkSecurityGroup"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get network security group": {
+            "$ref": "./examples/NetworkSecurityGroups_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "NetworkSecurityGroups_CreateOrUpdate",
+        "tags": [
+          "NetworkSecurityGroups"
+        ],
+        "description": "Creates or updates a network security group in the specified resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkSecurityGroupName",
+            "in": "path",
+            "description": "Name of the network security group",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Resource create parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/NetworkSecurityGroup"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'NetworkSecurityGroup' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/NetworkSecurityGroup"
+            }
+          },
+          "201": {
+            "description": "Resource 'NetworkSecurityGroup' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/NetworkSecurityGroup"
+            },
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "CreateNetworkSecurityGroup": {
+            "$ref": "./examples/NetworkSecurityGroups_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "NetworkSecurityGroups_UpdateTags",
+        "tags": [
+          "NetworkSecurityGroups"
+        ],
+        "description": "Updates a network security group tags.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkSecurityGroupName",
+            "in": "path",
+            "description": "Name of the network security group",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "properties",
+            "in": "body",
+            "description": "The resource properties to be updated.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/NetworkSecurityGroupTagsUpdate"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkSecurityGroup"
+            }
+          },
+          "202": {
+            "description": "Resource update request accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Update network security group tags": {
+            "$ref": "./examples/NetworkSecurityGroups_UpdateTags.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "NetworkSecurityGroups_Delete",
+        "tags": [
+          "NetworkSecurityGroups"
+        ],
+        "description": "Deletes the specified network security group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkSecurityGroupName",
+            "in": "path",
+            "description": "Name of the network security group",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete network security group": {
+            "$ref": "./examples/NetworkSecurityGroups_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/networkSecurityGroups/{networkSecurityGroupName}/securityRules": {
+      "get": {
+        "operationId": "SecurityRules_ListByNetworkSecurityGroup",
+        "tags": [
+          "SecurityRules"
+        ],
+        "description": "Gets all security rules in a Network Security Group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkSecurityGroupName",
+            "in": "path",
+            "description": "Name of the network security group",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SecurityRuleListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List network security rules in network security group": {
+            "$ref": "./examples/SecurityRules_ListByNetworkSecurityGroup.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/networkSecurityGroups/{networkSecurityGroupName}/securityRules/{securityRuleName}": {
+      "get": {
+        "operationId": "SecurityRules_Get",
+        "tags": [
+          "SecurityRules"
+        ],
+        "description": "Gets the specified security rule.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkSecurityGroupName",
+            "in": "path",
+            "description": "Name of the network security group",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "securityRuleName",
+            "in": "path",
+            "description": "Name of the security rule.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SecurityRule"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get network security rule in network security group": {
+            "$ref": "./examples/SecurityRules_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "SecurityRules_CreateOrUpdate",
+        "tags": [
+          "SecurityRules"
+        ],
+        "description": "Creates or updates a security rule in the specified resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkSecurityGroupName",
+            "in": "path",
+            "description": "Name of the network security group",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "securityRuleName",
+            "in": "path",
+            "description": "Name of the security rule.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Resource create parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/SecurityRule"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'SecurityRule' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/SecurityRule"
+            }
+          },
+          "201": {
+            "description": "Resource 'SecurityRule' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/SecurityRule"
+            },
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "SecurityRulesCreateOrUpdate": {
+            "$ref": "./examples/SecurityRules_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "SecurityRules_Delete",
+        "tags": [
+          "SecurityRules"
+        ],
+        "description": "Deletes the specified security rule.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkSecurityGroupName",
+            "in": "path",
+            "description": "Name of the network security group",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "securityRuleName",
+            "in": "path",
+            "description": "Name of the security rule.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "SecurityRulesDelete": {
+            "$ref": "./examples/SecurityRules_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/publicIPAddresses": {
+      "get": {
+        "operationId": "PublicIPAddresses_ListByResourceGroup",
+        "tags": [
+          "PublicIPAddresses"
+        ],
+        "description": "Lists all of the publicIPAddresses in the specified resource group. Use the nextLink property in the response to get the next page of PublicIP.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PublicIPAddressListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List public IPs in resource group": {
+            "$ref": "./examples/PublicIPAddresses_ListByResourceGroup.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/publicIPAddresses/{publicIPAddressName}": {
+      "get": {
+        "operationId": "PublicIPAddresses_Get",
+        "tags": [
+          "PublicIPAddresses"
+        ],
+        "description": "The operation to get a virtual network.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "publicIPAddressName",
+            "in": "path",
+            "description": "Name of the public IP",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PublicIPAddress"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get public IP address": {
+            "$ref": "./examples/PublicIPAddresses_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "PublicIPAddresses_CreateOrUpdate",
+        "tags": [
+          "PublicIPAddresses"
+        ],
+        "description": "The operation to create or update a publicIPAddress. Please note some properties can be set only during PublicIP creation.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "publicIPAddressName",
+            "in": "path",
+            "description": "Name of the public IP",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Resource create parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PublicIPAddress"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'PublicIPAddress' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/PublicIPAddress"
+            }
+          },
+          "201": {
+            "description": "Resource 'PublicIPAddress' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/PublicIPAddress"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "CreatePublicIPAddress": {
+            "$ref": "./examples/PublicIPAddresses_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "PublicIPAddresses_UpdateTags",
+        "tags": [
+          "PublicIPAddresses"
+        ],
+        "description": "Updates a publicIPAddress tags.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "publicIPAddressName",
+            "in": "path",
+            "description": "Name of the public IP",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "properties",
+            "in": "body",
+            "description": "The resource properties to be updated.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PublicIPAddressTagsUpdate"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PublicIPAddress"
+            }
+          },
+          "202": {
+            "description": "Resource update request accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Update public IP addresses tags": {
+            "$ref": "./examples/PublicIPAddresses_UpdateTags.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "PublicIPAddresses_Delete",
+        "tags": [
+          "PublicIPAddresses"
+        ],
+        "description": "The operation to delete a publicIPAddresses.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "publicIPAddressName",
+            "in": "path",
+            "description": "Name of the public IP",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete public IP address": {
+            "$ref": "./examples/PublicIPAddresses_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/snapshots": {
+      "get": {
+        "operationId": "Snapshots_ListByResourceGroup",
+        "tags": [
+          "Snapshots"
+        ],
+        "description": "Lists all of the snapshots in the specified resource group. Use the nextLink property in the response to get the next page of snapshots.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SnapshotListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List snapshots by resource group": {
+            "$ref": "./examples/Snapshots_ListByResourceGroup.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/snapshots/{snapshotName}": {
+      "get": {
+        "operationId": "Snapshots_Get",
+        "tags": [
+          "Snapshots"
+        ],
+        "description": "Gets a snapshot",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "snapshotName",
+            "in": "path",
+            "description": "Name of the snapshot",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Snapshot"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get a snapshot": {
+            "$ref": "./examples/Snapshots_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "Snapshots_CreateOrUpdate",
+        "tags": [
+          "Snapshots"
+        ],
+        "description": "The operation to create or update a snapshot. Please note some properties can be set only during snapshot creation.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "snapshotName",
+            "in": "path",
+            "description": "Name of the snapshot",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Resource create parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Snapshot"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'Snapshot' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Snapshot"
+            }
+          },
+          "201": {
+            "description": "Resource 'Snapshot' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Snapshot"
+            },
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create or update a snapshot": {
+            "$ref": "./examples/Snapshots_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "Snapshots_Update",
+        "tags": [
+          "Snapshots"
+        ],
+        "description": "The operation to update a snapshot.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "snapshotName",
+            "in": "path",
+            "description": "Name of the snapshot",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "properties",
+            "in": "body",
+            "description": "The resource properties to be updated.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/SnapshotTagsUpdate"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Snapshot"
+            }
+          },
+          "202": {
+            "description": "Resource update request accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Update a snapshot": {
+            "$ref": "./examples/Snapshots_Update.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "Snapshots_Delete",
+        "tags": [
+          "Snapshots"
+        ],
+        "description": "The operation to delete a snapshot.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "snapshotName",
+            "in": "path",
+            "description": "Name of the snapshot",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete a snapshot": {
+            "$ref": "./examples/Snapshots_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/storageContainers": {
+      "get": {
+        "operationId": "StorageContainers_ListByResourceGroup",
+        "tags": [
+          "StorageContainers"
+        ],
+        "description": "Lists all of the storage containers in the specified resource group. Use the nextLink property in the response to get the next page of storage containers.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/StorageContainerListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ListStorageContainerByResourceGroup": {
+            "$ref": "./examples/StorageContainers_ListByResourceGroup.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/storageContainers/{storageContainerName}": {
+      "get": {
+        "operationId": "StorageContainers_Get",
+        "tags": [
+          "StorageContainers"
+        ],
+        "description": "Gets a storage container",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "storageContainerName",
+            "in": "path",
+            "description": "Name of the storage container",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/StorageContainer"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "GetStorageContainer": {
+            "$ref": "./examples/StorageContainers_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "StorageContainers_CreateOrUpdate",
+        "tags": [
+          "StorageContainers"
+        ],
+        "description": "The operation to create or update a storage container. Please note some properties can be set only during storage container creation.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "storageContainerName",
+            "in": "path",
+            "description": "Name of the storage container",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Resource create parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/StorageContainer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'StorageContainer' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/StorageContainer"
+            }
+          },
+          "201": {
+            "description": "Resource 'StorageContainer' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/StorageContainer"
+            },
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PutStorageContainer": {
+            "$ref": "./examples/StorageContainers_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "StorageContainers_Update",
+        "tags": [
+          "StorageContainers"
+        ],
+        "description": "The operation to update a storage container.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "storageContainerName",
+            "in": "path",
+            "description": "Name of the storage container",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "properties",
+            "in": "body",
+            "description": "The resource properties to be updated.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/StorageContainerTagsUpdate"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/StorageContainer"
+            }
+          },
+          "202": {
+            "description": "Resource update request accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "UpdateStorageContainer": {
+            "$ref": "./examples/StorageContainers_Update.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "StorageContainers_Delete",
+        "tags": [
+          "StorageContainers"
+        ],
+        "description": "The operation to delete a storage container.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "storageContainerName",
+            "in": "path",
+            "description": "Name of the storage container",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DeleteStorageContainer": {
+            "$ref": "./examples/StorageContainers_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/virtualHardDisks": {
+      "get": {
+        "operationId": "VirtualHardDisks_ListByResourceGroup",
+        "tags": [
+          "VirtualHardDisks"
+        ],
+        "description": "Lists all of the virtual hard disks in the specified resource group. Use the nextLink property in the response to get the next page of virtual hard disks.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VirtualHardDiskListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ListVirtualHardDiskByResourceGroup": {
+            "$ref": "./examples/VirtualHardDisks_ListByResourceGroup.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/virtualHardDisks/{virtualHardDiskName}": {
+      "get": {
+        "operationId": "VirtualHardDisks_Get",
+        "tags": [
+          "VirtualHardDisks"
+        ],
+        "description": "Gets a virtual hard disk",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualHardDiskName",
+            "in": "path",
+            "description": "Name of the virtual hard disk",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VirtualHardDisk"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "GetVirtualHardDisk": {
+            "$ref": "./examples/VirtualHardDisks_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "VirtualHardDisks_CreateOrUpdate",
+        "tags": [
+          "VirtualHardDisks"
+        ],
+        "description": "The operation to create or update a virtual hard disk. Please note some properties can be set only during virtual hard disk creation.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualHardDiskName",
+            "in": "path",
+            "description": "Name of the virtual hard disk",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Resource create parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/VirtualHardDisk"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'VirtualHardDisk' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/VirtualHardDisk"
+            }
+          },
+          "201": {
+            "description": "Resource 'VirtualHardDisk' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/VirtualHardDisk"
+            },
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "CreateVirtualHardDiskFromLocal": {
+            "$ref": "./examples/VirtualHardDisks__CreateOrUpdate_CreateFromLocal.json"
+          },
+          "PutVirtualHardDisk": {
+            "$ref": "./examples/VirtualHardDisks_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "VirtualHardDisks_Update",
+        "tags": [
+          "VirtualHardDisks"
+        ],
+        "description": "The operation to update a virtual hard disk.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualHardDiskName",
+            "in": "path",
+            "description": "Name of the virtual hard disk",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "properties",
+            "in": "body",
+            "description": "The resource properties to be updated.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/VirtualHardDisksUpdateRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VirtualHardDisk"
+            }
+          },
+          "202": {
+            "description": "Resource update request accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "UpdateVirtualHardDisk": {
+            "$ref": "./examples/VirtualHardDisks_Update.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "VirtualHardDisks_Delete",
+        "tags": [
+          "VirtualHardDisks"
+        ],
+        "description": "The operation to delete a virtual hard disk.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualHardDiskName",
+            "in": "path",
+            "description": "Name of the virtual hard disk",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DeleteVirtualHardDisk": {
+            "$ref": "./examples/VirtualHardDisks_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/virtualHardDisks/{virtualHardDiskName}/upload": {
+      "post": {
+        "operationId": "VirtualHardDisks_Upload",
+        "tags": [
+          "VirtualHardDisks"
+        ],
+        "description": "The operation to upload a virtual hard disk.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualHardDiskName",
+            "in": "path",
+            "description": "Name of the virtual hard disk",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "The content of the action request",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/VirtualHardDiskUploadRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VirtualHardDiskUploadResponse"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "UploadVirtualHardDisk": {
+            "$ref": "./examples/VirtualHardDisks_Upload.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/virtualNetworks": {
+      "get": {
+        "operationId": "VirtualNetworks_ListByResourceGroup",
+        "tags": [
+          "VirtualNetworks"
+        ],
+        "description": "Lists all of the virtual networks in the specified resource group. Use the nextLink property in the response to get the next page of virtualNetwork networks.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ListVirtualNetworkByResourceGroup": {
+            "$ref": "./examples/VirtualNetworks_ListByResourceGroup.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/virtualNetworks/{virtualNetworkName}": {
+      "get": {
+        "operationId": "VirtualNetworks_Get",
+        "tags": [
+          "VirtualNetworks"
+        ],
+        "description": "The operation to get a virtual network.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkName",
+            "in": "path",
+            "description": "Name of the virtual network",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetwork"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "GetVirtualNetwork": {
+            "$ref": "./examples/VirtualNetworks_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "VirtualNetworks_CreateOrUpdate",
+        "tags": [
+          "VirtualNetworks"
+        ],
+        "description": "The operation to create or update a virtual network. Please note some properties can be set only during virtualNetwork network creation.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkName",
+            "in": "path",
+            "description": "Name of the virtual network",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Resource create parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/VirtualNetwork"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'VirtualNetwork' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetwork"
+            }
+          },
+          "201": {
+            "description": "Resource 'VirtualNetwork' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetwork"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PutVirtualNetwork": {
+            "$ref": "./examples/VirtualNetworks_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "VirtualNetworks_UpdateTags",
+        "tags": [
+          "VirtualNetworks"
+        ],
+        "description": "Updates a virtual network tags.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkName",
+            "in": "path",
+            "description": "Name of the virtual network",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "properties",
+            "in": "body",
+            "description": "The resource properties to be updated.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkTagsUpdate"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetwork"
+            }
+          },
+          "202": {
+            "description": "Resource update request accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Update virtual Network tags": {
+            "$ref": "./examples/VirtualNetworks_UpdateTags.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "VirtualNetworks_Delete",
+        "tags": [
+          "VirtualNetworks"
+        ],
+        "description": "The operation to delete a virtual network.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkName",
+            "in": "path",
+            "description": "Name of the virtual network",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DeleteVirtualNetwork": {
+            "$ref": "./examples/VirtualNetworks_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/virtualNetworks/{virtualNetworkName}/subnets": {
+      "get": {
+        "operationId": "VirtualNetworkSubnets_ListByVirtualNetwork",
+        "tags": [
+          "VirtualNetworkSubnets"
+        ],
+        "description": "Lists all of the virtual network subnets in a  virtual network.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkName",
+            "in": "path",
+            "description": "Name of the virtual network",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkSubnetListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ListVirtualNetworkSubnetsByVirtualNetwork": {
+            "$ref": "./examples/VirtualNetworkSubnets_ListByVirtualNetwork.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}": {
+      "get": {
+        "operationId": "VirtualNetworkSubnets_Get",
+        "tags": [
+          "VirtualNetworkSubnets"
+        ],
+        "description": "The operation to get a virtual network subnet.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkName",
+            "in": "path",
+            "description": "Name of the virtual network",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "subnetName",
+            "in": "path",
+            "description": "Name of the virtual network subnet",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkSubnet"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "GetVirtualNetworkSubnet": {
+            "$ref": "./examples/VirtualNetworkSubnets_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "VirtualNetworkSubnets_CreateOrUpdate",
+        "tags": [
+          "VirtualNetworkSubnets"
+        ],
+        "description": "The operation to create or update a virtual network subnet.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkName",
+            "in": "path",
+            "description": "Name of the virtual network",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "subnetName",
+            "in": "path",
+            "description": "Name of the virtual network subnet",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Resource create parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkSubnet"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'VirtualNetworkSubnet' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkSubnet"
+            }
+          },
+          "201": {
+            "description": "Resource 'VirtualNetworkSubnet' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkSubnet"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PutVirtualNetworkSubnet": {
+            "$ref": "./examples/VirtualNetworkSubnets_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "VirtualNetworkSubnets_Update",
+        "tags": [
+          "VirtualNetworkSubnets"
+        ],
+        "description": "The operation to update a virtual network subnet.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkName",
+            "in": "path",
+            "description": "Name of the virtual network",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "subnetName",
+            "in": "path",
+            "description": "Name of the virtual network subnet",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "properties",
+            "in": "body",
+            "description": "The resource properties to be updated.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkSubnetUpdateRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkSubnet"
+            }
+          },
+          "202": {
+            "description": "Resource update request accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "UpdateVirtualNetworkUpdates": {
+            "$ref": "./examples/VirtualNetworkSubnets_Update.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "VirtualNetworkSubnets_Delete",
+        "tags": [
+          "VirtualNetworkSubnets"
+        ],
+        "description": "The operation to delete a virtual network.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkName",
+            "in": "path",
+            "description": "Name of the virtual network",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "subnetName",
+            "in": "path",
+            "description": "Name of the virtual network subnet",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DeleteVirtualNetworkSubnet": {
+            "$ref": "./examples/VirtualNetworkSubnets_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    }
+  },
+  "definitions": {
+    "AttestBootIntegrityPropertyEnum": {
+      "type": "string",
+      "description": "The status of whether the list of boot integrity properties is validated.",
+      "enum": [
+        "Valid",
+        "Invalid",
+        "Unknown"
+      ],
+      "x-ms-enum": {
+        "name": "AttestBootIntegrityPropertyEnum",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Valid",
+            "value": "Valid",
+            "description": "Boot integrity properties are valid"
+          },
+          {
+            "name": "Invalid",
+            "value": "Invalid",
+            "description": "Boot integrity properties are invalid"
+          },
+          {
+            "name": "Unknown",
+            "value": "Unknown",
+            "description": "Boot integrity properties status is unknown"
+          }
+        ]
+      }
+    },
+    "AttestCertPropertyEnum": {
+      "type": "string",
+      "description": "The status of whether attestation certificate is validated.",
+      "enum": [
+        "Valid",
+        "Invalid",
+        "Unknown"
+      ],
+      "x-ms-enum": {
+        "name": "AttestCertPropertyEnum",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Valid",
+            "value": "Valid",
+            "description": "Attestation certificate is valid"
+          },
+          {
+            "name": "Invalid",
+            "value": "Invalid",
+            "description": "Attestation certificate is invalid"
+          },
+          {
+            "name": "Unknown",
+            "value": "Unknown",
+            "description": "Attestation certificate status is unknown"
+          }
+        ]
+      }
+    },
+    "AttestDiskSecurityEncryptionTypeEnum": {
+      "type": "string",
+      "description": "Defines type of managed disk security encryption type from attestation token.",
+      "enum": [
+        "NonPersistedTPM",
+        "Unknown"
+      ],
+      "x-ms-enum": {
+        "name": "AttestDiskSecurityEncryptionTypeEnum",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "NonPersistedTPM",
+            "value": "NonPersistedTPM",
+            "description": "Disk security encryption type is non-persisted Trusted Platform Module (TPM)"
+          },
+          {
+            "name": "Unknown",
+            "value": "Unknown",
+            "description": "Disk security encryption type is unknown"
+          }
+        ]
+      }
+    },
+    "AttestHWPlatformEnum": {
+      "type": "string",
+      "description": "Defines type of hardware platform from attestation token.",
+      "enum": [
+        "SEVSNP",
+        "Unknown"
+      ],
+      "x-ms-enum": {
+        "name": "AttestHWPlatformEnum",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "SEVSNP",
+            "value": "SEVSNP",
+            "description": "AttestHWPlatform is Secure Encrypted Virtualization Secure Nested Paging (SEVSNP)"
+          },
+          {
+            "name": "Unknown",
+            "value": "Unknown",
+            "description": "AttestHWPlatform is unknown"
+          }
+        ]
+      }
+    },
+    "AttestHealthStatusEnum": {
+      "type": "string",
+      "description": "The health status of attestation validation and parsing",
+      "enum": [
+        "Pending",
+        "Healthy",
+        "Unhealthy",
+        "Unknown"
+      ],
+      "x-ms-enum": {
+        "name": "AttestHealthStatusEnum",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Pending",
+            "value": "Pending",
+            "description": "Attestation validation and parsing pending"
+          },
+          {
+            "name": "Healthy",
+            "value": "Healthy",
+            "description": "Attestation validation and parsing healthy"
+          },
+          {
+            "name": "Unhealthy",
+            "value": "Unhealthy",
+            "description": "Attestation validation and parsing unhealthy"
+          },
+          {
+            "name": "Unknown",
+            "value": "Unknown",
+            "description": "Attestation validation and parsing status is unknown"
+          }
+        ]
+      }
+    },
+    "AttestSecureBootPropertyEnum": {
+      "type": "string",
+      "description": "The status of whether secure boot is enabled.",
+      "enum": [
+        "Enabled",
+        "Disabled",
+        "Unknown"
+      ],
+      "x-ms-enum": {
+        "name": "AttestSecureBootPropertyEnum",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Enabled",
+            "value": "Enabled",
+            "description": "Secure boot enabled"
+          },
+          {
+            "name": "Disabled",
+            "value": "Disabled",
+            "description": "Secure boot disabled"
+          },
+          {
+            "name": "Unknown",
+            "value": "Unknown",
+            "description": "Secure boot status is unknown"
+          }
+        ]
+      }
+    },
+    "AttestationStatus": {
+      "type": "object",
+      "description": "The attestation status of the virtual machine",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/AttestationStatusProperties",
+          "description": "The resource-specific properties for this resource.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "AttestationStatusProperties": {
+      "type": "object",
+      "description": "Defines the attestation status properties",
+      "properties": {
+        "attestSecureBootEnabled": {
+          "type": "string",
+          "description": "The status of whether secure boot is enabled.",
+          "default": "Unknown",
+          "enum": [
+            "Enabled",
+            "Disabled",
+            "Unknown"
+          ],
+          "x-ms-enum": {
+            "name": "AttestSecureBootPropertyEnum",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "Enabled",
+                "value": "Enabled",
+                "description": "Secure boot enabled"
+              },
+              {
+                "name": "Disabled",
+                "value": "Disabled",
+                "description": "Secure boot disabled"
+              },
+              {
+                "name": "Unknown",
+                "value": "Unknown",
+                "description": "Secure boot status is unknown"
+              }
+            ]
+          },
+          "readOnly": true
+        },
+        "attestationCertValidated": {
+          "type": "string",
+          "description": "The status of whether attestation certificate is validated.",
+          "default": "Unknown",
+          "enum": [
+            "Valid",
+            "Invalid",
+            "Unknown"
+          ],
+          "x-ms-enum": {
+            "name": "AttestCertPropertyEnum",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "Valid",
+                "value": "Valid",
+                "description": "Attestation certificate is valid"
+              },
+              {
+                "name": "Invalid",
+                "value": "Invalid",
+                "description": "Attestation certificate is invalid"
+              },
+              {
+                "name": "Unknown",
+                "value": "Unknown",
+                "description": "Attestation certificate status is unknown"
+              }
+            ]
+          },
+          "readOnly": true
+        },
+        "bootIntegrityValidated": {
+          "type": "string",
+          "description": "The status of whether the list of boot integrity properties is validated.",
+          "default": "Unknown",
+          "enum": [
+            "Valid",
+            "Invalid",
+            "Unknown"
+          ],
+          "x-ms-enum": {
+            "name": "AttestBootIntegrityPropertyEnum",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "Valid",
+                "value": "Valid",
+                "description": "Boot integrity properties are valid"
+              },
+              {
+                "name": "Invalid",
+                "value": "Invalid",
+                "description": "Boot integrity properties are invalid"
+              },
+              {
+                "name": "Unknown",
+                "value": "Unknown",
+                "description": "Boot integrity properties status is unknown"
+              }
+            ]
+          },
+          "readOnly": true
+        },
+        "linuxKernelVersion": {
+          "type": "string",
+          "description": "kernel version string for Linux VM.",
+          "readOnly": true
+        },
+        "healthStatus": {
+          "type": "string",
+          "description": "The health status of attestation validation and parsing",
+          "default": "Unknown",
+          "enum": [
+            "Pending",
+            "Healthy",
+            "Unhealthy",
+            "Unknown"
+          ],
+          "x-ms-enum": {
+            "name": "AttestHealthStatusEnum",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "Pending",
+                "value": "Pending",
+                "description": "Attestation validation and parsing pending"
+              },
+              {
+                "name": "Healthy",
+                "value": "Healthy",
+                "description": "Attestation validation and parsing healthy"
+              },
+              {
+                "name": "Unhealthy",
+                "value": "Unhealthy",
+                "description": "Attestation validation and parsing unhealthy"
+              },
+              {
+                "name": "Unknown",
+                "value": "Unknown",
+                "description": "Attestation validation and parsing status is unknown"
+              }
+            ]
+          },
+          "readOnly": true
+        },
+        "timestamp": {
+          "type": "string",
+          "description": "The time stamp of the last time attestation token is validated by relying party service.",
+          "readOnly": true
+        },
+        "errorMessage": {
+          "type": "string",
+          "description": "The error message of attestation validation and parsing",
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningStateEnum",
+          "description": "Provisioning state of the virtual machine instance.",
+          "readOnly": true
+        },
+        "attestHardwarePlatform": {
+          "$ref": "#/definitions/AttestHWPlatformEnum",
+          "description": "The hardware platform information from attestation token. This only applies to Confidential VM.",
+          "readOnly": true
+        },
+        "attestDiskSecurityEncryptionType": {
+          "$ref": "#/definitions/AttestDiskSecurityEncryptionTypeEnum",
+          "description": "The managed disk security encryption type from attestation token. This only applies to Confidential VM.",
+          "readOnly": true
+        }
+      }
+    },
+    "BackendAddressPool": {
+      "type": "object",
+      "description": "Backend address pool for the load balancer.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "name of the backend pool.",
+          "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "properties": {
+          "$ref": "#/definitions/BackendAddressPoolProperties",
+          "description": "properties for the backend pool"
+        }
+      },
+      "required": [
+        "name",
+        "properties"
+      ]
+    },
+    "BackendAddressPoolProperties": {
+      "type": "object",
+      "description": "Backend address pool for the load balancer.",
+      "properties": {
+        "loadBalancerBackendAddresses": {
+          "type": "array",
+          "description": "List of backend addresses for the backend pool",
+          "items": {
+            "$ref": "#/definitions/LoadBalancerBackendAddress"
+          },
+          "x-ms-identifiers": []
+        },
+        "virtualNetwork": {
+          "$ref": "#/definitions/VirtualNetworkArmReference",
+          "description": "Reference to the virtual network for this backend pool. Mutually exclusive with logicalNetwork"
+        },
+        "logicalNetwork": {
+          "$ref": "#/definitions/LogicalNetworkArmReference",
+          "description": "Reference to the logical network for this backend pool. Mutually exclusive with virtualNetwork"
+        }
+      }
+    },
+    "CloudInitDataSource": {
+      "type": "string",
+      "description": "Datasource for the gallery image when provisioning with cloud-init [NoCloud, Azure]",
+      "enum": [
+        "NoCloud",
+        "Azure"
+      ],
+      "x-ms-enum": {
+        "name": "CloudInitDataSource",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "NoCloud",
+            "value": "NoCloud",
+            "description": "NoCloud is used as the datasource"
+          },
+          {
+            "name": "Azure",
+            "value": "Azure",
+            "description": "Azure is used as the datasource"
+          }
+        ]
+      }
+    },
+    "CreationData": {
+      "type": "object",
+      "description": "Data used when creating a disk or snapshot",
+      "properties": {
+        "createOption": {
+          "$ref": "#/definitions/DiskCreateOption",
+          "description": "This enumerates the possible sources of a disk's creation"
+        },
+        "sourceResourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "ARM ID of the source resource used for disk creation. Required when createOption is Copy",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.AzureStackHCI/virtualHardDisks"
+              },
+              {
+                "type": "Microsoft.AzureStackHCI/snapshots"
+              }
+            ]
+          }
+        },
+        "sourceUniqueId": {
+          "type": "string",
+          "description": "Unique ID of the source resource used for disk creation. Read-only and not required for disk creation.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "createOption"
+      ]
+    },
+    "DiskCreateOption": {
+      "type": "string",
+      "description": "Disk creation option values [Copy, Empty]",
+      "enum": [
+        "Copy",
+        "Empty"
+      ],
+      "x-ms-enum": {
+        "name": "DiskCreateOption",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Copy",
+            "value": "Copy",
+            "description": "Create a disk by copying from a source resource"
+          },
+          {
+            "name": "Empty",
+            "value": "Empty",
+            "description": "Create an empty disk"
+          }
+        ]
+      }
+    },
+    "DiskFileFormat": {
+      "type": "string",
+      "description": "The format of the actual VHD file [vhd, vhdx]",
+      "enum": [
+        "vhdx",
+        "vhd"
+      ],
+      "x-ms-enum": {
+        "name": "DiskFileFormat",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "vhdx",
+            "value": "vhdx",
+            "description": "VHDX file format"
+          },
+          {
+            "name": "vhd",
+            "value": "vhd",
+            "description": "VHD file format"
+          }
+        ]
+      }
+    },
+    "ExtendedLocation": {
+      "type": "object",
+      "description": "The complex type of the extended location.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the extended location."
+        },
+        "type": {
+          "$ref": "#/definitions/ExtendedLocationTypes",
+          "description": "The type of the extended location."
+        }
+      }
+    },
+    "ExtendedLocationTypes": {
+      "type": "string",
+      "description": "The type of extendedLocation.",
+      "enum": [
+        "CustomLocation"
+      ],
+      "x-ms-enum": {
+        "name": "ExtendedLocationTypes",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "CustomLocation",
+            "value": "CustomLocation",
+            "description": "Custom extended location type"
+          }
+        ]
+      }
+    },
+    "FabricConnectionHealthEnum": {
+      "type": "string",
+      "description": "Fabric connection health state type",
+      "enum": [
+        "Healthy",
+        "Warning",
+        "Error",
+        "Unknown"
+      ],
+      "x-ms-enum": {
+        "name": "FabricConnectionHealthEnum",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Healthy",
+            "value": "Healthy",
+            "description": "Fabric connection health state - healthy type"
+          },
+          {
+            "name": "Warning",
+            "value": "Warning",
+            "description": "Fabric connection health state - warning type"
+          },
+          {
+            "name": "Error",
+            "value": "Error",
+            "description": "Fabric connection health state - error type"
+          },
+          {
+            "name": "Unknown",
+            "value": "Unknown",
+            "description": "Fabric connection health state - unknown type"
+          }
+        ]
+      }
+    },
+    "FabricIntegrationStateEnum": {
+      "type": "string",
+      "description": "Fabric integration state type",
+      "enum": [
+        "Connected",
+        "Disconnected",
+        "Misconfigured",
+        "NotApplicable",
+        "Connecting"
+      ],
+      "x-ms-enum": {
+        "name": "FabricIntegrationStateEnum",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Connected",
+            "value": "Connected",
+            "description": "Fabric integration state - connected type"
+          },
+          {
+            "name": "Disconnected",
+            "value": "Disconnected",
+            "description": "Fabric integration state - disconnected type"
+          },
+          {
+            "name": "Misconfigured",
+            "value": "Misconfigured",
+            "description": "Fabric integration state - misconfigured type"
+          },
+          {
+            "name": "NotApplicable",
+            "value": "NotApplicable",
+            "description": "Fabric integration state - notapplicable type"
+          },
+          {
+            "name": "Connecting",
+            "value": "Connecting",
+            "description": "Fabric integration state - connecting type"
+          }
+        ]
+      }
+    },
+    "FabricIntegrationStatus": {
+      "type": "object",
+      "description": "Enhanced fabric integration status with detailed health monitoring and connectivity state.",
+      "properties": {
+        "state": {
+          "$ref": "#/definitions/FabricIntegrationStateEnum",
+          "description": "Current fabric integration state.",
+          "readOnly": true
+        },
+        "health": {
+          "$ref": "#/definitions/FabricConnectionHealthEnum",
+          "description": "Health status of the fabric connection.",
+          "readOnly": true
+        },
+        "lastChecked": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp of the last fabric health check as ISO 8601 string",
+          "readOnly": true
+        },
+        "resourceType": {
+          "$ref": "#/definitions/FabricResourceTypeEnum",
+          "description": "Type of fabric resource referenced.",
+          "readOnly": true
+        },
+        "issues": {
+          "type": "array",
+          "description": "Issues raised by fabric",
+          "items": {
+            "$ref": "#/definitions/FabricIssue"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "FabricIssue": {
+      "type": "object",
+      "description": "Issues exposed by managed network fabric",
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "Specific error/warning code.",
+          "readOnly": true
+        },
+        "severity": {
+          "type": "string",
+          "description": "issue severity",
+          "readOnly": true
+        },
+        "message": {
+          "type": "string",
+          "description": "Description of the issue",
+          "readOnly": true
+        },
+        "target": {
+          "type": "string",
+          "description": "specific property or resource that has the issue",
+          "readOnly": true
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp of the issue as ISO 8601 string",
+          "readOnly": true
+        }
+      }
+    },
+    "FabricResourceTypeEnum": {
+      "type": "string",
+      "description": "Fabric resource type",
+      "enum": [
+        "L2IsolationDomain",
+        "L3InternalNetwork"
+      ],
+      "x-ms-enum": {
+        "name": "FabricResourceTypeEnum",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "L2IsolationDomain",
+            "value": "L2IsolationDomain",
+            "description": "Fabric resource of L2IsolationDomain type"
+          },
+          {
+            "name": "L3InternalNetwork",
+            "value": "L3InternalNetwork",
+            "description": "Fabric resource of L3InternalNetwork type"
+          }
+        ]
+      }
+    },
+    "FrontendIPConfiguration": {
+      "type": "object",
+      "description": "FrontendIP Configuration object for a load balancer.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "name for the frontend IP configuration.",
+          "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "properties": {
+          "$ref": "#/definitions/FrontendIPConfigurationProperties",
+          "description": "properties for this frontendIPConfiguration"
+        }
+      },
+      "required": [
+        "name",
+        "properties"
+      ]
+    },
+    "FrontendIPConfigurationProperties": {
+      "type": "object",
+      "description": "FrontendIP Configuration object for a load balancer.",
+      "properties": {
+        "privateIPAddress": {
+          "type": "string",
+          "description": "Private IP Address that was allocated (dynamic) or is to be allocated (static) from the subnet."
+        },
+        "privateIPAllocationMethod": {
+          "$ref": "#/definitions/IpAllocationMethodEnum",
+          "description": "privateIPAllocationMethod - set to Static for requesting a specific IP"
+        },
+        "subnet": {
+          "$ref": "#/definitions/VirtualNetworkSubnetArmReference",
+          "description": "subnet - the subnet from which to allocate the private IP"
+        },
+        "publicIPAddress": {
+          "$ref": "#/definitions/PublicIPAddressArmReference",
+          "description": "Public IP "
+        }
+      }
+    },
+    "GalleryDiskImage": {
+      "type": "object",
+      "description": "This is the disk image base class.",
+      "properties": {
+        "sizeInMB": {
+          "type": "integer",
+          "format": "int64",
+          "description": "This property indicates the size of the VHD to be created.",
+          "readOnly": true
+        }
+      }
+    },
+    "GalleryImage": {
+      "type": "object",
+      "description": "The gallery images resource definition.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/GalleryImageProperties",
+          "description": "The resource-specific properties for this resource.",
+          "x-ms-client-flatten": true
+        },
+        "extendedLocation": {
+          "$ref": "#/definitions/ExtendedLocation",
+          "description": "The extendedLocation of the resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/TrackedResource"
+        }
+      ],
+      "x-ms-azure-resource": true
+    },
+    "GalleryImageIdentifier": {
+      "type": "object",
+      "description": "This is the gallery image definition identifier.",
+      "properties": {
+        "publisher": {
+          "type": "string",
+          "description": "The name of the gallery image definition publisher."
+        },
+        "offer": {
+          "type": "string",
+          "description": "The name of the gallery image definition offer."
+        },
+        "sku": {
+          "type": "string",
+          "description": "The name of the gallery image definition SKU."
+        }
+      },
+      "required": [
+        "publisher",
+        "offer",
+        "sku"
+      ]
+    },
+    "GalleryImageListResult": {
+      "type": "object",
+      "description": "The response of a GalleryImage list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The GalleryImage items on this page",
+          "items": {
+            "$ref": "#/definitions/GalleryImage"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "GalleryImageProperties": {
+      "type": "object",
+      "description": "Properties under the gallery image resource",
+      "properties": {
+        "containerId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Storage ContainerID of the storage container to be used for gallery image",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.AzureStackHCI/storageContainers"
+              }
+            ]
+          }
+        },
+        "imagePath": {
+          "type": "string",
+          "format": "password",
+          "description": "location of the image the gallery image should be created from",
+          "x-ms-secret": true
+        },
+        "osType": {
+          "$ref": "#/definitions/OperatingSystemTypes",
+          "description": "Operating system type that the gallery image uses [Windows, Linux]"
+        },
+        "cloudInitDataSource": {
+          "$ref": "#/definitions/CloudInitDataSource",
+          "description": "Datasource for the gallery image when provisioning with cloud-init [NoCloud, Azure]"
+        },
+        "hyperVGeneration": {
+          "$ref": "#/definitions/HyperVGeneration",
+          "description": "The hypervisor generation of the Virtual Machine [V1, V2]"
+        },
+        "identifier": {
+          "$ref": "#/definitions/GalleryImageIdentifier",
+          "description": "This is the gallery image definition identifier."
+        },
+        "version": {
+          "$ref": "#/definitions/GalleryImageVersion",
+          "description": "Specifies information about the gallery image version that you want to create or update."
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningStateEnum",
+          "description": "Provisioning state of the gallery image.",
+          "readOnly": true
+        },
+        "status": {
+          "$ref": "#/definitions/GalleryImageStatus",
+          "description": "The observed state of gallery images",
+          "readOnly": true
+        },
+        "sourceVirtualMachineId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Resource ID of the source virtual machine from whose OS disk the gallery image is created.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.AzureStackHCI/virtualMachineInstance"
+              }
+            ]
+          }
+        }
+      },
+      "required": [
+        "osType"
+      ]
+    },
+    "GalleryImageStatus": {
+      "type": "object",
+      "description": "The observed state of gallery images",
+      "properties": {
+        "errorCode": {
+          "type": "string",
+          "description": "GalleryImage provisioning error code"
+        },
+        "errorMessage": {
+          "type": "string",
+          "description": "Descriptive error message"
+        },
+        "provisioningStatus": {
+          "$ref": "#/definitions/GalleryImageStatusProvisioningStatus",
+          "description": "provisioning status of the gallery image"
+        },
+        "downloadStatus": {
+          "$ref": "#/definitions/GalleryImageStatusDownloadStatus",
+          "description": "The download status of the gallery image"
+        },
+        "progressPercentage": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The progress of the operation in percentage"
+        }
+      }
+    },
+    "GalleryImageStatusDownloadStatus": {
+      "type": "object",
+      "description": "The download status of the gallery image",
+      "properties": {
+        "downloadSizeInMB": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The downloaded sized of the image in MB"
+        }
+      }
+    },
+    "GalleryImageStatusProvisioningStatus": {
+      "type": "object",
+      "description": "The status of the operation performed on the gallery image",
+      "properties": {
+        "operationId": {
+          "type": "string",
+          "description": "The ID of the operation performed on the gallery image"
+        },
+        "status": {
+          "$ref": "#/definitions/Status",
+          "description": "The status of the operation performed on the gallery image [Succeeded, Failed, InProgress]"
+        }
+      }
+    },
+    "GalleryImageTagsUpdate": {
+      "type": "object",
+      "description": "The type used for updating tags in GalleryImage resources.",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "GalleryImageVersion": {
+      "type": "object",
+      "description": "Specifies information about the gallery image version that you want to create or update.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "This is the version of the gallery image."
+        },
+        "properties": {
+          "$ref": "#/definitions/GalleryImageVersionProperties",
+          "description": "Describes the properties of a gallery image version.",
+          "x-ms-client-flatten": true
+        }
+      }
+    },
+    "GalleryImageVersionProperties": {
+      "type": "object",
+      "description": "Describes the properties of a gallery image version.",
+      "properties": {
+        "storageProfile": {
+          "$ref": "#/definitions/GalleryImageVersionStorageProfile",
+          "description": "This is the storage profile of a Gallery Image Version."
+        }
+      },
+      "required": [
+        "storageProfile"
+      ]
+    },
+    "GalleryImageVersionStorageProfile": {
+      "type": "object",
+      "description": "This is the storage profile of a Gallery Image Version.",
+      "properties": {
+        "osDiskImage": {
+          "$ref": "#/definitions/GalleryOSDiskImage",
+          "description": "This is the OS disk image."
+        }
+      }
+    },
+    "GalleryImagesUpdateRequest": {
+      "type": "object",
+      "description": "The gallery images resource patch definition.",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Resource tags",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "GalleryOSDiskImage": {
+      "type": "object",
+      "description": "This is the OS disk image.",
+      "properties": {
+        "sizeInMB": {
+          "type": "integer",
+          "format": "int64",
+          "description": "This property indicates the size of the VHD to be created.",
+          "readOnly": true
+        }
+      }
+    },
+    "GpuAssignmentTypeEnum": {
+      "type": "string",
+      "description": "Gpu Assignment types",
+      "enum": [
+        "GpuDDA",
+        "GpuP"
+      ],
+      "x-ms-enum": {
+        "name": "GpuAssignmentTypeEnum",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "GpuDDA",
+            "value": "GpuDDA",
+            "description": "Attach Graphics Processing Unit (GPU) using Discrete Device Assignment (DDA)"
+          },
+          {
+            "name": "GpuP",
+            "value": "GpuP",
+            "description": "Attach Graphics Processing Unit (GPU) using GPU Partitioning"
+          }
+        ]
+      }
+    },
+    "GuestAgent": {
+      "type": "object",
+      "description": "Defines the GuestAgent.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/GuestAgentProperties",
+          "description": "The resource-specific properties for this resource.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "GuestAgentInstallStatus": {
+      "type": "object",
+      "description": "Defines the status of a guest agent installation.",
+      "properties": {
+        "vmUuid": {
+          "type": "string",
+          "description": "Specifies the VM's unique SMBIOS ID.",
+          "readOnly": true
+        },
+        "status": {
+          "$ref": "#/definitions/StatusTypes",
+          "description": "The installation status of the hybrid machine agent installation.",
+          "readOnly": true
+        },
+        "lastStatusChange": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The time of the last status change.",
+          "readOnly": true
+        },
+        "agentVersion": {
+          "type": "string",
+          "description": "The hybrid machine agent full version.",
+          "readOnly": true
+        },
+        "errorDetails": {
+          "type": "array",
+          "description": "Details about the error state.",
+          "items": {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorDetail"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "GuestAgentListResult": {
+      "type": "object",
+      "description": "The response of a GuestAgent list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The GuestAgent items on this page",
+          "items": {
+            "$ref": "#/definitions/GuestAgent"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "GuestAgentProperties": {
+      "type": "object",
+      "description": "Defines the resource properties.",
+      "properties": {
+        "credentials": {
+          "$ref": "#/definitions/GuestCredential",
+          "description": "Username / Password Credentials to provision guest agent."
+        },
+        "provisioningAction": {
+          "$ref": "#/definitions/ProvisioningAction",
+          "description": "The guest agent provisioning action."
+        },
+        "status": {
+          "type": "string",
+          "description": "The guest agent status.",
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningStateEnum",
+          "description": "Provisioning state of the virtual machine instance.",
+          "readOnly": true
+        }
+      }
+    },
+    "GuestCredential": {
+      "type": "object",
+      "description": "Username / Password Credentials to connect to guest.",
+      "properties": {
+        "username": {
+          "type": "string",
+          "description": "The username to connect with the guest."
+        },
+        "password": {
+          "type": "string",
+          "format": "password",
+          "description": "The password to connect with the guest.",
+          "x-ms-mutability": [
+            "update",
+            "create"
+          ],
+          "x-ms-secret": true
+        }
+      }
+    },
+    "HardwareProfileUpdate": {
+      "type": "object",
+      "description": "HardwareProfile - Specifies the hardware settings for the virtual machine instance.",
+      "properties": {
+        "vmSize": {
+          "$ref": "#/definitions/VmSizeEnum",
+          "description": "VM Size Enum"
+        },
+        "processors": {
+          "type": "integer",
+          "format": "int32",
+          "description": "number of processors for the virtual machine instance"
+        },
+        "memoryMB": {
+          "type": "integer",
+          "format": "int64",
+          "description": "RAM in MB for the virtual machine instance"
+        },
+        "virtualMachineGPUs": {
+          "type": "array",
+          "description": "virtualMachineGPUs - updated list of GPUs on the virtual machine instance",
+          "items": {
+            "$ref": "#/definitions/VirtualMachineInstancePropertiesHardwareProfileVirtualMachineGPU"
+          },
+          "x-ms-identifiers": []
+        },
+        "dynamicMemoryConfig": {
+          "$ref": "#/definitions/VirtualMachineInstancePropertiesHardwareProfileDynamicMemoryConfig",
+          "description": "Dynamic memory config for day-2 updates and static-to-dynamic conversion of the virtual machine instance."
+        }
+      }
+    },
+    "HttpProxyConfiguration": {
+      "type": "object",
+      "description": "HTTP Proxy configuration for the VM.",
+      "properties": {
+        "httpProxy": {
+          "type": "string",
+          "format": "password",
+          "description": "The HTTP proxy server endpoint to use.",
+          "x-ms-secret": true
+        },
+        "httpsProxy": {
+          "type": "string",
+          "format": "password",
+          "description": "The HTTPS proxy server endpoint to use.",
+          "x-ms-secret": true
+        },
+        "noProxy": {
+          "type": "array",
+          "description": "The endpoints that should not go through proxy.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "trustedCa": {
+          "type": "string",
+          "description": "Alternative CA cert to use for connecting to proxy servers."
+        }
+      }
+    },
+    "HybridIdentityMetadata": {
+      "type": "object",
+      "description": "Defines the HybridIdentityMetadata.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/HybridIdentityMetadataProperties",
+          "description": "The resource-specific properties for this resource.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ],
+      "x-ms-azure-resource": true
+    },
+    "HybridIdentityMetadataListResult": {
+      "type": "object",
+      "description": "The response of a HybridIdentityMetadata list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The HybridIdentityMetadata items on this page",
+          "items": {
+            "$ref": "#/definitions/HybridIdentityMetadata"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "HybridIdentityMetadataProperties": {
+      "type": "object",
+      "description": "Defines the resource properties.",
+      "properties": {
+        "resourceUid": {
+          "type": "string",
+          "description": "The unique identifier for the resource."
+        },
+        "publicKey": {
+          "type": "string",
+          "description": "The Public Key."
+        },
+        "identity": {
+          "$ref": "#/definitions/Identity",
+          "description": "Identity for the resource.",
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningStateEnum",
+          "description": "Provisioning state of the virtual machine instance.",
+          "readOnly": true
+        }
+      }
+    },
+    "HyperVGeneration": {
+      "type": "string",
+      "description": "The hypervisor generation of the Virtual Machine [V1, V2]",
+      "enum": [
+        "V1",
+        "V2",
+        "NA"
+      ],
+      "x-ms-enum": {
+        "name": "HyperVGeneration",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "V1",
+            "value": "V1",
+            "description": "Generation 1 (V1) hypervisor"
+          },
+          {
+            "name": "V2",
+            "value": "V2",
+            "description": "Generation 2 (V2) hypervisor"
+          },
+          {
+            "name": "NA",
+            "value": "NA",
+            "description": "Not applicable/determined by platform"
+          }
+        ]
+      }
+    },
+    "IPConfiguration": {
+      "type": "object",
+      "description": "InterfaceIPConfiguration IPConfiguration in a network interface.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name - The name of the resource that is unique within a resource group. This name can be used to access the resource.",
+          "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,78}[_a-zA-Z0-9]$",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "properties": {
+          "$ref": "#/definitions/IPConfigurationProperties",
+          "description": "InterfaceIPConfigurationPropertiesFormat properties of IP configuration."
+        }
+      }
+    },
+    "IPConfigurationArmReference": {
+      "type": "object",
+      "description": "The Azure Resource ID of an IPConfiguration resource",
+      "properties": {
+        "resourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The Azure Resource ID of an IPConfiguration resource",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.AzureStackHCI/loadBalancer/frontendIPConfigurations"
+              },
+              {
+                "type": "Microsoft.AzureStackHCI/networkInterfaces"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "IPConfigurationProperties": {
+      "type": "object",
+      "description": "InterfaceIPConfigurationPropertiesFormat properties of IP configuration.",
+      "properties": {
+        "gateway": {
+          "type": "string",
+          "description": "Gateway for network interface",
+          "readOnly": true
+        },
+        "prefixLength": {
+          "type": "string",
+          "description": "prefixLength for network interface",
+          "readOnly": true
+        },
+        "privateIPAddress": {
+          "type": "string",
+          "description": "PrivateIPAddress - Private IP address of the IP configuration."
+        },
+        "subnet": {
+          "$ref": "#/definitions/LogicalNetworkArmReference",
+          "description": "Subnet - Name of Subnet bound to the IP configuration."
+        }
+      }
+    },
+    "IPPool": {
+      "type": "object",
+      "description": "Describes IPPool",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the IP-Pool"
+        },
+        "ipPoolType": {
+          "$ref": "#/definitions/IPPoolTypeEnum",
+          "description": "Type of the IP Pool [vm, vippool]"
+        },
+        "start": {
+          "type": "string",
+          "description": "Start of the IP address pool"
+        },
+        "end": {
+          "type": "string",
+          "description": "End of the IP address pool"
+        },
+        "info": {
+          "$ref": "#/definitions/IPPoolInfo",
+          "description": "IPPool info"
+        }
+      }
+    },
+    "IPPoolInfo": {
+      "type": "object",
+      "description": "IP Pool info",
+      "properties": {
+        "used": {
+          "type": "string",
+          "description": "Number of IP addresses allocated from the IP Pool",
+          "readOnly": true
+        },
+        "available": {
+          "type": "string",
+          "description": "Number of IP addresses available in the IP Pool",
+          "readOnly": true
+        }
+      }
+    },
+    "IPPoolTypeEnum": {
+      "type": "string",
+      "description": "Type of the IP Pool [vm, vippool]",
+      "enum": [
+        "vm",
+        "vippool"
+      ],
+      "x-ms-enum": {
+        "name": "IPPoolTypeEnum",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "vm",
+            "value": "vm",
+            "description": "Virtual Machine IP Pool"
+          },
+          {
+            "name": "vippool",
+            "value": "vippool",
+            "description": "VIP Pool"
+          }
+        ]
+      }
+    },
+    "Identity": {
+      "type": "object",
+      "description": "Identity for the resource.",
+      "properties": {
+        "principalId": {
+          "type": "string",
+          "description": "The principal ID of resource identity. The value must be an UUID.",
+          "readOnly": true
+        },
+        "tenantId": {
+          "type": "string",
+          "description": "The tenant ID of resource. The value must be an UUID.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "The identity type.",
+          "enum": [
+            "SystemAssigned"
+          ],
+          "x-ms-enum": {
+            "modelAsString": false
+          }
+        }
+      }
+    },
+    "ImageArmReference": {
+      "type": "object",
+      "description": "The Azure Resource ID for a Gallery Image.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The Azure Resource ID for an image resource used by the virtual machine instance.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ],
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.AzureStackHCI/galleryImages"
+              },
+              {
+                "type": "Microsoft.AzureStackHCI/marketplaceGalleryImages"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "InboundNATRule": {
+      "type": "object",
+      "description": "Inbound nat rule properties",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "name of the inbound nat rule",
+          "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "properties": {
+          "$ref": "#/definitions/InboundNATRuleProperties",
+          "description": "properties of the inbound nat rule"
+        }
+      },
+      "required": [
+        "name",
+        "properties"
+      ]
+    },
+    "InboundNATRuleProperties": {
+      "type": "object",
+      "description": "Inbound nat rule properties",
+      "properties": {
+        "protocol": {
+          "$ref": "#/definitions/InboundNATRuleProtocol",
+          "description": "Protocol for the NAT rule"
+        },
+        "frontendPort": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Frontend Port for the inbound rule"
+        },
+        "backendPort": {
+          "type": "integer",
+          "format": "int32",
+          "description": "backend Port for the inbound rule"
+        },
+        "backendIPConfiguration": {
+          "$ref": "#/definitions/IPConfigurationArmReference",
+          "description": "IP configuration for the target backend."
+        },
+        "publicIPAddress": {
+          "$ref": "#/definitions/PublicIPAddressArmReference",
+          "description": "Public IP Address for this NAT rule"
+        }
+      },
+      "required": [
+        "protocol",
+        "frontendPort",
+        "backendPort",
+        "backendIPConfiguration",
+        "publicIPAddress"
+      ]
+    },
+    "InboundNATRuleProtocol": {
+      "type": "string",
+      "description": "Protocol for inbound NAT rules",
+      "enum": [
+        "Tcp",
+        "Udp"
+      ],
+      "x-ms-enum": {
+        "name": "InboundNATRuleProtocol",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "TCP",
+            "value": "Tcp",
+            "description": "TCP - load balance only tcp traffic"
+          },
+          {
+            "name": "UDP",
+            "value": "Udp",
+            "description": "Udp - load balance only UDP traffic"
+          }
+        ]
+      }
+    },
+    "InboundRule": {
+      "type": "object",
+      "description": "The inbound rule resource definition.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/InboundRuleProperties",
+          "description": "The resource-specific properties for this resource."
+        },
+        "extendedLocation": {
+          "$ref": "#/definitions/ExtendedLocation",
+          "description": "The extendedLocation of the resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ],
+      "x-ms-azure-resource": true
+    },
+    "InboundRuleListResult": {
+      "type": "object",
+      "description": "The response of a InboundRule list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The InboundRule items on this page",
+          "items": {
+            "$ref": "#/definitions/InboundRule"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "InboundRuleProperties": {
+      "type": "object",
+      "description": "Inbound rule properties - extends InboundNATRuleProperties with additional status tracking",
+      "properties": {
+        "protocol": {
+          "$ref": "#/definitions/InboundNATRuleProtocol",
+          "description": "Protocol for the NAT rule"
+        },
+        "frontendPort": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Frontend Port for the inbound rule"
+        },
+        "backendPort": {
+          "type": "integer",
+          "format": "int32",
+          "description": "backend Port for the inbound rule"
+        },
+        "backendIPConfiguration": {
+          "$ref": "#/definitions/IPConfigurationArmReference",
+          "description": "IP configuration for the target backend."
+        },
+        "publicIPAddress": {
+          "$ref": "#/definitions/PublicIPAddressArmReference",
+          "description": "Public IP Address for this NAT rule"
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningStateEnum",
+          "description": "Provisioning state of the inbound rule",
+          "readOnly": true
+        },
+        "status": {
+          "$ref": "#/definitions/InboundRuleStatus",
+          "description": "The observed state of Inbound Rule",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "protocol",
+        "frontendPort",
+        "backendPort",
+        "backendIPConfiguration",
+        "publicIPAddress"
+      ]
+    },
+    "InboundRuleStatus": {
+      "type": "object",
+      "description": "The observed state of inbound rule",
+      "properties": {
+        "errorCode": {
+          "type": "string",
+          "description": "InboundRule provisioning error code"
+        },
+        "errorMessage": {
+          "type": "string",
+          "description": "Descriptive error message"
+        },
+        "provisioningStatus": {
+          "$ref": "#/definitions/InboundRuleStatusProvisioningStatus",
+          "description": "InboundRule provisioning status"
+        }
+      }
+    },
+    "InboundRuleStatusProvisioningStatus": {
+      "type": "object",
+      "description": "Provisioning status of Inbound Rule",
+      "properties": {
+        "operationId": {
+          "type": "string",
+          "description": "The ID of the operation performed on the inbound rule"
+        },
+        "status": {
+          "$ref": "#/definitions/Status",
+          "description": "The status of the operation performed on the inbound rule [Succeeded, Failed, InProgress]"
+        }
+      }
+    },
+    "InstanceViewStatus": {
+      "type": "object",
+      "description": "Instance view status.",
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "The status code."
+        },
+        "level": {
+          "$ref": "#/definitions/StatusLevelTypes",
+          "description": "The level code."
+        },
+        "displayStatus": {
+          "type": "string",
+          "description": "The short localizable label for the status."
+        },
+        "message": {
+          "type": "string",
+          "description": "The detailed status message, including for alerts and error messages."
+        },
+        "time": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The time of the status."
+        }
+      }
+    },
+    "InterfaceDNSSettings": {
+      "type": "object",
+      "description": "DNS Settings of the interface",
+      "properties": {
+        "dnsServers": {
+          "type": "array",
+          "description": "List of DNS server IP Addresses for the interface",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "IpAllocationMethodEnum": {
+      "type": "string",
+      "description": "IPAllocationMethod - The IP address allocation method. Possible values include: 'Static', 'Dynamic'",
+      "enum": [
+        "Dynamic",
+        "Static"
+      ],
+      "x-ms-enum": {
+        "name": "IpAllocationMethodEnum",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Dynamic",
+            "value": "Dynamic",
+            "description": "Dynamic IP allocation method"
+          },
+          {
+            "name": "Static",
+            "value": "Static",
+            "description": "Static IP allocation method"
+          }
+        ]
+      }
+    },
+    "LoadBalancer": {
+      "type": "object",
+      "description": "The LoadBalancer resource definition.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/LoadBalancerProperties",
+          "description": "The resource-specific properties for this resource."
+        },
+        "extendedLocation": {
+          "$ref": "#/definitions/ExtendedLocation",
+          "description": "The extendedLocation of the resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/TrackedResource"
+        }
+      ],
+      "x-ms-azure-resource": true
+    },
+    "LoadBalancerBackendAddress": {
+      "type": "object",
+      "description": "LoadBalancer Backend Address",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "name of the backend address",
+          "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "properties": {
+          "$ref": "#/definitions/LoadBalancerBackendAddressProperties",
+          "description": "backend address properties"
+        }
+      },
+      "required": [
+        "name",
+        "properties"
+      ]
+    },
+    "LoadBalancerBackendAddressAdminState": {
+      "type": "string",
+      "description": "Backend Address Admin states",
+      "enum": [
+        "Up",
+        "Down"
+      ],
+      "x-ms-enum": {
+        "name": "LoadBalancerBackendAddressAdminState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Up",
+            "value": "Up",
+            "description": "Up - forced admin state up"
+          },
+          {
+            "name": "Down",
+            "value": "Down",
+            "description": "Down - forced admin state down"
+          }
+        ]
+      }
+    },
+    "LoadBalancerBackendAddressPoolReference": {
+      "type": "object",
+      "description": "Reference to a LoadBalancer backend address pool reference",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "name of the backend address pool"
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
+    "LoadBalancerBackendAddressProperties": {
+      "type": "object",
+      "description": "LoadBalancer Backend Address properties",
+      "properties": {
+        "adminState": {
+          "$ref": "#/definitions/LoadBalancerBackendAddressAdminState",
+          "description": "admin state - if set to false, the address is removed from the pool"
+        },
+        "ipAddress": {
+          "type": "string",
+          "description": "IP address of the backend target. Populated automatically from the referenced IP configuration.",
+          "readOnly": true
+        },
+        "subnet": {
+          "$ref": "#/definitions/VirtualNetworkSubnetArmReference",
+          "description": "Reference to the subnet containing the backend address. Populated automatically from the referenced IP configuration. Mutually exclusive with logicalNetwork.",
+          "readOnly": true
+        },
+        "virtualNetwork": {
+          "$ref": "#/definitions/VirtualNetworkArmReference",
+          "description": "Reference to the virtual network containing the backend address. Populated automatically from the referenced IP configuration. Mutually exclusive with logicalNetwork.",
+          "readOnly": true
+        },
+        "logicalNetwork": {
+          "$ref": "#/definitions/LogicalNetworkArmReference",
+          "description": "Reference to the logical network containing this backend address. Populated automatically from the referenced IP configuration. Mutually exclusive with subnet and virtualNetwork.",
+          "readOnly": true
+        },
+        "networkInterfaceIPConfiguration": {
+          "$ref": "#/definitions/IPConfigurationArmReference",
+          "description": "Nic Based backend-ip association"
+        }
+      }
+    },
+    "LoadBalancerFrontendIPConfigurationReference": {
+      "type": "object",
+      "description": "Reference to a LoadBalancer Frontend IPConfiguration",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "name of the frontnedIPConfiguration"
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
+    "LoadBalancerListResult": {
+      "type": "object",
+      "description": "The response of a LoadBalancer list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The LoadBalancer items on this page",
+          "items": {
+            "$ref": "#/definitions/LoadBalancer"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "LoadBalancerProbeProtocol": {
+      "type": "string",
+      "description": "Protocol for health probes",
+      "enum": [
+        "Tcp",
+        "Http"
+      ],
+      "x-ms-enum": {
+        "name": "LoadBalancerProbeProtocol",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "TCP",
+            "value": "Tcp",
+            "description": "TCP - TCP port checking"
+          },
+          {
+            "name": "HTTP",
+            "value": "Http",
+            "description": "HTTP - HTTP request"
+          }
+        ]
+      }
+    },
+    "LoadBalancerProbeReference": {
+      "type": "object",
+      "description": "Reference to a LoadBalancer health probe",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "name of the health probe"
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
+    "LoadBalancerProperties": {
+      "type": "object",
+      "description": "Load Balancer resource properties",
+      "properties": {
+        "frontendIPConfigurations": {
+          "type": "array",
+          "description": "Frontend IPs for the loadbalancer.",
+          "items": {
+            "$ref": "#/definitions/FrontendIPConfiguration"
+          }
+        },
+        "backendAddressPools": {
+          "type": "array",
+          "description": "backendAddressPools for the loadbalancer",
+          "items": {
+            "$ref": "#/definitions/BackendAddressPool"
+          }
+        },
+        "loadBalancingRules": {
+          "type": "array",
+          "description": "load balancer rules",
+          "items": {
+            "$ref": "#/definitions/LoadBalancerRule"
+          }
+        },
+        "probes": {
+          "type": "array",
+          "description": "load balancer health probes",
+          "items": {
+            "$ref": "#/definitions/Probe"
+          }
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningStateEnum",
+          "description": "Provisioning state of the Load Balancer",
+          "readOnly": true
+        },
+        "status": {
+          "$ref": "#/definitions/LoadBalancerStatus",
+          "description": "observed state of the load balancer",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "frontendIPConfigurations"
+      ]
+    },
+    "LoadBalancerRule": {
+      "type": "object",
+      "description": "LoadBalancer Rules",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "name of the load balancer rule",
+          "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "properties": {
+          "$ref": "#/definitions/LoadBalancerRuleProperties",
+          "description": "load balancer rule properties"
+        }
+      },
+      "required": [
+        "name",
+        "properties"
+      ]
+    },
+    "LoadBalancerRuleProperties": {
+      "type": "object",
+      "description": "Properties for LoadBalancerRules",
+      "properties": {
+        "frontendIPConfiguration": {
+          "$ref": "#/definitions/LoadBalancerFrontendIPConfigurationReference",
+          "description": "arm reference to frontend IP being used by this LB"
+        },
+        "backendAddressPool": {
+          "$ref": "#/definitions/LoadBalancerBackendAddressPoolReference",
+          "description": "arm reference to backend pool being used by ths pool"
+        },
+        "frontendPort": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Frontend port to accept connections"
+        },
+        "backendPort": {
+          "type": "integer",
+          "format": "int32",
+          "description": "backendPort to forward connections"
+        },
+        "protocol": {
+          "$ref": "#/definitions/LoadBalancerRuleTransportProtocol",
+          "description": "IP Protocol that the rule must load-balance"
+        },
+        "probe": {
+          "$ref": "#/definitions/LoadBalancerProbeReference",
+          "description": "Reference for the health probe for this connection"
+        },
+        "loadDistribution": {
+          "type": "string",
+          "description": "SessionPersistence: Default (5-tuple), SourceIP(2-tuple), sourceIPProtocol(3-tuple)",
+          "default": "Default",
+          "enum": [
+            "Default",
+            "SourceIP",
+            "SourceIPProtocol"
+          ],
+          "x-ms-enum": {
+            "name": "LoadBalancerRuleSessionPersistenceType",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "Default",
+                "value": "Default",
+                "description": "Default - 5-tuple hashing"
+              },
+              {
+                "name": "SourceIP",
+                "value": "SourceIP",
+                "description": "Source IP - 2-tuple hashing looking at src-dst ip"
+              },
+              {
+                "name": "SourceIPProtocol",
+                "value": "SourceIPProtocol",
+                "description": "SourceIPProtocol - 3-tuple hashing looking at src-dst ip and ip protocol"
+              }
+            ]
+          }
+        },
+        "idleTimeoutInMinutes": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Time for which connections are preserved before being torn down."
+        }
+      },
+      "required": [
+        "frontendIPConfiguration",
+        "backendAddressPool",
+        "frontendPort",
+        "backendPort",
+        "protocol"
+      ]
+    },
+    "LoadBalancerRuleSessionPersistenceType": {
+      "type": "string",
+      "description": "Type of session persistence [Default, SourceIP, SourceIPProtocol]",
+      "enum": [
+        "Default",
+        "SourceIP",
+        "SourceIPProtocol"
+      ],
+      "x-ms-enum": {
+        "name": "LoadBalancerRuleSessionPersistenceType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Default",
+            "value": "Default",
+            "description": "Default - 5-tuple hashing"
+          },
+          {
+            "name": "SourceIP",
+            "value": "SourceIP",
+            "description": "Source IP - 2-tuple hashing looking at src-dst ip"
+          },
+          {
+            "name": "SourceIPProtocol",
+            "value": "SourceIPProtocol",
+            "description": "SourceIPProtocol - 3-tuple hashing looking at src-dst ip and ip protocol"
+          }
+        ]
+      }
+    },
+    "LoadBalancerRuleTransportProtocol": {
+      "type": "string",
+      "description": "Protocol for load balancing rules",
+      "enum": [
+        "Tcp",
+        "Udp",
+        "All"
+      ],
+      "x-ms-enum": {
+        "name": "LoadBalancerRuleTransportProtocol",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "TCP",
+            "value": "Tcp",
+            "description": "TCP - load balance only tcp traffic"
+          },
+          {
+            "name": "UDP",
+            "value": "Udp",
+            "description": "Udp - load balance only UDP traffic"
+          },
+          {
+            "name": "All",
+            "value": "All",
+            "description": "All - load balance all UDP and TCP traffic"
+          }
+        ]
+      }
+    },
+    "LoadBalancerStatus": {
+      "type": "object",
+      "description": "The observed status of the virtual network",
+      "properties": {
+        "errorCode": {
+          "type": "string",
+          "description": "LoadBalancer provisioning error code"
+        },
+        "errorMessage": {
+          "type": "string",
+          "description": "Descriptive error message"
+        },
+        "provisioningStatus": {
+          "$ref": "#/definitions/LoadBalancerStatusProvisioningStatus",
+          "description": "virtual network provisioning status"
+        }
+      }
+    },
+    "LoadBalancerStatusProvisioningStatus": {
+      "type": "object",
+      "description": "Status of load balancer operations",
+      "properties": {
+        "operationId": {
+          "type": "string",
+          "description": "The ID of the operation performed on the load balancer"
+        },
+        "status": {
+          "$ref": "#/definitions/Status",
+          "description": "The status of the operation performed on the loadbalancer [Succeeded, Failed, InProgress]"
+        }
+      }
+    },
+    "LoadBalancerTagsUpdate": {
+      "type": "object",
+      "description": "The type used for updating tags in LoadBalancer resources.",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "LogicalNetwork": {
+      "type": "object",
+      "description": "The logical network resource definition.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/LogicalNetworkProperties",
+          "description": "The resource-specific properties for this resource.",
+          "x-ms-client-flatten": true
+        },
+        "extendedLocation": {
+          "$ref": "#/definitions/ExtendedLocation",
+          "description": "The extendedLocation of the resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/TrackedResource"
+        }
+      ],
+      "x-ms-azure-resource": true
+    },
+    "LogicalNetworkArmReference": {
+      "type": "object",
+      "description": "The Azure Resource ID for a Logical Network.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The Azure Resource ID for a Logical Network.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.AzureStackHCI/logicalNetworks"
+              },
+              {
+                "type": "Microsoft.AzureStackHCI/virtualNetwork/subnets"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "LogicalNetworkListResult": {
+      "type": "object",
+      "description": "The response of a LogicalNetwork list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The LogicalNetwork items on this page",
+          "items": {
+            "$ref": "#/definitions/LogicalNetwork"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "LogicalNetworkProperties": {
+      "type": "object",
+      "description": "Properties under the logical network resource",
+      "properties": {
+        "dhcpOptions": {
+          "$ref": "#/definitions/LogicalNetworkPropertiesDhcpOptions",
+          "description": "DhcpOptions contains an array of DNS servers available to VMs deployed in the logical network. Standard DHCP option for a subnet overrides logical network DHCP options."
+        },
+        "fabricNetworkConfiguration": {
+          "$ref": "#/definitions/ManagedNetworkFabricArmReference",
+          "description": "Managed network fabric l2/l3 ISD for this logical network. If set empty, the logical network remains entirely local."
+        },
+        "subnets": {
+          "type": "array",
+          "description": "Subnet - list of subnets under the logical network",
+          "items": {
+            "$ref": "#/definitions/Subnet"
+          },
+          "x-ms-identifiers": []
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningStateEnum",
+          "description": "Provisioning state of the logical network.",
+          "readOnly": true
+        },
+        "vmSwitchName": {
+          "type": "string",
+          "description": "name of the network switch to be used for VMs"
+        },
+        "status": {
+          "$ref": "#/definitions/LogicalNetworkStatus",
+          "description": "The observed state of logical networks",
+          "readOnly": true
+        },
+        "networkType": {
+          "$ref": "#/definitions/LogicalNetworkTypeEnum",
+          "description": "Type of the Logical Network",
+          "readOnly": true
+        }
+      }
+    },
+    "LogicalNetworkPropertiesDhcpOptions": {
+      "type": "object",
+      "description": "DhcpOptions contains an array of DNS servers available to VMs deployed in the logical network. Standard DHCP option for a subnet overrides logical network DHCP options.",
+      "properties": {
+        "dnsServers": {
+          "type": "array",
+          "description": "The list of DNS servers IP addresses.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "LogicalNetworkStatus": {
+      "type": "object",
+      "description": "The observed state of logical networks",
+      "properties": {
+        "errorCode": {
+          "type": "string",
+          "description": "LogicalNetwork provisioning error code"
+        },
+        "errorMessage": {
+          "type": "string",
+          "description": "Descriptive error message"
+        },
+        "provisioningStatus": {
+          "$ref": "#/definitions/LogicalNetworkStatusProvisioningStatus",
+          "description": "Logical network provisioning status"
+        },
+        "fabricIntegration": {
+          "$ref": "#/definitions/FabricIntegrationStatus",
+          "description": "Enhanced fabric integration status with detailed health monitoring and connectivity state."
+        }
+      }
+    },
+    "LogicalNetworkStatusProvisioningStatus": {
+      "type": "object",
+      "description": "Describes the status of the provisioning.",
+      "properties": {
+        "operationId": {
+          "type": "string",
+          "description": "The ID of the operation performed on the logical network"
+        },
+        "status": {
+          "$ref": "#/definitions/Status",
+          "description": "The status of the operation performed on the logical network [Succeeded, Failed, InProgress]"
+        }
+      }
+    },
+    "LogicalNetworkTypeEnum": {
+      "type": "string",
+      "description": "Type of Logical Network",
+      "enum": [
+        "Workload",
+        "Infrastructure"
+      ],
+      "x-ms-enum": {
+        "name": "LogicalNetworkTypeEnum",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Workload",
+            "value": "Workload",
+            "description": "Logical Network of type Workload"
+          },
+          {
+            "name": "Infrastructure",
+            "value": "Infrastructure",
+            "description": "Logical Network of type Infrastructure"
+          }
+        ]
+      }
+    },
+    "LogicalNetworksUpdateRequest": {
+      "type": "object",
+      "description": "The logical network resource patch definition.",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Resource tags",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ManagedNetworkFabricArmReference": {
+      "type": "object",
+      "description": "The Azure Resource ID for a Managed Network Fabric L2ISD or L3ISD internal network",
+      "properties": {
+        "resourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The Azure Resource ID for a Managed Network Fabric L2ISD or L3ISD internal network",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.ManagedNetworkFabric/l2isolationdomains"
+              },
+              {
+                "type": "Microsoft.ManagedNetworkFabric/l3isolationdomain/internalnetworks"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "MarketplaceGalleryImage": {
+      "type": "object",
+      "description": "The marketplace gallery image resource definition.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/MarketplaceGalleryImageProperties",
+          "description": "The resource-specific properties for this resource.",
+          "x-ms-client-flatten": true
+        },
+        "extendedLocation": {
+          "$ref": "#/definitions/ExtendedLocation",
+          "description": "The extendedLocation of the resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/TrackedResource"
+        }
+      ],
+      "x-ms-azure-resource": true
+    },
+    "MarketplaceGalleryImageListResult": {
+      "type": "object",
+      "description": "The response of a MarketplaceGalleryImage list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The MarketplaceGalleryImage items on this page",
+          "items": {
+            "$ref": "#/definitions/MarketplaceGalleryImage"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "MarketplaceGalleryImageProperties": {
+      "type": "object",
+      "description": "Properties under the marketplace gallery image resource",
+      "properties": {
+        "containerId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Storage ContainerID of the storage container to be used for marketplace gallery image",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.AzureStackHCI/storageContainers"
+              }
+            ]
+          }
+        },
+        "osType": {
+          "$ref": "#/definitions/OperatingSystemTypes",
+          "description": "Operating system type that the gallery image uses [Windows, Linux]"
+        },
+        "cloudInitDataSource": {
+          "$ref": "#/definitions/CloudInitDataSource",
+          "description": "Datasource for the gallery image when provisioning with cloud-init [NoCloud, Azure]"
+        },
+        "hyperVGeneration": {
+          "$ref": "#/definitions/HyperVGeneration",
+          "description": "The hypervisor generation of the Virtual Machine [V1, V2]"
+        },
+        "identifier": {
+          "$ref": "#/definitions/GalleryImageIdentifier",
+          "description": "This is the gallery image definition identifier."
+        },
+        "version": {
+          "$ref": "#/definitions/GalleryImageVersion",
+          "description": "Specifies information about the gallery image version that you want to create or update."
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningStateEnum",
+          "description": "Provisioning state of the marketplace gallery image.",
+          "readOnly": true
+        },
+        "status": {
+          "$ref": "#/definitions/MarketplaceGalleryImageStatus",
+          "description": "The observed state of marketplace gallery images",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "osType"
+      ]
+    },
+    "MarketplaceGalleryImageStatus": {
+      "type": "object",
+      "description": "The observed state of marketplace gallery images",
+      "properties": {
+        "errorCode": {
+          "type": "string",
+          "description": "MarketplaceGalleryImage provisioning error code"
+        },
+        "errorMessage": {
+          "type": "string",
+          "description": "Descriptive error message"
+        },
+        "provisioningStatus": {
+          "$ref": "#/definitions/MarketplaceGalleryImageStatusProvisioningStatus",
+          "description": "Provisioning status of marketplace gallery image"
+        },
+        "downloadStatus": {
+          "$ref": "#/definitions/MarketplaceGalleryImageStatusDownloadStatus",
+          "description": "The download status of the gallery image"
+        },
+        "progressPercentage": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The progress of the operation in percentage"
+        }
+      }
+    },
+    "MarketplaceGalleryImageStatusDownloadStatus": {
+      "type": "object",
+      "description": "The download status of the gallery image",
+      "properties": {
+        "downloadSizeInMB": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The downloaded sized of the image in MB"
+        }
+      }
+    },
+    "MarketplaceGalleryImageStatusProvisioningStatus": {
+      "type": "object",
+      "description": "Marketplace GalleryImage provisioning status",
+      "properties": {
+        "operationId": {
+          "type": "string",
+          "description": "The ID of the operation performed on the gallery image"
+        },
+        "status": {
+          "$ref": "#/definitions/Status",
+          "description": "The status of the operation performed on the gallery image [Succeeded, Failed, InProgress]"
+        }
+      }
+    },
+    "MarketplaceGalleryImageTagsUpdate": {
+      "type": "object",
+      "description": "The type used for updating tags in MarketplaceGalleryImage resources.",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "MarketplaceGalleryImagesUpdateRequest": {
+      "type": "object",
+      "description": "The marketplace gallery image resource patch definition.",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Resource tags",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "NatGateway": {
+      "type": "object",
+      "description": "The NatGateway resource definition.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/NatGatewayProperties",
+          "description": "The resource-specific properties for this resource."
+        },
+        "extendedLocation": {
+          "$ref": "#/definitions/ExtendedLocation",
+          "description": "The extendedLocation of the resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/TrackedResource"
+        }
+      ],
+      "x-ms-azure-resource": true
+    },
+    "NatGatewayArmReference": {
+      "type": "object",
+      "description": "The ARM ID for a Network Security Group.",
+      "properties": {
+        "resourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The ARM ID for a Network Security Group.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.AzureStackHCI/natGateways"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "NatGatewayListResult": {
+      "type": "object",
+      "description": "The response of a NatGateway list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The NatGateway items on this page",
+          "items": {
+            "$ref": "#/definitions/NatGateway"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "NatGatewayProperties": {
+      "type": "object",
+      "description": "Nat Gateway resource properties",
+      "properties": {
+        "publicIPAddresses": {
+          "type": "array",
+          "description": "List of public ip addresses that the gateway can use for NAT.",
+          "items": {
+            "$ref": "#/definitions/PublicIPAddressArmReference"
+          },
+          "x-ms-identifiers": []
+        },
+        "subnets": {
+          "type": "array",
+          "description": "List of subnets associated with the nat gateway. These can only be vnet subnets and must be from the same vnet",
+          "items": {
+            "$ref": "#/definitions/VirtualNetworkSubnetArmReference"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": []
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningStateEnum",
+          "description": "Provisioning state of the public IP",
+          "readOnly": true
+        },
+        "status": {
+          "$ref": "#/definitions/NatGatewayStatus",
+          "description": "The observed state of Nat Gateway",
+          "readOnly": true
+        }
+      }
+    },
+    "NatGatewayStatus": {
+      "type": "object",
+      "description": "Nat Gateway resource status",
+      "properties": {
+        "errorCode": {
+          "type": "string",
+          "description": "NatGateway provisioning error code"
+        },
+        "errorMessage": {
+          "type": "string",
+          "description": "Descriptive error message"
+        },
+        "provisioningStatus": {
+          "$ref": "#/definitions/NatGatewayStatusProvisioningStatus",
+          "description": "NatGateway provisioning status"
+        }
+      }
+    },
+    "NatGatewayStatusProvisioningStatus": {
+      "type": "object",
+      "description": "Provisioning status of Nat Gateway ",
+      "properties": {
+        "operationId": {
+          "type": "string",
+          "description": "The ID of the operation performed on the nat gateway"
+        },
+        "status": {
+          "$ref": "#/definitions/Status",
+          "description": "The status of the operation performed on the nat gateway [Succeeded, Failed, InProgress]"
+        }
+      }
+    },
+    "NatGatewayTagsUpdate": {
+      "type": "object",
+      "description": "The type used for updating tags in NatGateway resources.",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "NetworkInterface": {
+      "type": "object",
+      "description": "The network interface resource definition.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/NetworkInterfaceProperties",
+          "description": "The resource-specific properties for this resource.",
+          "x-ms-client-flatten": true
+        },
+        "extendedLocation": {
+          "$ref": "#/definitions/ExtendedLocation",
+          "description": "The extendedLocation of the resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/TrackedResource"
+        }
+      ],
+      "x-ms-azure-resource": true
+    },
+    "NetworkInterfaceArmReference": {
+      "type": "object",
+      "description": "The Azure Resource ID for a Network Interface.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The Azure Resource ID for a Network Interface.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.AzureStackHCI/networkInterfaces"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "NetworkInterfaceListResult": {
+      "type": "object",
+      "description": "The response of a NetworkInterface list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The NetworkInterface items on this page",
+          "items": {
+            "$ref": "#/definitions/NetworkInterface"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "NetworkInterfaceProperties": {
+      "type": "object",
+      "description": "Properties under the network interface resource",
+      "properties": {
+        "ipConfigurations": {
+          "type": "array",
+          "description": "IPConfigurations - A list of IPConfigurations of the network interface.",
+          "items": {
+            "$ref": "#/definitions/IPConfiguration"
+          },
+          "x-ms-identifiers": []
+        },
+        "macAddress": {
+          "type": "string",
+          "description": "MacAddress - The MAC address of the network interface."
+        },
+        "dnsSettings": {
+          "$ref": "#/definitions/InterfaceDNSSettings",
+          "description": "DNS Settings for the interface"
+        },
+        "createFromLocal": {
+          "type": "boolean",
+          "description": "Boolean indicating whether this is a existing local network interface or if one should be created.",
+          "default": false
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningStateEnum",
+          "description": "Provisioning state of the network interface.",
+          "readOnly": true
+        },
+        "status": {
+          "$ref": "#/definitions/NetworkInterfaceStatus",
+          "description": "The observed state of network interfaces",
+          "readOnly": true
+        },
+        "networkSecurityGroup": {
+          "$ref": "#/definitions/NetworkSecurityGroupArmReference",
+          "description": "NetworkSecurityGroup - Network Security Group attached to the network interface."
+        },
+        "bypassSdnPolicies": {
+          "type": "boolean",
+          "description": "This setting is applicable only when SDN is supported and enabled in the environment. Indicates whether SDN policies should be bypassed for this network interface. By default, SDN is enabled. Set this value to true only if you want to disable SDN for the network interface."
+        }
+      }
+    },
+    "NetworkInterfaceStatus": {
+      "type": "object",
+      "description": "The observed state of network interfaces",
+      "properties": {
+        "errorCode": {
+          "type": "string",
+          "description": "NetworkInterface provisioning error code"
+        },
+        "errorMessage": {
+          "type": "string",
+          "description": "Descriptive error message"
+        },
+        "provisioningStatus": {
+          "$ref": "#/definitions/NetworkInterfaceStatusProvisioningStatus",
+          "description": "Network interface provisioning status"
+        }
+      }
+    },
+    "NetworkInterfaceStatusProvisioningStatus": {
+      "type": "object",
+      "description": "Network interface provisioning status",
+      "properties": {
+        "operationId": {
+          "type": "string",
+          "description": "The ID of the operation performed on the network interface"
+        },
+        "status": {
+          "$ref": "#/definitions/Status",
+          "description": "The status of the operation performed on the network interface [Succeeded, Failed, InProgress]"
+        }
+      }
+    },
+    "NetworkInterfacesUpdateProperties": {
+      "type": "object",
+      "description": "Defines the resource properties for the update.",
+      "properties": {
+        "networkSecurityGroup": {
+          "$ref": "#/definitions/NetworkSecurityGroupArmReference",
+          "description": "NetworkSecurityGroup - Network Security Group attached to the network interface."
+        },
+        "dnsSettings": {
+          "$ref": "#/definitions/InterfaceDNSSettings",
+          "description": "DNS Settings for the interface"
+        },
+        "bypassSdnPolicies": {
+          "type": "boolean",
+          "description": "This setting is applicable only when SDN is supported and enabled in the environment. Indicates whether SDN policies should be bypassed for this network interface. By default, SDN is enabled. Set this value to true only if you want to disable SDN for the network interface."
+        }
+      }
+    },
+    "NetworkInterfacesUpdateRequest": {
+      "type": "object",
+      "description": "The network interface resource patch definition.",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Resource tags",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "properties": {
+          "$ref": "#/definitions/NetworkInterfacesUpdateProperties",
+          "description": "Defines the resource properties for the update."
+        }
+      }
+    },
+    "NetworkProfileUpdate": {
+      "type": "object",
+      "description": "NetworkProfile - describes the network update configuration the virtual machine instance",
+      "properties": {
+        "networkInterfaces": {
+          "type": "array",
+          "description": "NetworkInterfaces - list of network interfaces to be attached to the virtual machine instance",
+          "items": {
+            "$ref": "#/definitions/NetworkInterfaceArmReference"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "NetworkSecurityGroup": {
+      "type": "object",
+      "description": "NetworkSecurityGroup resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/NetworkSecurityGroupProperties",
+          "description": "The resource-specific properties for this resource.",
+          "x-ms-client-flatten": true
+        },
+        "extendedLocation": {
+          "$ref": "#/definitions/ExtendedLocation",
+          "description": "The extendedLocation of the resource."
+        },
+        "eTag": {
+          "type": "string",
+          "description": "If eTag is provided in the response body, it may also be provided as a header per the normal etag convention.  Entity tags are used for comparing two or more entities from the same requested resource. HTTP/1.1 uses entity tags in the etag (section 14.19), If-Match (section 14.24), If-None-Match (section 14.26), and If-Range (section 14.27) header fields.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/TrackedResource"
+        }
+      ]
+    },
+    "NetworkSecurityGroupArmReference": {
+      "type": "object",
+      "description": "The Azure Resource ID for a Network Security Group.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The Azure Resource ID for a Network Security Group.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.AzureStackHCI/networkSecurityGroups"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "NetworkSecurityGroupListResult": {
+      "type": "object",
+      "description": "The response of a NetworkSecurityGroup list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The NetworkSecurityGroup items on this page",
+          "items": {
+            "$ref": "#/definitions/NetworkSecurityGroup"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "NetworkSecurityGroupProperties": {
+      "type": "object",
+      "description": "Network Security Group resource.",
+      "properties": {
+        "networkInterfaces": {
+          "type": "array",
+          "description": "A collection of references to network interfaces that are currently using this NSG.",
+          "items": {
+            "$ref": "#/definitions/NetworkInterfaceArmReference"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": []
+        },
+        "subnets": {
+          "type": "array",
+          "description": "A collection of references to logical networks that are currently using this NSG",
+          "items": {
+            "$ref": "#/definitions/LogicalNetworkArmReference"
+          },
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningStateEnum",
+          "description": "The provisioning state of the network security group resource.",
+          "readOnly": true
+        },
+        "status": {
+          "$ref": "#/definitions/NetworkSecurityGroupStatus",
+          "description": "The observed state of Network Security Group",
+          "readOnly": true
+        }
+      }
+    },
+    "NetworkSecurityGroupStatus": {
+      "type": "object",
+      "description": "The observed state of network security group",
+      "properties": {
+        "errorCode": {
+          "type": "string",
+          "description": "NetworkSecurityGroup provisioning error code"
+        },
+        "errorMessage": {
+          "type": "string",
+          "description": "Descriptive error message"
+        },
+        "provisioningStatus": {
+          "$ref": "#/definitions/NetworkSecurityGroupStatusProvisioningStatus",
+          "description": "network security group provisioning status"
+        }
+      }
+    },
+    "NetworkSecurityGroupStatusProvisioningStatus": {
+      "type": "object",
+      "description": "network security group provisioning status",
+      "properties": {
+        "operationId": {
+          "type": "string",
+          "description": "The ID of the operation performed on the network security group"
+        },
+        "status": {
+          "$ref": "#/definitions/Status",
+          "description": "The status of the operation performed on the network security group [Succeeded, Failed, InProgress]"
+        }
+      }
+    },
+    "NetworkSecurityGroupTagsUpdate": {
+      "type": "object",
+      "description": "The type used for updating tags in NetworkSecurityGroup resources.",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "OperatingSystemTypes": {
+      "type": "string",
+      "description": "Operating system type that the gallery image uses [Windows, Linux]",
+      "enum": [
+        "Windows",
+        "Linux"
+      ],
+      "x-ms-enum": {
+        "name": "OperatingSystemTypes",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Windows",
+            "value": "Windows",
+            "description": "Windows operating system"
+          },
+          {
+            "name": "Linux",
+            "value": "Linux",
+            "description": "Linux operating system"
+          }
+        ]
+      }
+    },
+    "OsProfileUpdate": {
+      "type": "object",
+      "description": "OsProfile - describes the update configuration of the operating system",
+      "properties": {
+        "computerName": {
+          "type": "string",
+          "description": "ComputerName - name of the computer"
+        },
+        "linuxConfiguration": {
+          "$ref": "#/definitions/OsProfileUpdateLinuxConfiguration",
+          "description": "Linux configuration properties"
+        },
+        "windowsConfiguration": {
+          "$ref": "#/definitions/OsProfileUpdateWindowsConfiguration",
+          "description": "Windows configuration properties"
+        }
+      }
+    },
+    "OsProfileUpdateLinuxConfiguration": {
+      "type": "object",
+      "description": "OSProfile update linux configuration",
+      "properties": {
+        "provisionVMAgent": {
+          "type": "boolean",
+          "description": "Used to indicate whether Arc for Servers agent onboarding should be triggered during the virtual machine instance creation process."
+        },
+        "provisionVMConfigAgent": {
+          "type": "boolean",
+          "description": "Used to indicate whether the VM Config Agent should be installed during the virtual machine creation process."
+        }
+      }
+    },
+    "OsProfileUpdateWindowsConfiguration": {
+      "type": "object",
+      "description": "OSProfile update windows configuration",
+      "properties": {
+        "provisionVMAgent": {
+          "type": "boolean",
+          "description": "Used to indicate whether Arc for Servers agent onboarding should be triggered during the virtual machine instance creation process."
+        },
+        "provisionVMConfigAgent": {
+          "type": "boolean",
+          "description": "Used to indicate whether the VM Config Agent should be installed during the virtual machine creation process."
+        }
+      }
+    },
+    "PowerOffVirtualMachineOptions": {
+      "type": "object",
+      "description": "The operation gracefully shuts down a virtual machine by requesting the operating system to shut down. The virtual machine can be restarted with the same provisioned resources. To force an immediate shut down, see the skipShutdown flag.",
+      "properties": {
+        "skipShutdown": {
+          "type": "boolean",
+          "description": "Indicates whether to perform an immediate shut down. When set to true, the VM is forcefully shut down. If not specified, the default value is false, and the operation attempts a graceful shut down of the VM.",
+          "default": false
+        }
+      }
+    },
+    "PowerStateEnum": {
+      "type": "string",
+      "description": "The power state of the virtual machine instance",
+      "enum": [
+        "Deallocated",
+        "Deallocating",
+        "Running",
+        "Starting",
+        "Stopped",
+        "Stopping",
+        "Paused",
+        "Saved",
+        "Unknown"
+      ],
+      "x-ms-enum": {
+        "name": "PowerStateEnum",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Deallocated",
+            "value": "Deallocated",
+            "description": "Virtual machine deallocated"
+          },
+          {
+            "name": "Deallocating",
+            "value": "Deallocating",
+            "description": "Virtual machine deallocating"
+          },
+          {
+            "name": "Running",
+            "value": "Running",
+            "description": "Virtual machine running"
+          },
+          {
+            "name": "Starting",
+            "value": "Starting",
+            "description": "Virtual machine starting"
+          },
+          {
+            "name": "Stopped",
+            "value": "Stopped",
+            "description": "Virtual machine stopped"
+          },
+          {
+            "name": "Stopping",
+            "value": "Stopping",
+            "description": "Virtual machine stopping"
+          },
+          {
+            "name": "Paused",
+            "value": "Paused",
+            "description": "Virtual machine paused"
+          },
+          {
+            "name": "Saved",
+            "value": "Saved",
+            "description": "Virtual machine Saved,"
+          },
+          {
+            "name": "Unknown",
+            "value": "Unknown",
+            "description": "Power state of the virtual machine is unknown"
+          }
+        ]
+      }
+    },
+    "Probe": {
+      "type": "object",
+      "description": "Load balancer health probes",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "name of the load balancer health probe",
+          "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,62}[a-zA-Z0-9]$",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "properties": {
+          "$ref": "#/definitions/ProbeProperties",
+          "description": "load balancer rule properties"
+        }
+      },
+      "required": [
+        "name",
+        "properties"
+      ]
+    },
+    "ProbeProperties": {
+      "type": "object",
+      "description": "properties for LoadBalancer health probes",
+      "properties": {
+        "protocol": {
+          "$ref": "#/definitions/LoadBalancerProbeProtocol",
+          "description": "Protocol for this probe: Can be Tcp or Http - Diverges from Azure where Https is also an option"
+        },
+        "port": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Port on the backend address to probe"
+        },
+        "requestPath": {
+          "type": "string",
+          "description": "For http probes, specify the request path e.g. /health"
+        },
+        "intervalInSeconds": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Probe interval in seconds (5-300) default 15",
+          "default": 15
+        },
+        "numberOfProbes": {
+          "type": "integer",
+          "format": "int32",
+          "description": "number of consecutive probe failures before marking unhealthy (1-20) default 2",
+          "default": 2
+        }
+      },
+      "required": [
+        "protocol",
+        "port"
+      ]
+    },
+    "ProvisioningAction": {
+      "type": "string",
+      "description": "Defines the different types of operations for guest agent.",
+      "enum": [
+        "install",
+        "uninstall",
+        "repair"
+      ],
+      "x-ms-enum": {
+        "name": "ProvisioningAction",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "install",
+            "value": "install",
+            "description": "Install guest agent"
+          },
+          {
+            "name": "uninstall",
+            "value": "uninstall",
+            "description": "Uninstall guest agent"
+          },
+          {
+            "name": "repair",
+            "value": "repair",
+            "description": "Repair guest agent"
+          }
+        ]
+      }
+    },
+    "ProvisioningStateEnum": {
+      "type": "string",
+      "description": "Provisioning state of the resource.",
+      "enum": [
+        "Succeeded",
+        "Failed",
+        "InProgress",
+        "Accepted",
+        "Deleting",
+        "Canceled"
+      ],
+      "x-ms-enum": {
+        "name": "ProvisioningStateEnum",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Provisioning has succeeded"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Provisioning has failed"
+          },
+          {
+            "name": "InProgress",
+            "value": "InProgress",
+            "description": "Provisioning is in progress"
+          },
+          {
+            "name": "Accepted",
+            "value": "Accepted",
+            "description": "Provisioning has been accepted"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "Deletion of the resource is in progress"
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Provisioning has been canceled"
+          }
+        ]
+      },
+      "readOnly": true
+    },
+    "PublicIPAddress": {
+      "type": "object",
+      "description": "The publicIP resource definition.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/PublicIPAddressProperties",
+          "description": "The resource-specific properties for this resource."
+        },
+        "extendedLocation": {
+          "$ref": "#/definitions/ExtendedLocation",
+          "description": "The extendedLocation of the resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/TrackedResource"
+        }
+      ],
+      "x-ms-azure-resource": true
+    },
+    "PublicIPAddressArmReference": {
+      "type": "object",
+      "description": "The Azure Resource ID of a Public IP resource",
+      "properties": {
+        "resourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The Azure Resource ID of a Public IP resource",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.AzureStackHCI/publicIPAddresses"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "PublicIPAddressListResult": {
+      "type": "object",
+      "description": "The response of a PublicIPAddress list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The PublicIPAddress items on this page",
+          "items": {
+            "$ref": "#/definitions/PublicIPAddress"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "PublicIPAddressProperties": {
+      "type": "object",
+      "description": "Public IP Properties resource.",
+      "properties": {
+        "publicIPAddressVersion": {
+          "$ref": "#/definitions/PublicIPAddressType",
+          "description": "Whether the public IP is v4 or v6. Defaults to IPv4"
+        },
+        "ipAllocationScope": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "ipAllocationScope: Azure Reference to a particular IP Pool (ALM) or a LogicalNetwork (ALL) for allocating public IP",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.AzureStackHCI/logicalNetworks"
+              },
+              {
+                "type": "Microsoft.AzureStackHCI/publicIPAddresses"
+              }
+            ]
+          }
+        },
+        "ipAddress": {
+          "type": "string",
+          "description": "IP Address. This is static. If the user specifies, we allocate that otherwise allocate from logical network address space."
+        },
+        "ipConfiguration": {
+          "$ref": "#/definitions/IPConfigurationArmReference",
+          "description": "network interface or LoadBalancer frontendIPconfiguration using this public IP",
+          "readOnly": true
+        },
+        "natGateway": {
+          "$ref": "#/definitions/NatGatewayArmReference",
+          "description": "natGateway using this public IP",
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningStateEnum",
+          "description": "Provisioning state of the public IP",
+          "readOnly": true
+        }
+      }
+    },
+    "PublicIPAddressTagsUpdate": {
+      "type": "object",
+      "description": "The type used for updating tags in PublicIPAddress resources.",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "PublicIPAddressType": {
+      "type": "string",
+      "description": "Type of public IP addresses",
+      "enum": [
+        "IPv4",
+        "IPv6"
+      ],
+      "x-ms-enum": {
+        "name": "PublicIPAddressType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "IPv4",
+            "value": "IPv4",
+            "description": "IPv4 IP Address"
+          },
+          {
+            "name": "IPv6",
+            "value": "IPv6",
+            "description": "IPv6 IP Address"
+          }
+        ]
+      }
+    },
+    "Route": {
+      "type": "object",
+      "description": "Route - Route resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/RouteProperties",
+          "description": "Properties of the route.",
+          "x-ms-client-flatten": true
+        },
+        "name": {
+          "type": "string",
+          "description": "Name - name of the subnet",
+          "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,78}[_a-zA-Z0-9]$"
+        }
+      }
+    },
+    "RouteProperties": {
+      "type": "object",
+      "description": "RoutePropertiesFormat - Route resource.",
+      "properties": {
+        "addressPrefix": {
+          "type": "string",
+          "description": "The destination CIDR to which the route applies."
+        },
+        "nextHopIpAddress": {
+          "type": "string",
+          "description": "The IP address packets should be forwarded to. Next hop values are only allowed in routes where the next hop type is VirtualAppliance."
+        }
+      }
+    },
+    "RouteTable": {
+      "type": "object",
+      "description": "Route table resource.",
+      "properties": {
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        },
+        "name": {
+          "type": "string",
+          "description": "Resource name.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "Resource type.",
+          "readOnly": true
+        },
+        "properties": {
+          "$ref": "#/definitions/RouteTableProperties",
+          "description": "Properties of the route table.",
+          "x-ms-client-flatten": true
+        }
+      }
+    },
+    "RouteTableProperties": {
+      "type": "object",
+      "description": "RouteTablePropertiesFormat - Route Table resource.",
+      "properties": {
+        "routes": {
+          "type": "array",
+          "description": "Collection of routes contained within a route table.",
+          "items": {
+            "$ref": "#/definitions/Route"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "SecurityEncryptionType": {
+      "type": "string",
+      "description": "Encryption type of the managed disk enum.",
+      "enum": [
+        "NonPersistedTPM"
+      ],
+      "x-ms-enum": {
+        "name": "SecurityEncryptionType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "NonPersistedTPM",
+            "value": "NonPersistedTPM",
+            "description": "Non-persisted TPM encryption type"
+          }
+        ]
+      }
+    },
+    "SecurityRule": {
+      "type": "object",
+      "description": "Security Rule resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/SecurityRuleProperties",
+          "description": "The resource-specific properties for this resource.",
+          "x-ms-client-flatten": true
+        },
+        "extendedLocation": {
+          "$ref": "#/definitions/ExtendedLocation",
+          "description": "The extendedLocation of the resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "SecurityRuleAccess": {
+      "type": "string",
+      "description": "Whether network traffic is allowed or denied.",
+      "enum": [
+        "Allow",
+        "Deny"
+      ],
+      "x-ms-enum": {
+        "name": "SecurityRuleAccess",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Allow",
+            "value": "Allow",
+            "description": "Network traffic is allowed"
+          },
+          {
+            "name": "Deny",
+            "value": "Deny",
+            "description": "Network traffic is denied"
+          }
+        ]
+      }
+    },
+    "SecurityRuleDirection": {
+      "type": "string",
+      "description": "The direction of the rule. The direction specifies if rule will be evaluated on incoming or outgoing traffic.",
+      "enum": [
+        "Inbound",
+        "Outbound"
+      ],
+      "x-ms-enum": {
+        "name": "SecurityRuleDirection",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Inbound",
+            "value": "Inbound",
+            "description": "Rule is evaluated on incoming traffic"
+          },
+          {
+            "name": "Outbound",
+            "value": "Outbound",
+            "description": "Rule is evaluated on outgoing traffic"
+          }
+        ]
+      }
+    },
+    "SecurityRuleListResult": {
+      "type": "object",
+      "description": "The response of a SecurityRule list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The SecurityRule items on this page",
+          "items": {
+            "$ref": "#/definitions/SecurityRule"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "SecurityRuleProperties": {
+      "type": "object",
+      "description": "Security rule resource.",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "A description for this rule. Restricted to 140 chars."
+        },
+        "protocol": {
+          "$ref": "#/definitions/SecurityRuleProtocol",
+          "description": "Network protocol this rule applies to."
+        },
+        "sourceAddressPrefixes": {
+          "type": "array",
+          "description": "The CIDR or source IP ranges.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "destinationAddressPrefixes": {
+          "type": "array",
+          "description": "The destination address prefixes. CIDR or destination IP ranges.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sourcePortRanges": {
+          "type": "array",
+          "description": "The source port ranges. Integer or range between 0 and 65535. Asterisk '*' can also be used to match all ports.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "destinationPortRanges": {
+          "type": "array",
+          "description": "The destination port ranges. Integer or range between 0 and 65535. Asterisk '*' can also be used to match all ports.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "access": {
+          "$ref": "#/definitions/SecurityRuleAccess",
+          "description": "The network traffic is allowed or denied."
+        },
+        "priority": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The priority of the rule. The value can be between 100 and 4096. The priority number must be unique for each rule in the collection. The lower the priority number, the higher the priority of the rule."
+        },
+        "direction": {
+          "$ref": "#/definitions/SecurityRuleDirection",
+          "description": "The direction of the rule. The direction specifies if rule will be evaluated on incoming or outgoing traffic."
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningStateEnum",
+          "description": "Provisioning state of the SR",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "protocol",
+        "access",
+        "priority",
+        "direction"
+      ]
+    },
+    "SecurityRuleProtocol": {
+      "type": "string",
+      "description": "Network protocol this rule applies to.",
+      "enum": [
+        "Tcp",
+        "Udp",
+        "Icmp",
+        "*"
+      ],
+      "x-ms-enum": {
+        "name": "SecurityRuleProtocol",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Tcp",
+            "value": "Tcp",
+            "description": "Transmission Control Protocol"
+          },
+          {
+            "name": "Udp",
+            "value": "Udp",
+            "description": "User Datagram Protocol"
+          },
+          {
+            "name": "Icmp",
+            "value": "Icmp",
+            "description": "Internet Control Message Protocol"
+          },
+          {
+            "name": "Asterisk",
+            "value": "*",
+            "description": "Wildcard rule for all protocols"
+          }
+        ]
+      }
+    },
+    "SecurityTypes": {
+      "type": "string",
+      "description": "Specifies the SecurityType of the virtual machine. EnableTPM and SecureBootEnabled must be set to true for SecurityType to function.",
+      "enum": [
+        "TrustedLaunch",
+        "ConfidentialVM"
+      ],
+      "x-ms-enum": {
+        "name": "SecurityTypes",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "TrustedLaunch",
+            "value": "TrustedLaunch",
+            "description": "Trusted Launch security type"
+          },
+          {
+            "name": "ConfidentialVM",
+            "value": "ConfidentialVM",
+            "description": "Confidential VM security type"
+          }
+        ]
+      }
+    },
+    "Snapshot": {
+      "type": "object",
+      "description": "The snapshot resource definition.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/SnapshotProperties",
+          "description": "The resource-specific properties for this resource."
+        },
+        "extendedLocation": {
+          "$ref": "#/definitions/ExtendedLocation",
+          "description": "The extendedLocation of the resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/TrackedResource"
+        }
+      ],
+      "x-ms-azure-resource": true
+    },
+    "SnapshotListResult": {
+      "type": "object",
+      "description": "The response of a Snapshot list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The Snapshot items on this page",
+          "items": {
+            "$ref": "#/definitions/Snapshot"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "SnapshotProperties": {
+      "type": "object",
+      "description": "Properties under the snapshot resource",
+      "properties": {
+        "creationData": {
+          "$ref": "#/definitions/CreationData",
+          "description": "Data used when creating a snapshot"
+        },
+        "timeCreated": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The time when the snapshot was created.",
+          "readOnly": true
+        },
+        "diskSizeBytes": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The size of the disk in bytes.",
+          "readOnly": true
+        },
+        "uniqueId": {
+          "type": "string",
+          "description": "Unique identifier for the snapshot.",
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningStateEnum",
+          "description": "Provisioning state of the snapshot.",
+          "readOnly": true
+        },
+        "status": {
+          "$ref": "#/definitions/SnapshotStatus",
+          "description": "The observed state of snapshots",
+          "readOnly": true
+        }
+      }
+    },
+    "SnapshotStatus": {
+      "type": "object",
+      "description": "The observed state of snapshots",
+      "properties": {
+        "errorCode": {
+          "type": "string",
+          "description": "Snapshot provisioning error code"
+        },
+        "errorMessage": {
+          "type": "string",
+          "description": "Descriptive error message"
+        },
+        "provisioningStatus": {
+          "$ref": "#/definitions/SnapshotStatusProvisioningStatus",
+          "description": "Provisioning status of the snapshot"
+        }
+      }
+    },
+    "SnapshotStatusProvisioningStatus": {
+      "type": "object",
+      "description": "Snapshot Status provisioning status",
+      "properties": {
+        "operationId": {
+          "type": "string",
+          "description": "The ID of the operation performed on the snapshot"
+        },
+        "status": {
+          "$ref": "#/definitions/Status",
+          "description": "The status of the operation performed on the snapshot [Succeeded, Failed, InProgress]"
+        }
+      }
+    },
+    "SnapshotTagsUpdate": {
+      "type": "object",
+      "description": "The type used for updating tags in Snapshot resources.",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "SshConfiguration": {
+      "type": "object",
+      "description": "SSH configuration for Linux based VMs running on Azure",
+      "properties": {
+        "publicKeys": {
+          "type": "array",
+          "description": "The list of SSH public keys used to authenticate with linux based VMs.",
+          "items": {
+            "$ref": "#/definitions/SshPublicKey"
+          },
+          "x-ms-identifiers": [
+            "path"
+          ]
+        }
+      }
+    },
+    "SshPublicKey": {
+      "type": "object",
+      "description": "Contains information about SSH certificate public key and the path on the Linux VM where the public key is placed.",
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "Specifies the full path on the created VM where ssh public key is stored. If the file already exists, the specified key is appended to the file. Example: /home/user/.ssh/authorized_keys"
+        },
+        "keyData": {
+          "type": "string",
+          "description": "SSH public key certificate used to authenticate with the VM through ssh. The key needs to be at least 2048-bit and in ssh-rsa format. <br><br> For creating ssh keys, see [Create SSH keys on Linux and Mac for Linux VMs in Azure]https://learn.microsoft.com/azure/virtual-machines/linux/create-ssh-keys-detailed)."
+        }
+      }
+    },
+    "Status": {
+      "type": "string",
+      "description": "The status of the operation performed on the resource [Succeeded, Failed, InProgress]",
+      "enum": [
+        "Succeeded",
+        "Failed",
+        "InProgress"
+      ],
+      "x-ms-enum": {
+        "name": "Status",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Operation succeeded"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Operation failed"
+          },
+          {
+            "name": "InProgress",
+            "value": "InProgress",
+            "description": "Operation is in progress"
+          }
+        ]
+      },
+      "readOnly": true
+    },
+    "StatusLevelTypes": {
+      "type": "string",
+      "description": "The level code.",
+      "enum": [
+        "Info",
+        "Warning",
+        "Error"
+      ],
+      "x-ms-enum": {
+        "name": "StatusLevelTypes",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Info",
+            "value": "Info",
+            "description": "Informational status level"
+          },
+          {
+            "name": "Warning",
+            "value": "Warning",
+            "description": "Warning status level"
+          },
+          {
+            "name": "Error",
+            "value": "Error",
+            "description": "Error status level"
+          }
+        ]
+      }
+    },
+    "StatusTypes": {
+      "type": "string",
+      "description": "The installation status of the hybrid machine agent installation.",
+      "enum": [
+        "Succeeded",
+        "InProgress",
+        "Failed"
+      ],
+      "x-ms-enum": {
+        "name": "StatusTypes",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Installation succeeded"
+          },
+          {
+            "name": "InProgress",
+            "value": "InProgress",
+            "description": "Installation in progress"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Installation failed"
+          }
+        ]
+      },
+      "readOnly": true
+    },
+    "StorageContainer": {
+      "type": "object",
+      "description": "The storage container resource definition.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/StorageContainerProperties",
+          "description": "The resource-specific properties for this resource.",
+          "x-ms-client-flatten": true
+        },
+        "extendedLocation": {
+          "$ref": "#/definitions/ExtendedLocation",
+          "description": "The extendedLocation of the resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/TrackedResource"
+        }
+      ],
+      "x-ms-azure-resource": true
+    },
+    "StorageContainerArmReference": {
+      "type": "object",
+      "description": "The Azure Resource ID for a Storage Container.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The Azure Resource ID for a Storage Container.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.AzureStackHCI/storageContainers"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "StorageContainerListResult": {
+      "type": "object",
+      "description": "The response of a StorageContainer list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The StorageContainer items on this page",
+          "items": {
+            "$ref": "#/definitions/StorageContainer"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "StorageContainerProperties": {
+      "type": "object",
+      "description": "Properties under the storage container resource",
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "Path of the storage container on the disk"
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningStateEnum",
+          "description": "Provisioning state of the storage container.",
+          "readOnly": true
+        },
+        "status": {
+          "$ref": "#/definitions/StorageContainerStatus",
+          "description": "The observed state of storage containers",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "path"
+      ]
+    },
+    "StorageContainerStatus": {
+      "type": "object",
+      "description": "The observed state of storage containers",
+      "properties": {
+        "errorCode": {
+          "type": "string",
+          "description": "StorageContainer provisioning error code"
+        },
+        "errorMessage": {
+          "type": "string",
+          "description": "Descriptive error message"
+        },
+        "availableSizeMB": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Amount of space available on the disk in MB"
+        },
+        "containerSizeMB": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Total size of the disk in MB"
+        },
+        "provisioningStatus": {
+          "$ref": "#/definitions/StorageContainerStatusProvisioningStatus",
+          "description": "Storage container's provisioning status"
+        }
+      }
+    },
+    "StorageContainerStatusProvisioningStatus": {
+      "type": "object",
+      "description": "Storage container provisioning status",
+      "properties": {
+        "operationId": {
+          "type": "string",
+          "description": "The ID of the operation performed on the storage container"
+        },
+        "status": {
+          "$ref": "#/definitions/Status",
+          "description": "The status of the operation performed on the storage container [Succeeded, Failed, InProgress]"
+        }
+      }
+    },
+    "StorageContainerTagsUpdate": {
+      "type": "object",
+      "description": "The type used for updating tags in StorageContainer resources.",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "StorageContainersUpdateRequest": {
+      "type": "object",
+      "description": "The storage container resource patch definition.",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Resource tags",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "StorageProfileUpdate": {
+      "type": "object",
+      "description": "Storage profile update",
+      "properties": {
+        "dataDisks": {
+          "type": "array",
+          "description": "adds data disks to the virtual machine instance for the update call",
+          "items": {
+            "$ref": "#/definitions/VirtualHardDiskArmReference"
+          }
+        }
+      }
+    },
+    "Subnet": {
+      "type": "object",
+      "description": "Properties of the subnet.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/SubnetProperties",
+          "description": "Properties of the subnet.",
+          "x-ms-client-flatten": true
+        },
+        "name": {
+          "type": "string",
+          "description": "Name - The name of the resource that is unique within a resource group. This name can be used to access the resource.",
+          "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-._a-zA-Z0-9]{0,78}[_a-zA-Z0-9]$"
+        }
+      }
+    },
+    "SubnetIpConfigurationReference": {
+      "type": "object",
+      "description": "The Azure Resource ID for a Network Interface.",
+      "properties": {
+        "ID": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The Azure Resource ID for a Network Interface.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.AzureStackHCI/networkInterfaces"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "SubnetProperties": {
+      "type": "object",
+      "description": "Properties of the subnet.",
+      "properties": {
+        "addressPrefix": {
+          "type": "string",
+          "description": "The address prefix for the subnet: Cidr for this subnet - IPv4, IPv6."
+        },
+        "addressPrefixes": {
+          "type": "array",
+          "description": "List of address prefixes for the subnet.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ipAllocationMethod": {
+          "$ref": "#/definitions/IpAllocationMethodEnum",
+          "description": "IPAllocationMethod - The IP address allocation method. Possible values include: 'Static', 'Dynamic'"
+        },
+        "ipConfigurationReferences": {
+          "type": "array",
+          "description": "IPConfigurationReferences - list of IPConfigurationReferences",
+          "items": {
+            "$ref": "#/definitions/SubnetIpConfigurationReference"
+          },
+          "x-ms-identifiers": []
+        },
+        "networkSecurityGroup": {
+          "$ref": "#/definitions/NetworkSecurityGroupArmReference",
+          "description": "NetworkSecurityGroup - Network Security Group attached to the logical network."
+        },
+        "routeTable": {
+          "$ref": "#/definitions/RouteTable",
+          "description": "Route table resource."
+        },
+        "ipPools": {
+          "type": "array",
+          "description": "network associated pool of IP Addresses",
+          "items": {
+            "$ref": "#/definitions/IPPool"
+          },
+          "x-ms-identifiers": []
+        },
+        "vlan": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Vlan to use for the subnet"
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningStateEnum",
+          "description": "Provisioning state of the subnet resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "TagsObject": {
+      "type": "object",
+      "description": "Tags object for patch operations.",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "VMDiskSecurityProfile": {
+      "type": "object",
+      "description": "Specifies the security profile settings for the managed disk. NOTE: It can only be set for Confidential VMs",
+      "properties": {
+        "securityEncryptionType": {
+          "$ref": "#/definitions/SecurityEncryptionType",
+          "description": "Specifies the EncryptionType of the managed disk. It is set to NonPersistedTPM for not persisting firmware state in the VMGuestState blob. NOTE: It can be set for only Confidential VMs."
+        }
+      }
+    },
+    "VirtualHardDisk": {
+      "type": "object",
+      "description": "The virtual hard disk resource definition.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/VirtualHardDiskProperties",
+          "description": "The resource-specific properties for this resource.",
+          "x-ms-client-flatten": true
+        },
+        "extendedLocation": {
+          "$ref": "#/definitions/ExtendedLocation",
+          "description": "The extendedLocation of the resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/TrackedResource"
+        }
+      ],
+      "x-ms-azure-resource": true
+    },
+    "VirtualHardDiskArmReference": {
+      "type": "object",
+      "description": "The Azure Resource ID for a Virtual Hard Disk.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The Azure Resource ID for a Virtual Hard Disk.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.AzureStackHCI/virtualHardDisks"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "VirtualHardDiskDownloadStatus": {
+      "type": "object",
+      "description": "The download status of the virtual hard disk",
+      "properties": {
+        "downloadedSizeInMB": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The downloaded sized of the virtual hard disk in MB"
+        },
+        "status": {
+          "$ref": "#/definitions/Status",
+          "description": "The status of Uploading virtual hard disk [Succeeded, Failed, InProgress]"
+        },
+        "progressPercentage": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The progress of the operation in percentage"
+        }
+      }
+    },
+    "VirtualHardDiskListResult": {
+      "type": "object",
+      "description": "The response of a VirtualHardDisk list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The VirtualHardDisk items on this page",
+          "items": {
+            "$ref": "#/definitions/VirtualHardDisk"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "VirtualHardDiskProperties": {
+      "type": "object",
+      "description": "Properties under the virtual hard disk resource",
+      "properties": {
+        "blockSizeBytes": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Block size in bytes"
+        },
+        "creationData": {
+          "$ref": "#/definitions/CreationData",
+          "description": "Data used when creating a virtual hard disk"
+        },
+        "diskSizeGB": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Size of the disk in GB"
+        },
+        "dynamic": {
+          "type": "boolean",
+          "description": "Boolean for enabling dynamic sizing on the virtual hard disk"
+        },
+        "logicalSectorBytes": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Logical sector in bytes"
+        },
+        "physicalSectorBytes": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Physical sector in bytes"
+        },
+        "downloadUrl": {
+          "type": "string",
+          "format": "password",
+          "description": "URL for downloading or accessing the virtual hard disk. This URL points to a secure link from where the VHD can be downloaded or accessed directly.",
+          "x-ms-secret": true
+        },
+        "hyperVGeneration": {
+          "$ref": "#/definitions/HyperVGeneration",
+          "description": "The hypervisor generation of the Virtual Machine [V1, V2]"
+        },
+        "diskFileFormat": {
+          "$ref": "#/definitions/DiskFileFormat",
+          "description": "The format of the actual VHD file [vhd, vhdx]"
+        },
+        "createFromLocal": {
+          "type": "boolean",
+          "description": "Boolean indicating whether it is an existing local hard disk or if one should be created.",
+          "default": false
+        },
+        "localVhdPath": {
+          "type": "string",
+          "format": "password",
+          "description": "Absolute path of the VHD. This is only applicable when createFromLocal is true.",
+          "x-ms-secret": true
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningStateEnum",
+          "description": "Provisioning state of the virtual hard disk.",
+          "readOnly": true
+        },
+        "containerId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Storage ContainerID of the storage container to be used for VHD",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.AzureStackHCI/storageContainers"
+              }
+            ]
+          }
+        },
+        "status": {
+          "$ref": "#/definitions/VirtualHardDiskStatus",
+          "description": "The observed state of virtual hard disks",
+          "readOnly": true
+        },
+        "maxShares": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The maximum number of VMs that can attach to the disk at the same time. Value greater than one indicates a disk that can be mounted on multiple VMs at the same time."
+        }
+      }
+    },
+    "VirtualHardDiskStatus": {
+      "type": "object",
+      "description": "The observed state of virtual hard disks",
+      "properties": {
+        "errorCode": {
+          "type": "string",
+          "description": "VirtualHardDisk provisioning error code"
+        },
+        "errorMessage": {
+          "type": "string",
+          "description": "Descriptive error message"
+        },
+        "provisioningStatus": {
+          "$ref": "#/definitions/VirtualHardDiskStatusProvisioningStatus",
+          "description": "Provisioning status of the vhd"
+        },
+        "downloadStatus": {
+          "$ref": "#/definitions/VirtualHardDiskDownloadStatus",
+          "description": "The download status of the virtual hard disk"
+        },
+        "uploadStatus": {
+          "$ref": "#/definitions/VirtualHardDiskUploadStatus",
+          "description": "The upload status of the virtual hard disk"
+        },
+        "managedBy": {
+          "type": "array",
+          "description": "Azure Resource IDs of the VMs that are consuming the VHD.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "uniqueId": {
+          "type": "string",
+          "description": "Unique Guid identifying the resource."
+        }
+      }
+    },
+    "VirtualHardDiskStatusProvisioningStatus": {
+      "type": "object",
+      "description": "VHD Status provisioning status",
+      "properties": {
+        "operationId": {
+          "type": "string",
+          "description": "The ID of the operation performed on the virtual hard disk"
+        },
+        "status": {
+          "$ref": "#/definitions/Status",
+          "description": "The status of the operation performed on the virtual hard disk [Succeeded, Failed, InProgress]"
+        }
+      }
+    },
+    "VirtualHardDiskUploadRequest": {
+      "type": "object",
+      "description": "Request for uploading virtual hard disk.",
+      "properties": {
+        "azureManagedDiskUploadUrl": {
+          "type": "string",
+          "format": "password",
+          "description": "The Azure managed disk SAS URL to upload the virtual hard disk to.",
+          "x-ms-secret": true
+        }
+      },
+      "required": [
+        "azureManagedDiskUploadUrl"
+      ]
+    },
+    "VirtualHardDiskUploadResponse": {
+      "type": "object",
+      "description": "Response for uploading virtual hard disk.",
+      "properties": {
+        "virtualHardDiskId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The Azure Resource ID for a Virtual Hard Disk.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.AzureStackHCI/virtualHardDisks"
+              }
+            ]
+          }
+        },
+        "uploadStatus": {
+          "$ref": "#/definitions/VirtualHardDiskUploadStatus",
+          "description": "The upload status of the virtual hard disk"
+        }
+      }
+    },
+    "VirtualHardDiskUploadStatus": {
+      "type": "object",
+      "description": "The upload status of the virtual hard disk",
+      "properties": {
+        "uploadedSizeInMB": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The uploaded sized of the virtual hard disk in MB"
+        },
+        "status": {
+          "$ref": "#/definitions/Status",
+          "description": "The status of Uploading virtual hard disk [Succeeded, Failed, InProgress]"
+        },
+        "progressPercentage": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The progress of the operation in percentage"
+        },
+        "errorCode": {
+          "type": "string",
+          "description": "VirtualHardDisk upload error code"
+        },
+        "errorMessage": {
+          "type": "string",
+          "description": "Descriptive upload error message"
+        }
+      }
+    },
+    "VirtualHardDisksUpdateProperties": {
+      "type": "object",
+      "description": "Defines the resource properties for the update.",
+      "properties": {
+        "diskSizeGB": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Size of the disk in GB"
+        }
+      }
+    },
+    "VirtualHardDisksUpdateRequest": {
+      "type": "object",
+      "description": "The virtual hard disk resource patch definition.",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Resource tags",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "properties": {
+          "$ref": "#/definitions/VirtualHardDisksUpdateProperties",
+          "description": "Defines the resource properties for the update."
+        }
+      }
+    },
+    "VirtualMachineArmReference": {
+      "type": "object",
+      "description": "The Azure Resource ID for a Virtual Machine.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The Azure Resource ID for a Virtual Machine.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.AzureStackHCI/virtualMachineInstance"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "VirtualMachineConfigAgentInstanceView": {
+      "type": "object",
+      "description": "The instance view of the VM Config Agent running on the virtual machine.",
+      "properties": {
+        "vmConfigAgentVersion": {
+          "type": "string",
+          "description": "The VM Config Agent full version."
+        },
+        "statuses": {
+          "type": "array",
+          "description": "The resource status information.",
+          "items": {
+            "$ref": "#/definitions/InstanceViewStatus"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "VirtualMachineInstance": {
+      "type": "object",
+      "description": "The virtual machine instance resource definition.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/VirtualMachineInstanceProperties",
+          "description": "The resource-specific properties for this resource.",
+          "x-ms-client-flatten": true
+        },
+        "extendedLocation": {
+          "$ref": "#/definitions/ExtendedLocation",
+          "description": "The extendedLocation of the resource."
+        },
+        "identity": {
+          "$ref": "../../../../../../common-types/resource-management/v5/managedidentity.json#/definitions/ManagedServiceIdentity",
+          "description": "The managed service identities assigned to this resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ],
+      "x-ms-azure-resource": true
+    },
+    "VirtualMachineInstanceListResult": {
+      "type": "object",
+      "description": "The response of a VirtualMachineInstance list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The VirtualMachineInstance items on this page",
+          "items": {
+            "$ref": "#/definitions/VirtualMachineInstance"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "VirtualMachineInstanceManagedDiskParameters": {
+      "type": "object",
+      "description": "The parameters of a managed disk.",
+      "properties": {
+        "securityProfile": {
+          "$ref": "#/definitions/VMDiskSecurityProfile",
+          "description": "Specifies the security profile for the managed disk."
+        }
+      }
+    },
+    "VirtualMachineInstanceProperties": {
+      "type": "object",
+      "description": "Properties under the virtual machine instance resource",
+      "properties": {
+        "hardwareProfile": {
+          "$ref": "#/definitions/VirtualMachineInstancePropertiesHardwareProfile",
+          "description": "HardwareProfile - Specifies the hardware settings for the virtual machine instance."
+        },
+        "placementProfile": {
+          "$ref": "#/definitions/VirtualMachineInstancePropertiesPlacementProfile",
+          "description": "PlacementProfile - Specifies the placement related settings for the virtual machine."
+        },
+        "networkProfile": {
+          "$ref": "#/definitions/VirtualMachineInstancePropertiesNetworkProfile",
+          "description": "NetworkProfile - describes the network configuration the virtual machine instance"
+        },
+        "osProfile": {
+          "$ref": "#/definitions/VirtualMachineInstancePropertiesOsProfile",
+          "description": "OsProfile - describes the configuration of the operating system and sets login data"
+        },
+        "securityProfile": {
+          "$ref": "#/definitions/VirtualMachineInstancePropertiesSecurityProfile",
+          "description": "SecurityProfile - Specifies the security settings for the virtual machine instance."
+        },
+        "storageProfile": {
+          "$ref": "#/definitions/VirtualMachineInstancePropertiesStorageProfile",
+          "description": "StorageProfile - contains information about the disks and storage information for the virtual machine instance"
+        },
+        "httpProxyConfig": {
+          "$ref": "#/definitions/HttpProxyConfiguration",
+          "description": "HTTP Proxy configuration for the VM."
+        },
+        "createFromLocal": {
+          "type": "boolean",
+          "description": "Boolean indicating whether this is an existing local virtual machine or if one should be created.",
+          "default": false
+        },
+        "localVmName": {
+          "type": "string",
+          "description": "HyperV name of the VM. This is only applicable when createFromLocal is true."
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningStateEnum",
+          "description": "Provisioning state of the virtual machine instance.",
+          "readOnly": true
+        },
+        "instanceView": {
+          "$ref": "#/definitions/VirtualMachineInstanceView",
+          "description": "The virtual machine instance view.",
+          "readOnly": true
+        },
+        "status": {
+          "$ref": "#/definitions/VirtualMachineInstanceStatus",
+          "description": "The observed state of virtual machine instances",
+          "readOnly": true
+        },
+        "guestAgentInstallStatus": {
+          "$ref": "#/definitions/GuestAgentInstallStatus",
+          "description": "Guest agent install status."
+        },
+        "vmId": {
+          "type": "string",
+          "description": "Unique identifier for the vm resource.",
+          "readOnly": true
+        },
+        "resourceUid": {
+          "type": "string",
+          "description": "Unique identifier defined by ARC to identify the guest of the VM."
+        },
+        "hyperVVmId": {
+          "type": "string",
+          "description": "Unique identifier for the Hyper-V VM resource.",
+          "readOnly": true
+        },
+        "hostNodeName": {
+          "type": "string",
+          "description": "Name of the host node that the VM is on.",
+          "readOnly": true
+        },
+        "hostNodeIpAddress": {
+          "type": "string",
+          "description": "Name of the host node that the VM is on.",
+          "readOnly": true
+        }
+      }
+    },
+    "VirtualMachineInstancePropertiesHardwareProfile": {
+      "type": "object",
+      "description": "HardwareProfile - Specifies the hardware settings for the virtual machine instance.",
+      "properties": {
+        "vmSize": {
+          "type": "string",
+          "description": "Enum of VM Sizes",
+          "default": "Default",
+          "enum": [
+            "Default",
+            "Standard_A2_v2",
+            "Standard_A4_v2",
+            "Standard_D2s_v3",
+            "Standard_D4s_v3",
+            "Standard_D8s_v3",
+            "Standard_D16s_v3",
+            "Standard_D32s_v3",
+            "Standard_DS2_v2",
+            "Standard_DS3_v2",
+            "Standard_DS4_v2",
+            "Standard_DS5_v2",
+            "Standard_DS13_v2",
+            "Standard_K8S_v1",
+            "Standard_K8S2_v1",
+            "Standard_K8S3_v1",
+            "Standard_K8S4_v1",
+            "Standard_NK6",
+            "Standard_NK12",
+            "Standard_NV6",
+            "Standard_NV12",
+            "Standard_K8S5_v1",
+            "Custom"
+          ],
+          "x-ms-enum": {
+            "name": "VmSizeEnum",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "Default",
+                "value": "Default",
+                "description": "Default virtual machine size"
+              },
+              {
+                "name": "Standard_A2_v2",
+                "value": "Standard_A2_v2",
+                "description": "Standard A2 v2 virtual machine size"
+              },
+              {
+                "name": "Standard_A4_v2",
+                "value": "Standard_A4_v2",
+                "description": "Standard A4 v2 virtual machine size"
+              },
+              {
+                "name": "Standard_D2s_v3",
+                "value": "Standard_D2s_v3",
+                "description": "Standard D2s v3 virtual machine size"
+              },
+              {
+                "name": "Standard_D4s_v3",
+                "value": "Standard_D4s_v3",
+                "description": "Standard D4s v3 virtual machine size"
+              },
+              {
+                "name": "Standard_D8s_v3",
+                "value": "Standard_D8s_v3",
+                "description": "Standard D8s v3 virtual machine size"
+              },
+              {
+                "name": "Standard_D16s_v3",
+                "value": "Standard_D16s_v3",
+                "description": "Standard D16s v3 virtual machine size"
+              },
+              {
+                "name": "Standard_D32s_v3",
+                "value": "Standard_D32s_v3",
+                "description": "Standard D32s v3 virtual machine size"
+              },
+              {
+                "name": "Standard_DS2_v2",
+                "value": "Standard_DS2_v2",
+                "description": "Standard DS2 v2 virtual machine size"
+              },
+              {
+                "name": "Standard_DS3_v2",
+                "value": "Standard_DS3_v2",
+                "description": "Standard DS3 v2 virtual machine size"
+              },
+              {
+                "name": "Standard_DS4_v2",
+                "value": "Standard_DS4_v2",
+                "description": "Standard DS4 v2 virtual machine size"
+              },
+              {
+                "name": "Standard_DS5_v2",
+                "value": "Standard_DS5_v2",
+                "description": "Standard DS5 v2 virtual machine size"
+              },
+              {
+                "name": "Standard_DS13_v2",
+                "value": "Standard_DS13_v2",
+                "description": "Standard DS13 v2 virtual machine size"
+              },
+              {
+                "name": "Standard_K8S_v1",
+                "value": "Standard_K8S_v1",
+                "description": "Standard K8S v1 virtual machine size"
+              },
+              {
+                "name": "Standard_K8S2_v1",
+                "value": "Standard_K8S2_v1",
+                "description": "Standard K8S2 v1 virtual machine size"
+              },
+              {
+                "name": "Standard_K8S3_v1",
+                "value": "Standard_K8S3_v1",
+                "description": "Standard K8S3 v1 virtual machine size"
+              },
+              {
+                "name": "Standard_K8S4_v1",
+                "value": "Standard_K8S4_v1",
+                "description": "Standard K8S4 v1 virtual machine size"
+              },
+              {
+                "name": "Standard_NK6",
+                "value": "Standard_NK6",
+                "description": "Standard NK6 virtual machine size"
+              },
+              {
+                "name": "Standard_NK12",
+                "value": "Standard_NK12",
+                "description": "Standard NK12 virtual machine size"
+              },
+              {
+                "name": "Standard_NV6",
+                "value": "Standard_NV6",
+                "description": "Standard NV6 virtual machine size"
+              },
+              {
+                "name": "Standard_NV12",
+                "value": "Standard_NV12",
+                "description": "Standard NV12 virtual machine size"
+              },
+              {
+                "name": "Standard_K8S5_v1",
+                "value": "Standard_K8S5_v1",
+                "description": "Standard K8S5 v1 virtual machine size"
+              },
+              {
+                "name": "Custom",
+                "value": "Custom",
+                "description": "Custom virtual machine size"
+              }
+            ]
+          }
+        },
+        "processors": {
+          "type": "integer",
+          "format": "int32",
+          "description": "number of processors for the virtual machine instance"
+        },
+        "memoryMB": {
+          "type": "integer",
+          "format": "int64",
+          "description": "RAM in MB for the virtual machine instance"
+        },
+        "dynamicMemoryConfig": {
+          "$ref": "#/definitions/VirtualMachineInstancePropertiesHardwareProfileDynamicMemoryConfig",
+          "description": "Dynamic memory config"
+        },
+        "virtualMachineGPUs": {
+          "type": "array",
+          "description": "virtualMachineGPUs - list of gpus to be attached to the virtual machine instance",
+          "items": {
+            "$ref": "#/definitions/VirtualMachineInstancePropertiesHardwareProfileVirtualMachineGPU"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "VirtualMachineInstancePropertiesHardwareProfileDynamicMemoryConfig": {
+      "type": "object",
+      "description": "Dynamic memory config",
+      "properties": {
+        "maximumMemoryMB": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Maximum memory in MB"
+        },
+        "minimumMemoryMB": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Minimum memory in MB"
+        },
+        "targetMemoryBuffer": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Defines the amount of extra memory that should be reserved for a virtual machine instance at runtime, as a percentage of the total memory that the virtual machine instance is thought to need. This only applies to virtual systems with dynamic memory enabled. This property can be in the range of 5 to 2000."
+        },
+        "enabled": {
+          "type": "boolean",
+          "description": "Specifies whether dynamic memory is enabled for the virtual machine instance. When omitted, dynamic memory remains enabled; setting this to false converts the virtual machine instance to static memory."
+        }
+      }
+    },
+    "VirtualMachineInstancePropertiesHardwareProfileVirtualMachineGPU": {
+      "type": "object",
+      "description": "GPU properties - describes the GPU configuration.",
+      "properties": {
+        "assignmentType": {
+          "$ref": "#/definitions/GpuAssignmentTypeEnum",
+          "description": "GPU assignment type"
+        },
+        "partitionSizeMB": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Size of gpu partition in MB for GPU-P"
+        },
+        "gpuName": {
+          "type": "string",
+          "description": "Name of the GPU"
+        }
+      },
+      "required": [
+        "assignmentType"
+      ]
+    },
+    "VirtualMachineInstancePropertiesNetworkProfile": {
+      "type": "object",
+      "description": "NetworkProfile - describes the network configuration the virtual machine instance",
+      "properties": {
+        "networkInterfaces": {
+          "type": "array",
+          "description": "NetworkInterfaces - list of network interfaces to be attached to the virtual machine instance",
+          "items": {
+            "$ref": "#/definitions/NetworkInterfaceArmReference"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "VirtualMachineInstancePropertiesOsProfile": {
+      "type": "object",
+      "description": "OsProfile - describes the configuration of the operating system and sets login data",
+      "properties": {
+        "adminPassword": {
+          "type": "string",
+          "format": "password",
+          "description": "AdminPassword - admin password",
+          "x-ms-mutability": [
+            "create"
+          ],
+          "x-ms-secret": true
+        },
+        "adminUsername": {
+          "type": "string",
+          "description": "AdminUsername - admin username"
+        },
+        "computerName": {
+          "type": "string",
+          "description": "ComputerName - name of the compute"
+        },
+        "linuxConfiguration": {
+          "$ref": "#/definitions/VirtualMachineInstancePropertiesOsProfileLinuxConfiguration",
+          "description": "LinuxConfiguration - linux specific configuration values for the virtual machine instance"
+        },
+        "windowsConfiguration": {
+          "$ref": "#/definitions/VirtualMachineInstancePropertiesOsProfileWindowsConfiguration",
+          "description": "Windows Configuration for the virtual machine instance"
+        }
+      }
+    },
+    "VirtualMachineInstancePropertiesOsProfileLinuxConfiguration": {
+      "type": "object",
+      "description": "LinuxConfiguration - linux specific configuration values for the virtual machine instance",
+      "properties": {
+        "disablePasswordAuthentication": {
+          "type": "boolean",
+          "description": "DisablePasswordAuthentication - whether password authentication should be disabled"
+        },
+        "ssh": {
+          "$ref": "#/definitions/SshConfiguration",
+          "description": "Specifies the ssh key configuration for a Linux OS."
+        },
+        "provisionVMAgent": {
+          "type": "boolean",
+          "description": "Used to indicate whether Arc for Servers agent onboarding should be triggered during the virtual machine instance creation process.",
+          "default": true
+        },
+        "provisionVMConfigAgent": {
+          "type": "boolean",
+          "description": "Used to indicate whether the VM Config Agent should be installed during the virtual machine creation process.",
+          "default": true
+        }
+      }
+    },
+    "VirtualMachineInstancePropertiesOsProfileWindowsConfiguration": {
+      "type": "object",
+      "description": "Windows Configuration for the virtual machine instance",
+      "properties": {
+        "enableAutomaticUpdates": {
+          "type": "boolean",
+          "description": "Whether to EnableAutomaticUpdates on the machine"
+        },
+        "ssh": {
+          "$ref": "#/definitions/SshConfiguration",
+          "description": "Specifies the ssh key configuration for Windows OS."
+        },
+        "timeZone": {
+          "type": "string",
+          "description": "TimeZone for the virtual machine instance"
+        },
+        "provisionVMAgent": {
+          "type": "boolean",
+          "description": "Used to indicate whether Arc for Servers agent onboarding should be triggered during the virtual machine instance creation process.",
+          "default": true
+        },
+        "provisionVMConfigAgent": {
+          "type": "boolean",
+          "description": "Used to indicate whether the VM Config Agent should be installed during the virtual machine creation process.",
+          "default": true
+        }
+      }
+    },
+    "VirtualMachineInstancePropertiesPlacementProfile": {
+      "type": "object",
+      "description": "PlacementProfile - Specifies the placement related settings for the virtual machine.",
+      "properties": {
+        "zone": {
+          "type": "string",
+          "description": "The zone in which the VM should be placed in."
+        },
+        "strictPlacementPolicy": {
+          "type": "boolean",
+          "description": "Specifies whether VM can only failover strictly within the zone it was placed in"
+        }
+      }
+    },
+    "VirtualMachineInstancePropertiesSecurityProfile": {
+      "type": "object",
+      "description": "SecurityProfile - Specifies the security settings for the virtual machine instance.",
+      "properties": {
+        "enableTPM": {
+          "type": "boolean",
+          "description": "Enable TPM flag",
+          "default": false
+        },
+        "uefiSettings": {
+          "$ref": "#/definitions/VirtualMachineInstancePropertiesSecurityProfileUefiSettings",
+          "description": "Uefi settings of the virtual machine instance"
+        },
+        "securityType": {
+          "$ref": "#/definitions/SecurityTypes",
+          "description": "Specifies the SecurityType of the virtual machine. EnableTPM and SecureBootEnabled must be set to true for SecurityType to function."
+        }
+      }
+    },
+    "VirtualMachineInstancePropertiesSecurityProfileUefiSettings": {
+      "type": "object",
+      "description": "Uefi settings - Specifies whether secure boot should be enabled on the virtual machine instance.",
+      "properties": {
+        "secureBootEnabled": {
+          "type": "boolean",
+          "description": "Specifies whether secure boot should be enabled on the virtual machine instance.",
+          "default": false
+        }
+      }
+    },
+    "VirtualMachineInstancePropertiesStorageProfile": {
+      "type": "object",
+      "description": "StorageProfile - contains information about the disks and storage information for the virtual machine instance",
+      "properties": {
+        "dataDisks": {
+          "type": "array",
+          "description": "adds data disks to the virtual machine instance",
+          "items": {
+            "$ref": "#/definitions/VirtualHardDiskArmReference"
+          }
+        },
+        "imageReference": {
+          "$ref": "#/definitions/ImageArmReference",
+          "description": "Which Image to use for the virtual machine instance",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "osDisk": {
+          "$ref": "#/definitions/VirtualMachineInstancePropertiesStorageProfileOsDisk",
+          "description": "VHD to attach as OS disk"
+        },
+        "vmConfigStoragePathId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Id of the storage container that hosts the VM configuration file",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.AzureStackHCI/storageContainers"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "VirtualMachineInstancePropertiesStorageProfileOsDisk": {
+      "type": "object",
+      "description": "VHD to attach as OS disk",
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The Azure Resource ID for a Virtual Hard Disk.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.AzureStackHCI/virtualHardDisks"
+              }
+            ]
+          }
+        },
+        "osType": {
+          "$ref": "#/definitions/OperatingSystemTypes",
+          "description": "This property allows you to specify the type of the OS that is included in the disk if creating a VM from user-image or a specialized VHD. Possible values are: Windows, Linux."
+        },
+        "managedDisk": {
+          "$ref": "#/definitions/VirtualMachineInstanceManagedDiskParameters",
+          "description": "The managed disk parameters."
+        }
+      }
+    },
+    "VirtualMachineInstanceStatus": {
+      "type": "object",
+      "description": "The observed state of virtual machine instances",
+      "properties": {
+        "errorCode": {
+          "type": "string",
+          "description": "VirtualMachine provisioning error code"
+        },
+        "errorMessage": {
+          "type": "string",
+          "description": "Descriptive error message"
+        },
+        "powerState": {
+          "$ref": "#/definitions/PowerStateEnum",
+          "description": "The power state of the virtual machine instance"
+        },
+        "provisioningStatus": {
+          "$ref": "#/definitions/VirtualMachineInstanceStatusProvisioningStatus",
+          "description": "Provisioning status of the virtual machine instance"
+        }
+      }
+    },
+    "VirtualMachineInstanceStatusProvisioningStatus": {
+      "type": "object",
+      "description": "Virtual machine instance provisioning status.",
+      "properties": {
+        "operationId": {
+          "type": "string",
+          "description": "The ID of the operation performed on the virtual machine instance"
+        },
+        "status": {
+          "$ref": "#/definitions/Status",
+          "description": "The status of the operation performed on the virtual machine instance [Succeeded, Failed, InProgress]"
+        }
+      }
+    },
+    "VirtualMachineInstanceUpdateProperties": {
+      "type": "object",
+      "description": "Defines the resource properties for the update.",
+      "properties": {
+        "hardwareProfile": {
+          "$ref": "#/definitions/HardwareProfileUpdate",
+          "description": "HardwareProfile - Specifies the hardware settings for the virtual machine instance."
+        },
+        "storageProfile": {
+          "$ref": "#/definitions/StorageProfileUpdate",
+          "description": "StorageProfile - Specifies the storage settings for the virtual machine instance."
+        },
+        "networkProfile": {
+          "$ref": "#/definitions/NetworkProfileUpdate",
+          "description": "NetworkProfile - describes the network update configuration the virtual machine instance"
+        },
+        "osProfile": {
+          "$ref": "#/definitions/OsProfileUpdate",
+          "description": "OsProfile - describes the update configuration of the operating system"
+        }
+      }
+    },
+    "VirtualMachineInstanceUpdateRequest": {
+      "type": "object",
+      "description": "The virtual machine instance resource patch definition.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/VirtualMachineInstanceUpdateProperties",
+          "description": "Defines the resource properties for the update."
+        },
+        "identity": {
+          "$ref": "#/definitions/Identity",
+          "description": "Identity for the resource."
+        }
+      }
+    },
+    "VirtualMachineInstanceView": {
+      "type": "object",
+      "description": "The instance view of a virtual machine.",
+      "properties": {
+        "vmAgent": {
+          "$ref": "#/definitions/VirtualMachineConfigAgentInstanceView",
+          "description": "The VM Config Agent running on the virtual machine."
+        }
+      }
+    },
+    "VirtualNetwork": {
+      "type": "object",
+      "description": "The virtual network resource definition.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/VirtualNetworkProperties",
+          "description": "The resource-specific properties for this resource."
+        },
+        "extendedLocation": {
+          "$ref": "#/definitions/ExtendedLocation",
+          "description": "The extendedLocation of the resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/TrackedResource"
+        }
+      ],
+      "x-ms-azure-resource": true
+    },
+    "VirtualNetworkAddressSpace": {
+      "type": "object",
+      "description": "Address Space Information",
+      "properties": {
+        "addressPrefixes": {
+          "type": "array",
+          "description": "A list of one or more CIDR blocks that define the address space.",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "addressPrefixes"
+      ]
+    },
+    "VirtualNetworkArmReference": {
+      "type": "object",
+      "description": "The Azure Resource ID for a Virtual Network",
+      "properties": {
+        "resourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The Azure Resource ID for a Virtual Network.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.AzureStackHCI/virtualnetworks"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "VirtualNetworkDhcpOptions": {
+      "type": "object",
+      "description": "DHCP options for virtual networks",
+      "properties": {
+        "dnsServers": {
+          "type": "array",
+          "description": "An array of DNS server IP addresses that VMs or wokloads in the vnet can inherit",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "VirtualNetworkListResult": {
+      "type": "object",
+      "description": "The response of a VirtualNetwork list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The VirtualNetwork items on this page",
+          "items": {
+            "$ref": "#/definitions/VirtualNetwork"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "VirtualNetworkProperties": {
+      "type": "object",
+      "description": "Virtual network resource properties",
+      "properties": {
+        "addressSpace": {
+          "$ref": "#/definitions/VirtualNetworkAddressSpace",
+          "description": "Virtual Network address space. All subnets must be within the defined range."
+        },
+        "dhcpOptions": {
+          "$ref": "#/definitions/VirtualNetworkDhcpOptions",
+          "description": "Virtual Network DHCP options. Inherited by all subnets and VMs."
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningStateEnum",
+          "description": "The provisioning state of the virtual network resource.",
+          "readOnly": true
+        },
+        "status": {
+          "$ref": "#/definitions/VirtualNetworkStatus",
+          "description": "The observed status of Virtual Network"
+        }
+      },
+      "required": [
+        "addressSpace",
+        "dhcpOptions"
+      ]
+    },
+    "VirtualNetworkStatus": {
+      "type": "object",
+      "description": "The observed status of the virtual network",
+      "properties": {
+        "errorCode": {
+          "type": "string",
+          "description": "VirtualNetwork provisioning error code"
+        },
+        "errorMessage": {
+          "type": "string",
+          "description": "Descriptive error message"
+        },
+        "provisioningStatus": {
+          "$ref": "#/definitions/VirtualNetworkStatusProvisioningStatus",
+          "description": "virtual network provisioning status"
+        }
+      }
+    },
+    "VirtualNetworkStatusProvisioningStatus": {
+      "type": "object",
+      "description": "Status of virtual network operations",
+      "properties": {
+        "operationId": {
+          "type": "string",
+          "description": "The ID of the operation performed on the virtual network"
+        },
+        "status": {
+          "$ref": "#/definitions/Status",
+          "description": "The status of the operation performed on the virtual network [Succeeded, Failed, InProgress]"
+        }
+      }
+    },
+    "VirtualNetworkSubnet": {
+      "type": "object",
+      "description": "The virtual network resource definition.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/VirtualNetworkSubnetProperties",
+          "description": "The resource-specific properties for this resource."
+        },
+        "extendedLocation": {
+          "$ref": "#/definitions/ExtendedLocation",
+          "description": "The extendedLocation of the resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ],
+      "x-ms-azure-resource": true
+    },
+    "VirtualNetworkSubnetArmReference": {
+      "type": "object",
+      "description": "The Azure Resource ID for a Virtual Network subnet",
+      "properties": {
+        "resourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The Azure Resource ID for a Virtual Network subnet.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.AzureStackHCI/virtualnetwork/subnets"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "VirtualNetworkSubnetIpConfigurationReference": {
+      "type": "object",
+      "description": "The Azure Resource ID for a resource consuming IP on a subnet",
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The Azure Resource ID for a Network Interface.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.AzureStackHCI/networkInterfaces"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "VirtualNetworkSubnetListResult": {
+      "type": "object",
+      "description": "The response of a VirtualNetworkSubnet list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The VirtualNetworkSubnet items on this page",
+          "items": {
+            "$ref": "#/definitions/VirtualNetworkSubnet"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "VirtualNetworkSubnetProperties": {
+      "type": "object",
+      "description": "VirtualNetwork subnet resource",
+      "properties": {
+        "addressPrefix": {
+          "type": "string",
+          "description": "Subnet CIDR"
+        },
+        "networkSecurityGroup": {
+          "$ref": "#/definitions/NetworkSecurityGroupArmReference",
+          "description": "Network Security Group attached to the subnet."
+        },
+        "natGateway": {
+          "$ref": "#/definitions/NatGatewayArmReference",
+          "description": "Nat Gateway attached to the subnet for non-vnet traffic."
+        },
+        "routeTable": {
+          "$ref": "#/definitions/RouteTable",
+          "description": "RouteTable defining custom routes for the subnet."
+        },
+        "ipConfigurations": {
+          "type": "array",
+          "description": "List of ip configurations for the subnet",
+          "items": {
+            "$ref": "#/definitions/VirtualNetworkSubnetIpConfigurationReference"
+          },
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningStateEnum",
+          "description": "The provisioning state of the virtual network subnet resource.",
+          "readOnly": true
+        },
+        "status": {
+          "$ref": "#/definitions/VirtualNetworkSubnetStatus",
+          "description": "The observed status of the virtual network subnet resource.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "addressPrefix"
+      ]
+    },
+    "VirtualNetworkSubnetStatus": {
+      "type": "object",
+      "description": "Status of virtual network subnet operations",
+      "properties": {
+        "errorCode": {
+          "type": "string",
+          "description": "VirtualNetworkSubnet provisioning error code"
+        },
+        "errorMessage": {
+          "type": "string",
+          "description": "Descriptive error message"
+        },
+        "provisioningStatus": {
+          "$ref": "#/definitions/VirtualNetworkSubnetStatusProvisioningStatus",
+          "description": "Public IP provisioning status"
+        }
+      }
+    },
+    "VirtualNetworkSubnetStatusProvisioningStatus": {
+      "type": "object",
+      "description": "Status of virtual network subnet operations",
+      "properties": {
+        "operationId": {
+          "type": "string",
+          "description": "The ID of the operation performed on the virtual network subnet"
+        },
+        "status": {
+          "$ref": "#/definitions/Status",
+          "description": "The status of the operation performed on the virtual network subnet [Succeeded, Failed, InProgress]"
+        }
+      }
+    },
+    "VirtualNetworkSubnetUpdateProperties": {
+      "type": "object",
+      "description": "The virtual network subnet resource patch properties definition.",
+      "properties": {
+        "networkSecurityGroup": {
+          "$ref": "#/definitions/NetworkSecurityGroupArmReference",
+          "description": "NetworkSecurityGroup - Network Security Group attached to the subnet."
+        },
+        "natGateway": {
+          "$ref": "#/definitions/NatGatewayArmReference",
+          "description": "NatGateway - NatGateway attached to the subnet."
+        }
+      }
+    },
+    "VirtualNetworkSubnetUpdateRequest": {
+      "type": "object",
+      "description": "The virtual network subnet resource patch definition.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/VirtualNetworkSubnetUpdateProperties",
+          "description": "properties to update"
+        }
+      }
+    },
+    "VirtualNetworkTagsUpdate": {
+      "type": "object",
+      "description": "The type used for updating tags in VirtualNetwork resources.",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "VmSizeEnum": {
+      "type": "string",
+      "description": "VM Sizes",
+      "enum": [
+        "Default",
+        "Standard_A2_v2",
+        "Standard_A4_v2",
+        "Standard_D2s_v3",
+        "Standard_D4s_v3",
+        "Standard_D8s_v3",
+        "Standard_D16s_v3",
+        "Standard_D32s_v3",
+        "Standard_DS2_v2",
+        "Standard_DS3_v2",
+        "Standard_DS4_v2",
+        "Standard_DS5_v2",
+        "Standard_DS13_v2",
+        "Standard_K8S_v1",
+        "Standard_K8S2_v1",
+        "Standard_K8S3_v1",
+        "Standard_K8S4_v1",
+        "Standard_NK6",
+        "Standard_NK12",
+        "Standard_NV6",
+        "Standard_NV12",
+        "Standard_K8S5_v1",
+        "Custom"
+      ],
+      "x-ms-enum": {
+        "name": "VmSizeEnum",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Default",
+            "value": "Default",
+            "description": "Default virtual machine size"
+          },
+          {
+            "name": "Standard_A2_v2",
+            "value": "Standard_A2_v2",
+            "description": "Standard A2 v2 virtual machine size"
+          },
+          {
+            "name": "Standard_A4_v2",
+            "value": "Standard_A4_v2",
+            "description": "Standard A4 v2 virtual machine size"
+          },
+          {
+            "name": "Standard_D2s_v3",
+            "value": "Standard_D2s_v3",
+            "description": "Standard D2s v3 virtual machine size"
+          },
+          {
+            "name": "Standard_D4s_v3",
+            "value": "Standard_D4s_v3",
+            "description": "Standard D4s v3 virtual machine size"
+          },
+          {
+            "name": "Standard_D8s_v3",
+            "value": "Standard_D8s_v3",
+            "description": "Standard D8s v3 virtual machine size"
+          },
+          {
+            "name": "Standard_D16s_v3",
+            "value": "Standard_D16s_v3",
+            "description": "Standard D16s v3 virtual machine size"
+          },
+          {
+            "name": "Standard_D32s_v3",
+            "value": "Standard_D32s_v3",
+            "description": "Standard D32s v3 virtual machine size"
+          },
+          {
+            "name": "Standard_DS2_v2",
+            "value": "Standard_DS2_v2",
+            "description": "Standard DS2 v2 virtual machine size"
+          },
+          {
+            "name": "Standard_DS3_v2",
+            "value": "Standard_DS3_v2",
+            "description": "Standard DS3 v2 virtual machine size"
+          },
+          {
+            "name": "Standard_DS4_v2",
+            "value": "Standard_DS4_v2",
+            "description": "Standard DS4 v2 virtual machine size"
+          },
+          {
+            "name": "Standard_DS5_v2",
+            "value": "Standard_DS5_v2",
+            "description": "Standard DS5 v2 virtual machine size"
+          },
+          {
+            "name": "Standard_DS13_v2",
+            "value": "Standard_DS13_v2",
+            "description": "Standard DS13 v2 virtual machine size"
+          },
+          {
+            "name": "Standard_K8S_v1",
+            "value": "Standard_K8S_v1",
+            "description": "Standard K8S v1 virtual machine size"
+          },
+          {
+            "name": "Standard_K8S2_v1",
+            "value": "Standard_K8S2_v1",
+            "description": "Standard K8S2 v1 virtual machine size"
+          },
+          {
+            "name": "Standard_K8S3_v1",
+            "value": "Standard_K8S3_v1",
+            "description": "Standard K8S3 v1 virtual machine size"
+          },
+          {
+            "name": "Standard_K8S4_v1",
+            "value": "Standard_K8S4_v1",
+            "description": "Standard K8S4 v1 virtual machine size"
+          },
+          {
+            "name": "Standard_NK6",
+            "value": "Standard_NK6",
+            "description": "Standard NK6 virtual machine size"
+          },
+          {
+            "name": "Standard_NK12",
+            "value": "Standard_NK12",
+            "description": "Standard NK12 virtual machine size"
+          },
+          {
+            "name": "Standard_NV6",
+            "value": "Standard_NV6",
+            "description": "Standard NV6 virtual machine size"
+          },
+          {
+            "name": "Standard_NV12",
+            "value": "Standard_NV12",
+            "description": "Standard NV12 virtual machine size"
+          },
+          {
+            "name": "Standard_K8S5_v1",
+            "value": "Standard_K8S5_v1",
+            "description": "Standard K8S5 v1 virtual machine size"
+          },
+          {
+            "name": "Custom",
+            "value": "Custom",
+            "description": "Custom virtual machine size"
+          }
+        ]
+      }
+    }
+  },
+  "parameters": {
+    "Azure.ResourceManager.ResourceUriParameter": {
+      "name": "resourceUri",
+      "in": "path",
+      "description": "The fully qualified Azure Resource manager identifier of the resource.",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method",
+      "x-ms-skip-url-encoding": true
+    }
+  }
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/readme.md
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/readme.md
@@ -29,7 +29,7 @@ title: Microsoft.AzureStackHCI
 description: Azure Stack HCI management service
 openapi-type: arm
 openapi-subtype: rpaas
-tag: package-preview-2026-04-01-preview
+tag: package-preview-2026-07-01-preview
 ```
 
 ## Suppression
@@ -60,6 +60,15 @@ suppressions:
     reason: resourceUri in virtualmachineinstances is the parent resource. It consists of an even number of segmented paths.
     from:
       - stackhcivm.json
+```
+
+### Tag: package-preview-2026-07-01-preview
+
+These settings apply only when `--tag=package-preview-2026-07-01-preview` is specified on the command line.
+
+```yaml $(tag) == 'package-preview-2026-07-01-preview'
+input-file:
+  - preview/2026-07-01-preview/stackhcivm.json
 ```
 
 ### Tag: package-preview-2026-04-01-preview

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/service.yaml
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCIVM/service.yaml
@@ -104,3 +104,7 @@ versions:
     source: typespec
     swagger-files:
       - preview/2026-04-01-preview/stackhcivm.json
+  - version: 2026-07-01-preview
+    source: typespec
+    swagger-files:
+      - preview/2026-07-01-preview/stackhcivm.json


### PR DESCRIPTION
This adds the **2026-07-01-preview** API version for Microsoft.AzureStackHCI StackHCIVM with:

- New `enabled` property on `VirtualMachineInstancePropertiesHardwareProfileDynamicMemoryConfig` — allows converting a virtual machine instance from dynamic to static memory
- New `dynamicMemoryConfig` property on `HardwareProfileUpdate` — dynamic memory day-2 updates and static-to-dynamic conversion
- Generated OpenAPI spec and 113 example files
- Updated readme.md with new default tag `package-preview-2026-07-01-preview`

## Why

The api-version was merged to `azure-rest-api-specs-pr` @ `RPSaaSMaster` on **2026-07-10** in [PR #29273](https://github.com/Azure/azure-rest-api-specs-pr/pull/29273), but the corresponding public release PR was never opened. As a result `2026-07-01-preview` is **not registered in ARM** — `az provider show -n Microsoft.AzureStackHCI` returns no resource type for it, and the newest registered version is `2026-04-01-preview`.

This is currently breaking pre-production CI: clients calling with this api-version get

```
No registered resource provider found for location 'eastus' and API version
'2026-07-01-preview' for type 'virtualMachineInstances'
```

which leaves `virtualMachineInstances` stuck in `InProgress` until the ARM deployment times out.

Every previously released version followed the same two-step pattern (RPSaaSMaster ➜ public release PR):

| version | RPSaaSMaster | public release PR |
|---|---|---|
| 2025-09-01-preview | 2025-07-16 | #38577 / #38834 |
| 2026-02-01-preview | 2025-12-12 | #39909 |
| 2026-04-01-preview | 2026-01-15 | #41384 |
| **2026-07-01-preview** | **2026-07-10** | **this PR** |

## How this was produced

- TypeSpec source changes (`main.tsp`, `models.tsp`) and the example inputs under `examples/2026-07-01-preview/` are ported verbatim from `RPSaaSMaster`
- `preview/2026-07-01-preview/stackhcivm.json`, the 113 files under `preview/2026-07-01-preview/examples/`, and the `service.yaml` entry are generated output from `npx tsp compile .` (TypeSpec 1.15.0, `@azure-tools/typespec-autorest` 0.71.0) — compiled with no errors or warnings
- The generated swagger was diffed against the `RPSaaSMaster` copy: paths and example set match exactly. The only delta is three definitions (`LogicalNetworkUpdateProperties`, `SubnetUpdate`, `SubnetUpdateProperties`) that are a pre-existing `RPSaaSMaster`-only divergence — they are also present in its `2026-04-01-preview` but have never been released publicly, so they are correctly excluded here.

Modelled on #41384.

> [!NOTE]
> Opened as a **draft** and prepared by someone outside the StackHCIVM feature team while investigating the CI breakage. Please have the api-version owners ([@Fr-Wang-MS](https://github.com/Fr-Wang-MS), who authored the RPSaaSMaster change) confirm the content and scope before merging.
