### PR TITLE
Rename CloudHealth aggregation types for C#

### DIFF
--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/client.tsp
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/client.tsp
@@ -49,6 +49,8 @@ using Microsoft.CloudHealth;
 @@clientName(AuthenticationKind, "HealthModelAuthenticationKind", "csharp");
 @@clientName(EvaluationRule, "EntitySignalEvaluationRule", "csharp");
 @@clientName(HealthState, "EntityHealthState", "csharp");
+@@clientName(AggregationType, "HealthStateAggregationType", "csharp");
+@@clientName(AggregationUnit, "HealthStateAggregationUnit", "csharp");
 @@clientName(ThresholdRule, "EntitySignalThresholdRule", "csharp");
 @@clientName(IconDefinition, "EntityIcon", "csharp");
 @@clientName(RefreshInterval, "EntitySignalRefreshInterval", "csharp");


### PR DESCRIPTION
Renames the generic C# SDK types `AggregationType` and `AggregationUnit` to `HealthStateAggregationType` and `HealthStateAggregationUnit` through `client.tsp` customizations.\n\nAddresses API review feedback on Azure/azure-sdk-for-net#62419.