### PR TITLE
Fix model validation: valid URIs for storageAccountContainerUrl examples

### DIFF
--- a/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/examples/2026-11-01/CreateOrReplace_SchemaRegistry.json
+++ b/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/examples/2026-11-01/CreateOrReplace_SchemaRegistry.json
@@ -12,7 +12,7 @@
         "namespace": "sr-namespace-001",
         "displayName": "Schema Registry namespace 001",
         "description": "This is a sample Schema Registry",
-        "storageAccountContainerUrl": "my-blob-storage.blob.core.windows.net/my-container"
+        "storageAccountContainerUrl": "https://my-blob-storage.blob.core.windows.net/my-container"
       },
       "tags": {},
       "location": "West Europe"
@@ -39,7 +39,7 @@
           "namespace": "sr-namespace-001",
           "displayName": "Schema Registry namespace 001",
           "description": "This is a sample Schema Registry",
-          "storageAccountContainerUrl": "my-blob-storage.blob.core.windows.net/my-container",
+          "storageAccountContainerUrl": "https://my-blob-storage.blob.core.windows.net/my-container",
           "provisioningState": "Succeeded"
         }
       }
@@ -64,7 +64,7 @@
           "namespace": "sr-namespace-001",
           "displayName": "Schema Registry namespace 001",
           "description": "This is a sample Schema Registry",
-          "storageAccountContainerUrl": "my-blob-storage.blob.core.windows.net/my-container",
+          "storageAccountContainerUrl": "https://my-blob-storage.blob.core.windows.net/my-container",
           "provisioningState": "Accepted"
         }
       }

--- a/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/examples/2026-11-01/Get_SchemaRegistry.json
+++ b/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/examples/2026-11-01/Get_SchemaRegistry.json
@@ -29,7 +29,7 @@
           "namespace": "sr-namespace-001",
           "displayName": "Schema Registry namespace 001",
           "description": "This is a sample Schema Registry",
-          "storageAccountContainerUrl": "my-blob-storage.blob.core.windows.net/my-container",
+          "storageAccountContainerUrl": "https://my-blob-storage.blob.core.windows.net/my-container",
           "provisioningState": "Succeeded"
         }
       }

--- a/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/examples/2026-11-01/List_SchemaRegistries_ByResourceGroup.json
+++ b/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/examples/2026-11-01/List_SchemaRegistries_ByResourceGroup.json
@@ -30,7 +30,7 @@
               "namespace": "sr-namespace-001",
               "displayName": "Schema Registry namespace 001",
               "description": "This is a sample Schema Registry",
-              "storageAccountContainerUrl": "my-blob-storage.blob.core.windows.net/my-container",
+              "storageAccountContainerUrl": "https://my-blob-storage.blob.core.windows.net/my-container",
               "provisioningState": "Succeeded"
             }
           },
@@ -53,7 +53,7 @@
               "namespace": "sr-namespace-002",
               "displayName": "Schema Registry namespace 002",
               "description": "This is another sample Schema Registry",
-              "storageAccountContainerUrl": "my-blob-storage-2.blob.core.windows.net/my-container",
+              "storageAccountContainerUrl": "https://my-blob-storage-2.blob.core.windows.net/my-container",
               "provisioningState": "Succeeded"
             }
           }

--- a/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/examples/2026-11-01/List_SchemaRegistries_BySubscription.json
+++ b/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/examples/2026-11-01/List_SchemaRegistries_BySubscription.json
@@ -29,7 +29,7 @@
               "namespace": "sr-namespace-001",
               "displayName": "Schema Registry namespace 001",
               "description": "This is a sample Schema Registry",
-              "storageAccountContainerUrl": "my-blob-storage.blob.core.windows.net/my-container",
+              "storageAccountContainerUrl": "https://my-blob-storage.blob.core.windows.net/my-container",
               "provisioningState": "Succeeded"
             }
           }

--- a/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/examples/2026-11-01/Update_SchemaRegistry.json
+++ b/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/examples/2026-11-01/Update_SchemaRegistry.json
@@ -36,7 +36,7 @@
           "namespace": "sr-namespace-001",
           "displayName": "Schema Registry namespace 001",
           "description": "This is a sample Schema Registry",
-          "storageAccountContainerUrl": "my-blob-storage.blob.core.windows.net/my-container",
+          "storageAccountContainerUrl": "https://my-blob-storage.blob.core.windows.net/my-container",
           "provisioningState": "Succeeded"
         }
       }

--- a/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/examples/2026-11-02-preview/CreateOrReplace_SchemaRegistry.json
+++ b/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/examples/2026-11-02-preview/CreateOrReplace_SchemaRegistry.json
@@ -12,7 +12,7 @@
         "namespace": "sr-namespace-001",
         "displayName": "Schema Registry namespace 001",
         "description": "This is a sample Schema Registry",
-        "storageAccountContainerUrl": "my-blob-storage.blob.core.windows.net/my-container"
+        "storageAccountContainerUrl": "https://my-blob-storage.blob.core.windows.net/my-container"
       },
       "tags": {},
       "location": "West Europe"
@@ -39,7 +39,7 @@
           "namespace": "sr-namespace-001",
           "displayName": "Schema Registry namespace 001",
           "description": "This is a sample Schema Registry",
-          "storageAccountContainerUrl": "my-blob-storage.blob.core.windows.net/my-container",
+          "storageAccountContainerUrl": "https://my-blob-storage.blob.core.windows.net/my-container",
           "provisioningState": "Succeeded"
         }
       }
@@ -64,7 +64,7 @@
           "namespace": "sr-namespace-001",
           "displayName": "Schema Registry namespace 001",
           "description": "This is a sample Schema Registry",
-          "storageAccountContainerUrl": "my-blob-storage.blob.core.windows.net/my-container",
+          "storageAccountContainerUrl": "https://my-blob-storage.blob.core.windows.net/my-container",
           "provisioningState": "Accepted"
         }
       }

--- a/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/examples/2026-11-02-preview/Get_SchemaRegistry.json
+++ b/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/examples/2026-11-02-preview/Get_SchemaRegistry.json
@@ -29,7 +29,7 @@
           "namespace": "sr-namespace-001",
           "displayName": "Schema Registry namespace 001",
           "description": "This is a sample Schema Registry",
-          "storageAccountContainerUrl": "my-blob-storage.blob.core.windows.net/my-container",
+          "storageAccountContainerUrl": "https://my-blob-storage.blob.core.windows.net/my-container",
           "provisioningState": "Succeeded"
         }
       }

--- a/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/examples/2026-11-02-preview/List_SchemaRegistries_ByResourceGroup.json
+++ b/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/examples/2026-11-02-preview/List_SchemaRegistries_ByResourceGroup.json
@@ -30,7 +30,7 @@
               "namespace": "sr-namespace-001",
               "displayName": "Schema Registry namespace 001",
               "description": "This is a sample Schema Registry",
-              "storageAccountContainerUrl": "my-blob-storage.blob.core.windows.net/my-container",
+              "storageAccountContainerUrl": "https://my-blob-storage.blob.core.windows.net/my-container",
               "provisioningState": "Succeeded"
             }
           },
@@ -53,7 +53,7 @@
               "namespace": "sr-namespace-002",
               "displayName": "Schema Registry namespace 002",
               "description": "This is another sample Schema Registry",
-              "storageAccountContainerUrl": "my-blob-storage-2.blob.core.windows.net/my-container",
+              "storageAccountContainerUrl": "https://my-blob-storage-2.blob.core.windows.net/my-container",
               "provisioningState": "Succeeded"
             }
           }

--- a/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/examples/2026-11-02-preview/List_SchemaRegistries_BySubscription.json
+++ b/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/examples/2026-11-02-preview/List_SchemaRegistries_BySubscription.json
@@ -29,7 +29,7 @@
               "namespace": "sr-namespace-001",
               "displayName": "Schema Registry namespace 001",
               "description": "This is a sample Schema Registry",
-              "storageAccountContainerUrl": "my-blob-storage.blob.core.windows.net/my-container",
+              "storageAccountContainerUrl": "https://my-blob-storage.blob.core.windows.net/my-container",
               "provisioningState": "Succeeded"
             }
           }

--- a/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/examples/2026-11-02-preview/Update_SchemaRegistry.json
+++ b/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/examples/2026-11-02-preview/Update_SchemaRegistry.json
@@ -36,7 +36,7 @@
           "namespace": "sr-namespace-001",
           "displayName": "Schema Registry namespace 001",
           "description": "This is a sample Schema Registry",
-          "storageAccountContainerUrl": "my-blob-storage.blob.core.windows.net/my-container",
+          "storageAccountContainerUrl": "https://my-blob-storage.blob.core.windows.net/my-container",
           "provisioningState": "Succeeded"
         }
       }

--- a/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/preview/2026-11-02-preview/examples/CreateOrReplace_SchemaRegistry.json
+++ b/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/preview/2026-11-02-preview/examples/CreateOrReplace_SchemaRegistry.json
@@ -12,7 +12,7 @@
         "namespace": "sr-namespace-001",
         "displayName": "Schema Registry namespace 001",
         "description": "This is a sample Schema Registry",
-        "storageAccountContainerUrl": "my-blob-storage.blob.core.windows.net/my-container"
+        "storageAccountContainerUrl": "https://my-blob-storage.blob.core.windows.net/my-container"
       },
       "tags": {},
       "location": "West Europe"
@@ -39,7 +39,7 @@
           "namespace": "sr-namespace-001",
           "displayName": "Schema Registry namespace 001",
           "description": "This is a sample Schema Registry",
-          "storageAccountContainerUrl": "my-blob-storage.blob.core.windows.net/my-container",
+          "storageAccountContainerUrl": "https://my-blob-storage.blob.core.windows.net/my-container",
           "provisioningState": "Succeeded"
         }
       }
@@ -64,7 +64,7 @@
           "namespace": "sr-namespace-001",
           "displayName": "Schema Registry namespace 001",
           "description": "This is a sample Schema Registry",
-          "storageAccountContainerUrl": "my-blob-storage.blob.core.windows.net/my-container",
+          "storageAccountContainerUrl": "https://my-blob-storage.blob.core.windows.net/my-container",
           "provisioningState": "Accepted"
         }
       }

--- a/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/preview/2026-11-02-preview/examples/Get_SchemaRegistry.json
+++ b/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/preview/2026-11-02-preview/examples/Get_SchemaRegistry.json
@@ -29,7 +29,7 @@
           "namespace": "sr-namespace-001",
           "displayName": "Schema Registry namespace 001",
           "description": "This is a sample Schema Registry",
-          "storageAccountContainerUrl": "my-blob-storage.blob.core.windows.net/my-container",
+          "storageAccountContainerUrl": "https://my-blob-storage.blob.core.windows.net/my-container",
           "provisioningState": "Succeeded"
         }
       }

--- a/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/preview/2026-11-02-preview/examples/List_SchemaRegistries_ByResourceGroup.json
+++ b/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/preview/2026-11-02-preview/examples/List_SchemaRegistries_ByResourceGroup.json
@@ -30,7 +30,7 @@
               "namespace": "sr-namespace-001",
               "displayName": "Schema Registry namespace 001",
               "description": "This is a sample Schema Registry",
-              "storageAccountContainerUrl": "my-blob-storage.blob.core.windows.net/my-container",
+              "storageAccountContainerUrl": "https://my-blob-storage.blob.core.windows.net/my-container",
               "provisioningState": "Succeeded"
             }
           },
@@ -53,7 +53,7 @@
               "namespace": "sr-namespace-002",
               "displayName": "Schema Registry namespace 002",
               "description": "This is another sample Schema Registry",
-              "storageAccountContainerUrl": "my-blob-storage-2.blob.core.windows.net/my-container",
+              "storageAccountContainerUrl": "https://my-blob-storage-2.blob.core.windows.net/my-container",
               "provisioningState": "Succeeded"
             }
           }

--- a/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/preview/2026-11-02-preview/examples/List_SchemaRegistries_BySubscription.json
+++ b/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/preview/2026-11-02-preview/examples/List_SchemaRegistries_BySubscription.json
@@ -29,7 +29,7 @@
               "namespace": "sr-namespace-001",
               "displayName": "Schema Registry namespace 001",
               "description": "This is a sample Schema Registry",
-              "storageAccountContainerUrl": "my-blob-storage.blob.core.windows.net/my-container",
+              "storageAccountContainerUrl": "https://my-blob-storage.blob.core.windows.net/my-container",
               "provisioningState": "Succeeded"
             }
           }

--- a/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/preview/2026-11-02-preview/examples/Update_SchemaRegistry.json
+++ b/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/preview/2026-11-02-preview/examples/Update_SchemaRegistry.json
@@ -36,7 +36,7 @@
           "namespace": "sr-namespace-001",
           "displayName": "Schema Registry namespace 001",
           "description": "This is a sample Schema Registry",
-          "storageAccountContainerUrl": "my-blob-storage.blob.core.windows.net/my-container",
+          "storageAccountContainerUrl": "https://my-blob-storage.blob.core.windows.net/my-container",
           "provisioningState": "Succeeded"
         }
       }

--- a/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/stable/2026-11-01/examples/CreateOrReplace_SchemaRegistry.json
+++ b/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/stable/2026-11-01/examples/CreateOrReplace_SchemaRegistry.json
@@ -12,7 +12,7 @@
         "namespace": "sr-namespace-001",
         "displayName": "Schema Registry namespace 001",
         "description": "This is a sample Schema Registry",
-        "storageAccountContainerUrl": "my-blob-storage.blob.core.windows.net/my-container"
+        "storageAccountContainerUrl": "https://my-blob-storage.blob.core.windows.net/my-container"
       },
       "tags": {},
       "location": "West Europe"
@@ -39,7 +39,7 @@
           "namespace": "sr-namespace-001",
           "displayName": "Schema Registry namespace 001",
           "description": "This is a sample Schema Registry",
-          "storageAccountContainerUrl": "my-blob-storage.blob.core.windows.net/my-container",
+          "storageAccountContainerUrl": "https://my-blob-storage.blob.core.windows.net/my-container",
           "provisioningState": "Succeeded"
         }
       }
@@ -64,7 +64,7 @@
           "namespace": "sr-namespace-001",
           "displayName": "Schema Registry namespace 001",
           "description": "This is a sample Schema Registry",
-          "storageAccountContainerUrl": "my-blob-storage.blob.core.windows.net/my-container",
+          "storageAccountContainerUrl": "https://my-blob-storage.blob.core.windows.net/my-container",
           "provisioningState": "Accepted"
         }
       }

--- a/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/stable/2026-11-01/examples/Get_SchemaRegistry.json
+++ b/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/stable/2026-11-01/examples/Get_SchemaRegistry.json
@@ -29,7 +29,7 @@
           "namespace": "sr-namespace-001",
           "displayName": "Schema Registry namespace 001",
           "description": "This is a sample Schema Registry",
-          "storageAccountContainerUrl": "my-blob-storage.blob.core.windows.net/my-container",
+          "storageAccountContainerUrl": "https://my-blob-storage.blob.core.windows.net/my-container",
           "provisioningState": "Succeeded"
         }
       }

--- a/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/stable/2026-11-01/examples/List_SchemaRegistries_ByResourceGroup.json
+++ b/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/stable/2026-11-01/examples/List_SchemaRegistries_ByResourceGroup.json
@@ -30,7 +30,7 @@
               "namespace": "sr-namespace-001",
               "displayName": "Schema Registry namespace 001",
               "description": "This is a sample Schema Registry",
-              "storageAccountContainerUrl": "my-blob-storage.blob.core.windows.net/my-container",
+              "storageAccountContainerUrl": "https://my-blob-storage.blob.core.windows.net/my-container",
               "provisioningState": "Succeeded"
             }
           },
@@ -53,7 +53,7 @@
               "namespace": "sr-namespace-002",
               "displayName": "Schema Registry namespace 002",
               "description": "This is another sample Schema Registry",
-              "storageAccountContainerUrl": "my-blob-storage-2.blob.core.windows.net/my-container",
+              "storageAccountContainerUrl": "https://my-blob-storage-2.blob.core.windows.net/my-container",
               "provisioningState": "Succeeded"
             }
           }

--- a/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/stable/2026-11-01/examples/List_SchemaRegistries_BySubscription.json
+++ b/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/stable/2026-11-01/examples/List_SchemaRegistries_BySubscription.json
@@ -29,7 +29,7 @@
               "namespace": "sr-namespace-001",
               "displayName": "Schema Registry namespace 001",
               "description": "This is a sample Schema Registry",
-              "storageAccountContainerUrl": "my-blob-storage.blob.core.windows.net/my-container",
+              "storageAccountContainerUrl": "https://my-blob-storage.blob.core.windows.net/my-container",
               "provisioningState": "Succeeded"
             }
           }

--- a/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/stable/2026-11-01/examples/Update_SchemaRegistry.json
+++ b/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/stable/2026-11-01/examples/Update_SchemaRegistry.json
@@ -36,7 +36,7 @@
           "namespace": "sr-namespace-001",
           "displayName": "Schema Registry namespace 001",
           "description": "This is a sample Schema Registry",
-          "storageAccountContainerUrl": "my-blob-storage.blob.core.windows.net/my-container",
+          "storageAccountContainerUrl": "https://my-blob-storage.blob.core.windows.net/my-container",
           "provisioningState": "Succeeded"
         }
       }


### PR DESCRIPTION
Fixes the ModelValidation INVALID_FORMAT failures introduced by #46224 (storageAccountContainerUrl -> url/format:uri). Prefixes the scheme-less SchemaRegistry example values with https:// in 2026-11-01 and 2026-11-02-preview. Verified with oav validate-example (both swaggers): completes without errors.