### PR TITLE
[Container Apps] Preserve Java private endpoint collection association

### DIFF
--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/tspconfig.yaml
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/tspconfig.yaml
@@ -28,6 +28,8 @@ options:
     resource-collection-associations:
       - resource: Certificate
         collection: ConnectedEnvironmentsCertificates
+      - resource: PrivateEndpointConnection
+        collection: ManagedEnvironmentPrivateEndpointConnections
     rename-model:
       OpenIdConnectClientCredentialMethod: ClientCredentialMethod
   "@azure-tools/typespec-ts":


### PR DESCRIPTION
## Summary

Preserve `ManagedEnvironmentPrivateEndpointConnections` as the Java fluent collection for `PrivateEndpointConnection`.

The 2026-07-01 API adds Container App private endpoint operations. Without an explicit association, Java moves `define`, by-ID methods, and `withExistingManagedEnvironment` away from the collection used by the released GA SDK.

## Validation

`npx tsp compile specification\app\resource-manager\Microsoft.App\ContainerApps --warn-as-error`
