### PR TITLE
feat(voice): add end-conversation TypeSpec contracts

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -70872,7 +70872,8 @@
             "mcp_approval_response": "#/components/schemas/OpenAI.RealtimeMCPApprovalResponse",
             "mcp_list_tools": "#/components/schemas/OpenAI.RealtimeMCPListTools",
             "mcp_call": "#/components/schemas/OpenAI.RealtimeMCPToolCall",
-            "mcp_approval_request": "#/components/schemas/OpenAI.RealtimeMCPApprovalRequest"
+            "mcp_approval_request": "#/components/schemas/OpenAI.RealtimeMCPApprovalRequest",
+            "system_tool": "#/components/schemas/VoiceAgentResponseSystemToolItem"
           }
         },
         "description": "A single item within a Realtime conversation.",
@@ -71392,7 +71393,8 @@
               "mcp_list_tools",
               "mcp_call",
               "mcp_approval_request",
-              "message"
+              "message",
+              "system_tool"
             ]
           }
         ]
@@ -88679,6 +88681,75 @@
           ]
         }
       },
+      "VoiceAgentResponseSystemToolItem": {
+        "type": "object",
+        "required": [
+          "id",
+          "type",
+          "status",
+          "name",
+          "call_id",
+          "arguments"
+        ],
+        "properties": {
+          "created_at": {
+            "$ref": "#/components/schemas/FoundryTimestamp",
+            "description": "The Unix timestamp (in seconds) for when the item was persisted.",
+            "readOnly": true
+          },
+          "response_id": {
+            "type": "string",
+            "description": "The id of the response that produced this item, when applicable.",
+            "readOnly": true
+          },
+          "id": {
+            "type": "string",
+            "description": "The server-generated identifier for the response item."
+          },
+          "object": {
+            "type": "string",
+            "enum": [
+              "realtime.item"
+            ],
+            "description": "The object type. Always `realtime.item`.",
+            "default": "realtime.item"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "system_tool"
+            ],
+            "description": "The item type. Always `system_tool`."
+          },
+          "status": {
+            "$ref": "#/components/schemas/VoiceAgentSystemToolCallStatus",
+            "description": "The lifecycle status of the system-tool invocation."
+          },
+          "name": {
+            "$ref": "#/components/schemas/VoiceAgentSystemToolName",
+            "description": "The service-managed system-tool name."
+          },
+          "call_id": {
+            "type": "string",
+            "description": "The model-generated identifier that correlates the tool item and its lifecycle events."
+          },
+          "arguments": {
+            "type": "string",
+            "description": "The JSON-encoded system-tool arguments. This value is empty while argument generation is in progress."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.RealtimeConversationItem"
+          }
+        ],
+        "description": "A service-managed system-tool invocation emitted by a voice-agent session.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "VoiceAgents=V1Preview"
+          ]
+        }
+      },
       "VoiceAgentSemanticVadTurnDetection": {
         "type": "object",
         "required": [
@@ -88975,7 +89046,7 @@
           },
           "description": {
             "type": "string",
-            "description": "An optional description of the system tool."
+            "description": "Optional model-facing guidance for when and how to invoke the system tool. For `end_conversation`, omit this\nproperty or use an empty string to apply the service default, which instructs the model to speak a closing\nassistant message before invoking the tool. A non-empty value replaces the service default."
           }
         },
         "allOf": [
@@ -88984,6 +89055,27 @@
           }
         ],
         "description": "A service-managed control that acts on the active voice session without customer code or external authentication.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "VoiceAgents=V1Preview"
+          ]
+        }
+      },
+      "VoiceAgentSystemToolCallStatus": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "in_progress",
+              "completed",
+              "incomplete"
+            ]
+          }
+        ],
+        "description": "The lifecycle status of a service-managed system-tool invocation.",
         "x-ms-foundry-meta": {
           "required_previews": [
             "VoiceAgents=V1Preview"

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -69382,6 +69382,7 @@ components:
           mcp_list_tools: '#/components/schemas/OpenAI.RealtimeMCPListTools'
           mcp_call: '#/components/schemas/OpenAI.RealtimeMCPToolCall'
           mcp_approval_request: '#/components/schemas/OpenAI.RealtimeMCPApprovalRequest'
+          system_tool: '#/components/schemas/VoiceAgentResponseSystemToolItem'
       description: A single item within a Realtime conversation.
       x-ms-foundry-meta:
         required_previews:
@@ -69749,6 +69750,7 @@ components:
             - mcp_call
             - mcp_approval_request
             - message
+            - system_tool
     OpenAI.RealtimeCreateClientSecretRequest:
       type: object
       properties:
@@ -82794,6 +82796,56 @@ components:
       x-ms-foundry-meta:
         required_previews:
           - VoiceAgents=V1Preview
+    VoiceAgentResponseSystemToolItem:
+      type: object
+      required:
+        - id
+        - type
+        - status
+        - name
+        - call_id
+        - arguments
+      properties:
+        created_at:
+          $ref: '#/components/schemas/FoundryTimestamp'
+          description: The Unix timestamp (in seconds) for when the item was persisted.
+          readOnly: true
+        response_id:
+          type: string
+          description: The id of the response that produced this item, when applicable.
+          readOnly: true
+        id:
+          type: string
+          description: The server-generated identifier for the response item.
+        object:
+          type: string
+          enum:
+            - realtime.item
+          description: The object type. Always `realtime.item`.
+          default: realtime.item
+        type:
+          type: string
+          enum:
+            - system_tool
+          description: The item type. Always `system_tool`.
+        status:
+          $ref: '#/components/schemas/VoiceAgentSystemToolCallStatus'
+          description: The lifecycle status of the system-tool invocation.
+        name:
+          $ref: '#/components/schemas/VoiceAgentSystemToolName'
+          description: The service-managed system-tool name.
+        call_id:
+          type: string
+          description: The model-generated identifier that correlates the tool item and its lifecycle events.
+        arguments:
+          type: string
+          description: The JSON-encoded system-tool arguments. This value is empty while argument generation is in progress.
+      allOf:
+        - $ref: '#/components/schemas/OpenAI.RealtimeConversationItem'
+      description: A service-managed system-tool invocation emitted by a voice-agent session.
+      x-ms-foundry-meta:
+        required_previews:
+          - VoiceAgents=V1Preview
     VoiceAgentSemanticVadTurnDetection:
       type: object
       required:
@@ -82992,10 +83044,25 @@ components:
           description: The service-managed control action. Known values are stable; additional values may be added over time.
         description:
           type: string
-          description: An optional description of the system tool.
+          description: |-
+            Optional model-facing guidance for when and how to invoke the system tool. For `end_conversation`, omit this
+            property or use an empty string to apply the service default, which instructs the model to speak a closing
+            assistant message before invoking the tool. A non-empty value replaces the service default.
       allOf:
         - $ref: '#/components/schemas/VoiceAgentTool'
       description: A service-managed control that acts on the active voice session without customer code or external authentication.
+      x-ms-foundry-meta:
+        required_previews:
+          - VoiceAgents=V1Preview
+    VoiceAgentSystemToolCallStatus:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - in_progress
+            - completed
+            - incomplete
+      description: The lifecycle status of a service-managed system-tool invocation.
       x-ms-foundry-meta:
         required_previews:
           - VoiceAgents=V1Preview

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -76362,7 +76362,8 @@
             "mcp_approval_response": "#/components/schemas/OpenAI.RealtimeMCPApprovalResponse",
             "mcp_list_tools": "#/components/schemas/OpenAI.RealtimeMCPListTools",
             "mcp_call": "#/components/schemas/OpenAI.RealtimeMCPToolCall",
-            "mcp_approval_request": "#/components/schemas/OpenAI.RealtimeMCPApprovalRequest"
+            "mcp_approval_request": "#/components/schemas/OpenAI.RealtimeMCPApprovalRequest",
+            "system_tool": "#/components/schemas/VoiceAgentResponseSystemToolItem"
           }
         },
         "description": "A single item within a Realtime conversation.",
@@ -76882,7 +76883,8 @@
               "mcp_list_tools",
               "mcp_call",
               "mcp_approval_request",
-              "message"
+              "message",
+              "system_tool"
             ]
           }
         ]
@@ -94380,6 +94382,75 @@
           ]
         }
       },
+      "VoiceAgentResponseSystemToolItem": {
+        "type": "object",
+        "required": [
+          "id",
+          "type",
+          "status",
+          "name",
+          "call_id",
+          "arguments"
+        ],
+        "properties": {
+          "created_at": {
+            "$ref": "#/components/schemas/FoundryTimestamp",
+            "description": "The Unix timestamp (in seconds) for when the item was persisted.",
+            "readOnly": true
+          },
+          "response_id": {
+            "type": "string",
+            "description": "The id of the response that produced this item, when applicable.",
+            "readOnly": true
+          },
+          "id": {
+            "type": "string",
+            "description": "The server-generated identifier for the response item."
+          },
+          "object": {
+            "type": "string",
+            "enum": [
+              "realtime.item"
+            ],
+            "description": "The object type. Always `realtime.item`.",
+            "default": "realtime.item"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "system_tool"
+            ],
+            "description": "The item type. Always `system_tool`."
+          },
+          "status": {
+            "$ref": "#/components/schemas/VoiceAgentSystemToolCallStatus",
+            "description": "The lifecycle status of the system-tool invocation."
+          },
+          "name": {
+            "$ref": "#/components/schemas/VoiceAgentSystemToolName",
+            "description": "The service-managed system-tool name."
+          },
+          "call_id": {
+            "type": "string",
+            "description": "The model-generated identifier that correlates the tool item and its lifecycle events."
+          },
+          "arguments": {
+            "type": "string",
+            "description": "The JSON-encoded system-tool arguments. This value is empty while argument generation is in progress."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.RealtimeConversationItem"
+          }
+        ],
+        "description": "A service-managed system-tool invocation emitted by a voice-agent session.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "VoiceAgents=V1Preview"
+          ]
+        }
+      },
       "VoiceAgentSemanticVadTurnDetection": {
         "type": "object",
         "required": [
@@ -94676,7 +94747,7 @@
           },
           "description": {
             "type": "string",
-            "description": "An optional description of the system tool."
+            "description": "Optional model-facing guidance for when and how to invoke the system tool. For `end_conversation`, omit this\nproperty or use an empty string to apply the service default, which instructs the model to speak a closing\nassistant message before invoking the tool. A non-empty value replaces the service default."
           }
         },
         "allOf": [
@@ -94685,6 +94756,27 @@
           }
         ],
         "description": "A service-managed control that acts on the active voice session without customer code or external authentication.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "VoiceAgents=V1Preview"
+          ]
+        }
+      },
+      "VoiceAgentSystemToolCallStatus": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "in_progress",
+              "completed",
+              "incomplete"
+            ]
+          }
+        ],
+        "description": "The lifecycle status of a service-managed system-tool invocation.",
         "x-ms-foundry-meta": {
           "required_previews": [
             "VoiceAgents=V1Preview"

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -73155,6 +73155,7 @@ components:
           mcp_list_tools: '#/components/schemas/OpenAI.RealtimeMCPListTools'
           mcp_call: '#/components/schemas/OpenAI.RealtimeMCPToolCall'
           mcp_approval_request: '#/components/schemas/OpenAI.RealtimeMCPApprovalRequest'
+          system_tool: '#/components/schemas/VoiceAgentResponseSystemToolItem'
       description: A single item within a Realtime conversation.
       x-ms-foundry-meta:
         required_previews:
@@ -73522,6 +73523,7 @@ components:
             - mcp_call
             - mcp_approval_request
             - message
+            - system_tool
     OpenAI.RealtimeCreateClientSecretRequest:
       type: object
       properties:
@@ -86718,6 +86720,56 @@ components:
       x-ms-foundry-meta:
         required_previews:
           - VoiceAgents=V1Preview
+    VoiceAgentResponseSystemToolItem:
+      type: object
+      required:
+        - id
+        - type
+        - status
+        - name
+        - call_id
+        - arguments
+      properties:
+        created_at:
+          $ref: '#/components/schemas/FoundryTimestamp'
+          description: The Unix timestamp (in seconds) for when the item was persisted.
+          readOnly: true
+        response_id:
+          type: string
+          description: The id of the response that produced this item, when applicable.
+          readOnly: true
+        id:
+          type: string
+          description: The server-generated identifier for the response item.
+        object:
+          type: string
+          enum:
+            - realtime.item
+          description: The object type. Always `realtime.item`.
+          default: realtime.item
+        type:
+          type: string
+          enum:
+            - system_tool
+          description: The item type. Always `system_tool`.
+        status:
+          $ref: '#/components/schemas/VoiceAgentSystemToolCallStatus'
+          description: The lifecycle status of the system-tool invocation.
+        name:
+          $ref: '#/components/schemas/VoiceAgentSystemToolName'
+          description: The service-managed system-tool name.
+        call_id:
+          type: string
+          description: The model-generated identifier that correlates the tool item and its lifecycle events.
+        arguments:
+          type: string
+          description: The JSON-encoded system-tool arguments. This value is empty while argument generation is in progress.
+      allOf:
+        - $ref: '#/components/schemas/OpenAI.RealtimeConversationItem'
+      description: A service-managed system-tool invocation emitted by a voice-agent session.
+      x-ms-foundry-meta:
+        required_previews:
+          - VoiceAgents=V1Preview
     VoiceAgentSemanticVadTurnDetection:
       type: object
       required:
@@ -86916,10 +86968,25 @@ components:
           description: The service-managed control action. Known values are stable; additional values may be added over time.
         description:
           type: string
-          description: An optional description of the system tool.
+          description: |-
+            Optional model-facing guidance for when and how to invoke the system tool. For `end_conversation`, omit this
+            property or use an empty string to apply the service default, which instructs the model to speak a closing
+            assistant message before invoking the tool. A non-empty value replaces the service default.
       allOf:
         - $ref: '#/components/schemas/VoiceAgentTool'
       description: A service-managed control that acts on the active voice session without customer code or external authentication.
+      x-ms-foundry-meta:
+        required_previews:
+          - VoiceAgents=V1Preview
+    VoiceAgentSystemToolCallStatus:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - in_progress
+            - completed
+            - incomplete
+      description: The lifecycle status of a service-managed system-tool invocation.
       x-ms-foundry-meta:
         required_previews:
           - VoiceAgents=V1Preview

--- a/specification/ai-foundry/data-plane/Foundry/src/voice-agents/agents.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/voice-agents/agents.tsp
@@ -385,7 +385,11 @@ model VoiceAgentSystemTool extends VoiceAgentTool {
   @doc("The service-managed control action. Known values are stable; additional values may be added over time.")
   name: VoiceAgentSystemToolName;
 
-  @doc("An optional description of the system tool.")
+  @doc("""
+    Optional model-facing guidance for when and how to invoke the system tool. For `end_conversation`, omit this
+    property or use an empty string to apply the service default, which instructs the model to speak a closing
+    assistant message before invoking the tool. A non-empty value replaces the service default.
+    """)
   description?: string;
 }
 
@@ -394,7 +398,7 @@ model VoiceAgentSystemTool extends VoiceAgentTool {
 union VoiceAgentSystemToolName {
   string,
 
-  @doc("Ends the active conversation.")
+  @doc("Ends the active conversation after pending response output, including farewell audio, has finished.")
   end_conversation: "end_conversation",
 }
 

--- a/specification/ai-foundry/data-plane/Foundry/src/voice-agents/protocol.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/voice-agents/protocol.tsp
@@ -17,6 +17,12 @@ alias VoiceAgentClientEventUsage = Usage.input | Usage.json;
 alias VoiceAgentServerEventUsage = Usage.output | Usage.json;
 alias VoiceAgentWebSocketMessageUsage = Usage.input | Usage.output | Usage.json;
 
+@doc("Additional conversation-item discriminators emitted by a voice-agent session.")
+union VoiceAgentConversationItemTypeExtension {
+  @doc("A service-managed system-tool invocation.")
+  system_tool: "system_tool",
+}
+
 union VoiceAgentClientEventTypeExtension {
   session_avatar_connect: "session.avatar.connect",
   rtc_call_sdp_create: "rtc.call.sdp.create",
@@ -24,6 +30,10 @@ union VoiceAgentClientEventTypeExtension {
 
 union VoiceAgentServerEventTypeExtension {
   warning: "warning",
+  response_system_tool_arguments_delta: "response.system_tool_arguments.delta",
+  response_system_tool_arguments_done: "response.system_tool_arguments.done",
+  session_end_conversation_cancelled: "session.end_conversation.cancelled",
+  session_end_conversation_completed: "session.end_conversation.completed",
   session_subagent_started: "session.subagent.started",
   session_subagent_completed: "session.subagent.completed",
   session_subagent_aborted: "session.subagent.aborted",
@@ -41,6 +51,11 @@ union VoiceAgentServerEventTypeExtension {
   response_video_delta: "response.video.delta",
 }
 
+#suppress "@azure-tools/typespec-azure-core/experimental-feature" "Registering Voice-only literals in the imported OpenAI discriminator union preserves a single polymorphic hierarchy."
+@@copyVariants(
+  OpenAI.RealtimeConversationItemType,
+  VoiceAgentConversationItemTypeExtension
+);
 #suppress "@azure-tools/typespec-azure-core/experimental-feature" "Registering Voice-only literals in the imported OpenAI discriminator union preserves a single polymorphic hierarchy."
 @@copyVariants(
   OpenAI.RealtimeClientEventType,
@@ -135,6 +150,8 @@ union VoiceAgentServerEvent {
   response_done: OpenAI.RealtimeServerEventResponseDone,
   response_function_call_arguments_delta: OpenAI.RealtimeServerEventResponseFunctionCallArgumentsDelta,
   response_function_call_arguments_done: OpenAI.RealtimeServerEventResponseFunctionCallArgumentsDone,
+  response_system_tool_arguments_delta: VoiceAgentServerEventResponseSystemToolArgumentsDelta,
+  response_system_tool_arguments_done: VoiceAgentServerEventResponseSystemToolArgumentsDone,
   response_mcp_call_arguments_delta: OpenAI.RealtimeServerEventResponseMCPCallArgumentsDelta,
   response_mcp_call_arguments_done: OpenAI.RealtimeServerEventResponseMCPCallArgumentsDone,
   response_mcp_call_completed: OpenAI.RealtimeServerEventResponseMCPCallCompleted,
@@ -145,6 +162,8 @@ union VoiceAgentServerEvent {
   response_output_text_delta: OpenAI.RealtimeServerEventResponseTextDelta,
   response_output_text_done: OpenAI.RealtimeServerEventResponseTextDone,
   session_created: OpenAI.RealtimeServerEventSessionCreated,
+  session_end_conversation_cancelled: VoiceAgentServerEventSessionEndConversationCancelled,
+  session_end_conversation_completed: VoiceAgentServerEventSessionEndConversationCompleted,
   session_subagent_started: VoiceAgentServerEventSessionSubagentStarted,
   session_subagent_completed: VoiceAgentServerEventSessionSubagentCompleted,
   session_subagent_aborted: VoiceAgentServerEventSessionSubagentAborted,
@@ -317,6 +336,49 @@ model VoiceAgentRealtimeResponseBase {
   ...OmitProperties<OpenAI.RealtimeResponse, "audio" | "output">;
 }
 
+@doc("The lifecycle status of a service-managed system-tool invocation.")
+@extension("x-ms-foundry-meta", VoiceAgentRequiredPreview)
+union VoiceAgentSystemToolCallStatus {
+  string,
+
+  @doc("The system tool is still receiving model-generated arguments.")
+  in_progress: "in_progress",
+
+  @doc("The system-tool arguments are complete.")
+  completed: "completed",
+
+  @doc("The system-tool invocation ended before all arguments were generated.")
+  incomplete: "incomplete",
+}
+
+@doc("A service-managed system-tool invocation emitted by a voice-agent session.")
+@usage(VoiceAgentServerEventUsage)
+@extension("x-ms-foundry-meta", VoiceAgentRequiredPreview)
+model VoiceAgentResponseSystemToolItem extends OpenAI.RealtimeConversationItem {
+  ...VoiceConversationItemPersistence;
+
+  @doc("The server-generated identifier for the response item.")
+  id: string;
+
+  @doc("The object type. Always `realtime.item`.")
+  object?: "realtime.item" = "realtime.item";
+
+  @doc("The item type. Always `system_tool`.")
+  type: "system_tool";
+
+  @doc("The lifecycle status of the system-tool invocation.")
+  status: VoiceAgentSystemToolCallStatus;
+
+  @doc("The service-managed system-tool name.")
+  name: VoiceAgentSystemToolName;
+
+  @doc("The model-generated identifier that correlates the tool item and its lifecycle events.")
+  call_id: string;
+
+  @doc("The JSON-encoded system-tool arguments. This value is empty while argument generation is in progress.")
+  arguments: string;
+}
+
 #suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "Inheritance preserves the upstream live response contract, including conversation_id, while replacing audio and output."
 @doc("A live realtime response returned by the voice-agent service in both `response.created` and `response.done` events.")
@@ -426,6 +488,97 @@ model VoiceAgentClientEventSessionUpdate {
   OpenAI.RealtimeServerEventSessionUpdated.session,
   VoiceAgentSessionResponse
 );
+
+@doc("The `response.system_tool_arguments.delta` server event.")
+@usage(VoiceAgentServerEventUsage)
+@extension("x-ms-foundry-meta", VoiceAgentRequiredPreview)
+model VoiceAgentServerEventResponseSystemToolArgumentsDelta
+  extends OpenAI.RealtimeServerEvent {
+  @doc("The server-generated event identifier.")
+  event_id: string;
+
+  @doc("The event type. Always `response.system_tool_arguments.delta`.")
+  type: "response.system_tool_arguments.delta";
+
+  @doc("The identifier of the response that contains the system-tool invocation.")
+  response_id: string;
+
+  @doc("The identifier of the system-tool response item.")
+  item_id: string;
+
+  @doc("The zero-based index of the system-tool item in the response output.")
+  output_index: int32;
+
+  @doc("The model-generated identifier for the system-tool invocation.")
+  call_id: string;
+
+  @doc("An incremental fragment of the JSON-encoded system-tool arguments.")
+  delta: string;
+
+  @doc("Optional upstream obfuscation metadata.")
+  obfuscation?: string;
+}
+
+@doc("The `response.system_tool_arguments.done` server event.")
+@usage(VoiceAgentServerEventUsage)
+@extension("x-ms-foundry-meta", VoiceAgentRequiredPreview)
+model VoiceAgentServerEventResponseSystemToolArgumentsDone
+  extends OpenAI.RealtimeServerEvent {
+  @doc("The server-generated event identifier.")
+  event_id: string;
+
+  @doc("The event type. Always `response.system_tool_arguments.done`.")
+  type: "response.system_tool_arguments.done";
+
+  @doc("The identifier of the response that contains the system-tool invocation.")
+  response_id: string;
+
+  @doc("The identifier of the system-tool response item.")
+  item_id: string;
+
+  @doc("The zero-based index of the system-tool item in the response output.")
+  output_index: int32;
+
+  @doc("The model-generated identifier for the system-tool invocation.")
+  call_id: string;
+
+  @doc("The service-managed system-tool name.")
+  name: VoiceAgentSystemToolName;
+
+  @doc("The complete JSON-encoded system-tool arguments.")
+  arguments: string;
+}
+
+@doc("Fields shared by server events that report an end-conversation close attempt.")
+model VoiceAgentServerEventSessionEndConversationLifecycle {
+  @doc("The server-generated event identifier.")
+  event_id: string;
+
+  @doc("The tool-call identifier for the `end_conversation` invocation.")
+  id: string;
+}
+
+@doc("The `session.end_conversation.cancelled` server event. New user input cancelled the pending close, so the session remains open.")
+@usage(VoiceAgentServerEventUsage)
+@extension("x-ms-foundry-meta", VoiceAgentRequiredPreview)
+model VoiceAgentServerEventSessionEndConversationCancelled
+  extends OpenAI.RealtimeServerEvent {
+  ...VoiceAgentServerEventSessionEndConversationLifecycle;
+
+  @doc("The event type. Always `session.end_conversation.cancelled`.")
+  type: "session.end_conversation.cancelled";
+}
+
+@doc("The `session.end_conversation.completed` server event. Pending response output has drained and the service has committed to closing the WebSocket.")
+@usage(VoiceAgentServerEventUsage)
+@extension("x-ms-foundry-meta", VoiceAgentRequiredPreview)
+model VoiceAgentServerEventSessionEndConversationCompleted
+  extends OpenAI.RealtimeServerEvent {
+  ...VoiceAgentServerEventSessionEndConversationLifecycle;
+
+  @doc("The event type. Always `session.end_conversation.completed`.")
+  type: "session.end_conversation.completed";
+}
 
 @doc("Fields shared by server events that report the lifecycle of a subagent consultation.")
 model VoiceAgentServerEventSessionSubagentLifecycle {

--- a/specification/ai/data-plane/VoiceLive/events.tsp
+++ b/specification/ai/data-plane/VoiceLive/events.tsp
@@ -87,6 +87,18 @@ union ServerEventType {
   response_function_call_arguments_done: "response.function_call_arguments.done",
 
   @added(Versions.v2026_01_01_preview)
+  response_system_tool_arguments_delta: "response.system_tool_arguments.delta",
+
+  @added(Versions.v2026_01_01_preview)
+  response_system_tool_arguments_done: "response.system_tool_arguments.done",
+
+  @added(Versions.v2026_01_01_preview)
+  session_end_conversation_cancelled: "session.end_conversation.cancelled",
+
+  @added(Versions.v2026_01_01_preview)
+  session_end_conversation_completed: "session.end_conversation.completed",
+
+  @added(Versions.v2026_01_01_preview)
   mcp_list_tools_in_progress: "mcp_list_tools.in_progress",
 
   @added(Versions.v2026_01_01_preview)

--- a/specification/ai/data-plane/VoiceLive/items.tsp
+++ b/specification/ai/data-plane/VoiceLive/items.tsp
@@ -13,6 +13,9 @@ union ItemType {
   function_call_output: "function_call_output",
 
   @added(Versions.v2026_01_01_preview)
+  system_tool: "system_tool",
+
+  @added(Versions.v2026_01_01_preview)
   mcp_list_tools: "mcp_list_tools",
 
   @added(Versions.v2026_01_01_preview)
@@ -204,6 +207,27 @@ model ResponseFunctionCallItem extends ResponseItem {
   call_id: string;
   arguments: string;
   status: ResponseItemStatus;
+}
+
+/** A service-managed system-tool invocation emitted by VoiceLive. */
+#suppress "@azure-tools/typespec-azure-core/casing-style" // Service message format is snake_case to remain close to OpenAI style.
+@added(Versions.v2026_01_01_preview)
+@usage(ResponseUsage)
+model ResponseSystemToolItem extends ResponseItem {
+  /** The item type. Always `system_tool`. */
+  type: ItemType.system_tool;
+
+  /** The processing status of the system-tool invocation. */
+  status: ResponseItemStatus;
+
+  /** The service-managed system-tool name, such as `end_conversation`. */
+  name: string;
+
+  /** The model-generated identifier that correlates the tool item and its lifecycle events. */
+  call_id: string;
+
+  /** The JSON-encoded system-tool arguments. This value is empty while argument generation is in progress. */
+  arguments: string;
 }
 
 /** A function call output item within a conversation. */

--- a/specification/ai/data-plane/VoiceLive/models.tsp
+++ b/specification/ai/data-plane/VoiceLive/models.tsp
@@ -1400,6 +1400,90 @@ model ServerEventResponseFunctionCallArgumentsDone extends ServerEvent {
   name: string;
 }
 
+/** Returned when the model-generated arguments for a service-managed system tool are updated. */
+#suppress "@azure-tools/typespec-azure-core/casing-style" // Service message format is snake_case to remain close to OpenAI style.
+@added(Versions.v2026_01_01_preview)
+@usage(ResponseUsage)
+model ServerEventResponseSystemToolArgumentsDelta extends ServerEvent {
+  /** The event type, must be `response.system_tool_arguments.delta`. */
+  type: ServerEventType.response_system_tool_arguments_delta;
+
+  /** The ID of the response containing the system-tool invocation. */
+  response_id: string;
+
+  /** The ID of the system-tool response item. */
+  item_id: string;
+
+  /** The zero-based index of the system-tool item in the response output. */
+  output_index: int32;
+
+  /** The model-generated ID of the system-tool invocation. */
+  call_id: string;
+
+  /** An incremental fragment of the JSON-encoded system-tool arguments. */
+  delta: string;
+
+  /** Optional upstream obfuscation metadata. */
+  obfuscation?: string;
+}
+
+/** Returned when the model-generated arguments for a service-managed system tool finish streaming. */
+#suppress "@azure-tools/typespec-azure-core/casing-style" // Service message format is snake_case to remain close to OpenAI style.
+@added(Versions.v2026_01_01_preview)
+@usage(ResponseUsage)
+model ServerEventResponseSystemToolArgumentsDone extends ServerEvent {
+  /** The event type, must be `response.system_tool_arguments.done`. */
+  type: ServerEventType.response_system_tool_arguments_done;
+
+  /** The ID of the response containing the system-tool invocation. */
+  response_id: string;
+
+  /** The ID of the system-tool response item. */
+  item_id: string;
+
+  /** The zero-based index of the system-tool item in the response output. */
+  output_index: int32;
+
+  /** The model-generated ID of the system-tool invocation. */
+  call_id: string;
+
+  /** The service-managed system-tool name. */
+  name: string;
+
+  /** The complete JSON-encoded system-tool arguments. */
+  arguments: string;
+}
+
+/**
+ * Returned when new user input cancels a pending `end_conversation` close attempt. The session remains open and a
+ * later tool invocation may begin another close attempt.
+ */
+#suppress "@azure-tools/typespec-azure-core/casing-style" // Service message format is snake_case to remain close to OpenAI style.
+@added(Versions.v2026_01_01_preview)
+@usage(ResponseUsage)
+model ServerEventSessionEndConversationCancelled extends ServerEvent {
+  /** The event type, must be `session.end_conversation.cancelled`. */
+  type: ServerEventType.session_end_conversation_cancelled;
+
+  /** The `call_id` of the corresponding `system_tool` response item. */
+  id: string;
+}
+
+/**
+ * Returned after pending farewell output has drained and VoiceLive commits to closing the WebSocket with close code
+ * `1001`.
+ */
+#suppress "@azure-tools/typespec-azure-core/casing-style" // Service message format is snake_case to remain close to OpenAI style.
+@added(Versions.v2026_01_01_preview)
+@usage(ResponseUsage)
+model ServerEventSessionEndConversationCompleted extends ServerEvent {
+  /** The event type, must be `session.end_conversation.completed`. */
+  type: ServerEventType.session_end_conversation_completed;
+
+  /** The `call_id` of the corresponding `system_tool` response item. */
+  id: string;
+}
+
 /** MCP list tools in progress message. */
 #suppress "@azure-tools/typespec-azure-core/casing-style"
 @added(Versions.v2026_01_01_preview)

--- a/specification/ai/data-plane/VoiceLive/preview/2026-01-01-preview/VoiceLive.json
+++ b/specification/ai/data-plane/VoiceLive/preview/2026-01-01-preview/VoiceLive.json
@@ -1365,6 +1365,22 @@
         "type"
       ]
     },
+    "EndConversationTool": {
+      "type": "object",
+      "description": "A service-managed tool that gracefully ends the active conversation. The model supplies a required, non-empty\n`reason` argument when invoking the tool. VoiceLive waits for pending response output, including farewell audio,\nbefore closing the WebSocket.",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "Optional model-facing guidance for when and how to invoke the tool. Omit this property or use an empty string to\napply the service default, which instructs the model to speak a closing assistant message before invoking the\ntool. A non-empty value replaces the service default."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Tool"
+        }
+      ],
+      "x-ms-discriminator-value": "end_conversation"
+    },
     "EouDetection": {
       "type": "object",
       "description": "Top-level union for end-of-utterance (EOU) semantic detection configuration.",
@@ -1751,6 +1767,7 @@
         "message",
         "function_call",
         "function_call_output",
+        "system_tool",
         "mcp_list_tools",
         "mcp_call",
         "mcp_approval_request",
@@ -1771,6 +1788,10 @@
           {
             "name": "function_call_output",
             "value": "function_call_output"
+          },
+          {
+            "name": "system_tool",
+            "value": "system_tool"
           },
           {
             "name": "mcp_list_tools",
@@ -3382,6 +3403,40 @@
         "type"
       ]
     },
+    "ResponseSystemToolItem": {
+      "type": "object",
+      "description": "A service-managed system-tool invocation emitted by VoiceLive.",
+      "properties": {
+        "status": {
+          "$ref": "#/definitions/ResponseItemStatus",
+          "description": "The processing status of the system-tool invocation."
+        },
+        "name": {
+          "type": "string",
+          "description": "The service-managed system-tool name, such as `end_conversation`."
+        },
+        "call_id": {
+          "type": "string",
+          "description": "The model-generated identifier that correlates the tool item and its lifecycle events."
+        },
+        "arguments": {
+          "type": "string",
+          "description": "The JSON-encoded system-tool arguments. This value is empty while argument generation is in progress."
+        }
+      },
+      "required": [
+        "status",
+        "name",
+        "call_id",
+        "arguments"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/ResponseItem"
+        }
+      ],
+      "x-ms-discriminator-value": "system_tool"
+    },
     "ResponseTextContentPart": {
       "type": "object",
       "description": "A text content part for a response.",
@@ -4628,6 +4683,95 @@
       ],
       "x-ms-discriminator-value": "response.output_item.done"
     },
+    "ServerEventResponseSystemToolArgumentsDelta": {
+      "type": "object",
+      "description": "Returned when the model-generated arguments for a service-managed system tool are updated.",
+      "properties": {
+        "response_id": {
+          "type": "string",
+          "description": "The ID of the response containing the system-tool invocation."
+        },
+        "item_id": {
+          "type": "string",
+          "description": "The ID of the system-tool response item."
+        },
+        "output_index": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The zero-based index of the system-tool item in the response output."
+        },
+        "call_id": {
+          "type": "string",
+          "description": "The model-generated ID of the system-tool invocation."
+        },
+        "delta": {
+          "type": "string",
+          "description": "An incremental fragment of the JSON-encoded system-tool arguments."
+        },
+        "obfuscation": {
+          "type": "string",
+          "description": "Optional upstream obfuscation metadata."
+        }
+      },
+      "required": [
+        "response_id",
+        "item_id",
+        "output_index",
+        "call_id",
+        "delta"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/ServerEvent"
+        }
+      ],
+      "x-ms-discriminator-value": "response.system_tool_arguments.delta"
+    },
+    "ServerEventResponseSystemToolArgumentsDone": {
+      "type": "object",
+      "description": "Returned when the model-generated arguments for a service-managed system tool finish streaming.",
+      "properties": {
+        "response_id": {
+          "type": "string",
+          "description": "The ID of the response containing the system-tool invocation."
+        },
+        "item_id": {
+          "type": "string",
+          "description": "The ID of the system-tool response item."
+        },
+        "output_index": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The zero-based index of the system-tool item in the response output."
+        },
+        "call_id": {
+          "type": "string",
+          "description": "The model-generated ID of the system-tool invocation."
+        },
+        "name": {
+          "type": "string",
+          "description": "The service-managed system-tool name."
+        },
+        "arguments": {
+          "type": "string",
+          "description": "The complete JSON-encoded system-tool arguments."
+        }
+      },
+      "required": [
+        "response_id",
+        "item_id",
+        "output_index",
+        "call_id",
+        "name",
+        "arguments"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/ServerEvent"
+        }
+      ],
+      "x-ms-discriminator-value": "response.system_tool_arguments.done"
+    },
     "ServerEventResponseTextDelta": {
       "type": "object",
       "description": "Returned when the text value of a \"text\" content part is updated.",
@@ -4747,6 +4891,44 @@
       ],
       "x-ms-discriminator-value": "session.created"
     },
+    "ServerEventSessionEndConversationCancelled": {
+      "type": "object",
+      "description": "Returned when new user input cancels a pending `end_conversation` close attempt. The session remains open and a\nlater tool invocation may begin another close attempt.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The `call_id` of the corresponding `system_tool` response item."
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/ServerEvent"
+        }
+      ],
+      "x-ms-discriminator-value": "session.end_conversation.cancelled"
+    },
+    "ServerEventSessionEndConversationCompleted": {
+      "type": "object",
+      "description": "Returned after pending farewell output has drained and VoiceLive commits to closing the WebSocket with close code\n`1001`.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The `call_id` of the corresponding `system_tool` response item."
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/ServerEvent"
+        }
+      ],
+      "x-ms-discriminator-value": "session.end_conversation.completed"
+    },
     "ServerEventSessionUpdated": {
       "type": "object",
       "description": "Returned when a session is updated with a `session.update` event, unless\nthere is an error.",
@@ -4805,6 +4987,10 @@
         "response.animation_viseme.done",
         "response.function_call_arguments.delta",
         "response.function_call_arguments.done",
+        "response.system_tool_arguments.delta",
+        "response.system_tool_arguments.done",
+        "session.end_conversation.cancelled",
+        "session.end_conversation.completed",
         "mcp_list_tools.in_progress",
         "mcp_list_tools.completed",
         "mcp_list_tools.failed",
@@ -4961,6 +5147,22 @@
           {
             "name": "response_function_call_arguments_done",
             "value": "response.function_call_arguments.done"
+          },
+          {
+            "name": "response_system_tool_arguments_delta",
+            "value": "response.system_tool_arguments.delta"
+          },
+          {
+            "name": "response_system_tool_arguments_done",
+            "value": "response.system_tool_arguments.done"
+          },
+          {
+            "name": "session_end_conversation_cancelled",
+            "value": "session.end_conversation.cancelled"
+          },
+          {
+            "name": "session_end_conversation_completed",
+            "value": "session.end_conversation.completed"
           },
           {
             "name": "mcp_list_tools_in_progress",
@@ -5231,10 +5433,11 @@
     },
     "ToolType": {
       "type": "string",
-      "description": "The supported tool type discriminators for voicelive tools.\nCurrently, only 'function' tools are supported.",
+      "description": "The supported tool type discriminators for voicelive tools.",
       "enum": [
         "function",
-        "mcp"
+        "mcp",
+        "end_conversation"
       ],
       "x-ms-enum": {
         "name": "ToolType",
@@ -5247,6 +5450,10 @@
           {
             "name": "mcp",
             "value": "mcp"
+          },
+          {
+            "name": "end_conversation",
+            "value": "end_conversation"
           }
         ]
       }

--- a/specification/ai/data-plane/VoiceLive/preview/2026-06-01-preview/VoiceLive.json
+++ b/specification/ai/data-plane/VoiceLive/preview/2026-06-01-preview/VoiceLive.json
@@ -1821,6 +1821,22 @@
         ]
       }
     },
+    "EndConversationTool": {
+      "type": "object",
+      "description": "A service-managed tool that gracefully ends the active conversation. The model supplies a required, non-empty\n`reason` argument when invoking the tool. VoiceLive waits for pending response output, including farewell audio,\nbefore closing the WebSocket.",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "Optional model-facing guidance for when and how to invoke the tool. Omit this property or use an empty string to\napply the service default, which instructs the model to speak a closing assistant message before invoking the\ntool. A non-empty value replaces the service default."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Tool"
+        }
+      ],
+      "x-ms-discriminator-value": "end_conversation"
+    },
     "EouDetection": {
       "type": "object",
       "description": "Top-level union for end-of-utterance (EOU) semantic detection configuration.",
@@ -2238,6 +2254,7 @@
         "message",
         "function_call",
         "function_call_output",
+        "system_tool",
         "mcp_list_tools",
         "mcp_call",
         "mcp_approval_request",
@@ -2260,6 +2277,10 @@
           {
             "name": "function_call_output",
             "value": "function_call_output"
+          },
+          {
+            "name": "system_tool",
+            "value": "system_tool"
           },
           {
             "name": "mcp_list_tools",
@@ -3988,6 +4009,40 @@
         "type"
       ]
     },
+    "ResponseSystemToolItem": {
+      "type": "object",
+      "description": "A service-managed system-tool invocation emitted by VoiceLive.",
+      "properties": {
+        "status": {
+          "$ref": "#/definitions/ResponseItemStatus",
+          "description": "The processing status of the system-tool invocation."
+        },
+        "name": {
+          "type": "string",
+          "description": "The service-managed system-tool name, such as `end_conversation`."
+        },
+        "call_id": {
+          "type": "string",
+          "description": "The model-generated identifier that correlates the tool item and its lifecycle events."
+        },
+        "arguments": {
+          "type": "string",
+          "description": "The JSON-encoded system-tool arguments. This value is empty while argument generation is in progress."
+        }
+      },
+      "required": [
+        "status",
+        "name",
+        "call_id",
+        "arguments"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/ResponseItem"
+        }
+      ],
+      "x-ms-discriminator-value": "system_tool"
+    },
     "ResponseTextContentPart": {
       "type": "object",
       "description": "A text content part for a response.",
@@ -5514,6 +5569,95 @@
       ],
       "x-ms-discriminator-value": "response.output_item.done"
     },
+    "ServerEventResponseSystemToolArgumentsDelta": {
+      "type": "object",
+      "description": "Returned when the model-generated arguments for a service-managed system tool are updated.",
+      "properties": {
+        "response_id": {
+          "type": "string",
+          "description": "The ID of the response containing the system-tool invocation."
+        },
+        "item_id": {
+          "type": "string",
+          "description": "The ID of the system-tool response item."
+        },
+        "output_index": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The zero-based index of the system-tool item in the response output."
+        },
+        "call_id": {
+          "type": "string",
+          "description": "The model-generated ID of the system-tool invocation."
+        },
+        "delta": {
+          "type": "string",
+          "description": "An incremental fragment of the JSON-encoded system-tool arguments."
+        },
+        "obfuscation": {
+          "type": "string",
+          "description": "Optional upstream obfuscation metadata."
+        }
+      },
+      "required": [
+        "response_id",
+        "item_id",
+        "output_index",
+        "call_id",
+        "delta"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/ServerEvent"
+        }
+      ],
+      "x-ms-discriminator-value": "response.system_tool_arguments.delta"
+    },
+    "ServerEventResponseSystemToolArgumentsDone": {
+      "type": "object",
+      "description": "Returned when the model-generated arguments for a service-managed system tool finish streaming.",
+      "properties": {
+        "response_id": {
+          "type": "string",
+          "description": "The ID of the response containing the system-tool invocation."
+        },
+        "item_id": {
+          "type": "string",
+          "description": "The ID of the system-tool response item."
+        },
+        "output_index": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The zero-based index of the system-tool item in the response output."
+        },
+        "call_id": {
+          "type": "string",
+          "description": "The model-generated ID of the system-tool invocation."
+        },
+        "name": {
+          "type": "string",
+          "description": "The service-managed system-tool name."
+        },
+        "arguments": {
+          "type": "string",
+          "description": "The complete JSON-encoded system-tool arguments."
+        }
+      },
+      "required": [
+        "response_id",
+        "item_id",
+        "output_index",
+        "call_id",
+        "name",
+        "arguments"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/ServerEvent"
+        }
+      ],
+      "x-ms-discriminator-value": "response.system_tool_arguments.done"
+    },
     "ServerEventResponseTextDelta": {
       "type": "object",
       "description": "Returned when the text value of a \"text\" content part is updated.",
@@ -5854,6 +5998,44 @@
       ],
       "x-ms-discriminator-value": "session.created"
     },
+    "ServerEventSessionEndConversationCancelled": {
+      "type": "object",
+      "description": "Returned when new user input cancels a pending `end_conversation` close attempt. The session remains open and a\nlater tool invocation may begin another close attempt.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The `call_id` of the corresponding `system_tool` response item."
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/ServerEvent"
+        }
+      ],
+      "x-ms-discriminator-value": "session.end_conversation.cancelled"
+    },
+    "ServerEventSessionEndConversationCompleted": {
+      "type": "object",
+      "description": "Returned after pending farewell output has drained and VoiceLive commits to closing the WebSocket with close code\n`1001`.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The `call_id` of the corresponding `system_tool` response item."
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/ServerEvent"
+        }
+      ],
+      "x-ms-discriminator-value": "session.end_conversation.completed"
+    },
     "ServerEventSessionUpdated": {
       "type": "object",
       "description": "Returned when a session is updated with a `session.update` event, unless\nthere is an error.",
@@ -5912,6 +6094,10 @@
         "response.animation_viseme.done",
         "response.function_call_arguments.delta",
         "response.function_call_arguments.done",
+        "response.system_tool_arguments.delta",
+        "response.system_tool_arguments.done",
+        "session.end_conversation.cancelled",
+        "session.end_conversation.completed",
         "mcp_list_tools.in_progress",
         "mcp_list_tools.completed",
         "mcp_list_tools.failed",
@@ -6084,6 +6270,22 @@
           {
             "name": "response_function_call_arguments_done",
             "value": "response.function_call_arguments.done"
+          },
+          {
+            "name": "response_system_tool_arguments_delta",
+            "value": "response.system_tool_arguments.delta"
+          },
+          {
+            "name": "response_system_tool_arguments_done",
+            "value": "response.system_tool_arguments.done"
+          },
+          {
+            "name": "session_end_conversation_cancelled",
+            "value": "session.end_conversation.cancelled"
+          },
+          {
+            "name": "session_end_conversation_completed",
+            "value": "session.end_conversation.completed"
           },
           {
             "name": "mcp_list_tools_in_progress",
@@ -6486,10 +6688,11 @@
     },
     "ToolType": {
       "type": "string",
-      "description": "The supported tool type discriminators for voicelive tools.\nCurrently, only 'function' tools are supported.",
+      "description": "The supported tool type discriminators for voicelive tools.",
       "enum": [
         "function",
-        "mcp"
+        "mcp",
+        "end_conversation"
       ],
       "x-ms-enum": {
         "name": "ToolType",
@@ -6502,6 +6705,10 @@
           {
             "name": "mcp",
             "value": "mcp"
+          },
+          {
+            "name": "end_conversation",
+            "value": "end_conversation"
           }
         ]
       }

--- a/specification/ai/data-plane/VoiceLive/stable/2025-10-01/VoiceLive.json
+++ b/specification/ai/data-plane/VoiceLive/stable/2025-10-01/VoiceLive.json
@@ -4208,7 +4208,7 @@
     },
     "ToolType": {
       "type": "string",
-      "description": "The supported tool type discriminators for voicelive tools.\nCurrently, only 'function' tools are supported.",
+      "description": "The supported tool type discriminators for voicelive tools.",
       "enum": [
         "function"
       ],

--- a/specification/ai/data-plane/VoiceLive/stable/2026-04-10/VoiceLive.json
+++ b/specification/ai/data-plane/VoiceLive/stable/2026-04-10/VoiceLive.json
@@ -1560,6 +1560,22 @@
         "type"
       ]
     },
+    "EndConversationTool": {
+      "type": "object",
+      "description": "A service-managed tool that gracefully ends the active conversation. The model supplies a required, non-empty\n`reason` argument when invoking the tool. VoiceLive waits for pending response output, including farewell audio,\nbefore closing the WebSocket.",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "Optional model-facing guidance for when and how to invoke the tool. Omit this property or use an empty string to\napply the service default, which instructs the model to speak a closing assistant message before invoking the\ntool. A non-empty value replaces the service default."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Tool"
+        }
+      ],
+      "x-ms-discriminator-value": "end_conversation"
+    },
     "EouDetection": {
       "type": "object",
       "description": "Top-level union for end-of-utterance (EOU) semantic detection configuration.",
@@ -1976,6 +1992,7 @@
         "message",
         "function_call",
         "function_call_output",
+        "system_tool",
         "mcp_list_tools",
         "mcp_call",
         "mcp_approval_request",
@@ -1998,6 +2015,10 @@
           {
             "name": "function_call_output",
             "value": "function_call_output"
+          },
+          {
+            "name": "system_tool",
+            "value": "system_tool"
           },
           {
             "name": "mcp_list_tools",
@@ -3711,6 +3732,40 @@
         "type"
       ]
     },
+    "ResponseSystemToolItem": {
+      "type": "object",
+      "description": "A service-managed system-tool invocation emitted by VoiceLive.",
+      "properties": {
+        "status": {
+          "$ref": "#/definitions/ResponseItemStatus",
+          "description": "The processing status of the system-tool invocation."
+        },
+        "name": {
+          "type": "string",
+          "description": "The service-managed system-tool name, such as `end_conversation`."
+        },
+        "call_id": {
+          "type": "string",
+          "description": "The model-generated identifier that correlates the tool item and its lifecycle events."
+        },
+        "arguments": {
+          "type": "string",
+          "description": "The JSON-encoded system-tool arguments. This value is empty while argument generation is in progress."
+        }
+      },
+      "required": [
+        "status",
+        "name",
+        "call_id",
+        "arguments"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/ResponseItem"
+        }
+      ],
+      "x-ms-discriminator-value": "system_tool"
+    },
     "ResponseTextContentPart": {
       "type": "object",
       "description": "A text content part for a response.",
@@ -5163,6 +5218,95 @@
       ],
       "x-ms-discriminator-value": "response.output_item.done"
     },
+    "ServerEventResponseSystemToolArgumentsDelta": {
+      "type": "object",
+      "description": "Returned when the model-generated arguments for a service-managed system tool are updated.",
+      "properties": {
+        "response_id": {
+          "type": "string",
+          "description": "The ID of the response containing the system-tool invocation."
+        },
+        "item_id": {
+          "type": "string",
+          "description": "The ID of the system-tool response item."
+        },
+        "output_index": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The zero-based index of the system-tool item in the response output."
+        },
+        "call_id": {
+          "type": "string",
+          "description": "The model-generated ID of the system-tool invocation."
+        },
+        "delta": {
+          "type": "string",
+          "description": "An incremental fragment of the JSON-encoded system-tool arguments."
+        },
+        "obfuscation": {
+          "type": "string",
+          "description": "Optional upstream obfuscation metadata."
+        }
+      },
+      "required": [
+        "response_id",
+        "item_id",
+        "output_index",
+        "call_id",
+        "delta"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/ServerEvent"
+        }
+      ],
+      "x-ms-discriminator-value": "response.system_tool_arguments.delta"
+    },
+    "ServerEventResponseSystemToolArgumentsDone": {
+      "type": "object",
+      "description": "Returned when the model-generated arguments for a service-managed system tool finish streaming.",
+      "properties": {
+        "response_id": {
+          "type": "string",
+          "description": "The ID of the response containing the system-tool invocation."
+        },
+        "item_id": {
+          "type": "string",
+          "description": "The ID of the system-tool response item."
+        },
+        "output_index": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The zero-based index of the system-tool item in the response output."
+        },
+        "call_id": {
+          "type": "string",
+          "description": "The model-generated ID of the system-tool invocation."
+        },
+        "name": {
+          "type": "string",
+          "description": "The service-managed system-tool name."
+        },
+        "arguments": {
+          "type": "string",
+          "description": "The complete JSON-encoded system-tool arguments."
+        }
+      },
+      "required": [
+        "response_id",
+        "item_id",
+        "output_index",
+        "call_id",
+        "name",
+        "arguments"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/ServerEvent"
+        }
+      ],
+      "x-ms-discriminator-value": "response.system_tool_arguments.done"
+    },
     "ServerEventResponseTextDelta": {
       "type": "object",
       "description": "Returned when the text value of a \"text\" content part is updated.",
@@ -5452,6 +5596,44 @@
       ],
       "x-ms-discriminator-value": "session.created"
     },
+    "ServerEventSessionEndConversationCancelled": {
+      "type": "object",
+      "description": "Returned when new user input cancels a pending `end_conversation` close attempt. The session remains open and a\nlater tool invocation may begin another close attempt.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The `call_id` of the corresponding `system_tool` response item."
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/ServerEvent"
+        }
+      ],
+      "x-ms-discriminator-value": "session.end_conversation.cancelled"
+    },
+    "ServerEventSessionEndConversationCompleted": {
+      "type": "object",
+      "description": "Returned after pending farewell output has drained and VoiceLive commits to closing the WebSocket with close code\n`1001`.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The `call_id` of the corresponding `system_tool` response item."
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/ServerEvent"
+        }
+      ],
+      "x-ms-discriminator-value": "session.end_conversation.completed"
+    },
     "ServerEventSessionUpdated": {
       "type": "object",
       "description": "Returned when a session is updated with a `session.update` event, unless\nthere is an error.",
@@ -5510,6 +5692,10 @@
         "response.animation_viseme.done",
         "response.function_call_arguments.delta",
         "response.function_call_arguments.done",
+        "response.system_tool_arguments.delta",
+        "response.system_tool_arguments.done",
+        "session.end_conversation.cancelled",
+        "session.end_conversation.completed",
         "mcp_list_tools.in_progress",
         "mcp_list_tools.completed",
         "mcp_list_tools.failed",
@@ -5677,6 +5863,22 @@
           {
             "name": "response_function_call_arguments_done",
             "value": "response.function_call_arguments.done"
+          },
+          {
+            "name": "response_system_tool_arguments_delta",
+            "value": "response.system_tool_arguments.delta"
+          },
+          {
+            "name": "response_system_tool_arguments_done",
+            "value": "response.system_tool_arguments.done"
+          },
+          {
+            "name": "session_end_conversation_cancelled",
+            "value": "session.end_conversation.cancelled"
+          },
+          {
+            "name": "session_end_conversation_completed",
+            "value": "session.end_conversation.completed"
           },
           {
             "name": "mcp_list_tools_in_progress",
@@ -6032,10 +6234,11 @@
     },
     "ToolType": {
       "type": "string",
-      "description": "The supported tool type discriminators for voicelive tools.\nCurrently, only 'function' tools are supported.",
+      "description": "The supported tool type discriminators for voicelive tools.",
       "enum": [
         "function",
-        "mcp"
+        "mcp",
+        "end_conversation"
       ],
       "x-ms-enum": {
         "name": "ToolType",
@@ -6048,6 +6251,10 @@
           {
             "name": "mcp",
             "value": "mcp"
+          },
+          {
+            "name": "end_conversation",
+            "value": "end_conversation"
           }
         ]
       }

--- a/specification/ai/data-plane/VoiceLive/stable/2026-07-15/VoiceLive.json
+++ b/specification/ai/data-plane/VoiceLive/stable/2026-07-15/VoiceLive.json
@@ -1792,6 +1792,22 @@
         ]
       }
     },
+    "EndConversationTool": {
+      "type": "object",
+      "description": "A service-managed tool that gracefully ends the active conversation. The model supplies a required, non-empty\n`reason` argument when invoking the tool. VoiceLive waits for pending response output, including farewell audio,\nbefore closing the WebSocket.",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "Optional model-facing guidance for when and how to invoke the tool. Omit this property or use an empty string to\napply the service default, which instructs the model to speak a closing assistant message before invoking the\ntool. A non-empty value replaces the service default."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Tool"
+        }
+      ],
+      "x-ms-discriminator-value": "end_conversation"
+    },
     "EouDetection": {
       "type": "object",
       "description": "Top-level union for end-of-utterance (EOU) semantic detection configuration.",
@@ -2208,6 +2224,7 @@
         "message",
         "function_call",
         "function_call_output",
+        "system_tool",
         "mcp_list_tools",
         "mcp_call",
         "mcp_approval_request",
@@ -2230,6 +2247,10 @@
           {
             "name": "function_call_output",
             "value": "function_call_output"
+          },
+          {
+            "name": "system_tool",
+            "value": "system_tool"
           },
           {
             "name": "mcp_list_tools",
@@ -3963,6 +3984,40 @@
         "type"
       ]
     },
+    "ResponseSystemToolItem": {
+      "type": "object",
+      "description": "A service-managed system-tool invocation emitted by VoiceLive.",
+      "properties": {
+        "status": {
+          "$ref": "#/definitions/ResponseItemStatus",
+          "description": "The processing status of the system-tool invocation."
+        },
+        "name": {
+          "type": "string",
+          "description": "The service-managed system-tool name, such as `end_conversation`."
+        },
+        "call_id": {
+          "type": "string",
+          "description": "The model-generated identifier that correlates the tool item and its lifecycle events."
+        },
+        "arguments": {
+          "type": "string",
+          "description": "The JSON-encoded system-tool arguments. This value is empty while argument generation is in progress."
+        }
+      },
+      "required": [
+        "status",
+        "name",
+        "call_id",
+        "arguments"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/ResponseItem"
+        }
+      ],
+      "x-ms-discriminator-value": "system_tool"
+    },
     "ResponseTextContentPart": {
       "type": "object",
       "description": "A text content part for a response.",
@@ -5435,6 +5490,95 @@
       ],
       "x-ms-discriminator-value": "response.output_item.done"
     },
+    "ServerEventResponseSystemToolArgumentsDelta": {
+      "type": "object",
+      "description": "Returned when the model-generated arguments for a service-managed system tool are updated.",
+      "properties": {
+        "response_id": {
+          "type": "string",
+          "description": "The ID of the response containing the system-tool invocation."
+        },
+        "item_id": {
+          "type": "string",
+          "description": "The ID of the system-tool response item."
+        },
+        "output_index": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The zero-based index of the system-tool item in the response output."
+        },
+        "call_id": {
+          "type": "string",
+          "description": "The model-generated ID of the system-tool invocation."
+        },
+        "delta": {
+          "type": "string",
+          "description": "An incremental fragment of the JSON-encoded system-tool arguments."
+        },
+        "obfuscation": {
+          "type": "string",
+          "description": "Optional upstream obfuscation metadata."
+        }
+      },
+      "required": [
+        "response_id",
+        "item_id",
+        "output_index",
+        "call_id",
+        "delta"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/ServerEvent"
+        }
+      ],
+      "x-ms-discriminator-value": "response.system_tool_arguments.delta"
+    },
+    "ServerEventResponseSystemToolArgumentsDone": {
+      "type": "object",
+      "description": "Returned when the model-generated arguments for a service-managed system tool finish streaming.",
+      "properties": {
+        "response_id": {
+          "type": "string",
+          "description": "The ID of the response containing the system-tool invocation."
+        },
+        "item_id": {
+          "type": "string",
+          "description": "The ID of the system-tool response item."
+        },
+        "output_index": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The zero-based index of the system-tool item in the response output."
+        },
+        "call_id": {
+          "type": "string",
+          "description": "The model-generated ID of the system-tool invocation."
+        },
+        "name": {
+          "type": "string",
+          "description": "The service-managed system-tool name."
+        },
+        "arguments": {
+          "type": "string",
+          "description": "The complete JSON-encoded system-tool arguments."
+        }
+      },
+      "required": [
+        "response_id",
+        "item_id",
+        "output_index",
+        "call_id",
+        "name",
+        "arguments"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/ServerEvent"
+        }
+      ],
+      "x-ms-discriminator-value": "response.system_tool_arguments.done"
+    },
     "ServerEventResponseTextDelta": {
       "type": "object",
       "description": "Returned when the text value of a \"text\" content part is updated.",
@@ -5724,6 +5868,44 @@
       ],
       "x-ms-discriminator-value": "session.created"
     },
+    "ServerEventSessionEndConversationCancelled": {
+      "type": "object",
+      "description": "Returned when new user input cancels a pending `end_conversation` close attempt. The session remains open and a\nlater tool invocation may begin another close attempt.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The `call_id` of the corresponding `system_tool` response item."
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/ServerEvent"
+        }
+      ],
+      "x-ms-discriminator-value": "session.end_conversation.cancelled"
+    },
+    "ServerEventSessionEndConversationCompleted": {
+      "type": "object",
+      "description": "Returned after pending farewell output has drained and VoiceLive commits to closing the WebSocket with close code\n`1001`.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The `call_id` of the corresponding `system_tool` response item."
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/ServerEvent"
+        }
+      ],
+      "x-ms-discriminator-value": "session.end_conversation.completed"
+    },
     "ServerEventSessionUpdated": {
       "type": "object",
       "description": "Returned when a session is updated with a `session.update` event, unless\nthere is an error.",
@@ -5782,6 +5964,10 @@
         "response.animation_viseme.done",
         "response.function_call_arguments.delta",
         "response.function_call_arguments.done",
+        "response.system_tool_arguments.delta",
+        "response.system_tool_arguments.done",
+        "session.end_conversation.cancelled",
+        "session.end_conversation.completed",
         "mcp_list_tools.in_progress",
         "mcp_list_tools.completed",
         "mcp_list_tools.failed",
@@ -5950,6 +6136,22 @@
           {
             "name": "response_function_call_arguments_done",
             "value": "response.function_call_arguments.done"
+          },
+          {
+            "name": "response_system_tool_arguments_delta",
+            "value": "response.system_tool_arguments.delta"
+          },
+          {
+            "name": "response_system_tool_arguments_done",
+            "value": "response.system_tool_arguments.done"
+          },
+          {
+            "name": "session_end_conversation_cancelled",
+            "value": "session.end_conversation.cancelled"
+          },
+          {
+            "name": "session_end_conversation_completed",
+            "value": "session.end_conversation.completed"
           },
           {
             "name": "mcp_list_tools_in_progress",
@@ -6310,10 +6512,11 @@
     },
     "ToolType": {
       "type": "string",
-      "description": "The supported tool type discriminators for voicelive tools.\nCurrently, only 'function' tools are supported.",
+      "description": "The supported tool type discriminators for voicelive tools.",
       "enum": [
         "function",
-        "mcp"
+        "mcp",
+        "end_conversation"
       ],
       "x-ms-enum": {
         "name": "ToolType",
@@ -6326,6 +6529,10 @@
           {
             "name": "mcp",
             "value": "mcp"
+          },
+          {
+            "name": "end_conversation",
+            "value": "end_conversation"
           }
         ]
       }

--- a/specification/ai/data-plane/VoiceLive/tools.tsp
+++ b/specification/ai/data-plane/VoiceLive/tools.tsp
@@ -7,7 +7,6 @@ namespace VoiceLive;
 
 /**
  * The supported tool type discriminators for voicelive tools.
- * Currently, only 'function' tools are supported.
  */
 union ToolType {
   string,
@@ -15,6 +14,9 @@ union ToolType {
 
   @added(Versions.v2026_01_01_preview)
   mcp: "mcp",
+
+  @added(Versions.v2026_01_01_preview)
+  end_conversation: "end_conversation",
 }
 
 /**
@@ -36,6 +38,25 @@ model FunctionTool extends Tool {
   name: string;
   description?: string;
   parameters?: unknown;
+}
+
+/**
+ * A service-managed tool that gracefully ends the active conversation. The model supplies a required, non-empty
+ * `reason` argument when invoking the tool. VoiceLive waits for pending response output, including farewell audio,
+ * before closing the WebSocket.
+ */
+@added(Versions.v2026_01_01_preview)
+@usage(RequestUsage)
+model EndConversationTool extends Tool {
+  /** The tool type. Always `end_conversation`. */
+  type: ToolType.end_conversation;
+
+  /**
+   * Optional model-facing guidance for when and how to invoke the tool. Omit this property or use an empty string to
+   * apply the service default, which instructs the model to speak a closing assistant message before invoking the
+   * tool. A non-empty value replaces the service default.
+   */
+  description?: string;
 }
 
 /**


### PR DESCRIPTION
# Data Plane API Specification Update Pull Request

Align the Microsoft Foundry Voice Agent and VoiceLive TypeSpec contracts with the graceful `end_conversation` system-tool implementation and its latest WebSocket wire protocol.

## Summary

- document the Foundry voice-agent `system` tool and default-description behavior for `end_conversation`
- add the VoiceLive `end_conversation` request tool beginning with `2026-01-01-preview`
- add the response-only `system_tool` item discriminator
- add `response.system_tool_arguments.delta` and `response.system_tool_arguments.done`
- add `session.end_conversation.cancelled` and `session.end_conversation.completed`
- document that farewell output is drained before the server closes the WebSocket with code `1001`
- regenerate Foundry `v1` / `virtual-public-preview` OpenAPI and all affected VoiceLive Swagger versions

## API Info: The Basics

* Link to API Spec engagement record issue: N/A — additive contract alignment for the existing Voice Agent and VoiceLive APIs.

Is this review for:

- [ ] a private preview
- [x] a public preview (Foundry Voice Agents; the VoiceLive change is additive in its existing versioned contracts)
- [ ] GA release

### Change Scope

* Design/implementation references:
  * Voice Live implementation PR: https://speedme.visualstudio.com/TextToSpeech/_git/voice-agent-orchestrator/pullrequest/40249
  * Vienna integration PR: https://dev.azure.com/msdata/Vienna/_git/vienna/pullrequest/2281226
* Previous API Spec Doc: existing contracts on `feature/voice-agent-batch2`
* Updated paths:
  * `specification/ai-foundry/data-plane/Foundry/src/voice-agents`
  * `specification/ai-foundry/data-plane/Foundry/openapi3`
  * `specification/ai/data-plane/VoiceLive`

## Validation

- `npx tsp compile . --no-emit --warn-as-error` — Foundry passed
- `npx tsv .` — Foundry passed
- `npx tsp compile . --no-emit --warn-as-error` — VoiceLive passed
- `npx tsv .` — VoiceLive passed, including client TypeSpec and five generated Swagger versions
- schema assertions passed for Foundry `v1` and `virtual-public-preview`
- versioned schema assertions passed for every VoiceLive version; `2025-10-01` does not expose the new wire types and all versions from `2026-01-01-preview` onward do
