### PR TITLE
Revert listKeys rename back to getKeys (push back on RPC-POST-V1-10)

### DIFF
--- a/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/examples/2026-11-02-preview/GetKeys_RegistryDeviceAuthenticationProfile.json
+++ b/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/examples/2026-11-02-preview/GetKeys_RegistryDeviceAuthenticationProfile.json
@@ -1,6 +1,6 @@
 {
-  "title": "ListKeys_RegistryDeviceAuthenticationProfile",
-  "operationId": "RegistryDeviceAuthenticationProfiles_ListKeys",
+  "title": "GetKeys_RegistryDeviceAuthenticationProfile",
+  "operationId": "RegistryDeviceAuthenticationProfiles_GetKeys",
   "description": "Retrieve the plaintext symmetric keys of a device authentication profile.",
   "parameters": {
     "api-version": "2026-11-02-preview",

--- a/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/preview/2026-11-02-preview/deviceregistry.json
+++ b/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/preview/2026-11-02-preview/deviceregistry.json
@@ -6383,9 +6383,9 @@
         }
       }
     },
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DeviceRegistry/namespaces/{namespaceName}/registryDevices/{registryDeviceName}/authenticationProfiles/{authenticationProfileName}/listKeys": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DeviceRegistry/namespaces/{namespaceName}/registryDevices/{registryDeviceName}/authenticationProfiles/{authenticationProfileName}/getKeys": {
       "post": {
-        "operationId": "RegistryDeviceAuthenticationProfiles_ListKeys",
+        "operationId": "RegistryDeviceAuthenticationProfiles_GetKeys",
         "tags": [
           "RegistryDeviceAuthenticationProfiles"
         ],
@@ -6446,8 +6446,8 @@
           }
         },
         "x-ms-examples": {
-          "ListKeys_RegistryDeviceAuthenticationProfile": {
-            "$ref": "./examples/ListKeys_RegistryDeviceAuthenticationProfile.json"
+          "GetKeys_RegistryDeviceAuthenticationProfile": {
+            "$ref": "./examples/GetKeys_RegistryDeviceAuthenticationProfile.json"
           }
         }
       }
@@ -9671,7 +9671,7 @@
     },
     "GetDeviceAuthenticationProfileKeysResponse": {
       "type": "object",
-      "description": "Response body for the listKeys action.",
+      "description": "Response body for the getKeys action.",
       "properties": {
         "symmetricKey": {
           "$ref": "#/definitions/SymmetricKeyCredentials",

--- a/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/preview/2026-11-02-preview/examples/GetKeys_RegistryDeviceAuthenticationProfile.json
+++ b/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/preview/2026-11-02-preview/examples/GetKeys_RegistryDeviceAuthenticationProfile.json
@@ -1,6 +1,6 @@
 {
-  "title": "ListKeys_RegistryDeviceAuthenticationProfile",
-  "operationId": "RegistryDeviceAuthenticationProfiles_ListKeys",
+  "title": "GetKeys_RegistryDeviceAuthenticationProfile",
+  "operationId": "RegistryDeviceAuthenticationProfiles_GetKeys",
   "description": "Retrieve the plaintext symmetric keys of a device authentication profile.",
   "parameters": {
     "api-version": "2026-11-02-preview",

--- a/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/registryDeviceAuthenticationProfiles.tsp
+++ b/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/registryDeviceAuthenticationProfiles.tsp
@@ -61,7 +61,7 @@ model RegistryDeviceAuthenticationProfile
 // ──────────────────────────────────────────────
 
 @added(Versions.v2026_11_02_preview)
-@doc("Response body for the listKeys action.")
+@doc("Response body for the getKeys action.")
 model GetDeviceAuthenticationProfileKeysResponse {
   @doc("Plaintext symmetric keys for the device authentication profile.")
   symmetricKey: SymmetricKeyCredentials;
@@ -78,7 +78,7 @@ interface RegistryDeviceAuthenticationProfiles {
     profile's authentication type is SymmetricKey; profiles of any other type return 400 with the
     InvalidAuthenticationType error code.
     """)
-  listKeys is ArmResourceActionSync<
+  getKeys is ArmResourceActionSync<
     RegistryDeviceAuthenticationProfile,
     void,
     GetDeviceAuthenticationProfileKeysResponse


### PR DESCRIPTION
Reverts the round-1 `getKeys` → `listKeys` rename on `RegistryDeviceAuthenticationProfiles` (originally done in #46159 to satisfy **RPC-POST-V1-10**). The team wants to **push back** on that finding and keep `getKeys`, rather than adopt the `list*` prefix.

## Changes
- `registryDeviceAuthenticationProfiles.tsp`: `listKeys` → `getKeys` (operation + doc).
- Example renamed back to `GetKeys_RegistryDeviceAuthenticationProfile.json` (`operationId: RegistryDeviceAuthenticationProfiles_GetKeys`).
- Regenerated `preview/2026-11-02-preview` swagger + example copy.

`tsp compile` and TypeSpec validation both pass. Reverting to `getKeys` does **not** trigger any TypeSpec linter error — RPC-POST-V1-10 is an ARM-reviewer guideline, not a hard lint rule, so no `#suppress` is required.

## ⚠️ Pushback draft for the review thread — PLEASE COMPLETE

I did **not** post this on the [RPC-POST-V1-10 thread](https://github.com/Azure/azure-rest-api-specs/pull/45288#discussion_r3938550766) — it's a placeholder for you to finalize the rationale and post yourself. (I removed my earlier inaccurate "Addressed in #46159" reply and re-opened the thread.)

> **[DRAFT — fill in the rationale]** We'd like to keep the `getKeys` action name rather than adopt the `list*` prefix from RPC-POST-V1-10 on `RegistryDeviceAuthenticationProfiles`. Rationale: _<TODO: your reason — e.g. these keys are retrieved at runtime via SDK/CLI only and are not intended to be resolvable through ARM template `list()`; and/or `getKeys` returns a single profile's keys as a point read rather than an enumeration>_. Requesting an exception for this operation; happy to discuss.
