### PR TITLE
Rename DevOps Infrastructure VM size model for C#

### DIFF
--- a/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/client.tsp
+++ b/specification/devopsinfrastructure/resource-manager/Microsoft.DevOpsInfrastructure/DevOpsInfrastructure/client.tsp
@@ -107,6 +107,8 @@ using Microsoft.DevOpsInfrastructure;
 
 @@clientName(StorageProfile, "DevOpsStorageProfile", "csharp");
 
+@@clientName(VmSize, "DevOpsVmSize", "csharp");
+
 @@clientName(VmssFabricProfile, "DevOpsVmssFabricProfile", "csharp");
 @@clientName(
   CheckNameAvailabilityResult,


### PR DESCRIPTION
Renames the C# SDK model generated from VmSize to DevOpsVmSize so the public type is scoped consistently with the Azure.ResourceManager.DevOpsInfrastructure package.\n\nRelated SDK PR: Azure/azure-sdk-for-net#61255