### PR TITLE
Integrate azsdk-cli breaking change detection

### DIFF
--- a/eng/tools/spec-gen-sdk-runner/src/azsdk-adapter.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/azsdk-adapter.ts
@@ -53,6 +53,52 @@ export interface AzsdkPackResponse {
 }
 
 /**
+ * Result payload from `azsdk pkg detect-breaking-change` when the tool produced
+ * a result.
+ */
+export interface AzsdkBreakingChangeResult {
+  hasBreakingChange?: boolean;
+  breakingChanges?: unknown[];
+  changes?: string;
+}
+
+/**
+ * Response shape from `azsdk pkg detect-breaking-change --output json`.
+ *
+ * `result` is polymorphic: a definitive run yields an {@link AzsdkBreakingChangeResult}
+ * object; a failed run yields the string `"failed"`.
+ */
+export interface AzsdkDetectBreakingChangeResponse {
+  result?: string | AzsdkBreakingChangeResult;
+  message?: string;
+  package_name?: string;
+  language?: string;
+  response_error?: string;
+  response_errors?: string[];
+}
+
+/**
+ * Extract a definitive breaking-change signal from a detect-breaking-change response.
+ *
+ * Returns a boolean only when the tool produced a result carrying a
+ * `hasBreakingChange` value. Any error shape (no result, `result === "failed"`, a
+ * response error, or a missing `hasBreakingChange`) yields `undefined` so the caller
+ * preserves the existing label instead of overriding it.
+ */
+export function getBreakingChangeSignal(
+  response: AzsdkDetectBreakingChangeResponse,
+): boolean | undefined {
+  if (response.response_error || (response.response_errors?.length ?? 0) > 0) {
+    return undefined;
+  }
+  const result = response.result;
+  if (result && typeof result === "object" && typeof result.hasBreakingChange === "boolean") {
+    return result.hasBreakingChange;
+  }
+  return undefined;
+}
+
+/**
  * Parses JSON output from an azsdk-cli command.
  * The CLI emits log lines before the JSON payload. The JSON object is always
  * the last block in the output, so we search backwards for the opening brace.

--- a/eng/tools/spec-gen-sdk-runner/src/command-helpers.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/command-helpers.ts
@@ -506,6 +506,16 @@ function isAzsdkCliAvailable(): boolean {
 }
 
 /**
+ * Whether azsdk-cli SDK breaking-change detection is enabled for this run.
+ *
+ * Code-level feature flag: flip to `true` and merge to enable the whole
+ * integration.
+ */
+export function isBreakingChangeDetectionEnabled(): boolean {
+  return false;
+}
+
+/**
  * Prepare the azsdk pkg generate command arguments.
  *
  * @param commandInput - The spec-gen-sdk command input.
@@ -551,6 +561,25 @@ export function prepareAzsdkPackCommand(packagePath: string, outputPath?: string
   if (outputPath) {
     args.push("--output-path", outputPath);
   }
+  return args;
+}
+
+/**
+ * Prepare the azsdk pkg detect-breaking-change command arguments.
+ *
+ * @param packagePath - Absolute path to the generated SDK package directory.
+ * @param tspConfigFullPath - Optional absolute path to the tspconfig.yaml file.
+ * @returns Array of arguments for the azsdk detect-breaking-change command.
+ */
+export function prepareAzsdkDetectBreakingChangeCommand(
+  packagePath: string,
+  tspConfigFullPath?: string,
+): string[] {
+  const args = ["pkg", "detect-breaking-change", "--package-path", packagePath];
+  if (tspConfigFullPath) {
+    args.push("--tsp-config-path", tspConfigFullPath);
+  }
+  args.push("--output", "json");
   return args;
 }
 

--- a/eng/tools/spec-gen-sdk-runner/src/command-helpers.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/command-helpers.ts
@@ -568,17 +568,12 @@ export function prepareAzsdkPackCommand(packagePath: string, outputPath?: string
  * Prepare the azsdk pkg detect-breaking-change command arguments.
  *
  * @param packagePath - Absolute path to the generated SDK package directory.
- * @param tspConfigFullPath - Optional absolute path to the tspconfig.yaml file.
  * @returns Array of arguments for the azsdk detect-breaking-change command.
  */
-export function prepareAzsdkDetectBreakingChangeCommand(
-  packagePath: string,
-  tspConfigFullPath?: string,
-): string[] {
+export function prepareAzsdkDetectBreakingChangeCommand(packagePath: string): string[] {
   const args = ["pkg", "detect-breaking-change", "--package-path", packagePath];
-  if (tspConfigFullPath) {
-    args.push("--tsp-config-path", tspConfigFullPath);
-  }
+
+  args.push("--changes-only");
   args.push("--output", "json");
   return args;
 }

--- a/eng/tools/spec-gen-sdk-runner/src/commands.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/commands.ts
@@ -4,9 +4,11 @@ import path from "node:path";
 import { inspect } from "node:util";
 import {
   type AzsdkBuildResponse,
+  type AzsdkDetectBreakingChangeResponse,
   type AzsdkGenerateResponse,
   type AzsdkPackResponse,
   buildExecutionReport,
+  getBreakingChangeSignal,
   parseAzsdkResponse,
 } from "./azsdk-adapter.ts";
 import {
@@ -16,9 +18,11 @@ import {
   getExecutionReport,
   getSpecPaths,
   installLanguageToolchain,
+  isBreakingChangeDetectionEnabled,
   logIssuesToPipeline,
   parseArguments,
   prepareAzsdkBuildCommand,
+  prepareAzsdkDetectBreakingChangeCommand,
   prepareAzsdkGenerateCommand,
   prepareAzsdkPackCommand,
   prepareSpecGenSdkCommand,
@@ -318,6 +322,46 @@ export async function generateSdkForSingleSpec(): Promise<CommandResult> {
   return { statusCode, executionResult: executionReport?.executionResult ?? "" };
 }
 
+/**
+ * Run azsdk-cli SDK breaking-change detection for each generated package in the
+ * execution report and fold the result into it. Non-fatal by contract: any
+ * failure leaves the package's existing breaking-change label untouched.
+ */
+async function detectSdkBreakingChange(
+  commandInput: SpecGenSdkCmdInput,
+  tspConfigRelativePath: string,
+  executionReport: ExecutionReport,
+): Promise<void> {
+  const azsdkExe = process.env.AZSDK || "azsdk";
+  const tspConfigFullPath = path.join(commandInput.localSpecRepoPath, tspConfigRelativePath);
+  for (const pkg of executionReport.packages) {
+    if (!pkg.packageRootPath) {
+      logMessage(
+        `Skipping breaking-change detection: no packageRootPath for ${pkg.packageName ?? "unknown package"}`,
+        LogLevel.Warn,
+      );
+      continue;
+    }
+    let signal: boolean | undefined;
+    try {
+      const args = prepareAzsdkDetectBreakingChangeCommand(pkg.packageRootPath, tspConfigFullPath);
+      logMessage(`Running: ${azsdkExe} ${args.join(" ")}`, LogLevel.Info);
+      const output = await runCommandWithOutput(azsdkExe, args);
+      const response = parseAzsdkResponse<AzsdkDetectBreakingChangeResponse>(output);
+      signal = getBreakingChangeSignal(response);
+      logMessage(`azsdk pkg detect-breaking-change hasBreakingChange: ${signal}`, LogLevel.Info);
+    } catch (error) {
+      logMessage(`Error running azsdk pkg detect-breaking-change:${inspect(error)}`, LogLevel.Warn);
+    }
+
+    // A definitive result is the single source of truth for the label; an
+    // error/unknown result leaves the spec-gen-sdk value in place.
+    if (signal !== undefined) {
+      pkg.shouldLabelBreakingChange = signal;
+    }
+  }
+}
+
 /* Generate SDKs for spec pull request */
 export async function generateSdkForSpecPr(): Promise<CommandResult> {
   // Parse the arguments
@@ -340,6 +384,7 @@ export async function generateSdkForSpecPr(): Promise<CommandResult> {
   let currentExecutionResult: string;
   let stagedArtifactsFolder = "";
   const apiViewRequestData: APIViewRequestData[] = [];
+  const breakingChangeDetectionEnabled = isBreakingChangeDetectionEnabled();
   // Tracks whether the SDK repo is currently checked out on a non-`main` branch
   // due to a `sdk-validation.yaml` pin from a previous spec in this run.
   let sdkRepoBranchSwitched = false;
@@ -478,6 +523,21 @@ export async function generateSdkForSpecPr(): Promise<CommandResult> {
         logMessage(`Runner: error reading execution-report.json:${inspect(error)}`, LogLevel.Error);
         statusCode = 1;
         executionReport = undefined;
+      }
+    }
+
+    // Run azsdk-cli breaking-change detection (spec-PR only, feature-flagged) and
+    // let its definitive result override the label from spec-gen-sdk.
+    if (
+      breakingChangeDetectionEnabled &&
+      changedSpec.typespecProject &&
+      executionReport &&
+      executionReport.packages.length > 0
+    ) {
+      try {
+        await detectSdkBreakingChange(commandInput, changedSpec.typespecProject, executionReport);
+      } catch (error) {
+        logMessage(`Runner: error in breaking-change detection:${inspect(error)}`, LogLevel.Warn);
       }
     }
 

--- a/eng/tools/spec-gen-sdk-runner/src/commands.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/commands.ts
@@ -327,13 +327,8 @@ export async function generateSdkForSingleSpec(): Promise<CommandResult> {
  * execution report and fold the result into it. Non-fatal by contract: any
  * failure leaves the package's existing breaking-change label untouched.
  */
-async function detectSdkBreakingChange(
-  commandInput: SpecGenSdkCmdInput,
-  tspConfigRelativePath: string,
-  executionReport: ExecutionReport,
-): Promise<void> {
+async function detectSdkBreakingChange(executionReport: ExecutionReport): Promise<void> {
   const azsdkExe = process.env.AZSDK || "azsdk";
-  const tspConfigFullPath = path.join(commandInput.localSpecRepoPath, tspConfigRelativePath);
   for (const pkg of executionReport.packages) {
     if (!pkg.packageRootPath) {
       logMessage(
@@ -344,7 +339,7 @@ async function detectSdkBreakingChange(
     }
     let signal: boolean | undefined;
     try {
-      const args = prepareAzsdkDetectBreakingChangeCommand(pkg.packageRootPath, tspConfigFullPath);
+      const args = prepareAzsdkDetectBreakingChangeCommand(pkg.packageRootPath);
       logMessage(`Running: ${azsdkExe} ${args.join(" ")}`, LogLevel.Info);
       const output = await runCommandWithOutput(azsdkExe, args);
       const response = parseAzsdkResponse<AzsdkDetectBreakingChangeResponse>(output);
@@ -535,7 +530,7 @@ export async function generateSdkForSpecPr(): Promise<CommandResult> {
       executionReport.packages.length > 0
     ) {
       try {
-        await detectSdkBreakingChange(commandInput, changedSpec.typespecProject, executionReport);
+        await detectSdkBreakingChange(executionReport);
       } catch (error) {
         logMessage(`Runner: error in breaking-change detection:${inspect(error)}`, LogLevel.Warn);
       }

--- a/eng/tools/spec-gen-sdk-runner/src/types.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/types.ts
@@ -27,6 +27,7 @@ export interface ExecutionReportPackage {
   installationInstructions?: string;
   apiViewArtifact?: string;
   shouldLabelBreakingChange?: boolean;
+  packageRootPath?: string;
 }
 
 /**

--- a/eng/tools/spec-gen-sdk-runner/test/azsdk-adapter.test.ts
+++ b/eng/tools/spec-gen-sdk-runner/test/azsdk-adapter.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, test } from "vitest";
 import {
   type AzsdkBuildResponse,
+  type AzsdkDetectBreakingChangeResponse,
   type AzsdkGenerateResponse,
   type AzsdkPackResponse,
   buildExecutionReport,
+  getBreakingChangeSignal,
   parseAzsdkResponse,
 } from "../src/azsdk-adapter.ts";
 import { type EmitterCheckResult } from "../src/emitter-check.ts";
@@ -238,5 +240,49 @@ describe("buildExecutionReport", () => {
     };
     const report = buildExecutionReport(succeededGenerate, undefined, emitter);
     expect(report.packages[0].packageName).toBe("test-package");
+  });
+});
+
+describe("getBreakingChangeSignal", () => {
+  test("returns true when result reports a breaking change", () => {
+    const response: AzsdkDetectBreakingChangeResponse = {
+      result: { hasBreakingChange: true, breakingChanges: [], changes: "# changes" },
+    };
+    expect(getBreakingChangeSignal(response)).toBe(true);
+  });
+
+  test("returns false when result reports no breaking change", () => {
+    const response: AzsdkDetectBreakingChangeResponse = {
+      result: { hasBreakingChange: false },
+    };
+    expect(getBreakingChangeSignal(response)).toBe(false);
+  });
+
+  test("returns undefined when result is the string 'failed'", () => {
+    expect(getBreakingChangeSignal({ result: "failed" })).toBeUndefined();
+  });
+
+  test("returns undefined when response_error is set", () => {
+    const response: AzsdkDetectBreakingChangeResponse = {
+      result: { hasBreakingChange: true },
+      response_error: "boom",
+    };
+    expect(getBreakingChangeSignal(response)).toBeUndefined();
+  });
+
+  test("returns undefined when response_errors is non-empty", () => {
+    const response: AzsdkDetectBreakingChangeResponse = {
+      result: { hasBreakingChange: false },
+      response_errors: ["boom"],
+    };
+    expect(getBreakingChangeSignal(response)).toBeUndefined();
+  });
+
+  test("returns undefined when result object omits hasBreakingChange", () => {
+    expect(getBreakingChangeSignal({ result: { changes: "# changes" } })).toBeUndefined();
+  });
+
+  test("returns undefined when there is no result", () => {
+    expect(getBreakingChangeSignal({})).toBeUndefined();
   });
 });

--- a/eng/tools/spec-gen-sdk-runner/test/command-helpers.test.ts
+++ b/eng/tools/spec-gen-sdk-runner/test/command-helpers.test.ts
@@ -10,8 +10,10 @@ import {
   getBuildFailedInfo,
   getRequiredSettingValue,
   getSpecPaths,
+  isBreakingChangeDetectionEnabled,
   logIssuesToPipeline,
   parseArguments,
+  prepareAzsdkDetectBreakingChangeCommand,
   prepareSpecGenSdkCommand,
   selectGenerationTool,
   setBuildFailedLabelVariable,
@@ -808,5 +810,37 @@ describe("commands.ts", () => {
       const result = selectGenerationTool(undefined, undefined, SdkName.Rust);
       expect(result).toBe("spec-gen-sdk");
     });
+  });
+});
+
+describe("prepareAzsdkDetectBreakingChangeCommand", () => {
+  test("includes package path, tsp config, and json output", () => {
+    expect(prepareAzsdkDetectBreakingChangeCommand("/pkg/path", "/spec/tspconfig.yaml")).toEqual([
+      "pkg",
+      "detect-breaking-change",
+      "--package-path",
+      "/pkg/path",
+      "--tsp-config-path",
+      "/spec/tspconfig.yaml",
+      "--output",
+      "json",
+    ]);
+  });
+
+  test("omits tsp config when not provided", () => {
+    expect(prepareAzsdkDetectBreakingChangeCommand("/pkg/path")).toEqual([
+      "pkg",
+      "detect-breaking-change",
+      "--package-path",
+      "/pkg/path",
+      "--output",
+      "json",
+    ]);
+  });
+});
+
+describe("isBreakingChangeDetectionEnabled", () => {
+  test("is disabled by default (code-level feature flag)", () => {
+    expect(isBreakingChangeDetectionEnabled()).toBe(false);
   });
 });

--- a/eng/tools/spec-gen-sdk-runner/test/command-helpers.test.ts
+++ b/eng/tools/spec-gen-sdk-runner/test/command-helpers.test.ts
@@ -814,25 +814,13 @@ describe("commands.ts", () => {
 });
 
 describe("prepareAzsdkDetectBreakingChangeCommand", () => {
-  test("includes package path, tsp config, and json output", () => {
-    expect(prepareAzsdkDetectBreakingChangeCommand("/pkg/path", "/spec/tspconfig.yaml")).toEqual([
-      "pkg",
-      "detect-breaking-change",
-      "--package-path",
-      "/pkg/path",
-      "--tsp-config-path",
-      "/spec/tspconfig.yaml",
-      "--output",
-      "json",
-    ]);
-  });
-
-  test("omits tsp config when not provided", () => {
+  test("includes package path, changes-only, and json output", () => {
     expect(prepareAzsdkDetectBreakingChangeCommand("/pkg/path")).toEqual([
       "pkg",
       "detect-breaking-change",
       "--package-path",
       "/pkg/path",
+      "--changes-only",
       "--output",
       "json",
     ]);


### PR DESCRIPTION
## Summary
- integrate `azsdk pkg detect-breaking-change` into the spec PR SDK generation flow
- use definitive azsdk-cli results to update the breaking-change label while preserving the existing result on errors or unknown responses
- keep the integration disabled by default behind a code-level feature flag
- add unit coverage for response handling, command construction, and the default feature-flag state

## Testing
- unit tests added for the new adapter and command-helper behavior