### PR TITLE
Add ARM lease for Microsoft.Weather

### DIFF
--- a/.github/arm-leases/weather/Microsoft.Weather/weather/lease.yaml
+++ b/.github/arm-leases/weather/Microsoft.Weather/weather/lease.yaml
@@ -1,0 +1,5 @@
+lease:
+  resource-provider: Microsoft.Weather
+  startdate: "2026-09-09"
+  duration: P180D
+  reviewer: "@vikeshi26"


### PR DESCRIPTION
## Summary

Adds a 180-day ARM lease for the `Microsoft.Weather` resource provider, following provisional approval at ARM API Modeling Review Office Hours.

Companion to private PR [`Azure/azure-rest-api-specs-pr#30193`](https://github.com/Azure/azure-rest-api-specs-pr/pull/30193), which introduces the RP with a single tracked resource type `dataFeeds` at API version `2026-09-01-preview`.

## Lease file

`.github/arm-leases/weather/Microsoft.Weather/weather/lease.yaml`

```yaml
lease:
  resource-provider: Microsoft.Weather
  startdate: "2026-09-09"
  duration: P180D
  reviewer: "@vikeshi26"
```

## Path rationale

The spec repo places the RP's TypeSpec under `specification/weather/resource-manager/Microsoft.Weather/weather/...`. The ARM Modeling Review workflow's `RESOURCE_MANAGER_WITH_GROUP_PATTERN` treats the 5th path segment (when not `stable`/`preview`) as a `serviceName`, so the validator looks up `.github/arm-leases/<orgName>/<rpNamespace>/<serviceName>/lease.yaml`, which matches the path above.

## Validation

- [x] Path matches `<orgName>/<rpNamespace>/<serviceName>/lease.yaml` with lowercase `orgName`
- [x] `resource-provider` matches the `<rpNamespace>` folder name exactly
- [x] `startdate` in `YYYY-MM-DD` format
- [x] `duration` is a valid ISO 8601 duration ≤ 180 days
- [x] `reviewer` starts with `@`
