### PR TITLE
Restrict SDK breaking change labels to supported branches

### DIFF
--- a/.github/workflows/src/sdk-breaking-change-labels.js
+++ b/.github/workflows/src/sdk-breaking-change-labels.js
@@ -3,6 +3,8 @@ import { getAdoBuildInfoFromUrl, getAzurePipelineArtifact } from "./artifacts.js
 import { extractInputs } from "./context.js";
 import { LabelAction } from "./label.js";
 
+const SUPPORTED_TARGET_BRANCHES = new Set(["main", "RPSaaSMaster"]);
+
 /**
  * @typedef {import("../../shared/src/sdk-types.js").SdkName} SdkName
  */
@@ -27,10 +29,27 @@ export async function getLabelAndAction({ github, context, core }) {
   if (!details_url) {
     throw new Error(`Required inputs are not valid: details_url:${details_url}`);
   }
-  return await getLabelAndActionImpl({
+  const result = await getLabelAndActionImpl({
     details_url,
     core,
   });
+
+  // This requirement only scopes label additions; target-branch handling for removals will be added later.
+  if (result.issueNumber > 0 && result.labelAction === LabelAction.Add) {
+    const { data: pullRequest } = await github.rest.pulls.get({
+      ...context.repo,
+      pull_number: result.issueNumber,
+    });
+    const targetBranch = pullRequest.base.ref;
+    core.info(`PR target branch: ${targetBranch}`);
+
+    if (!SUPPORTED_TARGET_BRANCHES.has(targetBranch)) {
+      core.info(`Skipping SDK breaking change label addition for unsupported target branch.`);
+      result.labelAction = LabelAction.None;
+    }
+  }
+
+  return result;
 }
 
 /**

--- a/.github/workflows/test/sdk-breaking-change-labels.test.js
+++ b/.github/workflows/test/sdk-breaking-change-labels.test.js
@@ -36,6 +36,9 @@ describe("sdk-breaking-change-labels", () => {
   beforeEach(() => {
     // Reset mocks
     vi.clearAllMocks();
+    mockGithub.rest.pulls.get.mockResolvedValue({
+      data: { base: { ref: "main" } },
+    });
   });
 
   describe("getLabelAndAction", () => {
@@ -100,8 +103,90 @@ describe("sdk-breaking-change-labels", () => {
         labelAction: LabelAction.Add,
         issueNumber: 123,
       });
+      expect(mockGithub.rest.pulls.get).toHaveBeenCalledWith({
+        owner: "owner",
+        repo: "repo",
+        pull_number: 123,
+      });
     });
-    it("should correctly set labelAction to Remove", async () => {
+    it.each(["main", "RPSaaSMaster"])(
+      "should retain the label action for the %s target branch",
+      async (targetBranch) => {
+        const mockInputs = {
+          details_url: "https://dev.azure.com/project/_build/results?buildId=12345",
+        };
+        const { extractInputs } = await import("../src/context.js");
+        /** @type {import("vitest").Mock} */ (extractInputs).mockResolvedValue(mockInputs);
+        mockGithub.rest.pulls.get.mockResolvedValue({
+          data: { base: { ref: targetBranch } },
+        });
+        mockFetch
+          .mockResolvedValueOnce({
+            ok: true,
+            json: vi.fn().mockResolvedValue({
+              resource: { downloadUrl: "https://dev.azure.com/download?format=zip" },
+            }),
+          })
+          .mockResolvedValueOnce({
+            ok: true,
+            text: vi.fn().mockResolvedValue(
+              JSON.stringify(
+                createMockSpecGenSdkArtifactInfo({
+                  labelAction: true,
+                  language: "azure-sdk-for-js",
+                  prNumber: "123",
+                }),
+              ),
+            ),
+          });
+
+        const result = await getLabelAndAction({
+          github: mockGithub,
+          context: mockContext,
+          core: mockCore,
+        });
+
+        expect(result.labelAction).toBe(LabelAction.Add);
+      },
+    );
+    it("should suppress the label action for other target branches", async () => {
+      const mockInputs = {
+        details_url: "https://dev.azure.com/project/_build/results?buildId=12345",
+      };
+      const { extractInputs } = await import("../src/context.js");
+      /** @type {import("vitest").Mock} */ (extractInputs).mockResolvedValue(mockInputs);
+      mockGithub.rest.pulls.get.mockResolvedValue({
+        data: { base: { ref: "release-feature" } },
+      });
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: vi.fn().mockResolvedValue({
+            resource: { downloadUrl: "https://dev.azure.com/download?format=zip" },
+          }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          text: vi.fn().mockResolvedValue(
+            JSON.stringify(
+              createMockSpecGenSdkArtifactInfo({
+                labelAction: true,
+                language: "azure-sdk-for-js",
+                prNumber: "123",
+              }),
+            ),
+          ),
+        });
+
+      const result = await getLabelAndAction({
+        github: mockGithub,
+        context: mockContext,
+        core: mockCore,
+      });
+
+      expect(result.labelAction).toBe(LabelAction.None);
+    });
+    it("should retain labelAction Remove without checking the target branch", async () => {
       // Setup inputs
       const inputs = {
         details_url: "https://dev.azure.com/project/_build/results?buildId=12345",
@@ -157,6 +242,7 @@ describe("sdk-breaking-change-labels", () => {
         labelAction: LabelAction.Remove,
         issueNumber: 123,
       });
+      expect(mockGithub.rest.pulls.get).not.toHaveBeenCalled();
     });
     it("should correctly set labelAction to none when label name is empty", async () => {
       // Setup inputs


### PR DESCRIPTION
## Summary
- restrict SDK breaking-change label additions to PRs targeting `main` or `RPSaaSMaster`
- skip additions for unsupported target branches while preserving existing label-removal behavior
- add unit coverage for supported, unsupported, and removal scenarios

## Testing
- `npm --prefix .github run test -- workflows/test/sdk-breaking-change-labels.test.js --run`