### PR TITLE
Use gpt-5.4 for skill evals

### DIFF
--- a/.github/skills/azsdk-common-apiview-feedback-resolution/evals/eval.yaml
+++ b/.github/skills/azsdk-common-apiview-feedback-resolution/evals/eval.yaml
@@ -11,7 +11,7 @@ tags:
 config:
   runs: 1
   timeout: "90s"
-  model: claude-opus-4.6
+  model: gpt-5.4
   executor: copilot-sdk
 
 scoring:

--- a/.github/skills/azsdk-common-apiview-feedback-resolution/evals/trigger.eval.yaml
+++ b/.github/skills/azsdk-common-apiview-feedback-resolution/evals/trigger.eval.yaml
@@ -11,7 +11,7 @@ tags:
 defaults:
   runs: 1
   timeout: "90s"
-  model: claude-opus-4.6
+  model: gpt-5.4
   executor: copilot-sdk
 
 scoring:

--- a/.github/skills/azsdk-common-generate-sdk-locally/evals/eval.yaml
+++ b/.github/skills/azsdk-common-generate-sdk-locally/evals/eval.yaml
@@ -11,7 +11,7 @@ tags:
 config:
   runs: 1
   timeout: "90s"
-  model: claude-opus-4.6
+  model: gpt-5.4
   executor: copilot-sdk
 
 scoring:

--- a/.github/skills/azsdk-common-pipeline-analysis/evals/trigger.eval.yaml
+++ b/.github/skills/azsdk-common-pipeline-analysis/evals/trigger.eval.yaml
@@ -11,7 +11,7 @@ tags:
 defaults:
   runs: 1
   timeout: "90s"
-  model: claude-opus-4.6
+  model: gpt-5.4
   executor: copilot-sdk
 
 scoring:

--- a/.github/skills/azsdk-common-pipeline-fixer/evals/trigger.eval.yaml
+++ b/.github/skills/azsdk-common-pipeline-fixer/evals/trigger.eval.yaml
@@ -15,7 +15,7 @@ defaults:
   # so the per-stimulus cap matches the Vally scenario evals (5m). Non-build-ref
   # routing prompts still complete in ~10-20s.
   timeout: "5m"
-  model: claude-opus-4.6
+  model: gpt-5.4
   executor: copilot-sdk
 
 scoring:

--- a/.github/skills/azsdk-common-prepare-release-plan/evals/eval.yaml
+++ b/.github/skills/azsdk-common-prepare-release-plan/evals/eval.yaml
@@ -11,7 +11,7 @@ tags:
 config:
   runs: 1
   timeout: "90s"
-  model: claude-opus-4.6
+  model: gpt-5.4
   executor: copilot-sdk
 
 scoring:

--- a/.github/skills/azsdk-common-prepare-release-plan/evals/trigger.eval.yaml
+++ b/.github/skills/azsdk-common-prepare-release-plan/evals/trigger.eval.yaml
@@ -11,7 +11,7 @@ tags:
 defaults:
   runs: 1
   timeout: "90s"
-  model: claude-opus-4.6
+  model: gpt-5.4
   executor: copilot-sdk
 
 scoring:

--- a/.github/skills/azsdk-common-sdk-release/evals/eval.yaml
+++ b/.github/skills/azsdk-common-sdk-release/evals/eval.yaml
@@ -11,7 +11,7 @@ tags:
 config:
   runs: 1
   timeout: "90s"
-  model: claude-opus-4.6
+  model: gpt-5.4
   executor: copilot-sdk
 
 scoring:

--- a/.github/skills/azsdk-common-sdk-release/evals/trigger.eval.yaml
+++ b/.github/skills/azsdk-common-sdk-release/evals/trigger.eval.yaml
@@ -11,7 +11,7 @@ tags:
 defaults:
   runs: 1
   timeout: "90s"
-  model: claude-opus-4.6
+  model: gpt-5.4
   executor: copilot-sdk
 
 scoring:

--- a/.github/skills/azure-api-review/evals/eval.yaml
+++ b/.github/skills/azure-api-review/evals/eval.yaml
@@ -11,7 +11,7 @@ tags:
 config:
   runs: 1
   timeout: "90s"
-  model: claude-opus-4.6
+  model: gpt-5.4
   executor: copilot-sdk
 
 scoring:

--- a/.github/skills/azure-api-review/evals/trigger.eval.yaml
+++ b/.github/skills/azure-api-review/evals/trigger.eval.yaml
@@ -11,7 +11,7 @@ tags:
 config:
   runs: 1
   timeout: "90s"
-  model: claude-opus-4.6
+  model: gpt-5.4
   executor: copilot-sdk
 
 scoring:

--- a/.github/skills/azure-ps-design-review/evals/eval.yaml
+++ b/.github/skills/azure-ps-design-review/evals/eval.yaml
@@ -11,7 +11,7 @@ tags:
 config:
   runs: 1
   timeout: "120s"
-  model: claude-opus-4.6
+  model: gpt-5.4
   executor: copilot-sdk
 
 scoring:

--- a/.github/skills/azure-ps-design-review/evals/workflow.eval.yaml
+++ b/.github/skills/azure-ps-design-review/evals/workflow.eval.yaml
@@ -33,7 +33,7 @@ tags:
 config:
   runs: 1
   timeout: "10m"
-  model: claude-opus-4.6
+  model: gpt-5.4
   executor: copilot-sdk
 
 scoring:

--- a/.github/skills/evals/arm-api-reviewer/vally/eval-arm-resource-structure.yaml
+++ b/.github/skills/evals/arm-api-reviewer/vally/eval-arm-resource-structure.yaml
@@ -17,8 +17,8 @@ tags:
 defaults:
   runs: 1
   timeout: "300s"
-  model: claude-opus-4.6
-  judge_model: claude-sonnet-4.6
+  model: gpt-5.4
+  judge_model: gpt-5.4
 
 scoring:
   threshold: 0.7

--- a/.github/skills/evals/arm-api-reviewer/vally/eval-breaking-changes.yaml
+++ b/.github/skills/evals/arm-api-reviewer/vally/eval-breaking-changes.yaml
@@ -18,8 +18,8 @@ tags:
 defaults:
   runs: 1
   timeout: "120s"
-  model: claude-sonnet-4.6
-  judge_model: claude-sonnet-4.6
+  model: gpt-5.4
+  judge_model: gpt-5.4
 
 scoring:
   threshold: 0.7

--- a/.github/skills/evals/arm-api-reviewer/vally/eval-check-name-availability.yaml
+++ b/.github/skills/evals/arm-api-reviewer/vally/eval-check-name-availability.yaml
@@ -18,8 +18,8 @@ tags:
 defaults:
   runs: 1
   timeout: "300s"
-  model: claude-opus-4.6
-  judge_model: claude-sonnet-4.6
+  model: gpt-5.4
+  judge_model: gpt-5.4
 
 scoring:
   threshold: 0.7

--- a/.github/skills/evals/arm-api-reviewer/vally/eval-citation-and-parity.yaml
+++ b/.github/skills/evals/arm-api-reviewer/vally/eval-citation-and-parity.yaml
@@ -29,8 +29,8 @@ tags:
 defaults:
   runs: 1
   timeout: "300s"
-  model: claude-opus-4.6
-  judge_model: claude-sonnet-4.6
+  model: gpt-5.4
+  judge_model: gpt-5.4
 
 scoring:
   threshold: 0.7

--- a/.github/skills/evals/arm-api-reviewer/vally/eval-classification.yaml
+++ b/.github/skills/evals/arm-api-reviewer/vally/eval-classification.yaml
@@ -18,8 +18,8 @@ tags:
 defaults:
   runs: 1
   timeout: "300s"
-  model: claude-opus-4.6
-  judge_model: claude-sonnet-4.6
+  model: gpt-5.4
+  judge_model: gpt-5.4
 
 scoring:
   threshold: 0.7

--- a/.github/skills/evals/arm-api-reviewer/vally/eval-examples.yaml
+++ b/.github/skills/evals/arm-api-reviewer/vally/eval-examples.yaml
@@ -18,8 +18,8 @@ tags:
 defaults:
   runs: 1
   timeout: "120s"
-  model: claude-sonnet-4.6
-  judge_model: claude-sonnet-4.6
+  model: gpt-5.4
+  judge_model: gpt-5.4
 
 scoring:
   threshold: 0.7

--- a/.github/skills/evals/arm-api-reviewer/vally/eval-fast-path-triage.yaml
+++ b/.github/skills/evals/arm-api-reviewer/vally/eval-fast-path-triage.yaml
@@ -22,8 +22,8 @@ tags:
 defaults:
   runs: 1
   timeout: "240s"
-  model: claude-sonnet-4.6
-  judge_model: claude-sonnet-4.6
+  model: gpt-5.4
+  judge_model: gpt-5.4
 
 scoring:
   threshold: 0.7

--- a/.github/skills/evals/arm-api-reviewer/vally/eval-operations.yaml
+++ b/.github/skills/evals/arm-api-reviewer/vally/eval-operations.yaml
@@ -18,8 +18,8 @@ tags:
 defaults:
   runs: 1
   timeout: "300s"
-  model: claude-opus-4.6
-  judge_model: claude-sonnet-4.6
+  model: gpt-5.4
+  judge_model: gpt-5.4
 
 scoring:
   threshold: 0.7

--- a/.github/skills/evals/arm-api-reviewer/vally/eval-pattern-validation.yaml
+++ b/.github/skills/evals/arm-api-reviewer/vally/eval-pattern-validation.yaml
@@ -20,8 +20,8 @@ tags:
 defaults:
   runs: 1
   timeout: "300s"
-  model: claude-opus-4.6
-  judge_model: claude-sonnet-4.6
+  model: gpt-5.4
+  judge_model: gpt-5.4
 
 scoring:
   threshold: 0.7

--- a/.github/skills/evals/arm-api-reviewer/vally/eval-property-design.yaml
+++ b/.github/skills/evals/arm-api-reviewer/vally/eval-property-design.yaml
@@ -18,8 +18,8 @@ tags:
 defaults:
   runs: 1
   timeout: "300s"
-  model: claude-opus-4.6
-  judge_model: claude-sonnet-4.6
+  model: gpt-5.4
+  judge_model: gpt-5.4
 
 scoring:
   threshold: 0.7

--- a/.github/skills/evals/arm-api-reviewer/vally/eval-protocol-safety.yaml
+++ b/.github/skills/evals/arm-api-reviewer/vally/eval-protocol-safety.yaml
@@ -18,8 +18,8 @@ tags:
 defaults:
   runs: 1
   timeout: "240s"
-  model: claude-sonnet-4.6
-  judge_model: claude-sonnet-4.6
+  model: gpt-5.4
+  judge_model: gpt-5.4
 
 scoring:
   threshold: 0.7

--- a/.github/skills/evals/arm-api-reviewer/vally/eval-report-format.yaml
+++ b/.github/skills/evals/arm-api-reviewer/vally/eval-report-format.yaml
@@ -18,8 +18,8 @@ tags:
 defaults:
   runs: 1
   timeout: "300s"
-  model: claude-opus-4.6
-  judge_model: claude-sonnet-4.6
+  model: gpt-5.4
+  judge_model: gpt-5.4
 
 scoring:
   threshold: 0.7

--- a/.github/skills/evals/arm-api-reviewer/vally/eval-suppressions-yaml.yaml
+++ b/.github/skills/evals/arm-api-reviewer/vally/eval-suppressions-yaml.yaml
@@ -22,8 +22,8 @@ tags:
 defaults:
   runs: 1
   timeout: "180s"
-  model: claude-sonnet-4.6
-  judge_model: claude-sonnet-4.6
+  model: gpt-5.4
+  judge_model: gpt-5.4
 
 scoring:
   threshold: 0.7

--- a/.github/skills/evals/arm-api-reviewer/vally/eval-suppressions.yaml
+++ b/.github/skills/evals/arm-api-reviewer/vally/eval-suppressions.yaml
@@ -18,8 +18,8 @@ tags:
 defaults:
   runs: 1
   timeout: "120s"
-  model: claude-sonnet-4.6
-  judge_model: claude-sonnet-4.6
+  model: gpt-5.4
+  judge_model: gpt-5.4
 
 scoring:
   threshold: 0.7

--- a/.github/skills/evals/arm-api-reviewer/vally/eval-true-negatives.yaml
+++ b/.github/skills/evals/arm-api-reviewer/vally/eval-true-negatives.yaml
@@ -18,8 +18,8 @@ tags:
 defaults:
   runs: 1
   timeout: "300s"
-  model: claude-opus-4.6
-  judge_model: claude-sonnet-4.6
+  model: gpt-5.4
+  judge_model: gpt-5.4
 
 scoring:
   threshold: 0.7

--- a/.github/skills/evals/arm-api-reviewer/vally/eval-typespec-required.yaml
+++ b/.github/skills/evals/arm-api-reviewer/vally/eval-typespec-required.yaml
@@ -21,8 +21,8 @@ tags:
 defaults:
   runs: 1
   timeout: "300s"
-  model: claude-opus-4.6
-  judge_model: claude-sonnet-4.6
+  model: gpt-5.4
+  judge_model: gpt-5.4
 
 scoring:
   threshold: 0.7

--- a/.github/skills/evals/arm-api-reviewer/vally/eval-typespec.yaml
+++ b/.github/skills/evals/arm-api-reviewer/vally/eval-typespec.yaml
@@ -19,8 +19,8 @@ tags:
 defaults:
   runs: 1
   timeout: "300s"
-  model: claude-opus-4.6
-  judge_model: claude-sonnet-4.6
+  model: gpt-5.4
+  judge_model: gpt-5.4
 
 scoring:
   threshold: 0.7

--- a/.github/skills/openai-typespec-update/evals/eval.yaml
+++ b/.github/skills/openai-typespec-update/evals/eval.yaml
@@ -11,7 +11,7 @@ tags:
 config:
   runs: 3
   timeout: "90s"
-  model: claude-opus-4.6
+  model: gpt-5.4
   executor: copilot-sdk
 
 scoring:

--- a/.github/skills/openai-typespec-update/evals/trigger.eval.yaml
+++ b/.github/skills/openai-typespec-update/evals/trigger.eval.yaml
@@ -11,7 +11,7 @@ tags:
 config:
   runs: 1
   timeout: "90s"
-  model: claude-opus-4.6
+  model: gpt-5.4
   executor: copilot-sdk
 
 scoring:


### PR DESCRIPTION
## Summary

- replace unavailable `claude-opus-4.6` and `claude-sonnet-4.6` execution models with `gpt-5.4`
- replace the ARM API Reviewer judge model pins with `gpt-5.4`

## Why

The scheduled `azure-rest-api-specs - eval-skills` pipeline fails every eval shard during `session.create` because the pinned Claude models are no longer available. The same pipeline credential successfully runs `gpt-5.4` sessions in the shared workflow eval pipeline.

Failed build: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6776944

## Validation

- parsed all 32 changed YAML files successfully
- verified 49 model pin replacements and no other changed lines
- `git diff --check` passes
