### PR TITLE
Fix model validation: align Delete_Group and generateReport example response codes

### DIFF
--- a/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/examples/2026-11-02-preview/Delete_Group.json
+++ b/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/examples/2026-11-02-preview/Delete_Group.json
@@ -10,11 +10,7 @@
     "groupName": "my-group-1"
   },
   "responses": {
-    "202": {
-      "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DeviceRegistry/locations/eastus/operationStatuses/00000000-0000-0000-0000-000000000001?api-version=2026-11-02-preview"
-      }
-    },
+    "200": {},
     "204": {}
   }
 }

--- a/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/examples/2026-11-02-preview/Namespaces_GenerateReport_GroupBestUpdates.json
+++ b/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/examples/2026-11-02-preview/Namespaces_GenerateReport_GroupBestUpdates.json
@@ -19,6 +19,7 @@
         "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DeviceRegistry/locations/eastus/operationStatuses/00000000-0000-0000-0000-000000000001?api-version=2026-11-02-preview",
         "Retry-After": 30
       }
-    }
+    },
+    "204": {}
   }
 }

--- a/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/examples/2026-11-02-preview/Namespaces_GenerateReport_GroupInstallableUpdates.json
+++ b/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/examples/2026-11-02-preview/Namespaces_GenerateReport_GroupInstallableUpdates.json
@@ -19,6 +19,7 @@
         "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DeviceRegistry/locations/eastus/operationStatuses/00000000-0000-0000-0000-000000000001?api-version=2026-11-02-preview",
         "Retry-After": 30
       }
-    }
+    },
+    "204": {}
   }
 }

--- a/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/examples/2026-11-02-preview/Namespaces_GenerateReport_NamespaceUpdateCompliance.json
+++ b/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/examples/2026-11-02-preview/Namespaces_GenerateReport_NamespaceUpdateCompliance.json
@@ -18,6 +18,7 @@
         "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DeviceRegistry/locations/eastus/operationStatuses/00000000-0000-0000-0000-000000000001?api-version=2026-11-02-preview",
         "Retry-After": 30
       }
-    }
+    },
+    "204": {}
   }
 }

--- a/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/preview/2026-11-02-preview/examples/Delete_Group.json
+++ b/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/preview/2026-11-02-preview/examples/Delete_Group.json
@@ -10,11 +10,7 @@
     "groupName": "my-group-1"
   },
   "responses": {
-    "202": {
-      "headers": {
-        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DeviceRegistry/locations/eastus/operationStatuses/00000000-0000-0000-0000-000000000001?api-version=2026-11-02-preview"
-      }
-    },
+    "200": {},
     "204": {}
   }
 }

--- a/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/preview/2026-11-02-preview/examples/Namespaces_GenerateReport_GroupBestUpdates.json
+++ b/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/preview/2026-11-02-preview/examples/Namespaces_GenerateReport_GroupBestUpdates.json
@@ -19,6 +19,7 @@
         "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DeviceRegistry/locations/eastus/operationStatuses/00000000-0000-0000-0000-000000000001?api-version=2026-11-02-preview",
         "Retry-After": 30
       }
-    }
+    },
+    "204": {}
   }
 }

--- a/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/preview/2026-11-02-preview/examples/Namespaces_GenerateReport_GroupInstallableUpdates.json
+++ b/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/preview/2026-11-02-preview/examples/Namespaces_GenerateReport_GroupInstallableUpdates.json
@@ -19,6 +19,7 @@
         "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DeviceRegistry/locations/eastus/operationStatuses/00000000-0000-0000-0000-000000000001?api-version=2026-11-02-preview",
         "Retry-After": 30
       }
-    }
+    },
+    "204": {}
   }
 }

--- a/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/preview/2026-11-02-preview/examples/Namespaces_GenerateReport_NamespaceUpdateCompliance.json
+++ b/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/preview/2026-11-02-preview/examples/Namespaces_GenerateReport_NamespaceUpdateCompliance.json
@@ -18,6 +18,7 @@
         "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DeviceRegistry/locations/eastus/operationStatuses/00000000-0000-0000-0000-000000000001?api-version=2026-11-02-preview",
         "Retry-After": 30
       }
-    }
+    },
+    "204": {}
   }
 }


### PR DESCRIPTION
Fixes the **Swagger ModelValidation** failure on #45288 introduced by two earlier changes on `adr-vnext-specs-v2`:

- **`groups` delete became synchronous** (`ArmResourceDeleteSync`) but `Delete_Group.json` still declared the async `202` → `RESPONSE_STATUS_CODE_NOT_IN_SPEC` (202) + `RESPONSE_STATUS_CODE_NOT_IN_EXAMPLE` (200). The example now uses `200`/`204`.
- **`generateReport` became no-content async** — its examples only had `202`; oav wants the terminal `204` too → `RESPONSE_STATUS_CODE_NOT_IN_EXAMPLE` (204). Added `204` to the three `Namespaces_GenerateReport_*` examples.

Verified locally with `oav validate-example` on both the stable and preview swaggers: **"Validation completes without errors."**
