### PR TITLE
Enable provisioning emitter for DevHub

### DIFF
--- a/specification/developerhub/resource-manager/Microsoft.DevHub/DeveloperHub/tspconfig.yaml
+++ b/specification/developerhub/resource-manager/Microsoft.DevHub/DeveloperHub/tspconfig.yaml
@@ -21,6 +21,10 @@ options:
   "@azure-typespec/http-client-csharp-mgmt":
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
     namespace: "Azure.ResourceManager.DevHub"
+  "@azure-typespec/http-client-csharp-provisioning":
+    namespace: "Azure.Provisioning.DevHub"
+    emitter-output-dir: "{output-dir}/sdk/developerhub/{namespace}"
+    api-version: "2025-03-01-preview"
   "@azure-tools/typespec-python":
     service-dir: "sdk/devhub"
     emitter-output-dir: "{output-dir}/{service-dir}/azure-mgmt-devhub"


### PR DESCRIPTION
## Summary
- enable the C# provisioning emitter for Microsoft.DevHub
- generate Azure.Provisioning.DevHub using API version 2025-03-01-preview