### PR TITLE
[Event Grid] Add Storage object replication failure system event

### DIFF
--- a/specification/eventgrid/data-plane/EventGridSystemEvents/Microsoft.Storage/Storage.tsp
+++ b/specification/eventgrid/data-plane/EventGridSystemEvents/Microsoft.Storage/Storage.tsp
@@ -1,4 +1,5 @@
 import "@typespec/versioning";
+import "./StorageExamples.tsp";
 using TypeSpec.Versioning;
 /** Describes the schema of the Azure Storage events published to Azure Event Grid. This corresponds to the Data property of an EventGridEvent. */
 namespace Microsoft.EventGrid.SystemEvents {
@@ -371,6 +372,96 @@ namespace Microsoft.EventGrid.SystemEvents {
 
     /** The summary report blob url for a storage task */
     summaryReportBlobUrl: url;
+  }
+
+  /** Schema of the Data property of an EventGridEvent for a Microsoft.Storage.Replication.OperationFailedForReplication event. */
+  @example(StorageOperationFailedForReplicationExample)
+  model StorageOperationFailedForReplicationEventData {
+    /** The name of the source storage API operation that failed to replicate. */
+    api: string;
+
+    /** The source storage event type associated with the replication operation. */
+    eventType: string;
+
+    /** The time at which the source storage event occurred. This property is omitted for bootstrap replication. */
+    timestamp?: utcDateTime;
+
+    /** The version identifier of the source blob. */
+    blobVersion?: string;
+
+    /** The object replication policy identifier. */
+    policyId: string;
+
+    /** The destination blob path, formatted as account/container/blob. */
+    destinationBlob: string;
+
+    /** The reason the replication operation failed. */
+    failureReason: StorageOperationFailedForReplicationReason;
+  }
+
+  /** The reason an object replication operation failed. */
+  union StorageOperationFailedForReplicationReason {
+    string,
+
+    /** The replication failure could not be categorized. */
+    UncategorizedFailure: "UncategorizedFailure",
+
+    /** The destination container has a conflicting object replication policy. */
+    DstContainerPolicyConflict: "DstContainerPolicyConflict",
+
+    /** The destination account was not found. */
+    DstAccountNotFound: "DstAccountNotFound",
+
+    /** The source container was not found. */
+    SrcContainerNotFound: "SrcContainerNotFound",
+
+    /** The destination container was not found. */
+    DstContainerNotFound: "DstContainerNotFound",
+
+    /** The source container is being deleted. */
+    SrcContainerBeingDeleted: "SrcContainerBeingDeleted",
+
+    /** The destination container is being deleted. */
+    DstContainerBeingDeleted: "DstContainerBeingDeleted",
+
+    /** The source blob is archived. */
+    SrcBlobArchived: "SrcBlobArchived",
+
+    /** The destination blob is archived. */
+    DstBlobArchived: "DstBlobArchived",
+
+    /** The source blob was not found. */
+    SrcBlobNotFound: "SrcBlobNotFound",
+
+    /** The destination blob was not found. */
+    DstBlobNotFound: "DstBlobNotFound",
+
+    /** The source blob is encrypted with a customer-provided key. */
+    SrcBlobEncryptedWithCPK: "SrcBlobEncryptedWithCPK",
+
+    /** The destination blob is immutable. */
+    DstBlobImmutable: "DstBlobImmutable",
+
+    /** The destination blob has snapshots. */
+    DstBlobSnapshotsPresent: "DstBlobSnapshotsPresent",
+
+    /** The destination container is leased. */
+    DstContainerLeased: "DstContainerLeased",
+
+    /** The destination blob is leased. */
+    DstBlobLeased: "DstBlobLeased",
+
+    /** The destination directory is not empty. */
+    DstDirectoryNotEmpty: "DstDirectoryNotEmpty",
+
+    /** The source path of the destination rename operation was not found. */
+    DstRenameSourceNotFound: "DstRenameSourceNotFound",
+
+    /** The destination path of the destination rename operation already exists. */
+    DstRenameDestinationAlreadyExists: "DstRenameDestinationAlreadyExists",
+
+    /** The parent of the destination path of the destination rename operation was not found. */
+    DstRenameDestinationParentPathNotFound: "DstRenameDestinationParentPathNotFound",
   }
 
   /** The status for a LCM policy. */

--- a/specification/eventgrid/data-plane/EventGridSystemEvents/Microsoft.Storage/StorageExamples.tsp
+++ b/specification/eventgrid/data-plane/EventGridSystemEvents/Microsoft.Storage/StorageExamples.tsp
@@ -1,0 +1,13 @@
+import "./Storage.tsp";
+
+namespace Microsoft.EventGrid.SystemEvents;
+
+const StorageOperationFailedForReplicationExample: StorageOperationFailedForReplicationEventData = #{
+  api: "PutBlob",
+  eventType: "BlobCreated",
+  timestamp: utcDateTime.fromISO("2026-09-03T22:30:00Z"),
+  blobVersion: "2026-09-03T22:30:00.0000000Z",
+  policyId: "2a65f2bb-0d93-465a-a189-96e3e7127c8f",
+  destinationBlob: "destinationaccount/destinationcontainer/path/to/blob.txt",
+  failureReason: "DstBlobImmutable",
+};

--- a/specification/eventgrid/data-plane/EventGridSystemEvents/Microsoft.Storage/client.tsp
+++ b/specification/eventgrid/data-plane/EventGridSystemEvents/Microsoft.Storage/client.tsp
@@ -127,7 +127,23 @@ using Azure.ClientGenerator.Core;
   Microsoft.EventGrid.SystemEvents.StorageTaskAssignmentCompletedEventData,
   Access.public
 );
+@@usage(
+  Microsoft.EventGrid.SystemEvents.StorageOperationFailedForReplicationEventData,
+  Usage.output | Usage.json
+);
+@@access(
+  Microsoft.EventGrid.SystemEvents.StorageOperationFailedForReplicationEventData,
+  Access.public
+);
 //Enums
+@@usage(
+  Microsoft.EventGrid.SystemEvents.StorageOperationFailedForReplicationReason,
+  Usage.output | Usage.json
+);
+@@access(
+  Microsoft.EventGrid.SystemEvents.StorageOperationFailedForReplicationReason,
+  Access.public
+);
 @@usage(
   Microsoft.EventGrid.SystemEvents.StorageTaskAssignmentCompletedStatus,
   Usage.output | Usage.json
@@ -184,6 +200,10 @@ using Azure.ClientGenerator.Core;
 );
 @@useSystemTextJsonConverter(
   Microsoft.EventGrid.SystemEvents.StorageLifecyclePolicyCompletedEventData,
+  "csharp"
+);
+@@useSystemTextJsonConverter(
+  Microsoft.EventGrid.SystemEvents.StorageOperationFailedForReplicationEventData,
   "csharp"
 );
 @@useSystemTextJsonConverter(

--- a/specification/eventgrid/data-plane/EventGridSystemEvents/stable/2018-01-01/GeneratedSystemEvents.json
+++ b/specification/eventgrid/data-plane/EventGridSystemEvents/stable/2018-01-01/GeneratedSystemEvents.json
@@ -9016,6 +9016,180 @@
         "completionStatus"
       ]
     },
+    "StorageOperationFailedForReplicationEventData": {
+      "type": "object",
+      "description": "Schema of the Data property of an EventGridEvent for a Microsoft.Storage.Replication.OperationFailedForReplication event.",
+      "properties": {
+        "api": {
+          "type": "string",
+          "description": "The name of the source storage API operation that failed to replicate."
+        },
+        "eventType": {
+          "type": "string",
+          "description": "The source storage event type associated with the replication operation."
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The time at which the source storage event occurred. This property is omitted for bootstrap replication."
+        },
+        "blobVersion": {
+          "type": "string",
+          "description": "The version identifier of the source blob."
+        },
+        "policyId": {
+          "type": "string",
+          "description": "The object replication policy identifier."
+        },
+        "destinationBlob": {
+          "type": "string",
+          "description": "The destination blob path, formatted as account/container/blob."
+        },
+        "failureReason": {
+          "$ref": "#/definitions/StorageOperationFailedForReplicationReason",
+          "description": "The reason the replication operation failed."
+        }
+      },
+      "required": [
+        "api",
+        "eventType",
+        "policyId",
+        "destinationBlob",
+        "failureReason"
+      ]
+    },
+    "StorageOperationFailedForReplicationReason": {
+      "type": "string",
+      "description": "The reason an object replication operation failed.",
+      "enum": [
+        "UncategorizedFailure",
+        "DstContainerPolicyConflict",
+        "DstAccountNotFound",
+        "SrcContainerNotFound",
+        "DstContainerNotFound",
+        "SrcContainerBeingDeleted",
+        "DstContainerBeingDeleted",
+        "SrcBlobArchived",
+        "DstBlobArchived",
+        "SrcBlobNotFound",
+        "DstBlobNotFound",
+        "SrcBlobEncryptedWithCPK",
+        "DstBlobImmutable",
+        "DstBlobSnapshotsPresent",
+        "DstContainerLeased",
+        "DstBlobLeased",
+        "DstDirectoryNotEmpty",
+        "DstRenameSourceNotFound",
+        "DstRenameDestinationAlreadyExists",
+        "DstRenameDestinationParentPathNotFound"
+      ],
+      "x-ms-enum": {
+        "name": "StorageOperationFailedForReplicationReason",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "UncategorizedFailure",
+            "value": "UncategorizedFailure",
+            "description": "The replication failure could not be categorized."
+          },
+          {
+            "name": "DstContainerPolicyConflict",
+            "value": "DstContainerPolicyConflict",
+            "description": "The destination container has a conflicting object replication policy."
+          },
+          {
+            "name": "DstAccountNotFound",
+            "value": "DstAccountNotFound",
+            "description": "The destination account was not found."
+          },
+          {
+            "name": "SrcContainerNotFound",
+            "value": "SrcContainerNotFound",
+            "description": "The source container was not found."
+          },
+          {
+            "name": "DstContainerNotFound",
+            "value": "DstContainerNotFound",
+            "description": "The destination container was not found."
+          },
+          {
+            "name": "SrcContainerBeingDeleted",
+            "value": "SrcContainerBeingDeleted",
+            "description": "The source container is being deleted."
+          },
+          {
+            "name": "DstContainerBeingDeleted",
+            "value": "DstContainerBeingDeleted",
+            "description": "The destination container is being deleted."
+          },
+          {
+            "name": "SrcBlobArchived",
+            "value": "SrcBlobArchived",
+            "description": "The source blob is archived."
+          },
+          {
+            "name": "DstBlobArchived",
+            "value": "DstBlobArchived",
+            "description": "The destination blob is archived."
+          },
+          {
+            "name": "SrcBlobNotFound",
+            "value": "SrcBlobNotFound",
+            "description": "The source blob was not found."
+          },
+          {
+            "name": "DstBlobNotFound",
+            "value": "DstBlobNotFound",
+            "description": "The destination blob was not found."
+          },
+          {
+            "name": "SrcBlobEncryptedWithCPK",
+            "value": "SrcBlobEncryptedWithCPK",
+            "description": "The source blob is encrypted with a customer-provided key."
+          },
+          {
+            "name": "DstBlobImmutable",
+            "value": "DstBlobImmutable",
+            "description": "The destination blob is immutable."
+          },
+          {
+            "name": "DstBlobSnapshotsPresent",
+            "value": "DstBlobSnapshotsPresent",
+            "description": "The destination blob has snapshots."
+          },
+          {
+            "name": "DstContainerLeased",
+            "value": "DstContainerLeased",
+            "description": "The destination container is leased."
+          },
+          {
+            "name": "DstBlobLeased",
+            "value": "DstBlobLeased",
+            "description": "The destination blob is leased."
+          },
+          {
+            "name": "DstDirectoryNotEmpty",
+            "value": "DstDirectoryNotEmpty",
+            "description": "The destination directory is not empty."
+          },
+          {
+            "name": "DstRenameSourceNotFound",
+            "value": "DstRenameSourceNotFound",
+            "description": "The source path of the destination rename operation was not found."
+          },
+          {
+            "name": "DstRenameDestinationAlreadyExists",
+            "value": "DstRenameDestinationAlreadyExists",
+            "description": "The destination path of the destination rename operation already exists."
+          },
+          {
+            "name": "DstRenameDestinationParentPathNotFound",
+            "value": "DstRenameDestinationParentPathNotFound",
+            "description": "The parent of the destination path of the destination rename operation was not found."
+          }
+        ]
+      }
+    },
     "StorageTaskAssignmentCompletedEventData": {
       "type": "object",
       "description": "Schema of the Data property of an EventGridEvent for an Microsoft.Storage.StorageTaskAssignmentCompleted event.",

--- a/specification/eventgrid/data-plane/EventGridSystemEvents/stable/2024-01-01/GeneratedSystemEvents.json
+++ b/specification/eventgrid/data-plane/EventGridSystemEvents/stable/2024-01-01/GeneratedSystemEvents.json
@@ -9162,6 +9162,180 @@
         "completionStatus"
       ]
     },
+    "StorageOperationFailedForReplicationEventData": {
+      "type": "object",
+      "description": "Schema of the Data property of an EventGridEvent for a Microsoft.Storage.Replication.OperationFailedForReplication event.",
+      "properties": {
+        "api": {
+          "type": "string",
+          "description": "The name of the source storage API operation that failed to replicate."
+        },
+        "eventType": {
+          "type": "string",
+          "description": "The source storage event type associated with the replication operation."
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The time at which the source storage event occurred. This property is omitted for bootstrap replication."
+        },
+        "blobVersion": {
+          "type": "string",
+          "description": "The version identifier of the source blob."
+        },
+        "policyId": {
+          "type": "string",
+          "description": "The object replication policy identifier."
+        },
+        "destinationBlob": {
+          "type": "string",
+          "description": "The destination blob path, formatted as account/container/blob."
+        },
+        "failureReason": {
+          "$ref": "#/definitions/StorageOperationFailedForReplicationReason",
+          "description": "The reason the replication operation failed."
+        }
+      },
+      "required": [
+        "api",
+        "eventType",
+        "policyId",
+        "destinationBlob",
+        "failureReason"
+      ]
+    },
+    "StorageOperationFailedForReplicationReason": {
+      "type": "string",
+      "description": "The reason an object replication operation failed.",
+      "enum": [
+        "UncategorizedFailure",
+        "DstContainerPolicyConflict",
+        "DstAccountNotFound",
+        "SrcContainerNotFound",
+        "DstContainerNotFound",
+        "SrcContainerBeingDeleted",
+        "DstContainerBeingDeleted",
+        "SrcBlobArchived",
+        "DstBlobArchived",
+        "SrcBlobNotFound",
+        "DstBlobNotFound",
+        "SrcBlobEncryptedWithCPK",
+        "DstBlobImmutable",
+        "DstBlobSnapshotsPresent",
+        "DstContainerLeased",
+        "DstBlobLeased",
+        "DstDirectoryNotEmpty",
+        "DstRenameSourceNotFound",
+        "DstRenameDestinationAlreadyExists",
+        "DstRenameDestinationParentPathNotFound"
+      ],
+      "x-ms-enum": {
+        "name": "StorageOperationFailedForReplicationReason",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "UncategorizedFailure",
+            "value": "UncategorizedFailure",
+            "description": "The replication failure could not be categorized."
+          },
+          {
+            "name": "DstContainerPolicyConflict",
+            "value": "DstContainerPolicyConflict",
+            "description": "The destination container has a conflicting object replication policy."
+          },
+          {
+            "name": "DstAccountNotFound",
+            "value": "DstAccountNotFound",
+            "description": "The destination account was not found."
+          },
+          {
+            "name": "SrcContainerNotFound",
+            "value": "SrcContainerNotFound",
+            "description": "The source container was not found."
+          },
+          {
+            "name": "DstContainerNotFound",
+            "value": "DstContainerNotFound",
+            "description": "The destination container was not found."
+          },
+          {
+            "name": "SrcContainerBeingDeleted",
+            "value": "SrcContainerBeingDeleted",
+            "description": "The source container is being deleted."
+          },
+          {
+            "name": "DstContainerBeingDeleted",
+            "value": "DstContainerBeingDeleted",
+            "description": "The destination container is being deleted."
+          },
+          {
+            "name": "SrcBlobArchived",
+            "value": "SrcBlobArchived",
+            "description": "The source blob is archived."
+          },
+          {
+            "name": "DstBlobArchived",
+            "value": "DstBlobArchived",
+            "description": "The destination blob is archived."
+          },
+          {
+            "name": "SrcBlobNotFound",
+            "value": "SrcBlobNotFound",
+            "description": "The source blob was not found."
+          },
+          {
+            "name": "DstBlobNotFound",
+            "value": "DstBlobNotFound",
+            "description": "The destination blob was not found."
+          },
+          {
+            "name": "SrcBlobEncryptedWithCPK",
+            "value": "SrcBlobEncryptedWithCPK",
+            "description": "The source blob is encrypted with a customer-provided key."
+          },
+          {
+            "name": "DstBlobImmutable",
+            "value": "DstBlobImmutable",
+            "description": "The destination blob is immutable."
+          },
+          {
+            "name": "DstBlobSnapshotsPresent",
+            "value": "DstBlobSnapshotsPresent",
+            "description": "The destination blob has snapshots."
+          },
+          {
+            "name": "DstContainerLeased",
+            "value": "DstContainerLeased",
+            "description": "The destination container is leased."
+          },
+          {
+            "name": "DstBlobLeased",
+            "value": "DstBlobLeased",
+            "description": "The destination blob is leased."
+          },
+          {
+            "name": "DstDirectoryNotEmpty",
+            "value": "DstDirectoryNotEmpty",
+            "description": "The destination directory is not empty."
+          },
+          {
+            "name": "DstRenameSourceNotFound",
+            "value": "DstRenameSourceNotFound",
+            "description": "The source path of the destination rename operation was not found."
+          },
+          {
+            "name": "DstRenameDestinationAlreadyExists",
+            "value": "DstRenameDestinationAlreadyExists",
+            "description": "The destination path of the destination rename operation already exists."
+          },
+          {
+            "name": "DstRenameDestinationParentPathNotFound",
+            "value": "DstRenameDestinationParentPathNotFound",
+            "description": "The parent of the destination path of the destination rename operation was not found."
+          }
+        ]
+      }
+    },
     "StorageTaskAssignmentCompletedEventData": {
       "type": "object",
       "description": "Schema of the Data property of an EventGridEvent for an Microsoft.Storage.StorageTaskAssignmentCompleted event.",


### PR DESCRIPTION
## Summary

Adds the `Microsoft.Storage.Replication.OperationFailedForReplication` Event Grid system event.

- Adds the TypeSpec event data model and extensible failure-reason union.
- Adds a typed example for the object replication failure payload.
- Registers the public SDK model metadata and C# JSON converter.
- Regenerates the 2018-01-01 and 2024-01-01 system-event Swagger files.

## Validation

- TypeSpec formatting check passed.
- TypeSpec compilation passed.
- Both generated Swagger files were validated as JSON.
- The generated changes are additive.

## Release requirement

This event must not be published to Event Grid production endpoints until Azure SDK Architecture Board review is complete and this PR is merged.