### PR TITLE
[AI Foundry] Mark Agent Insights preview surface experimental

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/docs/foundry-features-flag-summary.md
+++ b/specification/ai-foundry/data-plane/Foundry/docs/foundry-features-flag-summary.md
@@ -78,5 +78,18 @@ in order to successfully complete operations using these routes.
 | Data Generation Jobs | Create | POST | `/data_generation_jobs` | Required: `DataGenerationJobs=V1Preview` |
 | Data Generation Jobs | Cancel | POST | `/data_generation_jobs/{jobId}:cancel` | Required: `DataGenerationJobs=V1Preview` |
 | Data Generation Jobs | Delete | DELETE | `/data_generation_jobs/{jobId}` | Required: `DataGenerationJobs=V1Preview` |
+| Agent Insight Monitors | List | GET | `/agent_insight_monitors` | Required: `AgentInsights=V1Preview` |
+| Agent Insight Monitors | Create | POST | `/agent_insight_monitors` | Required: `AgentInsights=V1Preview` |
+| Agent Insight Monitors | Get | GET | `/agent_insight_monitors/{monitor_id}` | Required: `AgentInsights=V1Preview` |
+| Agent Insight Monitors | Delete | DELETE | `/agent_insight_monitors/{monitor_id}` | Required: `AgentInsights=V1Preview` |
+| Agent Insight Monitors | Update | PATCH | `/agent_insight_monitors/{monitor_id}` | Required: `AgentInsights=V1Preview` |
+| Agent Insight Monitors | Reset | POST | `/agent_insight_monitors/{monitor_id}:reset` | Required: `AgentInsights=V1Preview` |
+| Agent Insight Monitors | Create Run | POST | `/agent_insight_monitors/{monitor_id}/runs` | Required: `AgentInsights=V1Preview` |
+| Agent Insight Monitors | List Runs | GET | `/agent_insight_monitors/{monitor_id}/runs` | Required: `AgentInsights=V1Preview` |
+| Agent Insight Monitors | Get Run | GET | `/agent_insight_monitors/{monitor_id}/runs/{run_id}` | Required: `AgentInsights=V1Preview` |
+| Agent Insight Monitors | Cancel Run | POST | `/agent_insight_monitors/{monitor_id}/runs/{run_id}:cancel` | Required: `AgentInsights=V1Preview` |
+| Agent Insight Monitors | List Insights | GET | `/agent_insight_monitors/{monitor_id}/insights` | Required: `AgentInsights=V1Preview` |
+| Agent Insight Monitors | Get Insight | GET | `/agent_insight_monitors/{monitor_id}/insights/{insight_id}` | Required: `AgentInsights=V1Preview` |
+| Agent Insight Monitors | Update Insight | PATCH | `/agent_insight_monitors/{monitor_id}/insights/{insight_id}` | Required: `AgentInsights=V1Preview` |
 
 Note that only v1 operations are included in the above table. If an operation (or interface) is decorated with `@removed(Versions.v1)` the are not included here.

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -230,7 +230,7 @@
           {
             "name": "Foundry-Features",
             "in": "header",
-            "required": false,
+            "required": true,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
               "type": "string",
@@ -365,7 +365,12 @@
         },
         "tags": [
           "Agent Insight Monitors"
-        ]
+        ],
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       },
       "post": {
         "operationId": "AgentInsightMonitors_create",
@@ -374,7 +379,7 @@
           {
             "name": "Foundry-Features",
             "in": "header",
-            "required": false,
+            "required": true,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
               "type": "string",
@@ -448,6 +453,11 @@
             }
           },
           "description": "The monitor to create."
+        },
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
         }
       }
     },
@@ -459,7 +469,7 @@
           {
             "name": "Foundry-Features",
             "in": "header",
-            "required": false,
+            "required": true,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
               "type": "string",
@@ -522,7 +532,12 @@
         },
         "tags": [
           "Agent Insight Monitors"
-        ]
+        ],
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       },
       "delete": {
         "operationId": "AgentInsightMonitors_delete",
@@ -531,7 +546,7 @@
           {
             "name": "Foundry-Features",
             "in": "header",
-            "required": false,
+            "required": true,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
               "type": "string",
@@ -587,7 +602,12 @@
         },
         "tags": [
           "Agent Insight Monitors"
-        ]
+        ],
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       },
       "patch": {
         "operationId": "AgentInsightMonitors_update",
@@ -596,7 +616,7 @@
           {
             "name": "Foundry-Features",
             "in": "header",
-            "required": false,
+            "required": true,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
               "type": "string",
@@ -670,6 +690,11 @@
             }
           },
           "description": "The monitor fields to update."
+        },
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
         }
       }
     },
@@ -681,7 +706,7 @@
           {
             "name": "Foundry-Features",
             "in": "header",
-            "required": false,
+            "required": true,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
               "type": "string",
@@ -856,7 +881,12 @@
         },
         "tags": [
           "Agent Insight Monitors"
-        ]
+        ],
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       }
     },
     "/agent_insight_monitors/{monitor_id}/insights/{insight_id}": {
@@ -867,7 +897,7 @@
           {
             "name": "Foundry-Features",
             "in": "header",
-            "required": false,
+            "required": true,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
               "type": "string",
@@ -950,7 +980,12 @@
         },
         "tags": [
           "Agent Insight Monitors"
-        ]
+        ],
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       },
       "patch": {
         "operationId": "AgentInsightMonitors_updateInsight",
@@ -959,7 +994,7 @@
           {
             "name": "Foundry-Features",
             "in": "header",
-            "required": false,
+            "required": true,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
               "type": "string",
@@ -1042,6 +1077,11 @@
             }
           },
           "description": "The insight fields to update."
+        },
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
         }
       }
     },
@@ -1053,7 +1093,7 @@
           {
             "name": "Foundry-Features",
             "in": "header",
-            "required": false,
+            "required": true,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
               "type": "string",
@@ -1143,6 +1183,11 @@
             }
           },
           "description": "Run inputs. Send an empty object to use the default 168-hour lookback window."
+        },
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
         }
       },
       "get": {
@@ -1152,7 +1197,7 @@
           {
             "name": "Foundry-Features",
             "in": "header",
-            "required": false,
+            "required": true,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
               "type": "string",
@@ -1306,7 +1351,12 @@
         },
         "tags": [
           "Agent Insight Monitors"
-        ]
+        ],
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       }
     },
     "/agent_insight_monitors/{monitor_id}/runs/{run_id}": {
@@ -1317,7 +1367,7 @@
           {
             "name": "Foundry-Features",
             "in": "header",
-            "required": false,
+            "required": true,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
               "type": "string",
@@ -1389,7 +1439,12 @@
         },
         "tags": [
           "Agent Insight Monitors"
-        ]
+        ],
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       }
     },
     "/agent_insight_monitors/{monitor_id}/runs/{run_id}:cancel": {
@@ -1400,7 +1455,7 @@
           {
             "name": "Foundry-Features",
             "in": "header",
-            "required": false,
+            "required": true,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
               "type": "string",
@@ -1472,7 +1527,12 @@
         },
         "tags": [
           "Agent Insight Monitors"
-        ]
+        ],
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       }
     },
     "/agent_insight_monitors/{monitor_id}:reset": {
@@ -1483,7 +1543,7 @@
           {
             "name": "Foundry-Features",
             "in": "header",
-            "required": false,
+            "required": true,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
               "type": "string",
@@ -1539,7 +1599,12 @@
         },
         "tags": [
           "Agent Insight Monitors"
-        ]
+        ],
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       }
     },
     "/agent_optimization_jobs": {
@@ -28622,7 +28687,12 @@
             "readOnly": true
           }
         },
-        "description": "A persisted issue discovered from an agent's traces."
+        "description": "A persisted issue discovered from an agent's traces.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       },
       "AgentInsightDetails": {
         "type": "object",
@@ -28653,7 +28723,12 @@
             "description": "The recommended remediation for this insight."
           }
         },
-        "description": "Additional insight details. Omitted unless details are requested."
+        "description": "Additional insight details. Omitted unless details are requested.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       },
       "AgentInsightEstimatedCost": {
         "type": "object",
@@ -28675,7 +28750,12 @@
             "description": "Currency for the estimated cost amount. Agent Insights estimates are reported in US dollars."
           }
         },
-        "description": "Estimated Agent Insights cost."
+        "description": "Estimated Agent Insights cost.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       },
       "AgentInsightHighlightedTrace": {
         "type": "object",
@@ -28709,7 +28789,12 @@
             "description": "The time when the trace was recorded."
           }
         },
-        "description": "A highlighted trace that provides evidence for an agent insight."
+        "description": "A highlighted trace that provides evidence for an agent insight.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       },
       "AgentInsightLinkedTrace": {
         "type": "object",
@@ -28729,7 +28814,12 @@
             "readOnly": true
           }
         },
-        "description": "A lightweight trace reference linked to an agent insight as supporting evidence."
+        "description": "A lightweight trace reference linked to an agent insight as supporting evidence.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       },
       "AgentInsightMonitor": {
         "type": "object",
@@ -28812,7 +28902,12 @@
             "readOnly": true
           }
         },
-        "description": "A per-agent Agent Insights monitor that owns configuration, runs, and discovered insights."
+        "description": "A per-agent Agent Insights monitor that owns configuration, runs, and discovered insights.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       },
       "AgentInsightMonitorCreate": {
         "type": "object",
@@ -28843,7 +28938,12 @@
             "description": "The model deployment to use for analyzing traces. Accepts either the deployment name alone or with the connection name as '{connectionName}/modelDeploymentName'."
           }
         },
-        "description": "Fields accepted when creating an Agent Insights monitor for an agent."
+        "description": "Fields accepted when creating an Agent Insights monitor for an agent.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       },
       "AgentInsightMonitorListItem": {
         "type": "object",
@@ -28913,7 +29013,12 @@
             "readOnly": true
           }
         },
-        "description": "An Agent Insights monitor summary returned by list operations."
+        "description": "An Agent Insights monitor summary returned by list operations.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       },
       "AgentInsightMonitorUpdate": {
         "type": "object",
@@ -28945,7 +29050,12 @@
             "description": "Sets the effective user overview, or clears it when explicitly set to null. Omission leaves\nthe overview unchanged. This field cannot be combined with other monitor updates."
           }
         },
-        "description": "Fields that can be updated on an Agent Insights monitor."
+        "description": "Fields that can be updated on an Agent Insights monitor.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       },
       "AgentInsightOverviewSource": {
         "anyOf": [
@@ -28960,7 +29070,12 @@
             ]
           }
         ],
-        "description": "Identifies where an Agent Insights overview came from."
+        "description": "Identifies where an Agent Insights overview came from.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       },
       "AgentInsightPromptSurface": {
         "anyOf": [
@@ -28975,7 +29090,12 @@
             ]
           }
         ],
-        "description": "The Prompt surface changed by a proposed fix."
+        "description": "The Prompt surface changed by a proposed fix.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       },
       "AgentInsightProposedFix": {
         "type": "object",
@@ -29000,7 +29120,12 @@
             "description": "The concrete changes. Omitted for a prose-only fix."
           }
         },
-        "description": "A recommended fix for an agent insight."
+        "description": "A recommended fix for an agent insight.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       },
       "AgentInsightProposedFixChange": {
         "type": "object",
@@ -29044,7 +29169,12 @@
             "description": "The bounded Prompt value after the change. Present for Prompt changes, including when null."
           }
         },
-        "description": "A customer-renderable change in a proposed fix."
+        "description": "A customer-renderable change in a proposed fix.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       },
       "AgentInsightProposedFixKind": {
         "anyOf": [
@@ -29060,7 +29190,12 @@
             ]
           }
         ],
-        "description": "The customer-renderable kind of an agent insight's proposed fix."
+        "description": "The customer-renderable kind of an agent insight's proposed fix.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       },
       "AgentInsightRecommendedAction": {
         "type": "object",
@@ -29073,7 +29208,12 @@
             "description": "The single recommended fix for the issue represented by the insight."
           }
         },
-        "description": "The recommended remediation for an agent insight."
+        "description": "The recommended remediation for an agent insight.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       },
       "AgentInsightRun": {
         "type": "object",
@@ -29165,7 +29305,12 @@
             "readOnly": true
           }
         },
-        "description": "A long-running run that analyzes one agent's traces and updates that agent's insights."
+        "description": "A long-running run that analyzes one agent's traces and updates that agent's insights.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       },
       "AgentInsightRunCreate": {
         "type": "object",
@@ -29179,7 +29324,12 @@
             "default": 168
           }
         },
-        "description": "Inputs used when creating an agent insight run."
+        "description": "Inputs used when creating an agent insight run.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       },
       "AgentInsightRunResult": {
         "type": "object",
@@ -29222,7 +29372,12 @@
             "description": "Token usage for the run's insight-generation analysis."
           }
         },
-        "description": "Result statistics produced when an agent insight run succeeds."
+        "description": "Result statistics produced when an agent insight run succeeds.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       },
       "AgentInsightRunTrigger": {
         "anyOf": [
@@ -29237,7 +29392,12 @@
             ]
           }
         ],
-        "description": "The trigger that started an agent insight run."
+        "description": "The trigger that started an agent insight run.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       },
       "AgentInsightSeverity": {
         "anyOf": [
@@ -29253,7 +29413,12 @@
             ]
           }
         ],
-        "description": "The severity of an agent insight."
+        "description": "The severity of an agent insight.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       },
       "AgentInsightStatus": {
         "anyOf": [
@@ -29269,7 +29434,12 @@
             ]
           }
         ],
-        "description": "The lifecycle status of an agent insight."
+        "description": "The lifecycle status of an agent insight.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       },
       "AgentInsightSuspension": {
         "type": "object",
@@ -29297,7 +29467,12 @@
             "description": "Additional reason-specific suspension details."
           }
         },
-        "description": "Structured reason why scheduled generation is suspended for a monitor."
+        "description": "Structured reason why scheduled generation is suspended for a monitor.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       },
       "AgentInsightTokenUsage": {
         "type": "object",
@@ -29328,7 +29503,12 @@
             "description": "The total number of tokens used by the run."
           }
         },
-        "description": "Token usage for an Agent Insights run."
+        "description": "Token usage for an Agent Insights run.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       },
       "AgentInsightUpdate": {
         "type": "object",
@@ -29338,7 +29518,12 @@
             "description": "The lifecycle status to apply to the insight."
           }
         },
-        "description": "Fields that can be updated on an agent insight."
+        "description": "Fields that can be updated on an agent insight.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       },
       "AgentInsightsOverview": {
         "type": "object",
@@ -29361,7 +29546,12 @@
             "description": "The time when this overview was last updated."
           }
         },
-        "description": "The effective overview for an Agent Insights monitor."
+        "description": "The effective overview for an Agent Insights monitor.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       },
       "AgentInsightsOverviewOverride": {
         "type": "object",
@@ -29374,7 +29564,12 @@
             "description": "The nonblank overview content, limited to 64 KiB when encoded as UTF-8."
           }
         },
-        "description": "A user-provided overview that becomes effective immediately and seeds the next generation."
+        "description": "A user-provided overview that becomes effective immediately and seeds the next generation.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       },
       "AgentKind": {
         "anyOf": [

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -1103,6 +1103,15 @@
             }
           },
           {
+            "name": "Operation-Id",
+            "in": "header",
+            "required": false,
+            "description": "Client-generated unique ID for idempotent retries. When absent, the server creates the job unconditionally.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "monitor_id",
             "in": "path",
             "required": true,

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -122,7 +122,7 @@ paths:
       parameters:
         - name: Foundry-Features
           in: header
-          required: false
+          required: true
           description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
           schema:
             type: string
@@ -215,13 +215,16 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Agent Insight Monitors
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
     post:
       operationId: AgentInsightMonitors_create
       description: Create an Agent Insights monitor for an agent.
       parameters:
         - name: Foundry-Features
           in: header
-          required: false
+          required: true
           description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
           schema:
             type: string
@@ -268,6 +271,9 @@ paths:
             schema:
               $ref: '#/components/schemas/AgentInsightMonitorCreate'
         description: The monitor to create.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
   /agent_insight_monitors/{monitor_id}:
     get:
       operationId: AgentInsightMonitors_get
@@ -275,7 +281,7 @@ paths:
       parameters:
         - name: Foundry-Features
           in: header
-          required: false
+          required: true
           description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
           schema:
             type: string
@@ -315,13 +321,16 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Agent Insight Monitors
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
     delete:
       operationId: AgentInsightMonitors_delete
       description: Delete an Agent Insights monitor and all of its runs, insights, and state.
       parameters:
         - name: Foundry-Features
           in: header
-          required: false
+          required: true
           description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
           schema:
             type: string
@@ -357,13 +366,16 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Agent Insight Monitors
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
     patch:
       operationId: AgentInsightMonitors_update
       description: Update an Agent Insights monitor.
       parameters:
         - name: Foundry-Features
           in: header
-          required: false
+          required: true
           description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
           schema:
             type: string
@@ -410,6 +422,9 @@ paths:
             schema:
               $ref: '#/components/schemas/AgentInsightMonitorUpdate'
         description: The monitor fields to update.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
   /agent_insight_monitors/{monitor_id}/insights:
     get:
       operationId: AgentInsightMonitors_listInsights
@@ -417,7 +432,7 @@ paths:
       parameters:
         - name: Foundry-Features
           in: header
-          required: false
+          required: true
           description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
           schema:
             type: string
@@ -538,6 +553,9 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Agent Insight Monitors
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
   /agent_insight_monitors/{monitor_id}/insights/{insight_id}:
     get:
       operationId: AgentInsightMonitors_getInsight
@@ -545,7 +563,7 @@ paths:
       parameters:
         - name: Foundry-Features
           in: header
-          required: false
+          required: true
           description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
           schema:
             type: string
@@ -599,13 +617,16 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Agent Insight Monitors
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
     patch:
       operationId: AgentInsightMonitors_updateInsight
       description: Update the lifecycle status of an insight.
       parameters:
         - name: Foundry-Features
           in: header
-          required: false
+          required: true
           description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
           schema:
             type: string
@@ -658,6 +679,9 @@ paths:
             schema:
               $ref: '#/components/schemas/AgentInsightUpdate'
         description: The insight fields to update.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
   /agent_insight_monitors/{monitor_id}/runs:
     post:
       operationId: AgentInsightMonitors_createRun
@@ -665,7 +689,7 @@ paths:
       parameters:
         - name: Foundry-Features
           in: header
-          required: false
+          required: true
           description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
           schema:
             type: string
@@ -723,13 +747,16 @@ paths:
             schema:
               $ref: '#/components/schemas/AgentInsightRunCreate'
         description: Run inputs. Send an empty object to use the default 168-hour lookback window.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
     get:
       operationId: AgentInsightMonitors_listRuns
       description: List Agent Insights runs for a monitor.
       parameters:
         - name: Foundry-Features
           in: header
-          required: false
+          required: true
           description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
           schema:
             type: string
@@ -835,6 +862,9 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Agent Insight Monitors
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
   /agent_insight_monitors/{monitor_id}/runs/{run_id}:
     get:
       operationId: AgentInsightMonitors_getRun
@@ -842,7 +872,7 @@ paths:
       parameters:
         - name: Foundry-Features
           in: header
-          required: false
+          required: true
           description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
           schema:
             type: string
@@ -888,6 +918,9 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Agent Insight Monitors
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
   /agent_insight_monitors/{monitor_id}/runs/{run_id}:cancel:
     post:
       operationId: AgentInsightMonitors_cancelRun
@@ -895,7 +928,7 @@ paths:
       parameters:
         - name: Foundry-Features
           in: header
-          required: false
+          required: true
           description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
           schema:
             type: string
@@ -941,6 +974,9 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Agent Insight Monitors
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
   /agent_insight_monitors/{monitor_id}:reset:
     post:
       operationId: AgentInsightMonitors_reset
@@ -948,7 +984,7 @@ paths:
       parameters:
         - name: Foundry-Features
           in: header
-          required: false
+          required: true
           description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
           schema:
             type: string
@@ -984,6 +1020,9 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Agent Insight Monitors
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
   /agent_optimization_jobs:
     post:
       operationId: AgentOptimizationJobs_create
@@ -39489,6 +39528,9 @@ components:
           description: Additional insight details. Omitted unless details are requested.
           readOnly: true
       description: A persisted issue discovered from an agent's traces.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
     AgentInsightDetails:
       type: object
       required:
@@ -39512,6 +39554,9 @@ components:
           $ref: '#/components/schemas/AgentInsightRecommendedAction'
           description: The recommended remediation for this insight.
       description: Additional insight details. Omitted unless details are requested.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
     AgentInsightEstimatedCost:
       type: object
       required:
@@ -39528,6 +39573,9 @@ components:
             - USD
           description: Currency for the estimated cost amount. Agent Insights estimates are reported in US dollars.
       description: Estimated Agent Insights cost.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
     AgentInsightHighlightedTrace:
       type: object
       required:
@@ -39554,6 +39602,9 @@ components:
           $ref: '#/components/schemas/FoundryTimestamp'
           description: The time when the trace was recorded.
       description: A highlighted trace that provides evidence for an agent insight.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
     AgentInsightLinkedTrace:
       type: object
       required:
@@ -39569,6 +39620,9 @@ components:
           description: The time when the trace was recorded.
           readOnly: true
       description: A lightweight trace reference linked to an agent insight as supporting evidence.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
     AgentInsightMonitor:
       type: object
       required:
@@ -39629,6 +39683,9 @@ components:
           description: The time when this monitor was last updated.
           readOnly: true
       description: A per-agent Agent Insights monitor that owns configuration, runs, and discovered insights.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
     AgentInsightMonitorCreate:
       type: object
       required:
@@ -39653,6 +39710,9 @@ components:
           type: string
           description: The model deployment to use for analyzing traces. Accepts either the deployment name alone or with the connection name as '{connectionName}/modelDeploymentName'.
       description: Fields accepted when creating an Agent Insights monitor for an agent.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
     AgentInsightMonitorListItem:
       type: object
       required:
@@ -39706,6 +39766,9 @@ components:
           description: The time when this monitor was last updated.
           readOnly: true
       description: An Agent Insights monitor summary returned by list operations.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
     AgentInsightMonitorUpdate:
       type: object
       properties:
@@ -39729,6 +39792,9 @@ components:
             Sets the effective user overview, or clears it when explicitly set to null. Omission leaves
             the overview unchanged. This field cannot be combined with other monitor updates.
       description: Fields that can be updated on an Agent Insights monitor.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
     AgentInsightOverviewSource:
       anyOf:
         - type: string
@@ -39737,6 +39803,9 @@ components:
             - generated
             - user_override
       description: Identifies where an Agent Insights overview came from.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
     AgentInsightPromptSurface:
       anyOf:
         - type: string
@@ -39745,6 +39814,9 @@ components:
             - instructions
             - tool
       description: The Prompt surface changed by a proposed fix.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
     AgentInsightProposedFix:
       type: object
       required:
@@ -39763,6 +39835,9 @@ components:
             $ref: '#/components/schemas/AgentInsightProposedFixChange'
           description: The concrete changes. Omitted for a prose-only fix.
       description: A recommended fix for an agent insight.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
     AgentInsightProposedFixChange:
       type: object
       properties:
@@ -39792,6 +39867,9 @@ components:
             - type: 'null'
           description: The bounded Prompt value after the change. Present for Prompt changes, including when null.
       description: A customer-renderable change in a proposed fix.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
     AgentInsightProposedFixKind:
       anyOf:
         - type: string
@@ -39801,6 +39879,9 @@ components:
             - code_change
             - prompt_change
       description: The customer-renderable kind of an agent insight's proposed fix.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
     AgentInsightRecommendedAction:
       type: object
       required:
@@ -39810,6 +39891,9 @@ components:
           $ref: '#/components/schemas/AgentInsightProposedFix'
           description: The single recommended fix for the issue represented by the insight.
       description: The recommended remediation for an agent insight.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
     AgentInsightRun:
       type: object
       required:
@@ -39884,6 +39968,9 @@ components:
           description: The model deployment used to analyze traces for this run.
           readOnly: true
       description: A long-running run that analyzes one agent's traces and updates that agent's insights.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
     AgentInsightRunCreate:
       type: object
       properties:
@@ -39895,6 +39982,9 @@ components:
           exclusiveMinimum: 0
           default: 168
       description: Inputs used when creating an agent insight run.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
     AgentInsightRunResult:
       type: object
       required:
@@ -39929,6 +40019,9 @@ components:
           $ref: '#/components/schemas/AgentInsightTokenUsage'
           description: Token usage for the run's insight-generation analysis.
       description: Result statistics produced when an agent insight run succeeds.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
     AgentInsightRunTrigger:
       anyOf:
         - type: string
@@ -39937,6 +40030,9 @@ components:
             - on_demand
             - scheduled
       description: The trigger that started an agent insight run.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
     AgentInsightSeverity:
       anyOf:
         - type: string
@@ -39946,6 +40042,9 @@ components:
             - medium
             - low
       description: The severity of an agent insight.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
     AgentInsightStatus:
       anyOf:
         - type: string
@@ -39955,6 +40054,9 @@ components:
             - resolved
             - ignored
       description: The lifecycle status of an agent insight.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
     AgentInsightSuspension:
       type: object
       required:
@@ -39976,6 +40078,9 @@ components:
           unevaluatedProperties: {}
           description: Additional reason-specific suspension details.
       description: Structured reason why scheduled generation is suspended for a monitor.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
     AgentInsightTokenUsage:
       type: object
       required:
@@ -40000,6 +40105,9 @@ components:
           format: int32
           description: The total number of tokens used by the run.
       description: Token usage for an Agent Insights run.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
     AgentInsightUpdate:
       type: object
       properties:
@@ -40007,6 +40115,9 @@ components:
           $ref: '#/components/schemas/AgentInsightStatus'
           description: The lifecycle status to apply to the insight.
       description: Fields that can be updated on an agent insight.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
     AgentInsightsOverview:
       type: object
       required:
@@ -40024,6 +40135,9 @@ components:
           $ref: '#/components/schemas/FoundryTimestamp'
           description: The time when this overview was last updated.
       description: The effective overview for an Agent Insights monitor.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
     AgentInsightsOverviewOverride:
       type: object
       required:
@@ -40033,6 +40147,9 @@ components:
           type: string
           description: The nonblank overview content, limited to 64 KiB when encoded as UTF-8.
       description: A user-provided overview that becomes effective immediately and seeds the next generation.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
     AgentKind:
       anyOf:
         - type: string

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -695,6 +695,12 @@ paths:
             type: string
             enum:
               - AgentInsights=V1Preview
+        - name: Operation-Id
+          in: header
+          required: false
+          description: Client-generated unique ID for idempotent retries. When absent, the server creates the job unconditionally.
+          schema:
+            type: string
         - name: monitor_id
           in: path
           required: true

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -1115,6 +1115,15 @@
             }
           },
           {
+            "name": "Operation-Id",
+            "in": "header",
+            "required": false,
+            "description": "Client-generated unique ID for idempotent retries. When absent, the server creates the job unconditionally.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "monitor_id",
             "in": "path",
             "required": true,

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -242,7 +242,7 @@
           {
             "name": "Foundry-Features",
             "in": "header",
-            "required": false,
+            "required": true,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
               "type": "string",
@@ -377,7 +377,12 @@
         },
         "tags": [
           "Agent Insight Monitors"
-        ]
+        ],
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       },
       "post": {
         "operationId": "AgentInsightMonitors_create",
@@ -386,7 +391,7 @@
           {
             "name": "Foundry-Features",
             "in": "header",
-            "required": false,
+            "required": true,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
               "type": "string",
@@ -460,6 +465,11 @@
             }
           },
           "description": "The monitor to create."
+        },
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
         }
       }
     },
@@ -471,7 +481,7 @@
           {
             "name": "Foundry-Features",
             "in": "header",
-            "required": false,
+            "required": true,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
               "type": "string",
@@ -534,7 +544,12 @@
         },
         "tags": [
           "Agent Insight Monitors"
-        ]
+        ],
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       },
       "delete": {
         "operationId": "AgentInsightMonitors_delete",
@@ -543,7 +558,7 @@
           {
             "name": "Foundry-Features",
             "in": "header",
-            "required": false,
+            "required": true,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
               "type": "string",
@@ -599,7 +614,12 @@
         },
         "tags": [
           "Agent Insight Monitors"
-        ]
+        ],
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       },
       "patch": {
         "operationId": "AgentInsightMonitors_update",
@@ -608,7 +628,7 @@
           {
             "name": "Foundry-Features",
             "in": "header",
-            "required": false,
+            "required": true,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
               "type": "string",
@@ -682,6 +702,11 @@
             }
           },
           "description": "The monitor fields to update."
+        },
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
         }
       }
     },
@@ -693,7 +718,7 @@
           {
             "name": "Foundry-Features",
             "in": "header",
-            "required": false,
+            "required": true,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
               "type": "string",
@@ -868,7 +893,12 @@
         },
         "tags": [
           "Agent Insight Monitors"
-        ]
+        ],
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       }
     },
     "/agent_insight_monitors/{monitor_id}/insights/{insight_id}": {
@@ -879,7 +909,7 @@
           {
             "name": "Foundry-Features",
             "in": "header",
-            "required": false,
+            "required": true,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
               "type": "string",
@@ -962,7 +992,12 @@
         },
         "tags": [
           "Agent Insight Monitors"
-        ]
+        ],
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       },
       "patch": {
         "operationId": "AgentInsightMonitors_updateInsight",
@@ -971,7 +1006,7 @@
           {
             "name": "Foundry-Features",
             "in": "header",
-            "required": false,
+            "required": true,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
               "type": "string",
@@ -1054,6 +1089,11 @@
             }
           },
           "description": "The insight fields to update."
+        },
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
         }
       }
     },
@@ -1065,7 +1105,7 @@
           {
             "name": "Foundry-Features",
             "in": "header",
-            "required": false,
+            "required": true,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
               "type": "string",
@@ -1155,6 +1195,11 @@
             }
           },
           "description": "Run inputs. Send an empty object to use the default 168-hour lookback window."
+        },
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
         }
       },
       "get": {
@@ -1164,7 +1209,7 @@
           {
             "name": "Foundry-Features",
             "in": "header",
-            "required": false,
+            "required": true,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
               "type": "string",
@@ -1318,7 +1363,12 @@
         },
         "tags": [
           "Agent Insight Monitors"
-        ]
+        ],
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       }
     },
     "/agent_insight_monitors/{monitor_id}/runs/{run_id}": {
@@ -1329,7 +1379,7 @@
           {
             "name": "Foundry-Features",
             "in": "header",
-            "required": false,
+            "required": true,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
               "type": "string",
@@ -1401,7 +1451,12 @@
         },
         "tags": [
           "Agent Insight Monitors"
-        ]
+        ],
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       }
     },
     "/agent_insight_monitors/{monitor_id}/runs/{run_id}:cancel": {
@@ -1412,7 +1467,7 @@
           {
             "name": "Foundry-Features",
             "in": "header",
-            "required": false,
+            "required": true,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
               "type": "string",
@@ -1484,7 +1539,12 @@
         },
         "tags": [
           "Agent Insight Monitors"
-        ]
+        ],
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       }
     },
     "/agent_insight_monitors/{monitor_id}:reset": {
@@ -1495,7 +1555,7 @@
           {
             "name": "Foundry-Features",
             "in": "header",
-            "required": false,
+            "required": true,
             "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
             "schema": {
               "type": "string",
@@ -1551,7 +1611,12 @@
         },
         "tags": [
           "Agent Insight Monitors"
-        ]
+        ],
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       }
     },
     "/agent_optimization_jobs": {
@@ -34047,7 +34112,12 @@
             "readOnly": true
           }
         },
-        "description": "A persisted issue discovered from an agent's traces."
+        "description": "A persisted issue discovered from an agent's traces.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       },
       "AgentInsightDetails": {
         "type": "object",
@@ -34078,7 +34148,12 @@
             "description": "The recommended remediation for this insight."
           }
         },
-        "description": "Additional insight details. Omitted unless details are requested."
+        "description": "Additional insight details. Omitted unless details are requested.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       },
       "AgentInsightEstimatedCost": {
         "type": "object",
@@ -34100,7 +34175,12 @@
             "description": "Currency for the estimated cost amount. Agent Insights estimates are reported in US dollars."
           }
         },
-        "description": "Estimated Agent Insights cost."
+        "description": "Estimated Agent Insights cost.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       },
       "AgentInsightHighlightedTrace": {
         "type": "object",
@@ -34134,7 +34214,12 @@
             "description": "The time when the trace was recorded."
           }
         },
-        "description": "A highlighted trace that provides evidence for an agent insight."
+        "description": "A highlighted trace that provides evidence for an agent insight.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       },
       "AgentInsightLinkedTrace": {
         "type": "object",
@@ -34154,7 +34239,12 @@
             "readOnly": true
           }
         },
-        "description": "A lightweight trace reference linked to an agent insight as supporting evidence."
+        "description": "A lightweight trace reference linked to an agent insight as supporting evidence.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       },
       "AgentInsightMonitor": {
         "type": "object",
@@ -34237,7 +34327,12 @@
             "readOnly": true
           }
         },
-        "description": "A per-agent Agent Insights monitor that owns configuration, runs, and discovered insights."
+        "description": "A per-agent Agent Insights monitor that owns configuration, runs, and discovered insights.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       },
       "AgentInsightMonitorCreate": {
         "type": "object",
@@ -34268,7 +34363,12 @@
             "description": "The model deployment to use for analyzing traces. Accepts either the deployment name alone or with the connection name as '{connectionName}/modelDeploymentName'."
           }
         },
-        "description": "Fields accepted when creating an Agent Insights monitor for an agent."
+        "description": "Fields accepted when creating an Agent Insights monitor for an agent.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       },
       "AgentInsightMonitorListItem": {
         "type": "object",
@@ -34338,7 +34438,12 @@
             "readOnly": true
           }
         },
-        "description": "An Agent Insights monitor summary returned by list operations."
+        "description": "An Agent Insights monitor summary returned by list operations.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       },
       "AgentInsightMonitorUpdate": {
         "type": "object",
@@ -34370,7 +34475,12 @@
             "description": "Sets the effective user overview, or clears it when explicitly set to null. Omission leaves\nthe overview unchanged. This field cannot be combined with other monitor updates."
           }
         },
-        "description": "Fields that can be updated on an Agent Insights monitor."
+        "description": "Fields that can be updated on an Agent Insights monitor.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       },
       "AgentInsightOverviewSource": {
         "anyOf": [
@@ -34385,7 +34495,12 @@
             ]
           }
         ],
-        "description": "Identifies where an Agent Insights overview came from."
+        "description": "Identifies where an Agent Insights overview came from.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       },
       "AgentInsightPromptSurface": {
         "anyOf": [
@@ -34400,7 +34515,12 @@
             ]
           }
         ],
-        "description": "The Prompt surface changed by a proposed fix."
+        "description": "The Prompt surface changed by a proposed fix.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       },
       "AgentInsightProposedFix": {
         "type": "object",
@@ -34425,7 +34545,12 @@
             "description": "The concrete changes. Omitted for a prose-only fix."
           }
         },
-        "description": "A recommended fix for an agent insight."
+        "description": "A recommended fix for an agent insight.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       },
       "AgentInsightProposedFixChange": {
         "type": "object",
@@ -34469,7 +34594,12 @@
             "description": "The bounded Prompt value after the change. Present for Prompt changes, including when null."
           }
         },
-        "description": "A customer-renderable change in a proposed fix."
+        "description": "A customer-renderable change in a proposed fix.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       },
       "AgentInsightProposedFixKind": {
         "anyOf": [
@@ -34485,7 +34615,12 @@
             ]
           }
         ],
-        "description": "The customer-renderable kind of an agent insight's proposed fix."
+        "description": "The customer-renderable kind of an agent insight's proposed fix.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       },
       "AgentInsightRecommendedAction": {
         "type": "object",
@@ -34498,7 +34633,12 @@
             "description": "The single recommended fix for the issue represented by the insight."
           }
         },
-        "description": "The recommended remediation for an agent insight."
+        "description": "The recommended remediation for an agent insight.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       },
       "AgentInsightRun": {
         "type": "object",
@@ -34590,7 +34730,12 @@
             "readOnly": true
           }
         },
-        "description": "A long-running run that analyzes one agent's traces and updates that agent's insights."
+        "description": "A long-running run that analyzes one agent's traces and updates that agent's insights.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       },
       "AgentInsightRunCreate": {
         "type": "object",
@@ -34604,7 +34749,12 @@
             "default": 168
           }
         },
-        "description": "Inputs used when creating an agent insight run."
+        "description": "Inputs used when creating an agent insight run.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       },
       "AgentInsightRunResult": {
         "type": "object",
@@ -34647,7 +34797,12 @@
             "description": "Token usage for the run's insight-generation analysis."
           }
         },
-        "description": "Result statistics produced when an agent insight run succeeds."
+        "description": "Result statistics produced when an agent insight run succeeds.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       },
       "AgentInsightRunTrigger": {
         "anyOf": [
@@ -34662,7 +34817,12 @@
             ]
           }
         ],
-        "description": "The trigger that started an agent insight run."
+        "description": "The trigger that started an agent insight run.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       },
       "AgentInsightSeverity": {
         "anyOf": [
@@ -34678,7 +34838,12 @@
             ]
           }
         ],
-        "description": "The severity of an agent insight."
+        "description": "The severity of an agent insight.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       },
       "AgentInsightStatus": {
         "anyOf": [
@@ -34694,7 +34859,12 @@
             ]
           }
         ],
-        "description": "The lifecycle status of an agent insight."
+        "description": "The lifecycle status of an agent insight.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       },
       "AgentInsightSuspension": {
         "type": "object",
@@ -34722,7 +34892,12 @@
             "description": "Additional reason-specific suspension details."
           }
         },
-        "description": "Structured reason why scheduled generation is suspended for a monitor."
+        "description": "Structured reason why scheduled generation is suspended for a monitor.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       },
       "AgentInsightTokenUsage": {
         "type": "object",
@@ -34753,7 +34928,12 @@
             "description": "The total number of tokens used by the run."
           }
         },
-        "description": "Token usage for an Agent Insights run."
+        "description": "Token usage for an Agent Insights run.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       },
       "AgentInsightUpdate": {
         "type": "object",
@@ -34763,7 +34943,12 @@
             "description": "The lifecycle status to apply to the insight."
           }
         },
-        "description": "Fields that can be updated on an agent insight."
+        "description": "Fields that can be updated on an agent insight.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       },
       "AgentInsightsOverview": {
         "type": "object",
@@ -34786,7 +34971,12 @@
             "description": "The time when this overview was last updated."
           }
         },
-        "description": "The effective overview for an Agent Insights monitor."
+        "description": "The effective overview for an Agent Insights monitor.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       },
       "AgentInsightsOverviewOverride": {
         "type": "object",
@@ -34799,7 +34989,12 @@
             "description": "The nonblank overview content, limited to 64 KiB when encoded as UTF-8."
           }
         },
-        "description": "A user-provided overview that becomes effective immediately and seeds the next generation."
+        "description": "A user-provided overview that becomes effective immediately and seeds the next generation.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentInsights=V1Preview"
+          ]
+        }
       },
       "AgentKind": {
         "anyOf": [

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -699,6 +699,12 @@ paths:
             type: string
             enum:
               - AgentInsights=V1Preview
+        - name: Operation-Id
+          in: header
+          required: false
+          description: Client-generated unique ID for idempotent retries. When absent, the server creates the job unconditionally.
+          schema:
+            type: string
         - name: monitor_id
           in: path
           required: true

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -126,7 +126,7 @@ paths:
       parameters:
         - name: Foundry-Features
           in: header
-          required: false
+          required: true
           description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
           schema:
             type: string
@@ -219,13 +219,16 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Agent Insight Monitors
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
     post:
       operationId: AgentInsightMonitors_create
       description: Create an Agent Insights monitor for an agent.
       parameters:
         - name: Foundry-Features
           in: header
-          required: false
+          required: true
           description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
           schema:
             type: string
@@ -272,6 +275,9 @@ paths:
             schema:
               $ref: '#/components/schemas/AgentInsightMonitorCreate'
         description: The monitor to create.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
   /agent_insight_monitors/{monitor_id}:
     get:
       operationId: AgentInsightMonitors_get
@@ -279,7 +285,7 @@ paths:
       parameters:
         - name: Foundry-Features
           in: header
-          required: false
+          required: true
           description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
           schema:
             type: string
@@ -319,13 +325,16 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Agent Insight Monitors
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
     delete:
       operationId: AgentInsightMonitors_delete
       description: Delete an Agent Insights monitor and all of its runs, insights, and state.
       parameters:
         - name: Foundry-Features
           in: header
-          required: false
+          required: true
           description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
           schema:
             type: string
@@ -361,13 +370,16 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Agent Insight Monitors
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
     patch:
       operationId: AgentInsightMonitors_update
       description: Update an Agent Insights monitor.
       parameters:
         - name: Foundry-Features
           in: header
-          required: false
+          required: true
           description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
           schema:
             type: string
@@ -414,6 +426,9 @@ paths:
             schema:
               $ref: '#/components/schemas/AgentInsightMonitorUpdate'
         description: The monitor fields to update.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
   /agent_insight_monitors/{monitor_id}/insights:
     get:
       operationId: AgentInsightMonitors_listInsights
@@ -421,7 +436,7 @@ paths:
       parameters:
         - name: Foundry-Features
           in: header
-          required: false
+          required: true
           description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
           schema:
             type: string
@@ -542,6 +557,9 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Agent Insight Monitors
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
   /agent_insight_monitors/{monitor_id}/insights/{insight_id}:
     get:
       operationId: AgentInsightMonitors_getInsight
@@ -549,7 +567,7 @@ paths:
       parameters:
         - name: Foundry-Features
           in: header
-          required: false
+          required: true
           description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
           schema:
             type: string
@@ -603,13 +621,16 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Agent Insight Monitors
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
     patch:
       operationId: AgentInsightMonitors_updateInsight
       description: Update the lifecycle status of an insight.
       parameters:
         - name: Foundry-Features
           in: header
-          required: false
+          required: true
           description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
           schema:
             type: string
@@ -662,6 +683,9 @@ paths:
             schema:
               $ref: '#/components/schemas/AgentInsightUpdate'
         description: The insight fields to update.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
   /agent_insight_monitors/{monitor_id}/runs:
     post:
       operationId: AgentInsightMonitors_createRun
@@ -669,7 +693,7 @@ paths:
       parameters:
         - name: Foundry-Features
           in: header
-          required: false
+          required: true
           description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
           schema:
             type: string
@@ -727,13 +751,16 @@ paths:
             schema:
               $ref: '#/components/schemas/AgentInsightRunCreate'
         description: Run inputs. Send an empty object to use the default 168-hour lookback window.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
     get:
       operationId: AgentInsightMonitors_listRuns
       description: List Agent Insights runs for a monitor.
       parameters:
         - name: Foundry-Features
           in: header
-          required: false
+          required: true
           description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
           schema:
             type: string
@@ -839,6 +866,9 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Agent Insight Monitors
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
   /agent_insight_monitors/{monitor_id}/runs/{run_id}:
     get:
       operationId: AgentInsightMonitors_getRun
@@ -846,7 +876,7 @@ paths:
       parameters:
         - name: Foundry-Features
           in: header
-          required: false
+          required: true
           description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
           schema:
             type: string
@@ -892,6 +922,9 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Agent Insight Monitors
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
   /agent_insight_monitors/{monitor_id}/runs/{run_id}:cancel:
     post:
       operationId: AgentInsightMonitors_cancelRun
@@ -899,7 +932,7 @@ paths:
       parameters:
         - name: Foundry-Features
           in: header
-          required: false
+          required: true
           description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
           schema:
             type: string
@@ -945,6 +978,9 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Agent Insight Monitors
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
   /agent_insight_monitors/{monitor_id}:reset:
     post:
       operationId: AgentInsightMonitors_reset
@@ -952,7 +988,7 @@ paths:
       parameters:
         - name: Foundry-Features
           in: header
-          required: false
+          required: true
           description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
           schema:
             type: string
@@ -988,6 +1024,9 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Agent Insight Monitors
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
   /agent_optimization_jobs:
     post:
       operationId: AgentOptimizationJobs_create
@@ -43228,6 +43267,9 @@ components:
           description: Additional insight details. Omitted unless details are requested.
           readOnly: true
       description: A persisted issue discovered from an agent's traces.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
     AgentInsightDetails:
       type: object
       required:
@@ -43251,6 +43293,9 @@ components:
           $ref: '#/components/schemas/AgentInsightRecommendedAction'
           description: The recommended remediation for this insight.
       description: Additional insight details. Omitted unless details are requested.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
     AgentInsightEstimatedCost:
       type: object
       required:
@@ -43267,6 +43312,9 @@ components:
             - USD
           description: Currency for the estimated cost amount. Agent Insights estimates are reported in US dollars.
       description: Estimated Agent Insights cost.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
     AgentInsightHighlightedTrace:
       type: object
       required:
@@ -43293,6 +43341,9 @@ components:
           $ref: '#/components/schemas/FoundryTimestamp'
           description: The time when the trace was recorded.
       description: A highlighted trace that provides evidence for an agent insight.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
     AgentInsightLinkedTrace:
       type: object
       required:
@@ -43308,6 +43359,9 @@ components:
           description: The time when the trace was recorded.
           readOnly: true
       description: A lightweight trace reference linked to an agent insight as supporting evidence.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
     AgentInsightMonitor:
       type: object
       required:
@@ -43368,6 +43422,9 @@ components:
           description: The time when this monitor was last updated.
           readOnly: true
       description: A per-agent Agent Insights monitor that owns configuration, runs, and discovered insights.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
     AgentInsightMonitorCreate:
       type: object
       required:
@@ -43392,6 +43449,9 @@ components:
           type: string
           description: The model deployment to use for analyzing traces. Accepts either the deployment name alone or with the connection name as '{connectionName}/modelDeploymentName'.
       description: Fields accepted when creating an Agent Insights monitor for an agent.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
     AgentInsightMonitorListItem:
       type: object
       required:
@@ -43445,6 +43505,9 @@ components:
           description: The time when this monitor was last updated.
           readOnly: true
       description: An Agent Insights monitor summary returned by list operations.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
     AgentInsightMonitorUpdate:
       type: object
       properties:
@@ -43468,6 +43531,9 @@ components:
             Sets the effective user overview, or clears it when explicitly set to null. Omission leaves
             the overview unchanged. This field cannot be combined with other monitor updates.
       description: Fields that can be updated on an Agent Insights monitor.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
     AgentInsightOverviewSource:
       anyOf:
         - type: string
@@ -43476,6 +43542,9 @@ components:
             - generated
             - user_override
       description: Identifies where an Agent Insights overview came from.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
     AgentInsightPromptSurface:
       anyOf:
         - type: string
@@ -43484,6 +43553,9 @@ components:
             - instructions
             - tool
       description: The Prompt surface changed by a proposed fix.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
     AgentInsightProposedFix:
       type: object
       required:
@@ -43502,6 +43574,9 @@ components:
             $ref: '#/components/schemas/AgentInsightProposedFixChange'
           description: The concrete changes. Omitted for a prose-only fix.
       description: A recommended fix for an agent insight.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
     AgentInsightProposedFixChange:
       type: object
       properties:
@@ -43531,6 +43606,9 @@ components:
             - type: 'null'
           description: The bounded Prompt value after the change. Present for Prompt changes, including when null.
       description: A customer-renderable change in a proposed fix.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
     AgentInsightProposedFixKind:
       anyOf:
         - type: string
@@ -43540,6 +43618,9 @@ components:
             - code_change
             - prompt_change
       description: The customer-renderable kind of an agent insight's proposed fix.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
     AgentInsightRecommendedAction:
       type: object
       required:
@@ -43549,6 +43630,9 @@ components:
           $ref: '#/components/schemas/AgentInsightProposedFix'
           description: The single recommended fix for the issue represented by the insight.
       description: The recommended remediation for an agent insight.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
     AgentInsightRun:
       type: object
       required:
@@ -43623,6 +43707,9 @@ components:
           description: The model deployment used to analyze traces for this run.
           readOnly: true
       description: A long-running run that analyzes one agent's traces and updates that agent's insights.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
     AgentInsightRunCreate:
       type: object
       properties:
@@ -43634,6 +43721,9 @@ components:
           exclusiveMinimum: 0
           default: 168
       description: Inputs used when creating an agent insight run.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
     AgentInsightRunResult:
       type: object
       required:
@@ -43668,6 +43758,9 @@ components:
           $ref: '#/components/schemas/AgentInsightTokenUsage'
           description: Token usage for the run's insight-generation analysis.
       description: Result statistics produced when an agent insight run succeeds.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
     AgentInsightRunTrigger:
       anyOf:
         - type: string
@@ -43676,6 +43769,9 @@ components:
             - on_demand
             - scheduled
       description: The trigger that started an agent insight run.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
     AgentInsightSeverity:
       anyOf:
         - type: string
@@ -43685,6 +43781,9 @@ components:
             - medium
             - low
       description: The severity of an agent insight.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
     AgentInsightStatus:
       anyOf:
         - type: string
@@ -43694,6 +43793,9 @@ components:
             - resolved
             - ignored
       description: The lifecycle status of an agent insight.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
     AgentInsightSuspension:
       type: object
       required:
@@ -43715,6 +43817,9 @@ components:
           unevaluatedProperties: {}
           description: Additional reason-specific suspension details.
       description: Structured reason why scheduled generation is suspended for a monitor.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
     AgentInsightTokenUsage:
       type: object
       required:
@@ -43739,6 +43844,9 @@ components:
           format: int32
           description: The total number of tokens used by the run.
       description: Token usage for an Agent Insights run.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
     AgentInsightUpdate:
       type: object
       properties:
@@ -43746,6 +43854,9 @@ components:
           $ref: '#/components/schemas/AgentInsightStatus'
           description: The lifecycle status to apply to the insight.
       description: Fields that can be updated on an agent insight.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
     AgentInsightsOverview:
       type: object
       required:
@@ -43763,6 +43874,9 @@ components:
           $ref: '#/components/schemas/FoundryTimestamp'
           description: The time when this overview was last updated.
       description: The effective overview for an Agent Insights monitor.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
     AgentInsightsOverviewOverride:
       type: object
       required:
@@ -43772,6 +43886,9 @@ components:
           type: string
           description: The nonblank overview content, limited to 64 KiB when encoded as UTF-8.
       description: A user-provided overview that becomes effective immediately and seeds the next generation.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentInsights=V1Preview
     AgentKind:
       anyOf:
         - type: string

--- a/specification/ai-foundry/data-plane/Foundry/src/agent-insights/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agent-insights/models.tsp
@@ -2,11 +2,17 @@ import "../common/models.tsp";
 import "../common/servicepatterns.tsp";
 
 using TypeSpec.Rest;
+using TypeSpec.OpenAPI;
 using Azure.Core;
 
 namespace Azure.AI.Projects;
 
+const AgentInsightMonitorsRequiredPreviews = #{
+  required_previews: #[FoundryFeaturesOptInKeys.agent_insights_v1_preview],
+};
+
 /** The lifecycle status of an agent insight. */
+@extension("x-ms-foundry-meta", AgentInsightMonitorsRequiredPreviews)
 union AgentInsightStatus {
   string,
 
@@ -21,6 +27,7 @@ union AgentInsightStatus {
 }
 
 /** The severity of an agent insight. */
+@extension("x-ms-foundry-meta", AgentInsightMonitorsRequiredPreviews)
 union AgentInsightSeverity {
   string,
 
@@ -35,6 +42,7 @@ union AgentInsightSeverity {
 }
 
 /** Identifies where an Agent Insights overview came from. */
+@extension("x-ms-foundry-meta", AgentInsightMonitorsRequiredPreviews)
 union AgentInsightOverviewSource {
   string,
 
@@ -46,6 +54,7 @@ union AgentInsightOverviewSource {
 }
 
 /** A highlighted trace that provides evidence for an agent insight. */
+@extension("x-ms-foundry-meta", AgentInsightMonitorsRequiredPreviews)
 model AgentInsightHighlightedTrace {
   /** The trace identifier. */
   @key("trace_id")
@@ -66,6 +75,7 @@ model AgentInsightHighlightedTrace {
 }
 
 /** A lightweight trace reference linked to an agent insight as supporting evidence. */
+@extension("x-ms-foundry-meta", AgentInsightMonitorsRequiredPreviews)
 model AgentInsightLinkedTrace {
   /** The trace identifier. */
   @key("trace_id")
@@ -78,6 +88,7 @@ model AgentInsightLinkedTrace {
 }
 
 /** The customer-renderable kind of an agent insight's proposed fix. */
+@extension("x-ms-foundry-meta", AgentInsightMonitorsRequiredPreviews)
 union AgentInsightProposedFixKind {
   string,
 
@@ -92,6 +103,7 @@ union AgentInsightProposedFixKind {
 }
 
 /** The Prompt surface changed by a proposed fix. */
+@extension("x-ms-foundry-meta", AgentInsightMonitorsRequiredPreviews)
 union AgentInsightPromptSurface {
   string,
 
@@ -103,6 +115,7 @@ union AgentInsightPromptSurface {
 }
 
 /** A customer-renderable change in a proposed fix. */
+@extension("x-ms-foundry-meta", AgentInsightMonitorsRequiredPreviews)
 model AgentInsightProposedFixChange {
   /** The source path changed by a code change. */
   path?: string;
@@ -127,6 +140,7 @@ model AgentInsightProposedFixChange {
 }
 
 /** A recommended fix for an agent insight. */
+@extension("x-ms-foundry-meta", AgentInsightMonitorsRequiredPreviews)
 model AgentInsightProposedFix {
   /** The proposed-fix discriminator. */
   kind: AgentInsightProposedFixKind;
@@ -139,12 +153,14 @@ model AgentInsightProposedFix {
 }
 
 /** The recommended remediation for an agent insight. */
+@extension("x-ms-foundry-meta", AgentInsightMonitorsRequiredPreviews)
 model AgentInsightRecommendedAction {
   /** The single recommended fix for the issue represented by the insight. */
   proposed_fix: AgentInsightProposedFix;
 }
 
 /** Additional insight details. Omitted unless details are requested. */
+@extension("x-ms-foundry-meta", AgentInsightMonitorsRequiredPreviews)
 model AgentInsightDetails {
   /** Up to 5 highlighted traces that provide evidence for this insight. */
   @maxItems(5)
@@ -159,6 +175,7 @@ model AgentInsightDetails {
 }
 
 /** A persisted issue discovered from an agent's traces. */
+@extension("x-ms-foundry-meta", AgentInsightMonitorsRequiredPreviews)
 model AgentInsight {
   /** The insight identifier. */
   @visibility(Lifecycle.Read)
@@ -214,12 +231,14 @@ model AgentInsight {
 }
 
 /** Fields that can be updated on an agent insight. */
+@extension("x-ms-foundry-meta", AgentInsightMonitorsRequiredPreviews)
 model AgentInsightUpdate {
   /** The lifecycle status to apply to the insight. */
   status?: AgentInsightStatus;
 }
 
 /** Structured reason why scheduled generation is suspended for a monitor. */
+@extension("x-ms-foundry-meta", AgentInsightMonitorsRequiredPreviews)
 model AgentInsightSuspension {
   /** Stable, machine-readable suspension category. */
   code: string;
@@ -235,6 +254,7 @@ model AgentInsightSuspension {
 }
 
 /** The effective overview for an Agent Insights monitor. */
+@extension("x-ms-foundry-meta", AgentInsightMonitorsRequiredPreviews)
 model AgentInsightsOverview {
   /** The overview content. */
   content: string;
@@ -247,12 +267,14 @@ model AgentInsightsOverview {
 }
 
 /** A user-provided overview that becomes effective immediately and seeds the next generation. */
+@extension("x-ms-foundry-meta", AgentInsightMonitorsRequiredPreviews)
 model AgentInsightsOverviewOverride {
   /** The nonblank overview content, limited to 64 KiB when encoded as UTF-8. */
   content: string;
 }
 
 /** Estimated Agent Insights cost. */
+@extension("x-ms-foundry-meta", AgentInsightMonitorsRequiredPreviews)
 model AgentInsightEstimatedCost {
   /** Estimated cost amount. */
   amount: float64;
@@ -262,6 +284,7 @@ model AgentInsightEstimatedCost {
 }
 
 /** A per-agent Agent Insights monitor that owns configuration, runs, and discovered insights. */
+@extension("x-ms-foundry-meta", AgentInsightMonitorsRequiredPreviews)
 model AgentInsightMonitor {
   /** The monitor identifier. */
   @key("monitor_id")
@@ -308,12 +331,14 @@ model AgentInsightMonitor {
 }
 
 /** An Agent Insights monitor summary returned by list operations. */
+@extension("x-ms-foundry-meta", AgentInsightMonitorsRequiredPreviews)
 model AgentInsightMonitorListItem is OmitProperties<
   AgentInsightMonitor,
   "overview"
 >;
 
 /** Fields accepted when creating an Agent Insights monitor for an agent. */
+@extension("x-ms-foundry-meta", AgentInsightMonitorsRequiredPreviews)
 model AgentInsightMonitorCreate {
   /** The agent this monitor should analyze. */
   agent_name: string;
@@ -331,6 +356,7 @@ model AgentInsightMonitorCreate {
 }
 
 /** Fields that can be updated on an Agent Insights monitor. */
+@extension("x-ms-foundry-meta", AgentInsightMonitorsRequiredPreviews)
 model AgentInsightMonitorUpdate {
   /** Whether scheduled insight generation is armed for the monitor. */
   enabled?: boolean;
@@ -351,6 +377,7 @@ model AgentInsightMonitorUpdate {
 }
 
 /** The trigger that started an agent insight run. */
+@extension("x-ms-foundry-meta", AgentInsightMonitorsRequiredPreviews)
 union AgentInsightRunTrigger {
   string,
 
@@ -362,6 +389,7 @@ union AgentInsightRunTrigger {
 }
 
 /** Inputs used when creating an agent insight run. */
+@extension("x-ms-foundry-meta", AgentInsightMonitorsRequiredPreviews)
 model AgentInsightRunCreate {
   /** Optional finite positive number of hours of trace history to analyze, up to 2,160. Defaults to 168. */
   @minValueExclusive(0)
@@ -370,6 +398,7 @@ model AgentInsightRunCreate {
 }
 
 /** Result statistics produced when an agent insight run succeeds. */
+@extension("x-ms-foundry-meta", AgentInsightMonitorsRequiredPreviews)
 model AgentInsightRunResult {
   /** The number of traces in the analyzed time window. */
   traces_in_window: int32;
@@ -391,6 +420,7 @@ model AgentInsightRunResult {
 }
 
 /** Token usage for an Agent Insights run. */
+@extension("x-ms-foundry-meta", AgentInsightMonitorsRequiredPreviews)
 model AgentInsightTokenUsage {
   /** The number of input tokens used by the run. */
   input_tokens: int32;
@@ -406,6 +436,7 @@ model AgentInsightTokenUsage {
 }
 
 /** A long-running run that analyzes one agent's traces and updates that agent's insights. */
+@extension("x-ms-foundry-meta", AgentInsightMonitorsRequiredPreviews)
 model AgentInsightRun is JobLike<AgentInsightRunResult, AgentInsightRunCreate> {
   /** The Agent Insights monitor this run belongs to. */
   @visibility(Lifecycle.Read)

--- a/specification/ai-foundry/data-plane/Foundry/src/agent-insights/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agent-insights/routes.tsp
@@ -1,6 +1,7 @@
 import "./models.tsp";
 
 using TypeSpec.Http;
+using TypeSpec.OpenAPI;
 using Azure.Core;
 
 namespace Azure.AI.Projects;
@@ -61,14 +62,15 @@ alias AgentInsightMonitorCreatedResponse = ResourceCreatedResponse<AgentInsightM
   location: string;
 };
 
-#suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Agent Insights uses project-standard FoundryDataPlanePreviewOperation templates for Foundry data-plane preview routing and error handling."
+#suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Agent Insights uses project-standard FoundryDataPlaneRequiredPreviewOperation templates for Foundry data-plane preview routing and error handling."
 @tag("Agent Insight Monitors")
 interface AgentInsightMonitors {
   /** List Agent Insights monitors, optionally filtered by agent name. */
   @get
   @list
   @route("/agent_insight_monitors")
-  list is FoundryDataPlanePreviewOperation<
+  @extension("x-ms-foundry-meta", AgentInsightMonitorsRequiredPreviews)
+  list is FoundryDataPlaneRequiredPreviewOperation<
     AgentInsightsPreviewKey,
     {
       ...AgentInsightsPageQueryParameters;
@@ -80,7 +82,8 @@ interface AgentInsightMonitors {
   /** Create an Agent Insights monitor for an agent. */
   @post
   @route("/agent_insight_monitors")
-  create is FoundryDataPlanePreviewOperation<
+  @extension("x-ms-foundry-meta", AgentInsightMonitorsRequiredPreviews)
+  create is FoundryDataPlaneRequiredPreviewOperation<
     AgentInsightsPreviewKey,
     {
       /** The monitor to create. */
@@ -92,7 +95,8 @@ interface AgentInsightMonitors {
   /** Get an Agent Insights monitor. */
   @get
   @route("/agent_insight_monitors/{monitor_id}")
-  get is FoundryDataPlanePreviewOperation<
+  @extension("x-ms-foundry-meta", AgentInsightMonitorsRequiredPreviews)
+  get is FoundryDataPlaneRequiredPreviewOperation<
     AgentInsightsPreviewKey,
     {
       /** The identifier of the monitor. */
@@ -104,7 +108,8 @@ interface AgentInsightMonitors {
   /** Delete an Agent Insights monitor and all of its runs, insights, and state. */
   @delete
   @route("/agent_insight_monitors/{monitor_id}")
-  delete is FoundryDataPlanePreviewOperation<
+  @extension("x-ms-foundry-meta", AgentInsightMonitorsRequiredPreviews)
+  delete is FoundryDataPlaneRequiredPreviewOperation<
     AgentInsightsPreviewKey,
     {
       /** The identifier of the monitor. */
@@ -116,7 +121,8 @@ interface AgentInsightMonitors {
   /** Update an Agent Insights monitor. */
   @patch
   @route("/agent_insight_monitors/{monitor_id}")
-  update is FoundryDataPlanePreviewOperation<
+  @extension("x-ms-foundry-meta", AgentInsightMonitorsRequiredPreviews)
+  update is FoundryDataPlaneRequiredPreviewOperation<
     AgentInsightsPreviewKey,
     {
       /** The identifier of the monitor. */
@@ -135,7 +141,8 @@ interface AgentInsightMonitors {
   /** Reset an Agent Insights monitor's overview, checkpoint, and active insight state. */
   @post
   @route("/agent_insight_monitors/{monitor_id}:reset")
-  reset is FoundryDataPlanePreviewOperation<
+  @extension("x-ms-foundry-meta", AgentInsightMonitorsRequiredPreviews)
+  reset is FoundryDataPlaneRequiredPreviewOperation<
     AgentInsightsPreviewKey,
     {
       /** The identifier of the monitor. */
@@ -148,7 +155,8 @@ interface AgentInsightMonitors {
   @post
   @route("/agent_insight_monitors/{monitor_id}/runs")
   @pollingOperation(AgentInsightMonitors.getRun)
-  createRun is FoundryDataPlanePreviewOperation<
+  @extension("x-ms-foundry-meta", AgentInsightMonitorsRequiredPreviews)
+  createRun is FoundryDataPlaneRequiredPreviewOperation<
     AgentInsightsPreviewKey,
     {
       /** The identifier of the monitor. */
@@ -164,7 +172,8 @@ interface AgentInsightMonitors {
   @get
   @list
   @route("/agent_insight_monitors/{monitor_id}/runs")
-  listRuns is FoundryDataPlanePreviewOperation<
+  @extension("x-ms-foundry-meta", AgentInsightMonitorsRequiredPreviews)
+  listRuns is FoundryDataPlaneRequiredPreviewOperation<
     AgentInsightsPreviewKey,
     {
       /** The identifier of the monitor. */
@@ -179,7 +188,8 @@ interface AgentInsightMonitors {
   /** Get an Agent Insights run. */
   @get
   @route("/agent_insight_monitors/{monitor_id}/runs/{run_id}")
-  getRun is FoundryDataPlanePreviewOperation<
+  @extension("x-ms-foundry-meta", AgentInsightMonitorsRequiredPreviews)
+  getRun is FoundryDataPlaneRequiredPreviewOperation<
     AgentInsightsPreviewKey,
     {
       /** The identifier of the monitor. */
@@ -194,7 +204,8 @@ interface AgentInsightMonitors {
   /** Cancel an Agent Insights run. */
   @post
   @route("/agent_insight_monitors/{monitor_id}/runs/{run_id}:cancel")
-  cancelRun is FoundryDataPlanePreviewOperation<
+  @extension("x-ms-foundry-meta", AgentInsightMonitorsRequiredPreviews)
+  cancelRun is FoundryDataPlaneRequiredPreviewOperation<
     AgentInsightsPreviewKey,
     {
       /** The identifier of the monitor. */
@@ -210,7 +221,8 @@ interface AgentInsightMonitors {
   @get
   @list
   @route("/agent_insight_monitors/{monitor_id}/insights")
-  listInsights is FoundryDataPlanePreviewOperation<
+  @extension("x-ms-foundry-meta", AgentInsightMonitorsRequiredPreviews)
+  listInsights is FoundryDataPlaneRequiredPreviewOperation<
     AgentInsightsPreviewKey,
     {
       /** The identifier of the monitor. */
@@ -226,7 +238,8 @@ interface AgentInsightMonitors {
   /** Get a full insight for an Agent Insights monitor. */
   @get
   @route("/agent_insight_monitors/{monitor_id}/insights/{insight_id}")
-  getInsight is FoundryDataPlanePreviewOperation<
+  @extension("x-ms-foundry-meta", AgentInsightMonitorsRequiredPreviews)
+  getInsight is FoundryDataPlaneRequiredPreviewOperation<
     AgentInsightsPreviewKey,
     {
       /** The identifier of the monitor. */
@@ -243,7 +256,8 @@ interface AgentInsightMonitors {
   /** Update the lifecycle status of an insight. */
   @patch
   @route("/agent_insight_monitors/{monitor_id}/insights/{insight_id}")
-  updateInsight is FoundryDataPlanePreviewOperation<
+  @extension("x-ms-foundry-meta", AgentInsightMonitorsRequiredPreviews)
+  updateInsight is FoundryDataPlaneRequiredPreviewOperation<
     AgentInsightsPreviewKey,
     {
       /** The identifier of the monitor. */

--- a/specification/ai-foundry/data-plane/Foundry/src/agent-insights/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agent-insights/routes.tsp
@@ -159,6 +159,8 @@ interface AgentInsightMonitors {
   createRun is FoundryDataPlaneRequiredPreviewOperation<
     AgentInsightsPreviewKey,
     {
+      ...WithOperationId;
+
       /** The identifier of the monitor. */
       @path monitor_id: string;
 


### PR DESCRIPTION
## Summary

- mark all Agent Insights models and operations with `x-ms-foundry-meta.required_previews`
- require `Foundry-Features: AgentInsights=V1Preview` on all Agent Insights routes
- expose optional `Operation-Id` on `AgentInsightMonitors_createRun`
- document all required Agent Insights preview routes
- regenerate the `v1` and `virtual-public-preview` OpenAPI files

## Why

The Agent Insights surface is Public Preview, but its generated SDK models and operations did not carry the Foundry metadata that SDK tooling uses for experimental APIs. The specification also described the required feature header as optional.

Run creation is a durable long-running operation. Optional `Operation-Id` lets a client safely repeat a POST when it does not know whether the service committed the first request.

## Run creation contract

- requests without `Operation-Id` keep the existing unconditional-create behavior
- exact retries with the same header and inputs return the original run
- reuse with different inputs returns `409`
- the existing `201 Created`, `Location`, and `Operation-Location` response contract is unchanged

## Coordinated backend

Vienna PR 2282294:
https://msdata.visualstudio.com/Vienna/_git/vienna/pullrequest/2282294

The TypeSpec can merge slightly ahead, but the Vienna backend must be deployed before SDK clients rely on idempotent replay.

## Validation

- Foundry TypeSpec validation
- root TypeSpec compilation
- C# Azure AI Projects client TypeSpec compilation
- Java Azure AI Projects client TypeSpec compilation
- Python/JavaScript Azure AI Projects client TypeSpec compilation
- generated contract checks for all 26 models, 13 operations, required feature headers, and optional `Operation-Id`

Related: #45444
