### PR TITLE
Fix C# name for ContainerGroup update model

### DIFF
--- a/specification/containerinstance/resource-manager/Microsoft.ContainerInstance/ContainerInstance/client.tsp
+++ b/specification/containerinstance/resource-manager/Microsoft.ContainerInstance/ContainerInstance/client.tsp
@@ -377,6 +377,7 @@ using Microsoft.ContainerInstance;
 @@clientName(ContainerGroups.listLogs, "GetContainerLogs", "csharp");
 
 @@clientName(ContainerGroupUpdate, "Resource", "!autorest");
+@@clientName(ContainerGroupUpdate, "ContainerGroupPatch", "csharp");
 
 // Category D: Property renames for backward compat
 @@clientName(AzureFileVolume.readOnly, "IsReadOnly", "csharp");


### PR DESCRIPTION
## Summary

- preserve the existing .NET SDK name `ContainerGroupPatch` for `ContainerGroupUpdate`
- scope the rename to C# with `@@clientName`
- fix the ApiCompat break in Azure/azure-sdk-for-net#60891

## Validation

- regenerated `Azure.ResourceManager.ContainerInstance` from this local spec change
- package build and ApiCompat pass
- TypeSpec formatting passes
- .NET 8 playback tests pass