### PR TITLE
Add Voice Live conversation engine capability to hosted agents

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/examples/v1/Agents_CreateHostedAgent_VoiceLiveBridge_Gen.json
+++ b/specification/ai-foundry/data-plane/Foundry/examples/v1/Agents_CreateHostedAgent_VoiceLiveBridge_Gen.json
@@ -1,0 +1,65 @@
+{
+  "title": "Agents_CreateHostedAgent_VoiceLiveBridge",
+  "operationId": "Agents_createAgent_Agents_createAgentFromCode",
+  "parameters": {
+    "api-version": "v1",
+    "Foundry-Features": "VoiceAgents=V1Preview",
+    "name": "customer-support-text-agent",
+    "description": "A hosted customer support agent that supports Voice Live Bridge.",
+    "definition": {
+      "kind": "hosted",
+      "container_configuration": {
+        "image": "my-registry.azurecr.io/customer-support-agent:latest"
+      },
+      "cpu": "0.25",
+      "memory": "0.5Gi",
+      "protocol_versions": [
+        {
+          "protocol": "invocations_ws",
+          "version": "1.0.0"
+        }
+      ],
+      "voice_live_bridge": {
+        "version": "1.0"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "object": "agent",
+        "id": "agent_customer_support_text",
+        "name": "customer-support-text-agent",
+        "state": "enabled",
+        "versions": {
+          "latest": {
+            "metadata": null,
+            "object": "agent.version",
+            "id": "agent_customer_support_text:1",
+            "name": "customer-support-text-agent",
+            "version": "1",
+            "created_at": 1785772800,
+            "description": "A hosted customer support agent that supports Voice Live Bridge.",
+            "definition": {
+              "kind": "hosted",
+              "container_configuration": {
+                "image": "my-registry.azurecr.io/customer-support-agent:latest"
+              },
+              "cpu": "0.25",
+              "memory": "0.5Gi",
+              "protocol_versions": [
+                {
+                  "protocol": "invocations_ws",
+                  "version": "1.0.0"
+                }
+              ],
+              "voice_live_bridge": {
+                "version": "1.0"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/ai-foundry/data-plane/Foundry/examples/v1/Agents_CreateHostedAgent_VoiceLiveConversationEngine_Gen.json
+++ b/specification/ai-foundry/data-plane/Foundry/examples/v1/Agents_CreateHostedAgent_VoiceLiveConversationEngine_Gen.json
@@ -1,11 +1,11 @@
 {
-  "title": "Agents_CreateHostedAgent_VoiceLiveBridge",
+  "title": "Agents_CreateHostedAgent_VoiceLiveConversationEngine",
   "operationId": "Agents_createAgent_Agents_createAgentFromCode",
   "parameters": {
     "api-version": "v1",
     "Foundry-Features": "VoiceAgents=V1Preview",
     "name": "customer-support-text-agent",
-    "description": "A hosted customer support agent that supports Voice Live Bridge.",
+    "description": "A hosted customer support agent that can serve as a Voice Live conversation engine.",
     "definition": {
       "kind": "hosted",
       "container_configuration": {
@@ -19,8 +19,8 @@
           "version": "1.0.0"
         }
       ],
-      "voice_live_bridge": {
-        "version": "1.0"
+      "voice_live_conversation_engine": {
+        "protocol_version": "1.0"
       }
     }
   },
@@ -39,7 +39,7 @@
             "name": "customer-support-text-agent",
             "version": "1",
             "created_at": 1785772800,
-            "description": "A hosted customer support agent that supports Voice Live Bridge.",
+            "description": "A hosted customer support agent that can serve as a Voice Live conversation engine.",
             "definition": {
               "kind": "hosted",
               "container_configuration": {
@@ -53,8 +53,8 @@
                   "version": "1.0.0"
                 }
               ],
-              "voice_live_bridge": {
-                "version": "1.0"
+              "voice_live_conversation_engine": {
+                "protocol_version": "1.0"
               }
             }
           }

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -40735,6 +40735,15 @@
               ]
             ]
           },
+          "voice_live_bridge": {
+            "$ref": "#/components/schemas/VoiceLiveBridgeCapability",
+            "description": "The Voice Live Bridge application protocol capability implemented by this hosted agent. When provided, `protocol_versions` must include the `invocations_ws` endpoint protocol. The presence of this property selects the typed Bridge profile; no separate Bridge endpoint protocol is introduced.",
+            "x-ms-foundry-meta": {
+              "conditional_previews": [
+                "VoiceAgents=V1Preview"
+              ]
+            }
+          },
           "code_configuration": {
             "$ref": "#/components/schemas/CodeConfiguration",
             "description": "Code-based deployment configuration. Provide this for code-based deployments. Mutually exclusive with container_configuration — the service validates that exactly one is set."
@@ -89550,6 +89559,46 @@
           }
         },
         "description": "Metadata for a single conversation item's audio segment. For bring-your-own-storage (BYOS), the response includes\n`blob_uri`, a direct customer-storage URI without a SAS token, that the customer accesses with their own\ncredentials. For Foundry-managed storage, `blob_uri` is absent and the bytes are streamed through the item's\n`/audio/content` route.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "VoiceAgents=V1Preview"
+          ]
+        }
+      },
+      "VoiceLiveBridgeCapability": {
+        "type": "object",
+        "required": [
+          "version"
+        ],
+        "properties": {
+          "version": {
+            "$ref": "#/components/schemas/VoiceLiveBridgeProtocolVersion",
+            "description": "The exact Voice Live Bridge application protocol version implemented by the hosted agent. The service currently supports version `1.0`."
+          }
+        },
+        "unevaluatedProperties": {
+          "not": {}
+        },
+        "description": "The Voice Live Bridge application protocol capability implemented by a hosted agent.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "VoiceAgents=V1Preview"
+          ]
+        }
+      },
+      "VoiceLiveBridgeProtocolVersion": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "1.0"
+            ]
+          }
+        ],
+        "description": "Supported Voice Live Bridge application protocol versions.",
         "x-ms-foundry-meta": {
           "required_previews": [
             "VoiceAgents=V1Preview"

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -40735,9 +40735,9 @@
               ]
             ]
           },
-          "voice_live_bridge": {
-            "$ref": "#/components/schemas/VoiceLiveBridgeCapability",
-            "description": "The Voice Live Bridge application protocol capability implemented by this hosted agent. When provided, `protocol_versions` must include the `invocations_ws` endpoint protocol. The presence of this property selects the typed Bridge profile; no separate Bridge endpoint protocol is introduced.",
+          "voice_live_conversation_engine": {
+            "$ref": "#/components/schemas/VoiceLiveConversationEngineCapability",
+            "description": "Declares that this hosted agent can serve as a Voice Live conversation engine. When provided, `protocol_versions` must include the `invocations_ws` endpoint protocol.",
             "x-ms-foundry-meta": {
               "conditional_previews": [
                 "VoiceAgents=V1Preview"
@@ -89565,28 +89565,28 @@
           ]
         }
       },
-      "VoiceLiveBridgeCapability": {
+      "VoiceLiveConversationEngineCapability": {
         "type": "object",
         "required": [
-          "version"
+          "protocol_version"
         ],
         "properties": {
-          "version": {
-            "$ref": "#/components/schemas/VoiceLiveBridgeProtocolVersion",
-            "description": "The exact Voice Live Bridge application protocol version implemented by the hosted agent. The service currently supports version `1.0`."
+          "protocol_version": {
+            "$ref": "#/components/schemas/VoiceLiveConversationEngineProtocolVersion",
+            "description": "The exact application protocol version implemented by the hosted agent for Voice Live conversations. The service currently supports version `1.0`."
           }
         },
         "unevaluatedProperties": {
           "not": {}
         },
-        "description": "The Voice Live Bridge application protocol capability implemented by a hosted agent.",
+        "description": "The capability for a hosted agent to serve as a Voice Live conversation engine.",
         "x-ms-foundry-meta": {
           "required_previews": [
             "VoiceAgents=V1Preview"
           ]
         }
       },
-      "VoiceLiveBridgeProtocolVersion": {
+      "VoiceLiveConversationEngineProtocolVersion": {
         "anyOf": [
           {
             "type": "string"
@@ -89598,7 +89598,7 @@
             ]
           }
         ],
-        "description": "Supported Voice Live Bridge application protocol versions.",
+        "description": "Supported protocol versions for a hosted agent serving as a Voice Live conversation engine.",
         "x-ms-foundry-meta": {
           "required_previews": [
             "VoiceAgents=V1Preview"

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -48241,9 +48241,9 @@ components:
                 version: v0.1.1
               - protocol: a2a
                 version: v0.3.0
-        voice_live_bridge:
-          $ref: '#/components/schemas/VoiceLiveBridgeCapability'
-          description: The Voice Live Bridge application protocol capability implemented by this hosted agent. When provided, `protocol_versions` must include the `invocations_ws` endpoint protocol. The presence of this property selects the typed Bridge profile; no separate Bridge endpoint protocol is introduced.
+        voice_live_conversation_engine:
+          $ref: '#/components/schemas/VoiceLiveConversationEngineCapability'
+          description: Declares that this hosted agent can serve as a Voice Live conversation engine. When provided, `protocol_versions` must include the `invocations_ws` endpoint protocol.
           x-ms-foundry-meta:
             conditional_previews:
               - VoiceAgents=V1Preview
@@ -83396,27 +83396,27 @@ components:
       x-ms-foundry-meta:
         required_previews:
           - VoiceAgents=V1Preview
-    VoiceLiveBridgeCapability:
+    VoiceLiveConversationEngineCapability:
       type: object
       required:
-        - version
+        - protocol_version
       properties:
-        version:
-          $ref: '#/components/schemas/VoiceLiveBridgeProtocolVersion'
-          description: The exact Voice Live Bridge application protocol version implemented by the hosted agent. The service currently supports version `1.0`.
+        protocol_version:
+          $ref: '#/components/schemas/VoiceLiveConversationEngineProtocolVersion'
+          description: The exact application protocol version implemented by the hosted agent for Voice Live conversations. The service currently supports version `1.0`.
       unevaluatedProperties:
         not: {}
-      description: The Voice Live Bridge application protocol capability implemented by a hosted agent.
+      description: The capability for a hosted agent to serve as a Voice Live conversation engine.
       x-ms-foundry-meta:
         required_previews:
           - VoiceAgents=V1Preview
-    VoiceLiveBridgeProtocolVersion:
+    VoiceLiveConversationEngineProtocolVersion:
       anyOf:
         - type: string
         - type: string
           enum:
             - '1.0'
-      description: Supported Voice Live Bridge application protocol versions.
+      description: Supported protocol versions for a hosted agent serving as a Voice Live conversation engine.
       x-ms-foundry-meta:
         required_previews:
           - VoiceAgents=V1Preview

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -48241,6 +48241,12 @@ components:
                 version: v0.1.1
               - protocol: a2a
                 version: v0.3.0
+        voice_live_bridge:
+          $ref: '#/components/schemas/VoiceLiveBridgeCapability'
+          description: The Voice Live Bridge application protocol capability implemented by this hosted agent. When provided, `protocol_versions` must include the `invocations_ws` endpoint protocol. The presence of this property selects the typed Bridge profile; no separate Bridge endpoint protocol is introduced.
+          x-ms-foundry-meta:
+            conditional_previews:
+              - VoiceAgents=V1Preview
         code_configuration:
           $ref: '#/components/schemas/CodeConfiguration'
           description: Code-based deployment configuration. Provide this for code-based deployments. Mutually exclusive with container_configuration — the service validates that exactly one is set.
@@ -83387,6 +83393,30 @@ components:
         `blob_uri`, a direct customer-storage URI without a SAS token, that the customer accesses with their own
         credentials. For Foundry-managed storage, `blob_uri` is absent and the bytes are streamed through the item's
         `/audio/content` route.
+      x-ms-foundry-meta:
+        required_previews:
+          - VoiceAgents=V1Preview
+    VoiceLiveBridgeCapability:
+      type: object
+      required:
+        - version
+      properties:
+        version:
+          $ref: '#/components/schemas/VoiceLiveBridgeProtocolVersion'
+          description: The exact Voice Live Bridge application protocol version implemented by the hosted agent. The service currently supports version `1.0`.
+      unevaluatedProperties:
+        not: {}
+      description: The Voice Live Bridge application protocol capability implemented by a hosted agent.
+      x-ms-foundry-meta:
+        required_previews:
+          - VoiceAgents=V1Preview
+    VoiceLiveBridgeProtocolVersion:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - '1.0'
+      description: Supported Voice Live Bridge application protocol versions.
       x-ms-foundry-meta:
         required_previews:
           - VoiceAgents=V1Preview

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -46057,9 +46057,9 @@
               ]
             ]
           },
-          "voice_live_bridge": {
-            "$ref": "#/components/schemas/VoiceLiveBridgeCapability",
-            "description": "The Voice Live Bridge application protocol capability implemented by this hosted agent. When provided, `protocol_versions` must include the `invocations_ws` endpoint protocol. The presence of this property selects the typed Bridge profile; no separate Bridge endpoint protocol is introduced.",
+          "voice_live_conversation_engine": {
+            "$ref": "#/components/schemas/VoiceLiveConversationEngineCapability",
+            "description": "Declares that this hosted agent can serve as a Voice Live conversation engine. When provided, `protocol_versions` must include the `invocations_ws` endpoint protocol.",
             "x-ms-foundry-meta": {
               "conditional_previews": [
                 "VoiceAgents=V1Preview"
@@ -95266,28 +95266,28 @@
           ]
         }
       },
-      "VoiceLiveBridgeCapability": {
+      "VoiceLiveConversationEngineCapability": {
         "type": "object",
         "required": [
-          "version"
+          "protocol_version"
         ],
         "properties": {
-          "version": {
-            "$ref": "#/components/schemas/VoiceLiveBridgeProtocolVersion",
-            "description": "The exact Voice Live Bridge application protocol version implemented by the hosted agent. The service currently supports version `1.0`."
+          "protocol_version": {
+            "$ref": "#/components/schemas/VoiceLiveConversationEngineProtocolVersion",
+            "description": "The exact application protocol version implemented by the hosted agent for Voice Live conversations. The service currently supports version `1.0`."
           }
         },
         "unevaluatedProperties": {
           "not": {}
         },
-        "description": "The Voice Live Bridge application protocol capability implemented by a hosted agent.",
+        "description": "The capability for a hosted agent to serve as a Voice Live conversation engine.",
         "x-ms-foundry-meta": {
           "required_previews": [
             "VoiceAgents=V1Preview"
           ]
         }
       },
-      "VoiceLiveBridgeProtocolVersion": {
+      "VoiceLiveConversationEngineProtocolVersion": {
         "anyOf": [
           {
             "type": "string"
@@ -95299,7 +95299,7 @@
             ]
           }
         ],
-        "description": "Supported Voice Live Bridge application protocol versions.",
+        "description": "Supported protocol versions for a hosted agent serving as a Voice Live conversation engine.",
         "x-ms-foundry-meta": {
           "required_previews": [
             "VoiceAgents=V1Preview"

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -46057,6 +46057,15 @@
               ]
             ]
           },
+          "voice_live_bridge": {
+            "$ref": "#/components/schemas/VoiceLiveBridgeCapability",
+            "description": "The Voice Live Bridge application protocol capability implemented by this hosted agent. When provided, `protocol_versions` must include the `invocations_ws` endpoint protocol. The presence of this property selects the typed Bridge profile; no separate Bridge endpoint protocol is introduced.",
+            "x-ms-foundry-meta": {
+              "conditional_previews": [
+                "VoiceAgents=V1Preview"
+              ]
+            }
+          },
           "code_configuration": {
             "$ref": "#/components/schemas/CodeConfiguration",
             "description": "Code-based deployment configuration. Provide this for code-based deployments. Mutually exclusive with container_configuration — the service validates that exactly one is set."
@@ -95251,6 +95260,46 @@
           }
         },
         "description": "Metadata for a single conversation item's audio segment. For bring-your-own-storage (BYOS), the response includes\n`blob_uri`, a direct customer-storage URI without a SAS token, that the customer accesses with their own\ncredentials. For Foundry-managed storage, `blob_uri` is absent and the bytes are streamed through the item's\n`/audio/content` route.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "VoiceAgents=V1Preview"
+          ]
+        }
+      },
+      "VoiceLiveBridgeCapability": {
+        "type": "object",
+        "required": [
+          "version"
+        ],
+        "properties": {
+          "version": {
+            "$ref": "#/components/schemas/VoiceLiveBridgeProtocolVersion",
+            "description": "The exact Voice Live Bridge application protocol version implemented by the hosted agent. The service currently supports version `1.0`."
+          }
+        },
+        "unevaluatedProperties": {
+          "not": {}
+        },
+        "description": "The Voice Live Bridge application protocol capability implemented by a hosted agent.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "VoiceAgents=V1Preview"
+          ]
+        }
+      },
+      "VoiceLiveBridgeProtocolVersion": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "1.0"
+            ]
+          }
+        ],
+        "description": "Supported Voice Live Bridge application protocol versions.",
         "x-ms-foundry-meta": {
           "required_previews": [
             "VoiceAgents=V1Preview"

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -51901,9 +51901,9 @@ components:
                 version: v0.1.1
               - protocol: a2a
                 version: v0.3.0
-        voice_live_bridge:
-          $ref: '#/components/schemas/VoiceLiveBridgeCapability'
-          description: The Voice Live Bridge application protocol capability implemented by this hosted agent. When provided, `protocol_versions` must include the `invocations_ws` endpoint protocol. The presence of this property selects the typed Bridge profile; no separate Bridge endpoint protocol is introduced.
+        voice_live_conversation_engine:
+          $ref: '#/components/schemas/VoiceLiveConversationEngineCapability'
+          description: Declares that this hosted agent can serve as a Voice Live conversation engine. When provided, `protocol_versions` must include the `invocations_ws` endpoint protocol.
           x-ms-foundry-meta:
             conditional_previews:
               - VoiceAgents=V1Preview
@@ -87320,27 +87320,27 @@ components:
       x-ms-foundry-meta:
         required_previews:
           - VoiceAgents=V1Preview
-    VoiceLiveBridgeCapability:
+    VoiceLiveConversationEngineCapability:
       type: object
       required:
-        - version
+        - protocol_version
       properties:
-        version:
-          $ref: '#/components/schemas/VoiceLiveBridgeProtocolVersion'
-          description: The exact Voice Live Bridge application protocol version implemented by the hosted agent. The service currently supports version `1.0`.
+        protocol_version:
+          $ref: '#/components/schemas/VoiceLiveConversationEngineProtocolVersion'
+          description: The exact application protocol version implemented by the hosted agent for Voice Live conversations. The service currently supports version `1.0`.
       unevaluatedProperties:
         not: {}
-      description: The Voice Live Bridge application protocol capability implemented by a hosted agent.
+      description: The capability for a hosted agent to serve as a Voice Live conversation engine.
       x-ms-foundry-meta:
         required_previews:
           - VoiceAgents=V1Preview
-    VoiceLiveBridgeProtocolVersion:
+    VoiceLiveConversationEngineProtocolVersion:
       anyOf:
         - type: string
         - type: string
           enum:
             - '1.0'
-      description: Supported Voice Live Bridge application protocol versions.
+      description: Supported protocol versions for a hosted agent serving as a Voice Live conversation engine.
       x-ms-foundry-meta:
         required_previews:
           - VoiceAgents=V1Preview

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -51901,6 +51901,12 @@ components:
                 version: v0.1.1
               - protocol: a2a
                 version: v0.3.0
+        voice_live_bridge:
+          $ref: '#/components/schemas/VoiceLiveBridgeCapability'
+          description: The Voice Live Bridge application protocol capability implemented by this hosted agent. When provided, `protocol_versions` must include the `invocations_ws` endpoint protocol. The presence of this property selects the typed Bridge profile; no separate Bridge endpoint protocol is introduced.
+          x-ms-foundry-meta:
+            conditional_previews:
+              - VoiceAgents=V1Preview
         code_configuration:
           $ref: '#/components/schemas/CodeConfiguration'
           description: Code-based deployment configuration. Provide this for code-based deployments. Mutually exclusive with container_configuration — the service validates that exactly one is set.
@@ -87311,6 +87317,30 @@ components:
         `blob_uri`, a direct customer-storage URI without a SAS token, that the customer accesses with their own
         credentials. For Foundry-managed storage, `blob_uri` is absent and the bytes are streamed through the item's
         `/audio/content` route.
+      x-ms-foundry-meta:
+        required_previews:
+          - VoiceAgents=V1Preview
+    VoiceLiveBridgeCapability:
+      type: object
+      required:
+        - version
+      properties:
+        version:
+          $ref: '#/components/schemas/VoiceLiveBridgeProtocolVersion'
+          description: The exact Voice Live Bridge application protocol version implemented by the hosted agent. The service currently supports version `1.0`.
+      unevaluatedProperties:
+        not: {}
+      description: The Voice Live Bridge application protocol capability implemented by a hosted agent.
+      x-ms-foundry-meta:
+        required_previews:
+          - VoiceAgents=V1Preview
+    VoiceLiveBridgeProtocolVersion:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - '1.0'
+      description: Supported Voice Live Bridge application protocol versions.
       x-ms-foundry-meta:
         required_previews:
           - VoiceAgents=V1Preview

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
@@ -537,28 +537,28 @@ union CodeDependencyResolution {
   remote_build: "remote_build",
 }
 
-@doc("Supported Voice Live Bridge application protocol versions.")
+@doc("Supported protocol versions for a hosted agent serving as a Voice Live conversation engine.")
 @extension(
   "x-ms-foundry-meta",
   #{ required_previews: #[AgentDefinitionOptInKeys.voice_agents_v1_preview] }
 )
-union VoiceLiveBridgeProtocolVersion {
+union VoiceLiveConversationEngineProtocolVersion {
   string,
 
-  @doc("Voice Live Bridge Protocol 1.0.")
+  @doc("Voice Live conversation engine protocol 1.0.")
   v1_0: "1.0",
 }
 
-@doc("The Voice Live Bridge application protocol capability implemented by a hosted agent.")
+@doc("The capability for a hosted agent to serve as a Voice Live conversation engine.")
 @extension(
   "x-ms-foundry-meta",
   #{ required_previews: #[AgentDefinitionOptInKeys.voice_agents_v1_preview] }
 )
-model VoiceLiveBridgeCapability {
+model VoiceLiveConversationEngineCapability {
   ...Record<never>;
 
-  @doc("The exact Voice Live Bridge application protocol version implemented by the hosted agent. The service currently supports version `1.0`.")
-  version: VoiceLiveBridgeProtocolVersion;
+  @doc("The exact application protocol version implemented by the hosted agent for Voice Live conversations. The service currently supports version `1.0`.")
+  protocol_version: VoiceLiveConversationEngineProtocolVersion;
 }
 
 @doc("""
@@ -613,14 +613,14 @@ model HostedAgentDefinition extends AgentDefinition {
   ])
   protocol_versions?: ProtocolVersionRecord[];
 
-  @doc("The Voice Live Bridge application protocol capability implemented by this hosted agent. When provided, `protocol_versions` must include the `invocations_ws` endpoint protocol. The presence of this property selects the typed Bridge profile; no separate Bridge endpoint protocol is introduced.")
+  @doc("Declares that this hosted agent can serve as a Voice Live conversation engine. When provided, `protocol_versions` must include the `invocations_ws` endpoint protocol.")
   @extension(
     "x-ms-foundry-meta",
     #{
       conditional_previews: #[AgentDefinitionOptInKeys.voice_agents_v1_preview],
     }
   )
-  voice_live_bridge?: VoiceLiveBridgeCapability;
+  voice_live_conversation_engine?: VoiceLiveConversationEngineCapability;
 
   @doc("Code-based deployment configuration. Provide this for code-based deployments. Mutually exclusive with container_configuration — the service validates that exactly one is set.")
   code_configuration?: CodeConfiguration;

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
@@ -537,6 +537,30 @@ union CodeDependencyResolution {
   remote_build: "remote_build",
 }
 
+@doc("Supported Voice Live Bridge application protocol versions.")
+@extension(
+  "x-ms-foundry-meta",
+  #{ required_previews: #[AgentDefinitionOptInKeys.voice_agents_v1_preview] }
+)
+union VoiceLiveBridgeProtocolVersion {
+  string,
+
+  @doc("Voice Live Bridge Protocol 1.0.")
+  v1_0: "1.0",
+}
+
+@doc("The Voice Live Bridge application protocol capability implemented by a hosted agent.")
+@extension(
+  "x-ms-foundry-meta",
+  #{ required_previews: #[AgentDefinitionOptInKeys.voice_agents_v1_preview] }
+)
+model VoiceLiveBridgeCapability {
+  ...Record<never>;
+
+  @doc("The exact Voice Live Bridge application protocol version implemented by the hosted agent. The service currently supports version `1.0`.")
+  version: VoiceLiveBridgeProtocolVersion;
+}
+
 @doc("""
   The external agent definition. Represents a third-party agent hosted outside Foundry (for example, on GCP or AWS).
   Registration is metadata-only: Foundry records the agent definition to light up observability experiences (traces, evaluations)
@@ -588,6 +612,15 @@ model HostedAgentDefinition extends AgentDefinition {
     #{ protocol: "a2a", version: "v0.3.0" }
   ])
   protocol_versions?: ProtocolVersionRecord[];
+
+  @doc("The Voice Live Bridge application protocol capability implemented by this hosted agent. When provided, `protocol_versions` must include the `invocations_ws` endpoint protocol. The presence of this property selects the typed Bridge profile; no separate Bridge endpoint protocol is introduced.")
+  @extension(
+    "x-ms-foundry-meta",
+    #{
+      conditional_previews: #[AgentDefinitionOptInKeys.voice_agents_v1_preview],
+    }
+  )
+  voice_live_bridge?: VoiceLiveBridgeCapability;
 
   @doc("Code-based deployment configuration. Provide this for code-based deployments. Mutually exclusive with container_configuration — the service validates that exactly one is set.")
   code_configuration?: CodeConfiguration;


### PR DESCRIPTION
## Summary

- add an optional typed `voice_live_conversation_engine` capability to `HostedAgentDefinition`
- model `protocol_version` `1.0` as an extensible known-value union
- document that the capability requires the existing `invocations_ws` entry in `protocol_versions`
- add a focused hosted-agent example and regenerate the v1 and virtual-public-preview OpenAPI projections

## Design

The public property describes the customer-facing role: the hosted agent can serve as the conversation engine for Voice Live.

```json
{
  "protocol_versions": [
    {
      "protocol": "invocations_ws",
      "version": "1.0.0"
    }
  ],
  "voice_live_conversation_engine": {
    "protocol_version": "1.0"
  }
}
```

The conversation-engine application contract is layered on the existing `invocations_ws` endpoint transport. This change therefore keeps `protocol_versions` unchanged and does not add a second `AgentEndpointProtocol`.

The typed capability replaces the unreleased free-form `bridgeProtocolVersion` metadata concept. The older `voiceLiveCompatible` metadata is outside this public TypeSpec surface and is not changed here.

## Validation

- `npx tsp compile . --warn-as-error`
- `npx tsv .`
- `npx tsv . '{"baseCommitish":"upstream/feature/voice-agent-batch2","headCommitish":"HEAD"}'`
- v1/PuPr schema parity, preview metadata, closed-object, example, and unchanged-`protocol_versions` assertions
- C#, Java, Python, and JavaScript client TypeSpec projections relevant to the Foundry agents/projects surfaces
