### PR TITLE
Prefix Service Networking private link resource names

### DIFF
--- a/specification/servicenetworking/resource-manager/Microsoft.ServiceNetworking/ServiceNetworking/client.tsp
+++ b/specification/servicenetworking/resource-manager/Microsoft.ServiceNetworking/ServiceNetworking/client.tsp
@@ -161,6 +161,16 @@ using Microsoft.ServiceNetworking;
 );
 
 @@clientName(
+  PrivateEndpointConnection,
+  "ServiceNetworkingPrivateEndpointConnection",
+  "csharp"
+);
+@@clientName(
+  PrivateLinkResource,
+  "ServiceNetworkingPrivateLinkResource",
+  "csharp"
+);
+@@clientName(
   PublicNetworkAccess,
   "TrafficControllerPublicNetworkAccess",
   "csharp"


### PR DESCRIPTION
## Summary
- prefix the Service Networking private endpoint connection resource family for C#
- prefix the Service Networking private link resource family for C#

## Related SDK review
- Azure/azure-sdk-for-net#62517
- https://github.com/Azure/azure-sdk-for-net/pull/62517#discussion_r3920554070
- https://github.com/Azure/azure-sdk-for-net/pull/62517#discussion_r3920554680
- https://github.com/Azure/azure-sdk-for-net/pull/62517#discussion_r3920557867

## Validation
- `git diff --check`
- TypeSpec no-emit validation attempted; local dependencies are stale (`@typespec/compiler` 1.12.0) and do not contain the configured `client-sdk` ruleset. SDK generation will validate with the SDK repository's pinned toolchain.