### PR TITLE
Allow Fleet .NET preview SDK generation

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/fleet/tspconfig.yaml
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/fleet/tspconfig.yaml
@@ -27,7 +27,7 @@ options:
   "@azure-typespec/http-client-csharp-mgmt":
     namespace: "Azure.ResourceManager.ContainerServiceFleet"
     emitter-output-dir: "{output-dir}/sdk/fleet/{namespace}"
-    api-version: 2026-06-01
+    api-version: 2026-06-02-preview
     skip-api-version-override: true # this is temporary
   "@azure-tools/typespec-java":
     emitter-output-dir: "{output-dir}/{service-dir}/azure-resourcemanager-containerservicefleet"


### PR DESCRIPTION
Updates the Fleet C# management emitter configuration so .NET generation targets `2026-06-02-preview`.