### PR TITLE
Add bypass soft delete query parameter

### DIFF
--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/ComputeGallery/GalleryImageVersion.tsp
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/ComputeGallery/GalleryImageVersion.tsp
@@ -2,10 +2,12 @@ import "@azure-tools/typespec-azure-core";
 import "@azure-tools/typespec-azure-resource-manager";
 import "@typespec/openapi";
 import "@typespec/rest";
+import "@typespec/versioning";
 import "./models.tsp";
 import "./GalleryImage.tsp";
 
 using TypeSpec.Rest;
+using Versioning;
 using Azure.ResourceManager;
 using TypeSpec.Http;
 using TypeSpec.OpenAPI;
@@ -81,6 +83,14 @@ interface GalleryImageVersions {
   #suppress "@azure-tools/typespec-azure-resource-manager/arm-delete-operation-response-codes" "For backward compatibility"
   delete is ComputeResourceDeleteAsync<
     GalleryImageVersion,
+    Parameters = {
+      /**
+       * Specifies whether to bypass the gallery's soft-delete policy and permanently delete the gallery image version. If true, the version is not retained in the recycle bin and cannot be restored. If false or omitted, the version is soft-deleted when the gallery's soft-delete policy is enabled and permanently deleted when the policy is disabled.
+       */
+      @added(Versions.v2026_03_03)
+      @query("bypassSoftDelete")
+      bypassSoftDelete?: boolean;
+    },
     Response =
       | ArmDeletedResponse
       | ArmDeleteAcceptedLroResponse

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/ComputeGallery/examples/2026-03-03/galleryExamples/GalleryImageVersion_Delete_BypassSoftDelete.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/ComputeGallery/examples/2026-03-03/galleryExamples/GalleryImageVersion_Delete_BypassSoftDelete.json
@@ -1,0 +1,23 @@
+{
+  "parameters": {
+    "subscriptionId": "{subscription-id}",
+    "resourceGroupName": "myResourceGroup",
+    "api-version": "2026-03-03",
+    "galleryName": "myGalleryName",
+    "galleryImageName": "myGalleryImageName",
+    "galleryImageVersionName": "1.0.0",
+    "bypassSoftDelete": "true"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/000000-8de3-42e7-b00e-8970003527749a/providers/Microsoft.Compute/locations/westus2/capsOperations/0012b61c-2d36-40bc-b7ed-1f0e48757277?api-version=2022-01-03",
+        "Location": "https://management.azure.com/subscriptions/000000-8de3-42e7-b00e-8970003527749a/providers/Microsoft.Compute/locations/westus2/capsOperations/0012b61c-2d36-40bc-b7ed-1f0e48757277?monitor=true&api-version=2022-01-03"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "GalleryImageVersions_Delete",
+  "title": "Permanently delete a gallery image version by bypassing soft delete."
+}

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2026-03-03/GalleryRP.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2026-03-03/GalleryRP.json
@@ -2969,6 +2969,13 @@
             "description": "The name of the gallery image version to be retrieved.",
             "required": true,
             "type": "string"
+          },
+          {
+            "name": "bypassSoftDelete",
+            "in": "query",
+            "description": "Specifies whether to bypass the gallery's soft-delete policy and permanently delete the gallery image version. If true, the version is not retained in the recycle bin and cannot be restored. If false or omitted, the version is soft-deleted when the gallery's soft-delete policy is enabled and permanently deleted when the policy is disabled.",
+            "required": false,
+            "type": "boolean"
           }
         ],
         "responses": {
@@ -3002,6 +3009,9 @@
         "x-ms-examples": {
           "Delete a gallery image version.": {
             "$ref": "./examples/galleryExamples/GalleryImageVersion_Delete.json"
+          },
+          "Permanently delete a gallery image version by bypassing soft delete.": {
+            "$ref": "./examples/galleryExamples/GalleryImageVersion_Delete_BypassSoftDelete.json"
           }
         },
         "x-ms-long-running-operation-options": {

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2026-03-03/examples/galleryExamples/GalleryImageVersion_Delete_BypassSoftDelete.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2026-03-03/examples/galleryExamples/GalleryImageVersion_Delete_BypassSoftDelete.json
@@ -1,0 +1,23 @@
+{
+  "parameters": {
+    "subscriptionId": "{subscription-id}",
+    "resourceGroupName": "myResourceGroup",
+    "api-version": "2026-03-03",
+    "galleryName": "myGalleryName",
+    "galleryImageName": "myGalleryImageName",
+    "galleryImageVersionName": "1.0.0",
+    "bypassSoftDelete": "true"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/000000-8de3-42e7-b00e-8970003527749a/providers/Microsoft.Compute/locations/westus2/capsOperations/0012b61c-2d36-40bc-b7ed-1f0e48757277?api-version=2022-01-03",
+        "Location": "https://management.azure.com/subscriptions/000000-8de3-42e7-b00e-8970003527749a/providers/Microsoft.Compute/locations/westus2/capsOperations/0012b61c-2d36-40bc-b7ed-1f0e48757277?monitor=true&api-version=2022-01-03"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "GalleryImageVersions_Delete",
+  "title": "Permanently delete a gallery image version by bypassing soft delete."
+}


### PR DESCRIPTION
## Summary

Adds the optional `bypassSoftDelete` query parameter to `GalleryImageVersions_Delete` for API version `2026-03-03`.

## Behavior

| `bypassSoftDelete` | Gallery soft-delete policy | Result |
|---|---|---|
| `true` | Enabled or disabled | Permanently deletes the gallery image version. The version is not retained in the recycle bin and cannot be restored. |
| `false` or omitted | Enabled | Soft-deletes the version. The version is retained in the recycle bin and can be restored during the configured recovery period. |
| `false` or omitted | Disabled | Permanently deletes the version because no soft-delete policy applies. |

## API change

```http
DELETE /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/galleries/{galleryName}/images/{galleryImageName}/versions/{galleryImageVersionName}?api-version=2026-03-03&bypassSoftDelete=true
```

The parameter is optional and has type `boolean`. Setting it to `true` requests irreversible deletion by bypassing recycle-bin retention.

## Compatibility

- The parameter is version-gated with `@added(Versions.v2026_03_03)`.
- Existing behavior is preserved when the parameter is omitted or set to `false`.
- Gallery API versions `2024-03-03`, `2025-03-03`, and `2025-12-03` are unchanged.
- The PR includes the TypeSpec source, generated Swagger, and a dedicated bypass-soft-delete example.

# ARM (Control Plane) API Specification Update Pull Request

## Purpose of this PR

- [ ] New resource provider.
- [x] New API version for an existing resource provider. (If API spec is not defined in TypeSpec, the PR should have been created in adherence to [OpenAPI specs PR creation guidance](https://aka.ms/azsdkdocs/createopenapispec)).
- [ ] Update existing version for a new feature. (This is applicable only when you are revising a private preview API version.)
- [ ] Update existing version to fix OpenAPI spec quality issues in S360.
- [ ] Convert existing [OpenAPI spec to TypeSpec spec](https://aka.ms/typespec/conversion) (do not combine this with implementing changes for a new API version).
- [ ] Other, please clarify.

## Due diligence checklist

- [x] I confirm this PR is modifying Azure Resource Manager (ARM) related specifications, and not data plane related specifications.
- [x] I have reviewed the [Resource Provider guidelines](https://aka.ms/rpguidelines), including the [ARM resource provider contract](https://aka.ms/azurerpc) and [REST guidelines](https://github.com/microsoft/api-guidelines/blob/vNext/azure/Guidelines.md).
- [ ] A [release plan](https://aka.ms/azsdkdocs/release-plans) has been created.

## Additional information

For a convenient view of the API changes, refer to the URLs in the `Generated ApiView` comment on this PR.