### PR TITLE
Add SecurityCenter provisioning emitter configuration

### DIFF
--- a/specification/security/resource-manager/Microsoft.Security/Security/client.tsp
+++ b/specification/security/resource-manager/Microsoft.Security/Security/client.tsp
@@ -796,6 +796,11 @@ op privateLinkResourcesGetCustomization(
 @@clientName(AutomationsAPI.EventSource, "SecurityEventSource", "csharp");
 @@clientName(LocationsAPI.AscLocation, "SecurityCenterLocation", "csharp");
 @@clientName(PricingsAPI.Pricing, "SecurityCenterPricing", "csharp");
+@@clientName(
+  PrivateLinksAPI.PrivateLinkResource,
+  "SecurityCenterPrivateLinkResource",
+  "csharp"
+);
 @@clientName(LegacySettingsAPI.Compliance, "SecurityCompliance", "csharp");
 @@clientName(LegacySettingsAPI.Rank, "SensitivityLabelRank", "csharp");
 @@clientName(ApplicationsAPI.Application, "SecurityApplication", "csharp");

--- a/specification/security/resource-manager/Microsoft.Security/Security/tspconfig.yaml
+++ b/specification/security/resource-manager/Microsoft.Security/Security/tspconfig.yaml
@@ -5,6 +5,9 @@ options:
   "@azure-typespec/http-client-csharp-mgmt":
     namespace: "Azure.ResourceManager.SecurityCenter"
     emitter-output-dir: "{output-dir}/sdk/securitycenter/{namespace}"
+  "@azure-typespec/http-client-csharp-provisioning":
+    namespace: "Azure.Provisioning.SecurityCenter"
+    emitter-output-dir: "{output-dir}/sdk/securitycenter/{namespace}"
   "@azure-tools/typespec-python":
     service-dir: "sdk/security"
     emitter-output-dir: "{output-dir}/{service-dir}/azure-mgmt-security"


### PR DESCRIPTION
## Summary
- enable the C# provisioning emitter for the aggregate Microsoft.Security TypeSpec project
- preserve the SecurityCenter private-link resource name for SDK generation

## Validation
- generated Azure.Provisioning.SecurityCenter successfully from the local TypeSpec project
- verified consecutive generated outputs are byte-for-byte stable