### PR TITLE
Fix data-plane reviewer assignment 422 via azure-sdk-automation App token (#45985)

### DIFF
--- a/.github/workflows/data-plane-review-assignment.yaml
+++ b/.github/workflows/data-plane-review-assignment.yaml
@@ -45,6 +45,12 @@ jobs:
     # ubuntu-slim: REST-only job (no build) that runs on every Summarize Checks completion,
     # matching the other label-reaction workflows (arm-auto-signoff-status, update-labels).
     runs-on: ubuntu-slim
+    # Gate the App-token step on the secret being present: the `env` context is available in a
+    # step `if`, but the `secrets` context is not. Until AZURE_SDK_AUTOMATION_APP_ID is
+    # provisioned, APP_ID is empty, the token step is skipped, and the job falls back to the
+    # default GITHUB_TOKEN (team resolution 422s on that path, i.e. no worse than today).
+    env:
+      APP_ID: ${{ secrets.AZURE_SDK_AUTOMATION_APP_ID }}
     steps:
       # IMPORTANT: This workflow uses pull_request_target, which runs with repo write
       # permissions. Only base-branch code is checked out below, and no PR-head code is
@@ -57,9 +63,30 @@ jobs:
       - name: Install dependencies for github-script actions
         uses: ./.github/actions/install-deps-github-script
 
+      # Mint a short-lived installation token from the azure-sdk-automation GitHub App so the
+      # reviewer-team request can resolve the org team. The default GITHUB_TOKEN cannot read org
+      # team membership (members:read), so requesting the team fails with HTTP 422 (#45985). The
+      # App is installed on the Azure org with members:read; a repo-scoped token still carries
+      # that org permission. Scoped to the minimum this job's REST calls need.
+      - name: Mint azure-sdk-automation App token
+        id: app-token
+        if: ${{ env.APP_ID != '' }}
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.AZURE_SDK_AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.AZURE_SDK_AUTOMATION_PRIVATE_KEY }}
+          permission-members: read
+          permission-pull-requests: write
+          permission-issues: read
+          permission-actions: read
+          permission-contents: read
+
       - name: Assign data-plane review team
         uses: actions/github-script@v8
         with:
+          # App token (org members:read) resolves the team so native auto-delegation can pick a
+          # member. Falls back to GITHUB_TOKEN until the App secrets land (422s, as today).
+          github-token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
           script: |
             const { default: assignReviewers } =
               await import('${{ github.workspace }}/.github/workflows/src/data-plane-review/assign-reviewers.js');


### PR DESCRIPTION
Fixes the data-plane reviewer-assignment 422 (#45985) by minting an installation token from the **azure-sdk-automation** GitHub App for the assignment step.

## Problem
The assignment workflow requests the `azure-data-plane-api-reviewers` team via `requestReviewers({ team_reviewers })`. The default Actions `GITHUB_TOKEN` cannot read org team membership, so team resolution fails with **HTTP 422** and no reviewer is ever assigned.

## Fix 
Mint a short-lived token from the `azure-sdk-automation` App (installed on the Azure org with `members: read`) and use it as the `github-token` for the `github-script` step. The App token makes the `requestReviewers({ team })` call itself, so GitHub's native team auto-delegation still picks the member. `assign-reviewers.js` is unchanged.

The minted token is scoped to only what this job needs: `members:read`, `pull-requests:write`, `issues:read`, `actions:read`, `contents:read`.

## Confirmed this works
- A token with only `Organization -> Members: Read` resolves the closed team (200) - validated with a minimal fine-grained PAT.
- The same `requestReviewers({ team })` call returned 200 + auto-delegated to a member when run with an org-read token (throwaway PR #46022).

## Prerequisites before this activates (draft until then)
- [ ] Provision Actions secrets `AZURE_SDK_AUTOMATION_APP_ID` + `AZURE_SDK_AUTOMATION_PRIVATE_KEY` (repo or org).
- [ ] Confirm `azure-rest-api-specs` is in the App's selected repositories (needed for `pull-requests:write` on this repo).

## Safety
- Gated on the App ID secret: until it lands, the token step is skipped and the job falls back to `GITHUB_TOKEN` (team resolution 422s, i.e. no worse than today).
- `pull_request_target` runs base-branch code only; no PR-head code executes, so the token is never exposed to untrusted code.