### PR TITLE
Enable App Configuration C# provisioning generation

### DIFF
--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/client.tsp
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/client.tsp
@@ -113,7 +113,6 @@ using Azure.ClientGenerator.Core;
   "AppConfigurationPrivateEndpointConnectionReference",
   "csharp"
 );
-@@access(PrivateEndpointConnectionReference.type, Access.internal, "csharp");
 @@clientName(ProvisioningState, "AppConfigurationProvisioningState", "csharp");
 @@clientName(
   PrivateLinkDelegation,

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/client.tsp
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/client.tsp
@@ -216,3 +216,34 @@ using Azure.ClientGenerator.Core;
   "AppConfigurationIssueType",
   "csharp"
 );
+
+// Preserve provisioning metadata from the reflection-based generator.
+#suppress "@azure-tools/typespec-client-generator-core/client-option" "RBAC roles for provisioning compatibility"
+#suppress "@azure-tools/typespec-client-generator-core/client-option-requires-scope" "RBAC roles for provisioning compatibility"
+@@clientOption(
+  ConfigurationStore,
+  "resource-rbac-roles",
+  #{
+    AppConfigurationDataOwner: "5ae67dd6-50cb-40e7-96ff-dc2bfa4b606b",
+    AppConfigurationDataReader: "516239f1-63e1-4d78-a4de-a74fb236a071",
+  },
+  "csharp"
+);
+
+#suppress "@azure-tools/typespec-client-generator-core/client-option" "Name constraints for provisioning compatibility"
+#suppress "@azure-tools/typespec-client-generator-core/client-option-requires-scope" "Name constraints for provisioning compatibility"
+@@clientOption(
+  ConfigurationStore,
+  "resource-name-constraint",
+  #{ minLength: 5, maxLength: 50, pattern: "^[a-zA-Z0-9-]+$" },
+  "csharp"
+);
+
+#suppress "@azure-tools/typespec-client-generator-core/client-option" "Name constraints for provisioning compatibility"
+#suppress "@azure-tools/typespec-client-generator-core/client-option-requires-scope" "Name constraints for provisioning compatibility"
+@@clientOption(
+  Replica,
+  "resource-name-constraint",
+  #{ minLength: 1, maxLength: 50, pattern: "^[a-zA-Z0-9]+$" },
+  "csharp"
+);

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/client.tsp
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/client.tsp
@@ -113,6 +113,7 @@ using Azure.ClientGenerator.Core;
   "AppConfigurationPrivateEndpointConnectionReference",
   "csharp"
 );
+@@access(PrivateEndpointConnectionReference.type, Access.internal, "csharp");
 @@clientName(ProvisioningState, "AppConfigurationProvisioningState", "csharp");
 @@clientName(
   PrivateLinkDelegation,
@@ -181,6 +182,11 @@ using Azure.ClientGenerator.Core;
 );
 @@alternateType(Replica.location, Azure.Core.azureLocation, "csharp");
 @@alternateType(PrivateEndpoint.id, Azure.Core.armResourceIdentifier, "csharp");
+@@alternateType(
+  PrivateEndpointConnectionReference.id,
+  Azure.Core.armResourceIdentifier,
+  "csharp"
+);
 @@alternateType(
   KeyValueProperties.eTag,
   Azure.Core.EtagProperty.etag,

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/tspconfig.yaml
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/tspconfig.yaml
@@ -26,6 +26,10 @@ options:
     namespace: "Azure.ResourceManager.AppConfiguration"
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
     enable-wire-path-attribute: true
+  "@azure-typespec/http-client-csharp-provisioning":
+    namespace: "Azure.Provisioning.AppConfiguration"
+    emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
+    api-version: "2025-08-01-preview"
   "@azure-tools/typespec-ts":
     emitter-output-dir: "{output-dir}/{service-dir}/arm-appconfiguration"
     package-details:


### PR DESCRIPTION
## Summary
- enable the C# provisioning emitter for App Configuration
- preserve existing provisioning RBAC helpers, resource name constraints, and resource identifier types

## Related SDK PR
- Azure/azure-sdk-for-net#62814

## Validation
- compiled the TypeSpec project with the C# provisioning emitter