### PR TITLE
Type storageAccountContainerUrl as url (format: uri) from 2026-11-01

### DIFF
--- a/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/preview/2026-11-02-preview/deviceregistry.json
+++ b/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/preview/2026-11-02-preview/deviceregistry.json
@@ -14668,6 +14668,7 @@
         },
         "storageAccountContainerUrl": {
           "type": "string",
+          "format": "uri",
           "description": "The Storage Account's Container URL where schemas will be stored.",
           "x-ms-mutability": [
             "read",

--- a/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/schemaRegistries.tsp
+++ b/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/schemaRegistries.tsp
@@ -59,7 +59,8 @@ model SchemaRegistryProperties {
   #suppress "@azure-tools/typespec-client-generator-core/csharp-no-url-suffix" "Name kept for backward compatibility"
   @doc("The Storage Account's Container URL where schemas will be stored.")
   @visibility(Lifecycle.Read, Lifecycle.Create)
-  storageAccountContainerUrl: string;
+  @typeChangedFrom(Versions.v2026_11_01, string)
+  storageAccountContainerUrl: url;
 
   @added(Versions.v2026_11_01)
   @doc("The identity used for outbound calls from the ADR schema registry. If not specified and the schema registry has a system-assigned identity enabled, the system-assigned identity is used by default.")

--- a/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/stable/2026-11-01/deviceregistry.json
+++ b/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/stable/2026-11-01/deviceregistry.json
@@ -10291,6 +10291,7 @@
         },
         "storageAccountContainerUrl": {
           "type": "string",
+          "format": "uri",
           "description": "The Storage Account's Container URL where schemas will be stored.",
           "x-ms-mutability": [
             "read",


### PR DESCRIPTION
Addresses r3962001828 (TypeSpec URI rule). storageAccountContainerUrl now emits ormat: uri from v2026-11-01 via @typeChangedFrom; published versions unchanged. Validated with tsp compile + TypeSpec validation.