### PR TITLE
Add C# provisioning emitter configuration for Event Grid

### DIFF
--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/client.tsp
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/client.tsp
@@ -133,6 +133,19 @@ union PrivateEndpointConnectionsParentTypeCsharp {
 @@clientName(RetryPolicy, "EventSubscriptionRetryPolicy", "csharp");
 @@clientName(EventType, "EventTypeUnderTopic", "csharp");
 @@clientName(Microsoft.EventGrid.Topic, "EventGridTopic", "csharp");
+#suppress "@azure-tools/typespec-client-generator-core/client-option" "RBAC roles for provisioning"
+#suppress "@azure-tools/typespec-client-generator-core/client-option-requires-scope" "RBAC roles for provisioning"
+@@clientOption(
+  Microsoft.EventGrid.Topic,
+  "resource-rbac-roles",
+  #{
+    EventGridContributor: "1e241071-0855-49ea-94dc-649edcd759de",
+    EventGridDataSender: "d5a91429-5739-47e2-a06b-3470a27159e7",
+    EventGridEventSubscriptionContributor: "428e0ff0-5e57-4d9c-a221-2c70d0e0a443",
+    EventGridEventSubscriptionReader: "2414bbcf-6497-4faf-8c65-045460748405",
+  },
+  "csharp"
+);
 @@clientName(
   TopicProvisioningState,
   "EventGridTopicProvisioningState",

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/client.tsp
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/client.tsp
@@ -450,7 +450,15 @@ union PrivateEndpointConnectionsParentTypeCsharp {
   Azure.ResourceManager.Foundations.ExtendedLocation,
   "csharp"
 );
+@@alternateType(CustomDomainConfiguration.certificateUrl, url, "csharp");
+@@alternateType(InlineEventProperties.documentationUrl, url, "csharp");
+@@alternateType(InlineEventProperties.dataSchemaUrl, url, "csharp");
 @@alternateType(IssuerCertificateInfo.certificateUrl, url, "csharp");
+@@alternateType(
+  PartnerTopicInfo.azureSubscriptionId,
+  Azure.Core.uuid,
+  "csharp"
+);
 @@alternateType(
   EventSubscriptionsOperationGroup.listRegionalBySubscription::parameters.location,
   Azure.Core.azureLocation,

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/models.tsp
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/models.tsp
@@ -5508,6 +5508,12 @@ model WebhookPartnerDestinationInfo extends PartnerDestinationInfo {
   properties?: WebhookPartnerDestinationProperties;
 
   /**
+   * Change history of the resource move.
+   */
+  #suppress "@azure-tools/typespec-azure-resource-manager/missing-x-ms-identifiers" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+  resourceMoveChangeHistory?: ResourceMoveChangeHistory[];
+
+  /**
    * Type of the endpoint for the partner destination
    */
   endpointType: "WebHook";

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/models.tsp
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/models.tsp
@@ -5508,12 +5508,6 @@ model WebhookPartnerDestinationInfo extends PartnerDestinationInfo {
   properties?: WebhookPartnerDestinationProperties;
 
   /**
-   * Change history of the resource move.
-   */
-  #suppress "@azure-tools/typespec-azure-resource-manager/missing-x-ms-identifiers" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
-  resourceMoveChangeHistory?: ResourceMoveChangeHistory[];
-
-  /**
    * Type of the endpoint for the partner destination
    */
   endpointType: "WebHook";

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2025-11-15-preview/EventGrid.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2025-11-15-preview/EventGrid.json
@@ -20317,13 +20317,6 @@
           "$ref": "#/definitions/WebhookPartnerDestinationProperties",
           "description": "WebHook Properties of the partner destination.",
           "x-ms-client-flatten": true
-        },
-        "resourceMoveChangeHistory": {
-          "type": "array",
-          "description": "Change history of the resource move.",
-          "items": {
-            "$ref": "#/definitions/ResourceMoveChangeHistory"
-          }
         }
       },
       "allOf": [

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2025-11-15-preview/EventGrid.json
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/preview/2025-11-15-preview/EventGrid.json
@@ -20317,6 +20317,13 @@
           "$ref": "#/definitions/WebhookPartnerDestinationProperties",
           "description": "WebHook Properties of the partner destination.",
           "x-ms-client-flatten": true
+        },
+        "resourceMoveChangeHistory": {
+          "type": "array",
+          "description": "Change history of the resource move.",
+          "items": {
+            "$ref": "#/definitions/ResourceMoveChangeHistory"
+          }
         }
       },
       "allOf": [

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/tspconfig.yaml
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/tspconfig.yaml
@@ -49,7 +49,7 @@ options:
     enable-wire-path-attribute: true
   "@azure-typespec/http-client-csharp-provisioning":
     namespace: "Azure.Provisioning.EventGrid"
-    emitter-output-dir: "{project-root}/Azure.Provisioning.EventGrid"
+    emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
     api-version: "2025-11-15-preview"
 linter:
   extends:

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/tspconfig.yaml
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/tspconfig.yaml
@@ -47,6 +47,10 @@ options:
     namespace: "{package-name}"
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
     enable-wire-path-attribute: true
+  "@azure-typespec/http-client-csharp-provisioning":
+    namespace: "Azure.Provisioning.EventGrid"
+    emitter-output-dir: "{project-root}/Azure.Provisioning.EventGrid"
+    api-version: "2025-11-15-preview"
 linter:
   extends:
     - "@azure-tools/typespec-azure-rulesets/resource-manager"


### PR DESCRIPTION
Adds the C# provisioning emitter configuration for `Azure.Provisioning.EventGrid` using API version `2025-11-15-preview`.

Related SDK PR: https://github.com/Azure/azure-sdk-for-net/pull/62685