### PR TITLE
[Elastic] Enable Java advanced versioning

### DIFF
--- a/specification/elastic/resource-manager/Microsoft.Elastic/Elastic/tspconfig.yaml
+++ b/specification/elastic/resource-manager/Microsoft.Elastic/Elastic/tspconfig.yaml
@@ -26,6 +26,7 @@ options:
     namespace: "com.azure.resourcemanager.elastic"
     service-name: "Elastic" # human-readable service name, whitespace allowed
     flavor: azure
+    advanced-versioning: true
   "@azure-tools/typespec-ts":
     service-dir: sdk/elastic
     emitter-output-dir: "{output-dir}/{service-dir}/arm-elastic"


### PR DESCRIPTION
Enable Java advanced versioning for Elastic to test whether regeneration preserves the existing delete overloads after adding the optional `softDelete` parameter.

Related SDK PR: https://github.com/Azure/azure-sdk-for-java/pull/50377
