### PR TITLE
Bump @azure-tools/openai-typespec to 1.26.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "name": "azure-rest-api-specs",
       "devDependencies": {
         "@autorest/openapi-to-typespec": "0.11.14",
-        "@azure-tools/openai-typespec": "1.25.0",
+        "@azure-tools/openai-typespec": "1.26.0",
         "@azure-tools/spec-gen-sdk": "~0.9.1",
         "@azure-tools/specs-shared": "file:.github/shared",
         "@azure-tools/typespec-apiview": "0.7.2",
@@ -981,9 +981,9 @@
       "link": true
     },
     "node_modules/@azure-tools/openai-typespec": {
-      "version": "1.25.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@azure-tools/openai-typespec/-/openai-typespec-1.25.0.tgz",
-      "integrity": "sha1-ed6GUv9Y+v95/dfs3CR+Az1DaZ0=",
+      "version": "1.26.0",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@azure-tools/openai-typespec/-/openai-typespec-1.26.0.tgz",
+      "integrity": "sha1-MCoYtJLA5Ik5nV5uOooxtI8ZZ5g=",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "azure-rest-api-specs",
   "devDependencies": {
     "@autorest/openapi-to-typespec": "0.11.14",
-    "@azure-tools/openai-typespec": "1.25.0",
+    "@azure-tools/openai-typespec": "1.26.0",
     "@azure-tools/spec-gen-sdk": "~0.9.1",
     "@azure-tools/specs-shared": "file:.github/shared",
     "@azure-tools/typespec-apiview": "0.7.2",


### PR DESCRIPTION
This PR intentionally updates the root dependency manifest and lockfile to bump @azure-tools/openai-typespec from 1.25.0 to 1.26.0. The Protected Files check requires Azure SDK team handling. Could the team review and merge using the authorized bypass once the other required checks pass?

## Summary
- Bump the exact @azure-tools/openai-typespec dependency from 1.25.0 to 1.26.0 and update the lockfile.
- Align CI dependencies with the version used to generate the checked-in Foundry OpenAPI artifacts.
- No OpenAPI artifact changes are needed with 1.26.0.

## Validation
- npm install completed successfully.
- Foundry TypeSpec compilation passed.
- All four OpenAPI artifacts match the checked-in versions and remain unchanged on repeat compilation (SHA-256 comparison).

Related failing check: https://github.com/Azure/azure-rest-api-specs/actions/runs/34294477123/job/102287987304