### PR TITLE
Customize OffAzure C# SDK generation

### DIFF
--- a/specification/migrate/resource-manager/Microsoft.OffAzure/OffAzure/client.tsp
+++ b/specification/migrate/resource-manager/Microsoft.OffAzure/OffAzure/client.tsp
@@ -2,6 +2,7 @@ import "@azure-tools/typespec-client-generator-core";
 import "./main.tsp";
 
 using Azure.ClientGenerator.Core;
+using Azure.Core;
 using Microsoft.OffAzure;
 
 // Mitigate Java breaking changes: model renames (case changes from Swagger → TypeSpec)
@@ -29,3 +30,63 @@ using Microsoft.OffAzure;
 
 // Mitigate Java breaking changes: property rename dnsHostName → dnsHostname
 @@clientName(SqlServerApplication.dnsHostName, "dnsHostname", "java");
+
+// Resolve C# generated API name collisions.
+@@clientName(BaseResource, "MigrationDiscoveryJobBaseInfo", "csharp");
+@@clientName(Default, "SoftwareInventoryName", "csharp");
+@@clientName(
+  WebAppSites.listByWebAppSite,
+  "ListWebApplicationsByWebAppSite",
+  "csharp"
+);
+@@clientName(
+  WebAppSites.webServersControllerListByWebAppSite,
+  "ListWebServersByWebAppSite",
+  "csharp"
+);
+
+// Match current Azure.ResourceManager C# resource data base types.
+@@alternateType(Azure.ResourceManager.CommonTypes.Resource.id, armResourceIdentifier, "csharp");
+@@alternateType(BaseResource.id, armResourceIdentifier, "csharp");
+
+// Resolve C# analyzer model suffix rules.
+@@clientName(
+  DependencyMapServiceMapextensionsClientGroupMembersRequest,
+  "MigrationDiscoveryDependencyMapServiceMapextensionsClientGroupMembersRequestContent",
+  "csharp"
+);
+@@clientName(
+  DependencyMapServiceMapextensionsExportDependenciesRequest,
+  "MigrationDiscoveryDependencyMapServiceMapextensionsExportDependenciesRequestContent",
+  "csharp"
+);
+@@clientName(
+  DependencyMapServiceMapextensionsScopeMapRequest,
+  "MigrationDiscoveryDependencyMapServiceMapextensionsScopeMapRequestContent",
+  "csharp"
+);
+@@clientName(
+  DependencyMapServiceMapextensionsServerGroupMembersRequest,
+  "MigrationDiscoveryDependencyMapServiceMapextensionsServerGroupMembersRequestContent",
+  "csharp"
+);
+@@clientName(
+  DependencyMapServiceMapextensionsSingleMachineDetailedMapRequest,
+  "MigrationDiscoveryDependencyMapServiceMapextensionsSingleMachineDetailedMapRequestContent",
+  "csharp"
+);
+@@clientName(ErrorSummaryRequest, "MigrationDiscoveryErrorSummaryRequestContent", "csharp");
+@@clientName(
+  ExportMachineErrorsRequest,
+  "MigrationDiscoveryExportMachineErrorsRequestContent",
+  "csharp"
+);
+@@clientName(ExportMachinesRequest, "MigrationDiscoveryExportMachinesRequestContent", "csharp");
+@@clientName(ExportSqlServersRequest, "MigrationDiscoveryExportSqlServersRequestContent", "csharp");
+@@clientName(ExportWebAppsRequest, "MigrationDiscoveryExportWebAppsRequestContent", "csharp");
+@@clientName(FileMetaData, "FileMetadata", "csharp");
+@@clientName(MachineMetadataCollection, "MigrationDiscoveryMachineMetadataList", "csharp");
+@@clientName(SasUriResponse, "MigrationDiscoverySasUriResult", "csharp");
+@@clientName(ServerSiteUsageResponse, "MigrationDiscoveryServerSiteUsageResult", "csharp");
+@@clientName(SiteHealthSummaryCollection, "MigrationDiscoverySiteHealthSummaryList", "csharp");
+@@clientName(WebAppPropertiesCollection, "MigrationDiscoveryWebAppPropertiesList", "csharp");

--- a/specification/migrate/resource-manager/Microsoft.OffAzure/OffAzure/client.tsp
+++ b/specification/migrate/resource-manager/Microsoft.OffAzure/OffAzure/client.tsp
@@ -51,28 +51,33 @@ using Microsoft.OffAzure;
 
 // Resolve C# analyzer model suffix rules.
 @@clientName(
+  DependencyMapServiceMapextensionsDependencyMapRequestFilters,
+  "MigrationDiscoveryDependencyMapServiceMapExtensionsDependencyMapRequestFilters",
+  "csharp"
+);
+@@clientName(
   DependencyMapServiceMapextensionsClientGroupMembersRequest,
-  "MigrationDiscoveryDependencyMapServiceMapextensionsClientGroupMembersRequestContent",
+  "MigrationDiscoveryDependencyMapServiceMapExtensionsClientGroupMembersContent",
   "csharp"
 );
 @@clientName(
   DependencyMapServiceMapextensionsExportDependenciesRequest,
-  "MigrationDiscoveryDependencyMapServiceMapextensionsExportDependenciesRequestContent",
+  "MigrationDiscoveryDependencyMapServiceMapExtensionsExportDependenciesContent",
   "csharp"
 );
 @@clientName(
   DependencyMapServiceMapextensionsScopeMapRequest,
-  "MigrationDiscoveryDependencyMapServiceMapextensionsScopeMapRequestContent",
+  "MigrationDiscoveryDependencyMapServiceMapExtensionsScopeMapContent",
   "csharp"
 );
 @@clientName(
   DependencyMapServiceMapextensionsServerGroupMembersRequest,
-  "MigrationDiscoveryDependencyMapServiceMapextensionsServerGroupMembersRequestContent",
+  "MigrationDiscoveryDependencyMapServiceMapExtensionsServerGroupMembersContent",
   "csharp"
 );
 @@clientName(
   DependencyMapServiceMapextensionsSingleMachineDetailedMapRequest,
-  "MigrationDiscoveryDependencyMapServiceMapextensionsSingleMachineDetailedMapRequestContent",
+  "MigrationDiscoveryDependencyMapServiceMapExtensionsSingleMachineDetailedMapContent",
   "csharp"
 );
 @@clientName(ErrorSummaryRequest, "MigrationDiscoveryErrorSummaryRequestContent", "csharp");
@@ -86,7 +91,72 @@ using Microsoft.OffAzure;
 @@clientName(ExportWebAppsRequest, "MigrationDiscoveryExportWebAppsRequestContent", "csharp");
 @@clientName(FileMetaData, "FileMetadata", "csharp");
 @@clientName(MachineMetadataCollection, "MigrationDiscoveryMachineMetadataList", "csharp");
+@@clientName(ProxySiteRefreshBody, "ProxySiteRefreshContent", "csharp");
 @@clientName(SasUriResponse, "MigrationDiscoverySasUriResult", "csharp");
 @@clientName(ServerSiteUsageResponse, "MigrationDiscoveryServerSiteUsageResult", "csharp");
 @@clientName(SiteHealthSummaryCollection, "MigrationDiscoverySiteHealthSummaryList", "csharp");
+@@clientName(SQLInventoryImportBody, "SqlInventoryImportContent", "csharp");
+@@clientName(SqlSiteRefreshBody, "SqlSiteRefreshContent", "csharp");
 @@clientName(WebAppPropertiesCollection, "MigrationDiscoveryWebAppPropertiesList", "csharp");
+
+// Resolve C# status member spelling without changing wire values.
+@@clientName(
+  ApplicationDiscoveryScopeStatus.DiscoveryPartiallySucceded,
+  "DiscoveryPartiallySucceeded",
+  "csharp"
+);
+@@clientName(
+  ApplicationDiscoveryScopeStatus.DiscoverySucceededAtleastOnce,
+  "DiscoverySucceededAtLeastOnce",
+  "csharp"
+);
+@@clientName(
+  DependencyMapDiscoveryScopeStatus.DiscoveryPartiallySucceded,
+  "DiscoveryPartiallySucceeded",
+  "csharp"
+);
+@@clientName(
+  DependencyMapDiscoveryScopeStatus.DiscoverySucceededAtleastOnce,
+  "DiscoverySucceededAtLeastOnce",
+  "csharp"
+);
+@@clientName(
+  DiscoveryScopeStatus.DiscoveryPartiallySucceded,
+  "DiscoveryPartiallySucceeded",
+  "csharp"
+);
+@@clientName(
+  DiscoveryScopeStatus.DiscoverySucceededAtleastOnce,
+  "DiscoverySucceededAtLeastOnce",
+  "csharp"
+);
+@@clientName(
+  ShallowDiscoveryStatus.DiscoveryPartiallySucceded,
+  "DiscoveryPartiallySucceeded",
+  "csharp"
+);
+@@clientName(
+  ShallowDiscoveryStatus.DiscoverySucceededAtleastOnce,
+  "DiscoverySucceededAtLeastOnce",
+  "csharp"
+);
+@@clientName(
+  SQLDiscoveryScopeStatus.DiscoveryPartiallySucceded,
+  "DiscoveryPartiallySucceeded",
+  "csharp"
+);
+@@clientName(
+  SQLDiscoveryScopeStatus.DiscoverySucceededAtleastOnce,
+  "DiscoverySucceededAtLeastOnce",
+  "csharp"
+);
+@@clientName(
+  StaticDiscoveryScopeStatus.DiscoveryPartiallySucceded,
+  "DiscoveryPartiallySucceeded",
+  "csharp"
+);
+@@clientName(
+  StaticDiscoveryScopeStatus.DiscoverySucceededAtleastOnce,
+  "DiscoverySucceededAtLeastOnce",
+  "csharp"
+);


### PR DESCRIPTION
## Description
Adds C# client customizations for the OffAzure TypeSpec project so the initial Azure.ResourceManager.MigrationDiscovery SDK can generate cleanly.

Related SDK PR: Azure/azure-sdk-for-net#62739
Related issue: Azure/azure-sdk-for-net#60428

## Changes
- Rename C# models that conflict with generated API or analyzer suffix rules.
- Rename duplicate WebAppSite list operations for C#.
- Map resource `id` properties to `ResourceIdentifier` for C# ARM resource data types.