### PR TITLE
Add structured input query parameter for voice agents

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -3260,6 +3260,16 @@
             "explode": false
           },
           {
+            "name": "structured_input",
+            "in": "query",
+            "required": false,
+            "description": "Per-session values for the voice agent's declared `structured_inputs`, serialized as a JSON object and\nURL-encoded as this query parameter. Supplied values override definition defaults when rendering the\nagent's instructions and session-start greeting for this session only. The decoded value must be a JSON\nobject no larger than 32 KiB with a maximum nesting depth of 16.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
             "name": "x-agent-version-override",
             "in": "query",
             "required": false,

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -2191,6 +2191,17 @@ paths:
           schema:
             type: boolean
           explode: false
+        - name: structured_input
+          in: query
+          required: false
+          description: |-
+            Per-session values for the voice agent's declared `structured_inputs`, serialized as a JSON object and
+            URL-encoded as this query parameter. Supplied values override definition defaults when rendering the
+            agent's instructions and session-start greeting for this session only. The decoded value must be a JSON
+            object no larger than 32 KiB with a maximum nesting depth of 16.
+          schema:
+            type: string
+          explode: false
         - name: x-agent-version-override
           in: query
           required: false

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -3266,6 +3266,16 @@
             "explode": false
           },
           {
+            "name": "structured_input",
+            "in": "query",
+            "required": false,
+            "description": "Per-session values for the voice agent's declared `structured_inputs`, serialized as a JSON object and\nURL-encoded as this query parameter. Supplied values override definition defaults when rendering the\nagent's instructions and session-start greeting for this session only. The decoded value must be a JSON\nobject no larger than 32 KiB with a maximum nesting depth of 16.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
             "name": "x-agent-version-override",
             "in": "query",
             "required": false,

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -2193,6 +2193,17 @@ paths:
           schema:
             type: boolean
           explode: false
+        - name: structured_input
+          in: query
+          required: false
+          description: |-
+            Per-session values for the voice agent's declared `structured_inputs`, serialized as a JSON object and
+            URL-encoded as this query parameter. Supplied values override definition defaults when rendering the
+            agent's instructions and session-start greeting for this session only. The decoded value must be a JSON
+            object no larger than 32 KiB with a maximum nesting depth of 16.
+          schema:
+            type: string
+          explode: false
         - name: x-agent-version-override
           in: query
           required: false

--- a/specification/ai-foundry/data-plane/Foundry/src/voice-agents/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/voice-agents/routes.tsp
@@ -89,6 +89,14 @@ interface VoiceAgentWebSocket {
        */
       @query store?: boolean;
 
+      /**
+       * Per-session values for the voice agent's declared `structured_inputs`, serialized as a JSON object and
+       * URL-encoded as this query parameter. Supplied values override definition defaults when rendering the
+       * agent's instructions and session-start greeting for this session only. The decoded value must be a JSON
+       * object no larger than 32 KiB with a maximum nesting depth of 16.
+       */
+      @query structured_input?: string;
+
       /** Selects a specific version of the voice agent for this session. */
       @query("x-agent-version-override") agent_version_override?: string;
 


### PR DESCRIPTION
# Data Plane API Specification Update Pull Request

Adds the per-session `structured_input` query parameter to the Voice Agent WebSocket connection so callers can provide a URL-encoded JSON object for instruction and greeting template rendering.

This is a focused child PR for #45852.

## API Info: The Basics

Is this review for:

- [ ] a private preview
- [x] a public preview
- [ ] GA release

### Change Scope

- **Updated path:** `GET /agents/{agent_name}/endpoint/protocols/voice`
- **TypeSpec project:** `specification/ai-foundry/data-plane/Foundry`

## Changes

- Adds optional `structured_input?: string` to the Voice Agent WebSocket handshake.
- Documents JSON serialization, URL encoding, session-only override behavior, and validation limits.
- Regenerates the v1 and virtual-public-preview OpenAPI JSON and YAML artifacts.

## Validation

- TypeSpec 1.15 compilation passed with `--no-emit --warn-as-error`.
- TypeSpec formatting check passed.
- Generated v1 and virtual-public-preview JSON/YAML files parse successfully and expose exactly one optional string query parameter named `structured_input`.
- `git diff --check` passed.
