### PR TITLE
[Review] DeviceRegistry 2026-11 — session public changes (single-commit aggregate)

### DIFF
--- a/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/jobRuns.tsp
+++ b/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/jobRuns.tsp
@@ -30,6 +30,12 @@ model JobRun is ProxyResource<JobRunProperties> {
 }
 
 @added(Versions.v2026_11_02_preview)
+@doc("Defines the error details for a job run.")
+model JobRunError {
+  ...Error;
+}
+
+@added(Versions.v2026_11_02_preview)
 @doc("The job run properties.")
 model JobRunProperties {
   @doc("Globally unique, immutable, non-reusable ID.")
@@ -43,6 +49,10 @@ model JobRunProperties {
   @doc("The reason the run was canceled. Present only when status is Canceled.")
   @visibility(Lifecycle.Read)
   cancellationReason?: JobRunCancellationReason;
+
+  @doc("The error details explaining why the job run failed. Present only when status is Failed.")
+  @visibility(Lifecycle.Read)
+  error?: JobRunError;
 
   @doc("The scheduled time for the job run.")
   @visibility(Lifecycle.Create, Lifecycle.Read)
@@ -68,9 +78,6 @@ union JobRunStatus {
 
   @doc("The job run is scheduled.")
   Scheduled: "Scheduled",
-
-  @doc("The job run is queued for dispatch and is consuming concurrency quota.")
-  Queued: "Queued",
 
   @doc("The job run is actively executing.")
   Active: "Active",

--- a/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/namespaces.tsp
+++ b/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/namespaces.tsp
@@ -25,7 +25,13 @@ model Namespace is TrackedResource<NamespaceProperties> {
   @maxLength(64)
   name: string;
 
-  ...ManagedSystemAssignedIdentityProperty;
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "Explicit identity property required for @typeChangedFrom versioning"
+  @doc("The managed service identities assigned to this resource.")
+  @typeChangedFrom(
+    Versions.v2026_11_01,
+    Azure.ResourceManager.CommonTypes.SystemAssignedServiceIdentity
+  )
+  identity?: Azure.ResourceManager.CommonTypes.ManagedServiceIdentity;
 }
 
 @added(Versions.v2025_07_01_preview)

--- a/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/preview/2026-11-02-preview/deviceregistry.json
+++ b/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/preview/2026-11-02-preview/deviceregistry.json
@@ -9641,7 +9641,8 @@
       "description": "Defines the schema format.",
       "enum": [
         "JsonSchema/draft-07",
-        "Delta/1.0"
+        "Delta/1.0",
+        "JsonLD/1.1"
       ],
       "x-ms-enum": {
         "name": "Format",
@@ -9656,6 +9657,11 @@
             "name": "Delta_1_0",
             "value": "Delta/1.0",
             "description": "Delta format"
+          },
+          {
+            "name": "JsonLD_1_1",
+            "value": "JsonLD/1.1",
+            "description": "W3C Web of Things JSON-LD format"
           }
         ]
       }
@@ -10683,6 +10689,31 @@
         ]
       }
     },
+    "JobRunError": {
+      "type": "object",
+      "description": "Defines the error details for a job run.",
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "Error code for classification of errors (ex: '400', '404', '500', etc.).",
+          "readOnly": true
+        },
+        "message": {
+          "type": "string",
+          "description": "Human-readable helpful error message to provide additional context for error (e.g.,: “Capability ID 'foo' does not exist”).",
+          "readOnly": true
+        },
+        "details": {
+          "type": "array",
+          "description": "Array of error details that describe the status of each error.",
+          "items": {
+            "$ref": "#/definitions/ErrorDetails"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": []
+        }
+      }
+    },
     "JobRunListResult": {
       "type": "object",
       "description": "The response of a JobRun list operation.",
@@ -10721,6 +10752,11 @@
         "cancellationReason": {
           "$ref": "#/definitions/JobRunCancellationReason",
           "description": "The reason the run was canceled. Present only when status is Canceled.",
+          "readOnly": true
+        },
+        "error": {
+          "$ref": "#/definitions/JobRunError",
+          "description": "The error details explaining why the job run failed. Present only when status is Failed.",
           "readOnly": true
         },
         "scheduledTime": {
@@ -10896,7 +10932,6 @@
       "description": "The status of a job run.",
       "enum": [
         "Scheduled",
-        "Queued",
         "Active",
         "Succeeded",
         "Failed",
@@ -10911,11 +10946,6 @@
             "name": "Scheduled",
             "value": "Scheduled",
             "description": "The job run is scheduled."
-          },
-          {
-            "name": "Queued",
-            "value": "Queued",
-            "description": "The job run is queued for dispatch and is consuming concurrency quota."
           },
           {
             "name": "Active",
@@ -11537,7 +11567,7 @@
           "x-ms-client-flatten": true
         },
         "identity": {
-          "$ref": "../../../../../../common-types/resource-management/v5/managedidentity.json#/definitions/SystemAssignedServiceIdentity",
+          "$ref": "../../../../../../common-types/resource-management/v5/managedidentity.json#/definitions/ManagedServiceIdentity",
           "description": "The managed service identities assigned to this resource."
         }
       },
@@ -13592,7 +13622,7 @@
       "description": "The type used for update operations of the Namespace.",
       "properties": {
         "identity": {
-          "$ref": "../../../../../../common-types/resource-management/v5/managedidentity.json#/definitions/SystemAssignedServiceIdentity",
+          "$ref": "../../../../../../common-types/resource-management/v5/managedidentity.json#/definitions/ManagedServiceIdentity",
           "description": "The managed service identities assigned to this resource."
         },
         "tags": {
@@ -14569,7 +14599,7 @@
           "x-ms-client-flatten": true
         },
         "identity": {
-          "$ref": "../../../../../../common-types/resource-management/v5/managedidentity.json#/definitions/SystemAssignedServiceIdentity",
+          "$ref": "../../../../../../common-types/resource-management/v5/managedidentity.json#/definitions/ManagedServiceIdentity",
           "description": "The managed service identities assigned to this resource."
         }
       },
@@ -14655,7 +14685,7 @@
       "description": "The type used for update operations of the SchemaRegistry.",
       "properties": {
         "identity": {
-          "$ref": "../../../../../../common-types/resource-management/v5/managedidentity.json#/definitions/SystemAssignedServiceIdentity",
+          "$ref": "../../../../../../common-types/resource-management/v5/managedidentity.json#/definitions/ManagedServiceIdentity",
           "description": "The managed service identities assigned to this resource."
         },
         "tags": {
@@ -14694,7 +14724,9 @@
       "type": "string",
       "description": "Defines the schema type.",
       "enum": [
-        "MessageSchema"
+        "MessageSchema",
+        "ThingModel",
+        "ThingDescription"
       ],
       "x-ms-enum": {
         "name": "SchemaType",
@@ -14704,6 +14736,16 @@
             "name": "MessageSchema",
             "value": "MessageSchema",
             "description": "Message Schema schema type"
+          },
+          {
+            "name": "ThingModel",
+            "value": "ThingModel",
+            "description": "W3C Web of Things Thing Model document"
+          },
+          {
+            "name": "ThingDescription",
+            "value": "ThingDescription",
+            "description": "W3C Web of Things Thing Description document"
           }
         ]
       }

--- a/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/schemaRegistries.tsp
+++ b/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/schemaRegistries.tsp
@@ -26,7 +26,13 @@ model SchemaRegistry is TrackedResource<SchemaRegistryProperties> {
   @maxLength(64)
   name: string;
 
-  ...ManagedSystemAssignedIdentityProperty;
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "Explicit identity property required for @typeChangedFrom versioning"
+  @doc("The managed service identities assigned to this resource.")
+  @typeChangedFrom(
+    Versions.v2026_11_01,
+    Azure.ResourceManager.CommonTypes.SystemAssignedServiceIdentity
+  )
+  identity?: Azure.ResourceManager.CommonTypes.ManagedServiceIdentity;
 }
 
 @added(Versions.v2024_09_01_preview)
@@ -124,6 +130,10 @@ union Format {
   @doc("Delta format")
   Delta_1_0: "Delta/1.0",
 
+  @added(Versions.v2026_11_01)
+  @doc("W3C Web of Things JSON-LD format")
+  JsonLD_1_1: "JsonLD/1.1",
+
   string,
 }
 
@@ -134,6 +144,14 @@ union Format {
 union SchemaType {
   @doc("Message Schema schema type")
   MessageSchema: "MessageSchema",
+
+  @added(Versions.v2026_11_01)
+  @doc("W3C Web of Things Thing Model document")
+  ThingModel: "ThingModel",
+
+  @added(Versions.v2026_11_01)
+  @doc("W3C Web of Things Thing Description document")
+  ThingDescription: "ThingDescription",
 
   string,
 }

--- a/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/stable/2026-11-01/deviceregistry.json
+++ b/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/stable/2026-11-01/deviceregistry.json
@@ -6891,7 +6891,8 @@
       "description": "Defines the schema format.",
       "enum": [
         "JsonSchema/draft-07",
-        "Delta/1.0"
+        "Delta/1.0",
+        "JsonLD/1.1"
       ],
       "x-ms-enum": {
         "name": "Format",
@@ -6906,6 +6907,11 @@
             "name": "Delta_1_0",
             "value": "Delta/1.0",
             "description": "Delta format"
+          },
+          {
+            "name": "JsonLD_1_1",
+            "value": "JsonLD/1.1",
+            "description": "W3C Web of Things JSON-LD format"
           }
         ]
       }
@@ -7698,7 +7704,7 @@
           "x-ms-client-flatten": true
         },
         "identity": {
-          "$ref": "../../../../../../common-types/resource-management/v5/managedidentity.json#/definitions/SystemAssignedServiceIdentity",
+          "$ref": "../../../../../../common-types/resource-management/v5/managedidentity.json#/definitions/ManagedServiceIdentity",
           "description": "The managed service identities assigned to this resource."
         }
       },
@@ -9728,7 +9734,7 @@
       "description": "The type used for update operations of the Namespace.",
       "properties": {
         "identity": {
-          "$ref": "../../../../../../common-types/resource-management/v5/managedidentity.json#/definitions/SystemAssignedServiceIdentity",
+          "$ref": "../../../../../../common-types/resource-management/v5/managedidentity.json#/definitions/ManagedServiceIdentity",
           "description": "The managed service identities assigned to this resource."
         },
         "tags": {
@@ -10225,7 +10231,7 @@
           "x-ms-client-flatten": true
         },
         "identity": {
-          "$ref": "../../../../../../common-types/resource-management/v5/managedidentity.json#/definitions/SystemAssignedServiceIdentity",
+          "$ref": "../../../../../../common-types/resource-management/v5/managedidentity.json#/definitions/ManagedServiceIdentity",
           "description": "The managed service identities assigned to this resource."
         }
       },
@@ -10311,7 +10317,7 @@
       "description": "The type used for update operations of the SchemaRegistry.",
       "properties": {
         "identity": {
-          "$ref": "../../../../../../common-types/resource-management/v5/managedidentity.json#/definitions/SystemAssignedServiceIdentity",
+          "$ref": "../../../../../../common-types/resource-management/v5/managedidentity.json#/definitions/ManagedServiceIdentity",
           "description": "The managed service identities assigned to this resource."
         },
         "tags": {
@@ -10350,7 +10356,9 @@
       "type": "string",
       "description": "Defines the schema type.",
       "enum": [
-        "MessageSchema"
+        "MessageSchema",
+        "ThingModel",
+        "ThingDescription"
       ],
       "x-ms-enum": {
         "name": "SchemaType",
@@ -10360,6 +10368,16 @@
             "name": "MessageSchema",
             "value": "MessageSchema",
             "description": "Message Schema schema type"
+          },
+          {
+            "name": "ThingModel",
+            "value": "ThingModel",
+            "description": "W3C Web of Things Thing Model document"
+          },
+          {
+            "name": "ThingDescription",
+            "value": "ThingDescription",
+            "description": "W3C Web of Things Thing Description document"
           }
         ]
       }


### PR DESCRIPTION
## Review aggregate — not for merge

Single-commit view of **all changes this session made to the public DeviceRegistry 2026-11 specs**, for easy review. Base is the pre-change point (`71ba0504`); the real changes are already in **PR #45288** (branch `adr-vnext-specs-v2`).

### Contents (control plane, 2026-11 only)
| # | Change | Versions |
|---|---|---|
| 1 | `Namespace` & `SchemaRegistry` identity -> `ManagedServiceIdentity` (system+user) via `@typeChangedFrom` | 2026-11-01 + 2026-11-02-preview (GA/earlier unchanged) |
| 2 | Remove `Queued` from `JobRunStatus` | 2026-11-02-preview |
| 3 | `Format` += `JsonLD/1.1`; `SchemaType` += `ThingModel`, `ThingDescription` | 2026-11-01 + 2026-11-02-preview |
| 4 | Add `JobRunError` + `JobRunProperties.error` | 2026-11-02-preview |

Only the `stable/2026-11-01` and `preview/2026-11-02-preview` swaggers change. TypeSpec compiles cleanly (0 warnings) and repo validation passes.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
