### PR TITLE
Correct DevTest Labs Formula credential contract

### DIFF
--- a/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/DevTestLabs/models.tsp
+++ b/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/DevTestLabs/models.tsp
@@ -1521,6 +1521,19 @@ model CustomImageFragment extends UpdateResource {}
 model FormulaList is Azure.Core.Page<Formula>;
 
 /**
+ * The configured credential state of a formula.
+ */
+union FormulaCredentialState {
+  string,
+  /** No credential is configured. */
+  NotConfigured: "NotConfigured",
+  /** A password credential is configured. */
+  PasswordConfigured: "PasswordConfigured",
+  /** An SSH key credential is configured. */
+  SshKeyConfigured: "SshKeyConfigured",
+}
+
+/**
  * Properties of a formula.
  */
 model FormulaProperties {
@@ -1551,6 +1564,12 @@ model FormulaProperties {
    * The content of the formula.
    */
   formulaContent?: LabVirtualMachineCreationParameter;
+
+  /**
+   * The configured credential state of the formula. This property does not expose the credential value or storage mechanism.
+   */
+  @visibility(Lifecycle.Read)
+  credentialState?: FormulaCredentialState;
 
   /**
    * Information about a VM from which a formula is to be created.
@@ -1647,13 +1666,15 @@ model LabVirtualMachineCreationParameterProperties {
   /**
    * The password of the virtual machine administrator.
    */
-  #suppress "@azure-tools/typespec-azure-resource-manager/secret-prop" "TODO: Check if this is a secret and add @secret or update reason"
+  @secret
+  @visibility(Lifecycle.Create, Lifecycle.Update)
   password?: string;
 
   /**
    * The SSH key of the virtual machine administrator.
    */
-  #suppress "@azure-tools/typespec-azure-resource-manager/secret-prop" "TODO: Check if this is a secret and add @secret or update reason"
+  @secret
+  @visibility(Lifecycle.Create, Lifecycle.Update)
   sshKey?: string;
 
   /**

--- a/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/DevTestLabs/models.tsp
+++ b/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/DevTestLabs/models.tsp
@@ -1525,10 +1525,13 @@ model FormulaList is Azure.Core.Page<Formula>;
  */
 union FormulaCredentialState {
   string,
+
   /** No credential is configured. */
   NotConfigured: "NotConfigured",
+
   /** A password credential is configured. */
   PasswordConfigured: "PasswordConfigured",
+
   /** An SSH key credential is configured. */
   SshKeyConfigured: "SshKeyConfigured",
 }

--- a/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/DevTestLabs/stable/2018-09-15/DTL.json
+++ b/specification/devtestlabs/resource-manager/Microsoft.DevTestLab/DevTestLabs/stable/2018-09-15/DTL.json
@@ -10514,6 +10514,36 @@
         }
       ]
     },
+    "FormulaCredentialState": {
+      "type": "string",
+      "description": "The configured credential state of a formula.",
+      "enum": [
+        "NotConfigured",
+        "PasswordConfigured",
+        "SshKeyConfigured"
+      ],
+      "x-ms-enum": {
+        "name": "FormulaCredentialState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "NotConfigured",
+            "value": "NotConfigured",
+            "description": "No credential is configured."
+          },
+          {
+            "name": "PasswordConfigured",
+            "value": "PasswordConfigured",
+            "description": "A password credential is configured."
+          },
+          {
+            "name": "SshKeyConfigured",
+            "value": "SshKeyConfigured",
+            "description": "An SSH key credential is configured."
+          }
+        ]
+      }
+    },
     "FormulaFragment": {
       "type": "object",
       "description": "A formula for creating a VM, specifying an image base and other parameters",
@@ -10570,6 +10600,11 @@
         "formulaContent": {
           "$ref": "#/definitions/LabVirtualMachineCreationParameter",
           "description": "The content of the formula."
+        },
+        "credentialState": {
+          "$ref": "#/definitions/FormulaCredentialState",
+          "description": "The configured credential state of the formula. This property does not expose the credential value or storage mechanism.",
+          "readOnly": true
         },
         "vm": {
           "$ref": "#/definitions/FormulaPropertiesFromVm",
@@ -11652,11 +11687,23 @@
         },
         "password": {
           "type": "string",
-          "description": "The password of the virtual machine administrator."
+          "format": "password",
+          "description": "The password of the virtual machine administrator.",
+          "x-ms-mutability": [
+            "update",
+            "create"
+          ],
+          "x-ms-secret": true
         },
         "sshKey": {
           "type": "string",
-          "description": "The SSH key of the virtual machine administrator."
+          "format": "password",
+          "description": "The SSH key of the virtual machine administrator.",
+          "x-ms-mutability": [
+            "update",
+            "create"
+          ],
+          "x-ms-secret": true
         },
         "isAuthenticationWithSshKey": {
           "type": "boolean",


### PR DESCRIPTION
# ARM (Control Plane) API Specification Update Pull Request

## Purpose of this PR

- [ ] New resource provider.
- [ ] New API version for an existing resource provider.
- [ ] Update existing version for a new feature.
- [ ] Update existing version to fix OpenAPI spec quality issues in S360.
- [ ] Convert existing OpenAPI spec to TypeSpec spec.
- [x] Other, please clarify:
  - Correct the existing DevTest Labs Formula credential contract under breaking-change review. This does not introduce a new API version.

## Change summary

- Mark nested Formula VM administrator `password` and `sshKey` properties as secret and create/update-only.
- Add optional read-only, extensible `credentialState` output with `NotConfigured`, `PasswordConfigured`, and `SshKeyConfigured` values.
- Include the TypeSpec source and generated `2018-09-15` OpenAPI output.

The service implementation needs to stop returning literal Formula credential values through Formula responses across every Formula-capable existing API version. Restricting this behavior to a new API version would leave the prior response behavior available through older versions.

## API review decisions requested

1. Approve removal of literal Formula `password` and `sshKey` values from responses for every Formula-capable existing API version.
2. Confirm whether optional read-only `credentialState` may be returned through those existing versions, or must be restricted to a new API version.
3. Confirm how runtime versions not currently represented in this public TypeSpec tree should be documented: `2017-04-26-preview`, `2018-10-15-preview`, and `2021-09-01`.
4. Apply the appropriate authorized breaking-change approval label after review. The service team will not self-apply an approval label.

## Customer compatibility

- Generated SDK and CLI models tolerate an omitted optional credential value, but automation that reads the returned value must stop relying on credential readback.
- The Azure Portal is being updated with coordinated Keep/Replace semantics so unrelated Formula edits do not erase a hidden credential.
- GET-modify-PUT callers are protected by preserve-on-omission behavior in the coordinated service implementation.
- Valid Lab Secret and User Secret references remain opaque references; secret values are not returned.

Affected automation should treat Formula credentials as write-only: supply or replace them explicitly when needed, and omit credential fields when updating unrelated Formula properties.

## Validation

- TypeSpec compiler `1.15.0`: passed.
- Generated OpenAPI is committed with the TypeSpec source.
- Generated delta is limited to `credentialState`, `x-ms-secret`, and create/update `x-ms-mutability` for the credential fields.

## Due diligence checklist

- [x] I confirm this PR is modifying Azure Resource Manager specifications, not data plane specifications.
- [x] I have completed review of the Resource Provider, ARM contract, and REST guidelines required by the control-plane PR workflow.
- [ ] A release plan has been created, or the API reviewers have confirmed how the release-plan requirement applies to this existing-version correction.
- [ ] Breaking-change/API Board review is complete.
- [ ] The appropriate `BreakingChange-Approved-*` label has been applied by an authorized reviewer.
- [ ] CPEX classification/readiness tracking has been linked after API Board classification.

## Notes

This draft intentionally contains no restricted incident details or credential values. Authorized reviewers can request the corresponding internal service implementation and security-tracking references through the service team.
