### PR TITLE
Enable provisioning generation for Monitor split packages

### DIFF
--- a/specification/monitoringservice/resource-manager/Microsoft.Monitor/Accounts/tspconfig.yaml
+++ b/specification/monitoringservice/resource-manager/Microsoft.Monitor/Accounts/tspconfig.yaml
@@ -36,6 +36,10 @@ options:
   "@azure-typespec/http-client-csharp-mgmt":
     namespace: "Azure.ResourceManager.Monitor.Workspaces"
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
+  "@azure-typespec/http-client-csharp-provisioning":
+    namespace: "Azure.Provisioning.Monitor.Workspaces"
+    emitter-output-dir: "{project-root}/Azure.Provisioning.Monitor.Workspaces"
+    api-version: "2025-10-03"
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/monitor"
     emitter-output-dir: "{output-dir}/{service-dir}/armmonitorworkspaces"

--- a/specification/monitoringservice/resource-manager/Microsoft.Monitor/PipelineGroups/tspconfig.yaml
+++ b/specification/monitoringservice/resource-manager/Microsoft.Monitor/PipelineGroups/tspconfig.yaml
@@ -47,3 +47,7 @@ options:
   "@azure-typespec/http-client-csharp-mgmt":
     namespace: "Azure.ResourceManager.Monitor.PipelineGroups"
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
+  "@azure-typespec/http-client-csharp-provisioning":
+    namespace: "Azure.Provisioning.Monitor.PipelineGroups"
+    emitter-output-dir: "{project-root}/Azure.Provisioning.Monitor.PipelineGroups"
+    api-version: "2024-10-01-preview"


### PR DESCRIPTION
## Summary

- enable the C# provisioning emitter for Microsoft.Monitor Accounts
- enable the C# provisioning emitter for Microsoft.Monitor PipelineGroups
- keep the two new provisioning packages separate from the existing `Azure.Provisioning.Monitor` migration

## Related

- Azure/azure-sdk-for-net#62804
- Split from #46154
- Azure/azure-sdk-for-net#57387