### PR TITLE
Add ClusterMigrationAgent service group to Microsoft.ServiceFabric ARM lease

### DIFF
--- a/.github/arm-leases/servicefabricmanagedclusters/Microsoft.ServiceFabric/ClusterMigrationAgent/lease.yaml
+++ b/.github/arm-leases/servicefabricmanagedclusters/Microsoft.ServiceFabric/ClusterMigrationAgent/lease.yaml
@@ -1,0 +1,5 @@
+lease:
+  resource-provider: Microsoft.ServiceFabric
+  startdate: 2026-09-09
+  duration: P180D
+  reviewer: "@vidapour"


### PR DESCRIPTION
Adds an ARM lease for **Microsoft.ServiceFabric** (service group **ClusterMigrationAgent**) per `.github/arm-leases/README.md`.

- Path: `.github/arm-leases/servicefabricmanagedclusters/Microsoft.ServiceFabric/ClusterMigrationAgent/lease.yaml`
- Resource provider: `Microsoft.ServiceFabric`
- Start date: 2026-09-09
- Duration: P180D
- Reviewer: @vidapour