### PR TITLE
Cognitive Services: describe VM BYOC ARM preview contract

### DIFF
--- a/specification/cognitiveservices/CognitiveServices.Management/ManagedComputeDeployment.tsp
+++ b/specification/cognitiveservices/CognitiveServices.Management/ManagedComputeDeployment.tsp
@@ -15,7 +15,7 @@ using TypeSpec.Versioning;
 namespace Microsoft.CognitiveServices;
 
 /**
- * Cognitive Services account managed compute deployment, backed by managed compute (GPU) resources.
+ * Cognitive Services account deployment backed by accelerator-managed compute or a VM compute resource.
  */
 @added(Versions.v2026_03_15_preview)
 @removed(Versions.v2026_05_01)
@@ -31,9 +31,12 @@ model ManagedComputeDeployment
     SegmentName = "managedComputeDeployments",
     NamePattern = "^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$"
   >;
+  ...Azure.ResourceManager.Foundations.ArmTagsProperty;
+  ...ManagedServiceIdentityProperty;
 
   /**
-   * The resource model definition representing SKU
+   * The deployment SKU. Use VmManagedCompute for a deployment on a VM compute resource.
+   * The SKU name cannot change after creation. Capacity is the number of deployment instances and must be positive on creation.
    */
   #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "CogSvc defines its own Sku model — using ResourceSkuProperty causes duplicate-client-name errors in Java/Python SDK generation due to collision with ARM common-type Sku"
   sku?: Sku;
@@ -61,7 +64,18 @@ interface ManagedComputeDeployments {
   /**
    * Creates or updates a managed compute deployment associated with the Cognitive Services account.
    */
-  createOrUpdate is ArmResourceCreateOrReplaceAsync<ManagedComputeDeployment>;
+  createOrUpdate is ArmResourceCreateOrReplaceAsync<
+    ManagedComputeDeployment,
+    Parameters = {
+      /**
+       * Foundry project used when creating a VmManagedCompute deployment. If omitted, the account's default project is used.
+       * A project must be specified through this header or configured as the account default.
+       */
+      @added(Versions.v2026_07_15_preview)
+      @header("x-ms-foundry-project-name")
+      foundryProjectName?: string;
+    }
+  >;
 
   /**
    * Updates the specified managed compute deployment associated with the Cognitive Services account.
@@ -111,6 +125,17 @@ interface ManagedComputeDeployments {
   "The name of the managed compute deployment associated with the Cognitive Services Account"
 );
 @@encodedName(ManagedComputeDeployment.etag, "application/json", "etag");
+@@added(ManagedComputeDeployment.tags, Versions.v2026_07_15_preview);
+@@added(ManagedComputeDeployment.identity, Versions.v2026_07_15_preview);
+@@visibility(
+  ManagedComputeDeployment.identity,
+  Lifecycle.Read,
+  Lifecycle.Create
+);
+@@doc(
+  ManagedComputeDeployment.identity,
+  "Managed identity used when creating a VmManagedCompute deployment. Specify a user-assigned managed identity using its Azure resource ID. Updating the deployment identity is not supported."
+);
 @@doc(
   ManagedComputeDeployment.properties,
   "Properties of the Cognitive Services managed compute deployment."

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-07-15-preview/CreateOrUpdateVmManagedComputeDeploymentWithRegistryAssets.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-07-15-preview/CreateOrUpdateVmManagedComputeDeploymentWithRegistryAssets.json
@@ -1,6 +1,6 @@
 {
   "operationId": "ManagedComputeDeployments_CreateOrUpdate",
-  "title": "CreateOrUpdateVmManagedComputeDeployment",
+  "title": "CreateOrUpdateVmManagedComputeDeploymentWithRegistryAssets",
   "parameters": {
     "subscriptionId": "00000000-0000-0000-0000-000000000000",
     "resourceGroupName": "resourceGroupName",
@@ -11,8 +11,12 @@
     "resource": {
       "properties": {
         "model": "azureml://registries/azureml-openai-oss/models/gpt-oss-120b/versions/4",
-        "deploymentTemplate": "projects/my-project/deploymentTemplates/gpt-oss-120b-vllm-tuned/versions/2",
-        "computeId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/computes/my-h100-pool"
+        "deploymentTemplate": "azureml://registries/azureml-openai-oss/deploymenttemplates/gpt-oss-120b-short-context/versions/1",
+        "computeId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/computes/my-h100-pool",
+        "versionUpgradeOption": "NoAutoUpgrade",
+        "allowlistedObjectIds": [
+          "00000000-0000-0000-0000-000000000001"
+        ]
       },
       "identity": {
         "type": "UserAssigned",
@@ -20,9 +24,12 @@
           "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.ManagedIdentity/userAssignedIdentities/deploymentIdentity": {}
         }
       },
+      "tags": {
+        "environment": "development"
+      },
       "sku": {
         "name": "VmManagedCompute",
-        "capacity": 2
+        "capacity": 1
       }
     }
   },
@@ -32,27 +39,25 @@
         "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/managedComputeDeployments/gpt-oss-120b-byoc",
         "name": "gpt-oss-120b-byoc",
         "type": "Microsoft.CognitiveServices/accounts/managedComputeDeployments",
-        "etag": "\"0x8D...\"",
         "properties": {
           "model": "azureml://registries/azureml-openai-oss/models/gpt-oss-120b/versions/4",
-          "deploymentTemplate": "projects/my-project/deploymentTemplates/gpt-oss-120b-vllm-tuned/versions/2",
+          "deploymentTemplate": "azureml://registries/azureml-openai-oss/deploymenttemplates/gpt-oss-120b-short-context/versions/1",
           "computeId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/computes/my-h100-pool",
-          "versionUpgradeOption": "OnceNewDefaultVersionAvailable",
-          "capabilities": {
-            "assetsV2": "true"
-          },
+          "versionUpgradeOption": "NoAutoUpgrade",
+          "allowlistedObjectIds": [
+            "00000000-0000-0000-0000-000000000001"
+          ],
           "provisioningState": "Succeeded",
-          "provisioningDetails": {
-            "message": "Deployment is healthy and serving traffic.",
-            "lastOperationTimestamp": "2026-04-12T10:25:00Z"
-          },
           "routes": {
             "chatCompletionsScoringPath": "/managed-deployments/gpt-oss-120b-byoc/v1/chat/completions"
           }
         },
+        "tags": {
+          "environment": "development"
+        },
         "sku": {
           "name": "VmManagedCompute",
-          "capacity": 2
+          "capacity": 1
         }
       }
     },
@@ -67,13 +72,20 @@
         "type": "Microsoft.CognitiveServices/accounts/managedComputeDeployments",
         "properties": {
           "model": "azureml://registries/azureml-openai-oss/models/gpt-oss-120b/versions/4",
-          "deploymentTemplate": "projects/my-project/deploymentTemplates/gpt-oss-120b-vllm-tuned/versions/2",
+          "deploymentTemplate": "azureml://registries/azureml-openai-oss/deploymenttemplates/gpt-oss-120b-short-context/versions/1",
           "computeId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/computes/my-h100-pool",
+          "versionUpgradeOption": "NoAutoUpgrade",
+          "allowlistedObjectIds": [
+            "00000000-0000-0000-0000-000000000001"
+          ],
           "provisioningState": "Accepted"
+        },
+        "tags": {
+          "environment": "development"
         },
         "sku": {
           "name": "VmManagedCompute",
-          "capacity": 2
+          "capacity": 1
         }
       }
     }

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-07-15-preview/DeleteVmManagedComputeDeployment.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-07-15-preview/DeleteVmManagedComputeDeployment.json
@@ -1,0 +1,22 @@
+{
+  "operationId": "ManagedComputeDeployments_Delete",
+  "title": "DeleteVmManagedComputeDeployment",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "resourceGroupName",
+    "accountName": "accountName",
+    "deploymentName": "gpt-oss-120b-byoc",
+    "api-version": "2026-07-15-preview"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/eastus/operationResults/00000000-0000-0000-0000-000000000001?operationResultResponseType=Location&api-version=2026-07-15-preview",
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/eastus/operationResults/00000000-0000-0000-0000-000000000001?api-version=2026-07-15-preview",
+        "retry-after": "30"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-07-15-preview/GetVmManagedComputeDeployment.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-07-15-preview/GetVmManagedComputeDeployment.json
@@ -19,7 +19,6 @@
           "model": "azureml://registries/azureml-openai-oss/models/gpt-oss-120b/versions/4",
           "deploymentTemplate": "projects/my-project/deploymentTemplates/gpt-oss-120b-vllm-tuned/versions/2",
           "computeId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/computes/my-h100-pool",
-          "priority": "High",
           "versionUpgradeOption": "OnceNewDefaultVersionAvailable",
           "capabilities": {
             "assetsV2": "true"

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-07-15-preview/ListVmManagedComputeDeployments.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-07-15-preview/ListVmManagedComputeDeployments.json
@@ -19,7 +19,6 @@
               "model": "azureml://registries/azureml-openai-oss/models/gpt-oss-120b/versions/4",
               "deploymentTemplate": "projects/my-project/deploymentTemplates/gpt-oss-120b-vllm-tuned/versions/2",
               "computeId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/computes/my-h100-pool",
-              "priority": "High",
               "versionUpgradeOption": "OnceNewDefaultVersionAvailable",
               "capabilities": {
                 "assetsV2": "true"

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-07-15-preview/UpdateVmManagedComputeDeployment.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-07-15-preview/UpdateVmManagedComputeDeployment.json
@@ -8,6 +8,9 @@
     "deploymentName": "gpt-oss-120b-byoc",
     "api-version": "2026-07-15-preview",
     "properties": {
+      "tags": {
+        "environment": "development"
+      },
       "sku": {
         "name": "VmManagedCompute",
         "capacity": 2
@@ -21,11 +24,13 @@
         "name": "gpt-oss-120b-byoc",
         "type": "Microsoft.CognitiveServices/accounts/managedComputeDeployments",
         "etag": "\"0x8D...\"",
+        "tags": {
+          "environment": "development"
+        },
         "properties": {
           "model": "azureml://registries/azureml-openai-oss/models/gpt-oss-120b/versions/4",
           "deploymentTemplate": "projects/my-project/deploymentTemplates/gpt-oss-120b-vllm-tuned/versions/2",
           "computeId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/computes/my-h100-pool",
-          "priority": "High",
           "versionUpgradeOption": "OnceNewDefaultVersionAvailable",
           "capabilities": {
             "assetsV2": "true"
@@ -47,8 +52,8 @@
     },
     "202": {
       "headers": {
-        "location": "http://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/eastus/operationResults/00000000-0000-0000-0000-000000000001?operationResultResponseType=Location&api-version=2026-03-15-preview",
-        "azure-asyncoperation": "http://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/eastus/operationResults/00000000-0000-0000-0000-000000000001?api-version=2026-03-15-preview",
+        "location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/eastus/operationResults/00000000-0000-0000-0000-000000000001?operationResultResponseType=Location&api-version=2026-07-15-preview",
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/eastus/operationResults/00000000-0000-0000-0000-000000000001?api-version=2026-07-15-preview",
         "retry-after": "30"
       }
     }

--- a/specification/cognitiveservices/CognitiveServices.Management/models.tsp
+++ b/specification/cognitiveservices/CognitiveServices.Management/models.tsp
@@ -3441,7 +3441,7 @@ model SkuResource {
 }
 
 /**
- * The object being used to update sku of a resource, in general used for PATCH operations.
+ * The request used to update a managed compute deployment.
  */
 @added(Versions.v2026_03_15_preview)
 @removed(Versions.v2026_05_01)
@@ -3449,11 +3449,15 @@ model SkuResource {
 @removed(Versions.v2026_07_01)
 @added(Versions.v2026_07_15_preview)
 model PatchResourceSku {
+  ...Azure.ResourceManager.Foundations.ArmTagsProperty;
+
   /**
    * The resource model definition representing SKU
    */
   sku?: Sku;
 }
+
+@@added(PatchResourceSku.tags, Versions.v2026_07_15_preview);
 
 /**
  * Properties of Cognitive Services account commitment plan.
@@ -5905,6 +5909,7 @@ model ManagedComputeDeploymentProperties {
 
   /**
    * Accelerator type (e.g., H100_80GB). Optional on creation; immutable after creation.
+   * Must not be specified for VmManagedCompute deployments.
    */
   @visibility(Lifecycle.Read, Lifecycle.Create)
   acceleratorType?: string;
@@ -5914,6 +5919,14 @@ model ManagedComputeDeploymentProperties {
    */
   @visibility(Lifecycle.Read, Lifecycle.Create)
   versionUpgradeOption?: DeploymentModelVersionUpgradeOption;
+
+  /**
+   * Microsoft Entra object IDs allowed to access the VmManagedCompute deployment's serving endpoint.
+   * Set on creation; the returned set can also include service-managed identities.
+   */
+  @added(Versions.v2026_07_15_preview)
+  @visibility(Lifecycle.Read, Lifecycle.Create)
+  allowlistedObjectIds?: Azure.Core.uuid[];
 
   /**
    * Deployment capabilities represented as key-value pairs.
@@ -5927,7 +5940,8 @@ model ManagedComputeDeploymentProperties {
   capabilities?: Record<string>;
 
   /**
-   * Foundry compute ARM resource ID for VM-backed managed compute deployments. Required when sku.name is VmManagedCompute; immutable after creation.
+   * Foundry compute Azure resource ID for VM-backed managed compute deployments. Required when sku.name is VmManagedCompute; immutable after creation.
+   * Must not be specified for accelerator-managed compute deployments.
    */
   @visibility(Lifecycle.Read, Lifecycle.Create)
   computeId?: string;

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-03-15-preview/cognitiveservices.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-03-15-preview/cognitiveservices.json
@@ -15931,7 +15931,7 @@
     },
     "ManagedComputeDeployment": {
       "type": "object",
-      "description": "Cognitive Services account managed compute deployment, backed by managed compute (GPU) resources.",
+      "description": "Cognitive Services account deployment backed by accelerator-managed compute or a VM compute resource.",
       "properties": {
         "properties": {
           "$ref": "#/definitions/ManagedComputeDeploymentProperties",
@@ -15939,7 +15939,7 @@
         },
         "sku": {
           "$ref": "#/definitions/Sku",
-          "description": "The resource model definition representing SKU"
+          "description": "The deployment SKU. Use VmManagedCompute for a deployment on a VM compute resource.\nThe SKU name cannot change after creation. Capacity is the number of deployment instances and must be positive on creation."
         },
         "etag": {
           "type": "string",
@@ -16022,7 +16022,7 @@
         },
         "acceleratorType": {
           "type": "string",
-          "description": "Accelerator type (e.g., H100_80GB). Optional on creation; immutable after creation.",
+          "description": "Accelerator type (e.g., H100_80GB). Optional on creation; immutable after creation.\nMust not be specified for VmManagedCompute deployments.",
           "x-ms-mutability": [
             "read",
             "create"
@@ -16038,7 +16038,7 @@
         },
         "computeId": {
           "type": "string",
-          "description": "Foundry compute ARM resource ID for VM-backed managed compute deployments. Required when sku.name is VmManagedCompute; immutable after creation.",
+          "description": "Foundry compute Azure resource ID for VM-backed managed compute deployments. Required when sku.name is VmManagedCompute; immutable after creation.\nMust not be specified for accelerator-managed compute deployments.",
           "x-ms-mutability": [
             "read",
             "create"
@@ -17204,7 +17204,7 @@
     },
     "PatchResourceSku": {
       "type": "object",
-      "description": "The object being used to update sku of a resource, in general used for PATCH operations.",
+      "description": "The request used to update a managed compute deployment.",
       "properties": {
         "sku": {
           "$ref": "#/definitions/Sku",

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-05-15-preview/cognitiveservices.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-05-15-preview/cognitiveservices.json
@@ -15956,7 +15956,7 @@
     },
     "ManagedComputeDeployment": {
       "type": "object",
-      "description": "Cognitive Services account managed compute deployment, backed by managed compute (GPU) resources.",
+      "description": "Cognitive Services account deployment backed by accelerator-managed compute or a VM compute resource.",
       "properties": {
         "properties": {
           "$ref": "#/definitions/ManagedComputeDeploymentProperties",
@@ -15964,7 +15964,7 @@
         },
         "sku": {
           "$ref": "#/definitions/Sku",
-          "description": "The resource model definition representing SKU"
+          "description": "The deployment SKU. Use VmManagedCompute for a deployment on a VM compute resource.\nThe SKU name cannot change after creation. Capacity is the number of deployment instances and must be positive on creation."
         },
         "etag": {
           "type": "string",
@@ -16047,7 +16047,7 @@
         },
         "acceleratorType": {
           "type": "string",
-          "description": "Accelerator type (e.g., H100_80GB). Optional on creation; immutable after creation.",
+          "description": "Accelerator type (e.g., H100_80GB). Optional on creation; immutable after creation.\nMust not be specified for VmManagedCompute deployments.",
           "x-ms-mutability": [
             "read",
             "create"
@@ -16071,7 +16071,7 @@
         },
         "computeId": {
           "type": "string",
-          "description": "Foundry compute ARM resource ID for VM-backed managed compute deployments. Required when sku.name is VmManagedCompute; immutable after creation.",
+          "description": "Foundry compute Azure resource ID for VM-backed managed compute deployments. Required when sku.name is VmManagedCompute; immutable after creation.\nMust not be specified for accelerator-managed compute deployments.",
           "x-ms-mutability": [
             "read",
             "create"
@@ -17237,7 +17237,7 @@
     },
     "PatchResourceSku": {
       "type": "object",
-      "description": "The object being used to update sku of a resource, in general used for PATCH operations.",
+      "description": "The request used to update a managed compute deployment.",
       "properties": {
         "sku": {
           "$ref": "#/definitions/Sku",

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-07-15-preview/cognitiveservices.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-07-15-preview/cognitiveservices.json
@@ -4960,6 +4960,14 @@
             "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$"
           },
           {
+            "name": "x-ms-foundry-project-name",
+            "in": "header",
+            "description": "Foundry project used when creating a VmManagedCompute deployment. If omitted, the account's default project is used.\nA project must be specified through this header or configured as the account default.",
+            "required": false,
+            "type": "string",
+            "x-ms-client-name": "foundryProjectName"
+          },
+          {
             "name": "resource",
             "in": "body",
             "description": "The managed compute deployment properties.",
@@ -5006,6 +5014,9 @@
           },
           "CreateOrUpdateVmManagedComputeDeployment": {
             "$ref": "./examples/CreateOrUpdateVmManagedComputeDeployment.json"
+          },
+          "CreateOrUpdateVmManagedComputeDeploymentWithRegistryAssets": {
+            "$ref": "./examples/CreateOrUpdateVmManagedComputeDeploymentWithRegistryAssets.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -5175,6 +5186,9 @@
         "x-ms-examples": {
           "DeleteManagedComputeDeployment": {
             "$ref": "./examples/DeleteManagedComputeDeployment.json"
+          },
+          "DeleteVmManagedComputeDeployment": {
+            "$ref": "./examples/DeleteVmManagedComputeDeployment.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -16903,15 +16917,30 @@
     },
     "ManagedComputeDeployment": {
       "type": "object",
-      "description": "Cognitive Services account managed compute deployment, backed by managed compute (GPU) resources.",
+      "description": "Cognitive Services account deployment backed by accelerator-managed compute or a VM compute resource.",
       "properties": {
         "properties": {
           "$ref": "#/definitions/ManagedComputeDeploymentProperties",
           "description": "Properties of the Cognitive Services managed compute deployment."
         },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "identity": {
+          "$ref": "../../../../../common-types/resource-management/v3/managedidentity.json#/definitions/ManagedServiceIdentity",
+          "description": "Managed identity used when creating a VmManagedCompute deployment. Specify a user-assigned managed identity using its Azure resource ID. Updating the deployment identity is not supported.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
         "sku": {
           "$ref": "#/definitions/Sku",
-          "description": "The resource model definition representing SKU"
+          "description": "The deployment SKU. Use VmManagedCompute for a deployment on a VM compute resource.\nThe SKU name cannot change after creation. Capacity is the number of deployment instances and must be positive on creation."
         },
         "etag": {
           "type": "string",
@@ -16994,7 +17023,7 @@
         },
         "acceleratorType": {
           "type": "string",
-          "description": "Accelerator type (e.g., H100_80GB). Optional on creation; immutable after creation.",
+          "description": "Accelerator type (e.g., H100_80GB). Optional on creation; immutable after creation.\nMust not be specified for VmManagedCompute deployments.",
           "x-ms-mutability": [
             "read",
             "create"
@@ -17003,6 +17032,17 @@
         "versionUpgradeOption": {
           "$ref": "#/definitions/DeploymentModelVersionUpgradeOption",
           "description": "Template auto-upgrade policy. Defaults to OnceNewDefaultVersionAvailable.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "allowlistedObjectIds": {
+          "type": "array",
+          "description": "Microsoft Entra object IDs allowed to access the VmManagedCompute deployment's serving endpoint.\nSet on creation; the returned set can also include service-managed identities.",
+          "items": {
+            "$ref": "#/definitions/Azure.Core.uuid"
+          },
           "x-ms-mutability": [
             "read",
             "create"
@@ -17018,7 +17058,7 @@
         },
         "computeId": {
           "type": "string",
-          "description": "Foundry compute ARM resource ID for VM-backed managed compute deployments. Required when sku.name is VmManagedCompute; immutable after creation.",
+          "description": "Foundry compute Azure resource ID for VM-backed managed compute deployments. Required when sku.name is VmManagedCompute; immutable after creation.\nMust not be specified for accelerator-managed compute deployments.",
           "x-ms-mutability": [
             "read",
             "create"
@@ -18184,8 +18224,15 @@
     },
     "PatchResourceSku": {
       "type": "object",
-      "description": "The object being used to update sku of a resource, in general used for PATCH operations.",
+      "description": "The request used to update a managed compute deployment.",
       "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
         "sku": {
           "$ref": "#/definitions/Sku",
           "description": "The resource model definition representing SKU"

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-07-15-preview/examples/CreateOrUpdateVmManagedComputeDeployment.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-07-15-preview/examples/CreateOrUpdateVmManagedComputeDeployment.json
@@ -7,12 +7,18 @@
     "accountName": "accountName",
     "deploymentName": "gpt-oss-120b-byoc",
     "api-version": "2026-07-15-preview",
+    "x-ms-foundry-project-name": "my-project",
     "resource": {
       "properties": {
         "model": "azureml://registries/azureml-openai-oss/models/gpt-oss-120b/versions/4",
         "deploymentTemplate": "projects/my-project/deploymentTemplates/gpt-oss-120b-vllm-tuned/versions/2",
-        "computeId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/computes/my-h100-pool",
-        "priority": "High"
+        "computeId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/computes/my-h100-pool"
+      },
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.ManagedIdentity/userAssignedIdentities/deploymentIdentity": {}
+        }
       },
       "sku": {
         "name": "VmManagedCompute",
@@ -31,7 +37,6 @@
           "model": "azureml://registries/azureml-openai-oss/models/gpt-oss-120b/versions/4",
           "deploymentTemplate": "projects/my-project/deploymentTemplates/gpt-oss-120b-vllm-tuned/versions/2",
           "computeId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/computes/my-h100-pool",
-          "priority": "High",
           "versionUpgradeOption": "OnceNewDefaultVersionAvailable",
           "capabilities": {
             "assetsV2": "true"
@@ -53,7 +58,7 @@
     },
     "201": {
       "headers": {
-        "azure-asyncoperation": "http://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/eastus/operationResults/00000000-0000-0000-0000-000000000002?api-version=2026-03-15-preview",
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/eastus/operationResults/00000000-0000-0000-0000-000000000002?api-version=2026-07-15-preview",
         "retry-after": "30"
       },
       "body": {
@@ -64,7 +69,6 @@
           "model": "azureml://registries/azureml-openai-oss/models/gpt-oss-120b/versions/4",
           "deploymentTemplate": "projects/my-project/deploymentTemplates/gpt-oss-120b-vllm-tuned/versions/2",
           "computeId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/computes/my-h100-pool",
-          "priority": "High",
           "provisioningState": "Accepted"
         },
         "sku": {

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-07-15-preview/examples/CreateOrUpdateVmManagedComputeDeploymentWithRegistryAssets.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-07-15-preview/examples/CreateOrUpdateVmManagedComputeDeploymentWithRegistryAssets.json
@@ -1,6 +1,6 @@
 {
   "operationId": "ManagedComputeDeployments_CreateOrUpdate",
-  "title": "CreateOrUpdateVmManagedComputeDeployment",
+  "title": "CreateOrUpdateVmManagedComputeDeploymentWithRegistryAssets",
   "parameters": {
     "subscriptionId": "00000000-0000-0000-0000-000000000000",
     "resourceGroupName": "resourceGroupName",
@@ -11,8 +11,12 @@
     "resource": {
       "properties": {
         "model": "azureml://registries/azureml-openai-oss/models/gpt-oss-120b/versions/4",
-        "deploymentTemplate": "projects/my-project/deploymentTemplates/gpt-oss-120b-vllm-tuned/versions/2",
-        "computeId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/computes/my-h100-pool"
+        "deploymentTemplate": "azureml://registries/azureml-openai-oss/deploymenttemplates/gpt-oss-120b-short-context/versions/1",
+        "computeId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/computes/my-h100-pool",
+        "versionUpgradeOption": "NoAutoUpgrade",
+        "allowlistedObjectIds": [
+          "00000000-0000-0000-0000-000000000001"
+        ]
       },
       "identity": {
         "type": "UserAssigned",
@@ -20,9 +24,12 @@
           "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.ManagedIdentity/userAssignedIdentities/deploymentIdentity": {}
         }
       },
+      "tags": {
+        "environment": "development"
+      },
       "sku": {
         "name": "VmManagedCompute",
-        "capacity": 2
+        "capacity": 1
       }
     }
   },
@@ -32,27 +39,25 @@
         "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/managedComputeDeployments/gpt-oss-120b-byoc",
         "name": "gpt-oss-120b-byoc",
         "type": "Microsoft.CognitiveServices/accounts/managedComputeDeployments",
-        "etag": "\"0x8D...\"",
         "properties": {
           "model": "azureml://registries/azureml-openai-oss/models/gpt-oss-120b/versions/4",
-          "deploymentTemplate": "projects/my-project/deploymentTemplates/gpt-oss-120b-vllm-tuned/versions/2",
+          "deploymentTemplate": "azureml://registries/azureml-openai-oss/deploymenttemplates/gpt-oss-120b-short-context/versions/1",
           "computeId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/computes/my-h100-pool",
-          "versionUpgradeOption": "OnceNewDefaultVersionAvailable",
-          "capabilities": {
-            "assetsV2": "true"
-          },
+          "versionUpgradeOption": "NoAutoUpgrade",
+          "allowlistedObjectIds": [
+            "00000000-0000-0000-0000-000000000001"
+          ],
           "provisioningState": "Succeeded",
-          "provisioningDetails": {
-            "message": "Deployment is healthy and serving traffic.",
-            "lastOperationTimestamp": "2026-04-12T10:25:00Z"
-          },
           "routes": {
             "chatCompletionsScoringPath": "/managed-deployments/gpt-oss-120b-byoc/v1/chat/completions"
           }
         },
+        "tags": {
+          "environment": "development"
+        },
         "sku": {
           "name": "VmManagedCompute",
-          "capacity": 2
+          "capacity": 1
         }
       }
     },
@@ -67,13 +72,20 @@
         "type": "Microsoft.CognitiveServices/accounts/managedComputeDeployments",
         "properties": {
           "model": "azureml://registries/azureml-openai-oss/models/gpt-oss-120b/versions/4",
-          "deploymentTemplate": "projects/my-project/deploymentTemplates/gpt-oss-120b-vllm-tuned/versions/2",
+          "deploymentTemplate": "azureml://registries/azureml-openai-oss/deploymenttemplates/gpt-oss-120b-short-context/versions/1",
           "computeId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/computes/my-h100-pool",
+          "versionUpgradeOption": "NoAutoUpgrade",
+          "allowlistedObjectIds": [
+            "00000000-0000-0000-0000-000000000001"
+          ],
           "provisioningState": "Accepted"
+        },
+        "tags": {
+          "environment": "development"
         },
         "sku": {
           "name": "VmManagedCompute",
-          "capacity": 2
+          "capacity": 1
         }
       }
     }

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-07-15-preview/examples/DeleteVmManagedComputeDeployment.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-07-15-preview/examples/DeleteVmManagedComputeDeployment.json
@@ -1,0 +1,22 @@
+{
+  "operationId": "ManagedComputeDeployments_Delete",
+  "title": "DeleteVmManagedComputeDeployment",
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "resourceGroupName",
+    "accountName": "accountName",
+    "deploymentName": "gpt-oss-120b-byoc",
+    "api-version": "2026-07-15-preview"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/eastus/operationResults/00000000-0000-0000-0000-000000000001?operationResultResponseType=Location&api-version=2026-07-15-preview",
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/eastus/operationResults/00000000-0000-0000-0000-000000000001?api-version=2026-07-15-preview",
+        "retry-after": "30"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-07-15-preview/examples/GetVmManagedComputeDeployment.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-07-15-preview/examples/GetVmManagedComputeDeployment.json
@@ -19,7 +19,6 @@
           "model": "azureml://registries/azureml-openai-oss/models/gpt-oss-120b/versions/4",
           "deploymentTemplate": "projects/my-project/deploymentTemplates/gpt-oss-120b-vllm-tuned/versions/2",
           "computeId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/computes/my-h100-pool",
-          "priority": "High",
           "versionUpgradeOption": "OnceNewDefaultVersionAvailable",
           "capabilities": {
             "assetsV2": "true"

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-07-15-preview/examples/ListVmManagedComputeDeployments.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-07-15-preview/examples/ListVmManagedComputeDeployments.json
@@ -19,7 +19,6 @@
               "model": "azureml://registries/azureml-openai-oss/models/gpt-oss-120b/versions/4",
               "deploymentTemplate": "projects/my-project/deploymentTemplates/gpt-oss-120b-vllm-tuned/versions/2",
               "computeId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/computes/my-h100-pool",
-              "priority": "High",
               "versionUpgradeOption": "OnceNewDefaultVersionAvailable",
               "capabilities": {
                 "assetsV2": "true"

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-07-15-preview/examples/UpdateVmManagedComputeDeployment.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-07-15-preview/examples/UpdateVmManagedComputeDeployment.json
@@ -8,6 +8,9 @@
     "deploymentName": "gpt-oss-120b-byoc",
     "api-version": "2026-07-15-preview",
     "properties": {
+      "tags": {
+        "environment": "development"
+      },
       "sku": {
         "name": "VmManagedCompute",
         "capacity": 2
@@ -21,11 +24,13 @@
         "name": "gpt-oss-120b-byoc",
         "type": "Microsoft.CognitiveServices/accounts/managedComputeDeployments",
         "etag": "\"0x8D...\"",
+        "tags": {
+          "environment": "development"
+        },
         "properties": {
           "model": "azureml://registries/azureml-openai-oss/models/gpt-oss-120b/versions/4",
           "deploymentTemplate": "projects/my-project/deploymentTemplates/gpt-oss-120b-vllm-tuned/versions/2",
           "computeId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/computes/my-h100-pool",
-          "priority": "High",
           "versionUpgradeOption": "OnceNewDefaultVersionAvailable",
           "capabilities": {
             "assetsV2": "true"
@@ -47,8 +52,8 @@
     },
     "202": {
       "headers": {
-        "location": "http://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/eastus/operationResults/00000000-0000-0000-0000-000000000001?operationResultResponseType=Location&api-version=2026-03-15-preview",
-        "azure-asyncoperation": "http://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/eastus/operationResults/00000000-0000-0000-0000-000000000001?api-version=2026-03-15-preview",
+        "location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/eastus/operationResults/00000000-0000-0000-0000-000000000001?operationResultResponseType=Location&api-version=2026-07-15-preview",
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/eastus/operationResults/00000000-0000-0000-0000-000000000001?api-version=2026-07-15-preview",
         "retry-after": "30"
       }
     }


### PR DESCRIPTION
# ARM (Control Plane) API Specification Update

## Purpose of this PR

- [x] Other: propose additions to the existing `2026-07-15-preview` managed-compute specification for `VmManagedCompute` bring-your-own-container deployments.

This is a **draft proposal with three unresolved pre-merge blockers**, not a merge-ready or runtime-validated contract.

## Changes

- Describe VM SKU selection, instance capacity, and SKU-specific compute/accelerator constraints without narrowing the shared SKU type.
- Add July-preview-gated creation identity, tags, serving-endpoint object IDs, and the optional `x-ms-foundry-project-name` creation header.
- Describe tags alongside the existing SKU PATCH fields. Keep identity, deployment-template, and version-upgrade-policy changes out of PATCH.
- Update VM lifecycle examples, add a registry-model/registry-template creation example and a VM deletion example, and regenerate OpenAPI.
- Remove unsupported priority values from the revised examples while retaining the existing optional schema property for compatibility.

## Unresolved pre-merge blockers

**Do not merge. All three items below remain blocked; preparing this draft does not accept these risks for merge.**

### 1. Identity persistence and readback

The resource provider forwards deployment identity on creation but does not persist and return it through deployment GET/readback. The deployment execution path preserves its stored identity when an update omits it and explicitly rejects a different identity. The missing resource-provider readback does not satisfy the proposed readable creation-field contract. Provider implementation and lifecycle validation are required before the specification and examples can be qualified.

Identity PATCH is not advertised in this draft. [ARM guidance permits immutable identity](https://github.com/Azure/azure-rest-api-specs/blob/main/.github/instructions/arm-api-review.instructions.md#L384-L389); mutable identity is not mandatory if the agreed contract is immutable. Immutability does not remove the persistence/readback requirement or the need to preserve identity across supported unrelated updates.

The compiler still emits one identity `patch-envelope` warning. It remains **unsuppressed and unresolved**, requiring an explicit contract/review disposition; it is not, by itself, proof that identity must be mutable. No runtime fix or warning suppression is included.

### 2. Customer versus service ownership of `allowlistedObjectIds`

The proposed readable, creation-writable, immutable property mixes customer-supplied values with service-added serving identities. Its returned value can therefore differ from the customer's declared value and can change during unrelated updates. Acknowledging augmentation in a description does not resolve [clear field ownership](https://github.com/Azure/azure-rest-api-specs/blob/main/.github/skills/azure-api-review/references/property-mutability.md#oapi034-clear-field-ownership).

This is an **additional unresolved provider/API design question and merge blocker**: how should customer-declared values be preserved while service-required serving identities remain effective? An agreed contract and corresponding implementation/validation are required. This draft neither invents a separate field nor treats the current customer-writable field as read-only, and it makes no runtime authorization changes.

### 3. Published-version policy conflict

`2026-07-15-preview` already exists on public main. This proposal changes that existing version, including additions and mutability, while the repository's [published-version immutability policy](https://github.com/Azure/azure-rest-api-specs/blob/main/.github/instructions/arm-api-review.instructions.md#260-published-api-versions-are-immutable) covers optional additions and preview versions.

July is retained as the selected version for this **unresolved draft proposal only**. A maintainer versioning disposition is required before merge; alternatively, moving to a later API version while preserving July requires a separately agreed change. No maintainer approval, exception, or later-version change is claimed. Preserving earlier previews and passing static validation do not resolve this policy conflict.

Template and version-upgrade-policy replacement remain unadvertised: resource-provider admission or persistence alone does not establish end-to-end update support. The current deployment execution contract rejects changes to these fields.

## Validation

- Azure SDK CLI TypeSpec validation: passed.
- TypeSpec compilation and OpenAPI generation: completed with **0 errors and exactly 1 known identity `patch-envelope` warning**, still unresolved as described above.
- OAV example validation: **all 5** managed-compute lifecycle operations (create/update, get, list, patch, and delete) passed.
- Earlier March/May preview wire schemas remain unchanged; their generated differences are descriptions only.
- **No runtime validation was performed for this draft. No deployment or SDK-generation validation is claimed.** These static checks do not establish service behavior or resolve any pre-merge blocker.

## Due diligence

- [x] This PR modifies Azure Resource Manager specifications, not data-plane specifications.
- [ ] Identity persistence/readback and preservation across supported updates implemented and validated.
- [ ] Identity contract and unsuppressed `patch-envelope` warning disposition completed.
- [ ] Customer/service allowlist ownership design resolved, implemented, and validated.
- [ ] Published-version policy conflict resolved through maintainer disposition or an agreed later-version change.
- [ ] Release plan and SDK readiness requirements completed.

## Authoring references

- [Evolving APIs and versioned property changes](https://azure.github.io/typespec-azure/docs/howtos/versioning/06-evolving-apis/)
- [ARM resource operations and visibility](https://azure.github.io/typespec-azure/docs/howtos/arm/resource-operations/)
- [TypeSpec model composition](https://typespec.io/docs/language-basics/models/)
