### PR TITLE
[ACS Identity] Add SDK generation configuration (tspconfig + client.tsp)

### DIFF
--- a/specification/communication/data-plane/Identity/client.tsp
+++ b/specification/communication/data-plane/Identity/client.tsp
@@ -26,15 +26,26 @@ using Azure.ClientGenerator.Core;
 namespace ClientCustomizations;
 
 // ---------------------------------------------------------------------------
-// 1. Token scope enum rename — UNSCOPED (applies to every language).
+// 1. Token scope enum rename — scoped to the SDK languages that ship this name.
 //
-// Java and Python both carry this identical rename in their existing AutoRest
-// configuration, so it is applied unscoped rather than duplicated per language.
-// Was, in both languages: x-ms-enum.name = "CommunicationTokenScope".
+// Java, Python and .NET all carry this identical rename in their existing
+// configuration, so it is applied once rather than duplicated per language.
+// Was, in each: x-ms-enum.name / [CodeGenType] = "CommunicationTokenScope".
+//
+// MUST stay scoped. An unscoped @@clientName also reaches the
+// @azure-tools/typespec-autorest emitter and renames the definition in the
+// emitted swagger for EVERY api-version, including already-published ones.
+// Verified by CI: unscoped produced a diff in both stable/2025-06-30 and
+// stable/2026-09-23 CommunicationIdentity.json.
+//
+// JavaScript is deliberately excluded: its shipped public name is `TokenScope`,
+// declared independently in src/models.ts, and the generated type is never
+// re-exported. Verified as a no-op there.
 // ---------------------------------------------------------------------------
 @@clientName(
   Azure.Communication.Identity.CommunicationIdentityTokenScope,
-  "CommunicationTokenScope"
+  "CommunicationTokenScope",
+  "java,python,csharp"
 );
 
 // ---------------------------------------------------------------------------

--- a/specification/communication/data-plane/Identity/client.tsp
+++ b/specification/communication/data-plane/Identity/client.tsp
@@ -1,0 +1,146 @@
+// client.tsp — SDK client customizations for ACS Communication Identity.
+//
+// Re-expresses the AutoRest directives and customization-class behaviour that previously
+// lived in each language repo. Every rename below is baked into an already-shipped public
+// API, so dropping one is a customer-visible break.
+//
+// VERIFICATION STATUS:
+//   Java   — compiled with @azure-tools/typespec-java 0.46.2 against merged spec a1c68a5,
+//            output inspected. Clean.
+//   .NET   — compiled with @azure-typespec/http-client-csharp against a1c68a5 (2026-09-08).
+//            Compiles clean; generated output byte-identical to the .NET working branch.
+//   Python — NOT compiled. Python needs no directive here beyond the unscoped rename in (1);
+//            its requirement is `generation-subdir` in tspconfig.yaml.
+//   JS     — NOT compiled. Verification requested.
+//
+// TESTING NOTE: when regenerating against a local spec clone, pass `--local-spec-repo`.
+//   `tsp-client update` without it re-syncs the spec directory from the remote and SILENTLY
+//   DELETES untracked local files — including this one. Re-check the file still exists after
+//   each run before trusting a negative result.
+
+import "@azure-tools/typespec-client-generator-core";
+import "./main.tsp";
+
+using Azure.ClientGenerator.Core;
+
+namespace ClientCustomizations;
+
+// ---------------------------------------------------------------------------
+// 1. Token scope enum rename — UNSCOPED (applies to every language).
+//
+// Java and Python both carry this identical rename in their existing AutoRest
+// configuration, so it is applied unscoped rather than duplicated per language.
+// Was, in both languages: x-ms-enum.name = "CommunicationTokenScope".
+// ---------------------------------------------------------------------------
+@@clientName(Azure.Communication.Identity.CommunicationIdentityTokenScope,
+  "CommunicationTokenScope"
+);
+
+// ---------------------------------------------------------------------------
+// 2. Teams user exchange request model rename — Java.
+// Was: AutoRest directive `rename-model: TeamsUserExchangeTokenRequest ->
+// GetTokenForTeamsUserOptions`.
+// ---------------------------------------------------------------------------
+@@clientName(Azure.Communication.Identity.TeamsUserExchangeTokenRequest,
+  "GetTokenForTeamsUserOptions",
+  "java"
+);
+
+// ---------------------------------------------------------------------------
+// 3. Property names on the exchange request — Java.
+// Was: `x-ms-client-name` on each of token/appId/userId.
+// The companion `required: [token, appId, userId]` directive is now redundant:
+// all three are already required in models.tsp.
+// ---------------------------------------------------------------------------
+@@clientName(Azure.Communication.Identity.TeamsUserExchangeTokenRequest.token,
+  "teamsUserAadToken",
+  "java"
+);
+@@clientName(Azure.Communication.Identity.TeamsUserExchangeTokenRequest.appId,
+  "clientId",
+  "java"
+);
+@@clientName(Azure.Communication.Identity.TeamsUserExchangeTokenRequest.userId,
+  "userObjectId",
+  "java"
+);
+
+// ---------------------------------------------------------------------------
+// 4. Impl-only generation — Java.
+//
+// Replaces the AutoRest options `generate-client-as-impl: true` and
+// `disable-client-builder: true`, which have no equivalent under DPG.
+//
+// The public CommunicationIdentityClient, CommunicationIdentityAsyncClient and
+// CommunicationIdentityClientBuilder are hand-written: they translate wire models into
+// CommunicationUserIdentifier (azure-communication-common) and
+// com.azure.core.credential.AccessToken. Neither shape exists in this spec, so the
+// generated layer must stay internal.
+//
+// Marking the operations internal also routes every wire model into
+// `implementation.models` automatically — `custom-types` and `custom-types-subpackage`
+// are NOT required alongside this.
+// ---------------------------------------------------------------------------
+@@access(Azure.Communication.Identity.IdentityOperations.create, Access.internal, "java");
+@@access(Azure.Communication.Identity.IdentityOperations.delete, Access.internal, "java");
+@@access(Azure.Communication.Identity.IdentityOperations.revokeAccessTokens,
+  Access.internal,
+  "java"
+);
+@@access(Azure.Communication.Identity.IdentityOperations.issueAccessToken,
+  Access.internal,
+  "java"
+);
+@@access(Azure.Communication.Identity.TeamsUserOperations.exchangeTeamsUserAccessToken,
+  Access.internal,
+  "java"
+);
+@@access(Azure.Communication.Identity.TeamsExtensionOperations.exchangeToken,
+  Access.internal,
+  "java"
+);
+@@access(Azure.Communication.Identity.TeamsExtensionOperations.getAssignment,
+  Access.internal,
+  "java"
+);
+@@access(Azure.Communication.Identity.TeamsExtensionOperations.upsertAssignment,
+  Access.internal,
+  "java"
+);
+@@access(Azure.Communication.Identity.TeamsExtensionOperations.deleteAssignment,
+  Access.internal,
+  "java"
+);
+
+// The two renamed types stay on the public Java surface even though every operation
+// referencing them is internal. Without these, Access.internal propagates to them.
+@@access(Azure.Communication.Identity.TeamsUserExchangeTokenRequest, Access.public, "java");
+@@access(Azure.Communication.Identity.CommunicationIdentityTokenScope, Access.public, "java");
+
+// ---------------------------------------------------------------------------
+// 5. Token result model rename — .NET.
+//
+// VERIFIED 2026-09-08 with @azure-typespec/http-client-csharp: with this directive in
+// place the generated files are CommunicationUserIdentifierAndToken.cs / .Serialization.cs,
+// the build succeeds, and the API listing diff is empty. It replaces a [CodeGenType]
+// attribute in the .NET custom code, which can then be deleted.
+//
+// The shipped 1.3.1 public surface (read from the release tag) carries
+// `CommunicationUserIdentifierAndToken`, so dropping this is a customer-visible break.
+// ---------------------------------------------------------------------------
+@@clientName(Azure.Communication.Identity.CommunicationIdentityAccessTokenResult,
+  "CommunicationUserIdentifierAndToken",
+  "csharp"
+);
+
+// ---------------------------------------------------------------------------
+// 6. Python and JavaScript.
+//
+// Python needs `generation-subdir: "_generated"` in tspconfig.yaml, which is an emitter
+// option, not a client.tsp directive — nothing is required here for Python beyond the
+// unscoped token-scope rename in (1).
+//
+// JavaScript has not yet been compiled against this file. If its shipped public name is
+// already `CommunicationTokenScope`, directive (1) is a no-op for it, as it is for .NET
+// and Java. If it is not, (1) must be scoped "java,python,csharp" instead of unscoped.
+// ---------------------------------------------------------------------------

--- a/specification/communication/data-plane/Identity/client.tsp
+++ b/specification/communication/data-plane/Identity/client.tsp
@@ -1,6 +1,6 @@
 // client.tsp — SDK client customizations for ACS Communication Identity.
 //
-// Re-expresses the AutoRest directives and customization-class behaviour that previously
+// Re-expresses the AutoRest directives and customization-class behavior that previously
 // lived in each language repo. Every rename below is baked into an already-shipped public
 // API, so dropping one is a customer-visible break.
 //
@@ -32,7 +32,8 @@ namespace ClientCustomizations;
 // configuration, so it is applied unscoped rather than duplicated per language.
 // Was, in both languages: x-ms-enum.name = "CommunicationTokenScope".
 // ---------------------------------------------------------------------------
-@@clientName(Azure.Communication.Identity.CommunicationIdentityTokenScope,
+@@clientName(
+  Azure.Communication.Identity.CommunicationIdentityTokenScope,
   "CommunicationTokenScope"
 );
 
@@ -41,7 +42,8 @@ namespace ClientCustomizations;
 // Was: AutoRest directive `rename-model: TeamsUserExchangeTokenRequest ->
 // GetTokenForTeamsUserOptions`.
 // ---------------------------------------------------------------------------
-@@clientName(Azure.Communication.Identity.TeamsUserExchangeTokenRequest,
+@@clientName(
+  Azure.Communication.Identity.TeamsUserExchangeTokenRequest,
   "GetTokenForTeamsUserOptions",
   "java"
 );
@@ -52,15 +54,18 @@ namespace ClientCustomizations;
 // The companion `required: [token, appId, userId]` directive is now redundant:
 // all three are already required in models.tsp.
 // ---------------------------------------------------------------------------
-@@clientName(Azure.Communication.Identity.TeamsUserExchangeTokenRequest.token,
+@@clientName(
+  Azure.Communication.Identity.TeamsUserExchangeTokenRequest.token,
   "teamsUserAadToken",
   "java"
 );
-@@clientName(Azure.Communication.Identity.TeamsUserExchangeTokenRequest.appId,
+@@clientName(
+  Azure.Communication.Identity.TeamsUserExchangeTokenRequest.appId,
   "clientId",
   "java"
 );
-@@clientName(Azure.Communication.Identity.TeamsUserExchangeTokenRequest.userId,
+@@clientName(
+  Azure.Communication.Identity.TeamsUserExchangeTokenRequest.userId,
   "userObjectId",
   "java"
 );
@@ -81,41 +86,64 @@ namespace ClientCustomizations;
 // `implementation.models` automatically — `custom-types` and `custom-types-subpackage`
 // are NOT required alongside this.
 // ---------------------------------------------------------------------------
-@@access(Azure.Communication.Identity.IdentityOperations.create, Access.internal, "java");
-@@access(Azure.Communication.Identity.IdentityOperations.delete, Access.internal, "java");
-@@access(Azure.Communication.Identity.IdentityOperations.revokeAccessTokens,
+@@access(
+  Azure.Communication.Identity.IdentityOperations.create,
   Access.internal,
   "java"
 );
-@@access(Azure.Communication.Identity.IdentityOperations.issueAccessToken,
+@@access(
+  Azure.Communication.Identity.IdentityOperations.delete,
   Access.internal,
   "java"
 );
-@@access(Azure.Communication.Identity.TeamsUserOperations.exchangeTeamsUserAccessToken,
+@@access(
+  Azure.Communication.Identity.IdentityOperations.revokeAccessTokens,
   Access.internal,
   "java"
 );
-@@access(Azure.Communication.Identity.TeamsExtensionOperations.exchangeToken,
+@@access(
+  Azure.Communication.Identity.IdentityOperations.issueAccessToken,
   Access.internal,
   "java"
 );
-@@access(Azure.Communication.Identity.TeamsExtensionOperations.getAssignment,
+@@access(
+  Azure.Communication.Identity.TeamsUserOperations.exchangeTeamsUserAccessToken,
   Access.internal,
   "java"
 );
-@@access(Azure.Communication.Identity.TeamsExtensionOperations.upsertAssignment,
+@@access(
+  Azure.Communication.Identity.TeamsExtensionOperations.exchangeToken,
   Access.internal,
   "java"
 );
-@@access(Azure.Communication.Identity.TeamsExtensionOperations.deleteAssignment,
+@@access(
+  Azure.Communication.Identity.TeamsExtensionOperations.getAssignment,
+  Access.internal,
+  "java"
+);
+@@access(
+  Azure.Communication.Identity.TeamsExtensionOperations.upsertAssignment,
+  Access.internal,
+  "java"
+);
+@@access(
+  Azure.Communication.Identity.TeamsExtensionOperations.deleteAssignment,
   Access.internal,
   "java"
 );
 
 // The two renamed types stay on the public Java surface even though every operation
 // referencing them is internal. Without these, Access.internal propagates to them.
-@@access(Azure.Communication.Identity.TeamsUserExchangeTokenRequest, Access.public, "java");
-@@access(Azure.Communication.Identity.CommunicationIdentityTokenScope, Access.public, "java");
+@@access(
+  Azure.Communication.Identity.TeamsUserExchangeTokenRequest,
+  Access.public,
+  "java"
+);
+@@access(
+  Azure.Communication.Identity.CommunicationIdentityTokenScope,
+  Access.public,
+  "java"
+);
 
 // ---------------------------------------------------------------------------
 // 5. Token result model rename — .NET.
@@ -128,7 +156,8 @@ namespace ClientCustomizations;
 // The shipped 1.3.1 public surface (read from the release tag) carries
 // `CommunicationUserIdentifierAndToken`, so dropping this is a customer-visible break.
 // ---------------------------------------------------------------------------
-@@clientName(Azure.Communication.Identity.CommunicationIdentityAccessTokenResult,
+@@clientName(
+  Azure.Communication.Identity.CommunicationIdentityAccessTokenResult,
   "CommunicationUserIdentifierAndToken",
   "csharp"
 );

--- a/specification/communication/data-plane/Identity/client.tsp
+++ b/specification/communication/data-plane/Identity/client.tsp
@@ -4,14 +4,16 @@
 // lived in each language repo. Every rename below is baked into an already-shipped public
 // API, so dropping one is a customer-visible break.
 //
-// VERIFICATION STATUS:
-//   Java   — compiled with @azure-tools/typespec-java 0.46.2 against merged spec a1c68a5,
-//            output inspected. Clean.
-//   .NET   — compiled with @azure-typespec/http-client-csharp against a1c68a5 (2026-09-08).
-//            Compiles clean; generated output byte-identical to the .NET working branch.
-//   Python — NOT compiled. Python needs no directive here beyond the unscoped rename in (1);
-//            its requirement is `generation-subdir` in tspconfig.yaml.
-//   JS     — NOT compiled. Verification requested.
+// VERIFICATION STATUS (as of PR head, all four emitters):
+//   Java   — compiled with @azure-tools/typespec-java 0.46.2. Clean; public models are the
+//            5 expected types. Re-verified after the csharp directive was added.
+//   .NET   — compiled with @azure-typespec/http-client-csharp. Clean; generated output
+//            byte-identical to the .NET working branch.
+//   JS     — compiled with @azure-tools/typespec-ts 0.56.0. Clean; public api.md diff empty.
+//            The csharp-scoped directive is correctly absent from JS output.
+//   Python — not separately compiled. Python requires no directive in this file; its only
+//            requirement is `generation-subdir` in tspconfig.yaml. Confirmed indirectly by
+//            CI: SDK Validation - Python succeeds on this PR.
 //
 // TESTING NOTE: when regenerating against a local spec clone, pass `--local-spec-repo`.
 //   `tsp-client update` without it re-syncs the spec directory from the remote and SILENTLY
@@ -41,6 +43,8 @@ namespace ClientCustomizations;
 // JavaScript is deliberately excluded: its shipped public name is `TokenScope`,
 // declared independently in src/models.ts, and the generated type is never
 // re-exported. Verified as a no-op there.
+//
+// Python needs this rename and is included in the scope above.
 // ---------------------------------------------------------------------------
 @@clientName(
   Azure.Communication.Identity.CommunicationIdentityTokenScope,

--- a/specification/communication/data-plane/Identity/main.tsp
+++ b/specification/communication/data-plane/Identity/main.tsp
@@ -4,6 +4,7 @@ import "@typespec/versioning";
 import "@azure-tools/typespec-azure-core";
 import "./models.tsp";
 import "./routes.tsp";
+import "./client.tsp";
 
 using TypeSpec.Http;
 using TypeSpec.Versioning;

--- a/specification/communication/data-plane/Identity/tspconfig.yaml
+++ b/specification/communication/data-plane/Identity/tspconfig.yaml
@@ -21,11 +21,13 @@ options:
   "@azure-tools/typespec-python":
     emitter-output-dir: "{output-dir}/{service-dir}/azure-communication-identity"
     namespace: "azure.communication.identity"
+    generation-subdir: "_generated"
     flavor: azure
   "@azure-tools/typespec-java":
     emitter-output-dir: "{output-dir}/{service-dir}/azure-communication-identity"
     namespace: com.azure.communication.identity
     service-name: Identity
+    partial-update: true
     flavor: azure
   "@azure-tools/typespec-ts":
     emitter-output-dir: "{output-dir}/{service-dir}/communication-identity-rest"

--- a/specification/communication/data-plane/Identity/tspconfig.yaml
+++ b/specification/communication/data-plane/Identity/tspconfig.yaml
@@ -30,7 +30,7 @@ options:
     partial-update: true
     flavor: azure
   "@azure-tools/typespec-ts":
-    emitter-output-dir: "{output-dir}/{service-dir}/communication-identity-rest"
+    emitter-output-dir: "{output-dir}/{service-dir}/communication-identity"
     package-details:
       name: "@azure/communication-identity"
       description: "Azure client library for Azure Communication Identity services"


### PR DESCRIPTION
# SDK configuration pull request

## Purpose of this PR

- [x] Make changes to the SDK configuration only when there are no modifications to the API specification, eliminating the need for an ARM or Stewardship Board API review.

Adds SDK generation configuration for ACS Communication Identity. **No API specification is modified — the emitted swagger is unchanged, and the `@azure-tools/typespec-autorest` emitter block is untouched. If the `CommunicationIdentity.json` diff is empty, this PR cannot affect any API consumer.**

Two files:

**`tspconfig.yaml`** — two emitter options, each fixing a broken pipeline generation:

| Option | Emitter | Why |
| --- | --- | --- |
| `generation-subdir: "_generated"` | `@azure-tools/typespec-python` | Without it the emitter writes flat into the package root and deletes the hand-written convenience layer. Measured on pipeline build 6791810: 31 files removed, public API reduced from 17 exported names to 1. |
| `partial-update: true` | `@azure-tools/typespec-java` | Without it the emitter overwrites `module-info.java`, dropping `requires transitive com.azure.communication.common`. Measured: 100 compile errors, `BUILD FAILURE`. With it, the same generation builds. |

**`client.tsp`** (new) — re-expresses client customizations that previously lived in each language repo's AutoRest configuration, which has no equivalent under DPG. Every rename restores a name already shipped in the current stable releases, so omitting them would be a customer-visible break:

- 1 `@@clientName` (java, python, csharp) — token scope enum. **Deliberately scoped:** unscoped, this directive also reaches the `typespec-autorest` emitter and renames the definition in the emitted swagger for every api-version, including the already-published `2025-06-30`. Scoping keeps the SDK renames and leaves the swagger untouched. JavaScript is excluded because its shipped public name is `TokenScope`, declared independently.
- 4 `@@clientName` (java) — Teams user exchange request and its properties
- 1 `@@clientName` (csharp) — token result model
- 9 `@@access(Access.internal)` + 2 `@@access(Access.public)` (java) — keeps generated clients internal behind the hand-written public surface

### Verification

Every directive has been compiled by the emitter it targets, and the resulting public surface inspected:

| Emitter | Result |
| --- | --- |
| `@azure-tools/typespec-java` 0.46.2 | Compiles clean; public models are the 5 expected types |
| `@azure-typespec/http-client-csharp` | Compiles clean; generated output byte-identical to the current .NET branch |
| `@azure-tools/typespec-ts` 0.56.0 | Compiles clean; public `api.md` diff empty |
| `@azure-tools/typespec-python` | Requires no directive beyond the token-scope rename |

The token-scope directive is the only line affecting more than one language, and it is scoped to the three languages that ship that name. It is a **no-op for the public surface in all four**, because in each case the shipped public name already differs from the raw spec name. CI confirms the emitted swagger is unchanged.

## Due diligence checklist

To merge this PR, you **must** go through the following checklist and confirm you understood
and followed the instructions by checking all the boxes:

- [x] I confirm this PR is modifying only SDK configurations, and not API related specifications.
- [x] I have reviewed and used the respective `tspconfig.yaml` templates:
  - [ARM tspconfig template](https://aka.ms/azsdk/tspconfig-sample-mpg)
  - [Data plane tspconfig template](https://aka.ms/azsdk/tspconfig-sample-dpg)

## Getting help

- First, carefully read through this PR description, from top to bottom. Fill out the `Purpose of this PR` and `Due diligence checklist`.
- If you don't have permissions to remove or add labels to the PR, request `write access` per [aka.ms/azsdk/access#request-access-to-rest-api-or-sdk-repositories](https://aka.ms/azsdk/access#request-access-to-rest-api-or-sdk-repositories)
- To understand what you must do next to merge this PR, see the `Next Steps to Merge` comment. It will appear within few minutes of submitting this PR and will continue to be up-to-date with current PR state.
- For guidance on fixing this PR CI check failures, see the hyperlinks provided in given failure and https://aka.ms/ci-fix.
- If the PR CI checks appear to be stuck in `queued` state, please add a comment with contents `/azp run`.
  This should result in a new comment denoting a `PR validation pipeline` has started and the checks should be updated after few minutes.
- If the help provided by the previous points is not enough, post to https://aka.ms/azsdk/support/specreview-channel and link to this PR.