### PR TITLE
Update Cost Control ARM contract

### DIFF
--- a/specification/cognitiveservices/CognitiveServices.Management/CostControl.tsp
+++ b/specification/cognitiveservices/CognitiveServices.Management/CostControl.tsp
@@ -93,7 +93,7 @@ model CostControlPatch {
 @added(Versions.v2026_09_15_preview)
 model CostControlConnections {
   /**
-   * The full resource ID of the Application Insights connection used for cost control telemetry. This connection must be configured before a cost control can be attached and cannot be removed while any cost control remains attached.
+   * The full resource ID of the Application Insights connection used for cost control audit telemetry. This connection is optional for attachment, accounting, and enforcement, and can be configured later. Customer audit delivery requires this connection.
    */
   #suppress "@azure-tools/typespec-azure-core/no-nullable" "The service distinguishes an omitted appInsightsConnectionId from an explicit null in PATCH so callers can clear the value."
   appInsightsConnectionId?:
@@ -166,12 +166,11 @@ model CostControlRule {
   match?: CostControlMatch;
 
   /**
-   * The actions evaluated as consumption approaches the configured amount.
+   * The optional actions evaluated as consumption approaches the configured amount. Omitted, null, or empty thresholds define an audit-only rule. Explicit audit thresholds must use a value of zero. Only an explicit block threshold enforces a limit.
    */
-  @minItems(1)
+  #suppress "@azure-tools/typespec-azure-core/no-nullable" "The current preview accepts omitted, null, or empty thresholds as an audit-only rule."
   @maxItems(10)
-  @identifiers(#[])
-  thresholds: CostControlThreshold[];
+  thresholds?: CostControlThreshold[] | null;
 }
 
 /**
@@ -338,13 +337,13 @@ model CostControlThreshold {
   type: CostControlThresholdType;
 
   /**
-   * The threshold value. Percentage values range from 0 through 100, and absolute values cannot exceed the rule amount.
+   * The threshold value. Audit thresholds must use zero. Block and alert thresholds must be greater than zero. Percentage values cannot exceed 100, and absolute values cannot exceed the rule amount.
    */
   @minValue(0)
   value: float64;
 
   /**
-   * The action taken when the threshold is reached. The default is audit.
+   * The action taken when the threshold is reached. Omitted actions default to audit and therefore require a value of zero.
    */
   action?: CostControlThresholdAction = CostControlThresholdAction.Audit;
 }
@@ -375,7 +374,7 @@ union CostControlThresholdAction {
   string,
 
   /**
-   * Records the threshold crossing without notifying the customer or blocking requests.
+   * Audits every applied usage update. Authored audit thresholds must use zero. This action is retained in the current preview for compatibility; audit-only rules may omit thresholds.
    */
   Audit: "audit",
 
@@ -383,6 +382,11 @@ union CostControlThresholdAction {
    * Emits a customer-facing alert without blocking requests.
    */
   Alert: "alert",
+
+  /**
+   * Blocks the request without emitting a customer-facing alert.
+   */
+  Block: "block",
 }
 
 /**

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-09-15-preview/CostControl/createOrUpdate.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-09-15-preview/CostControl/createOrUpdate.json
@@ -43,8 +43,8 @@
               },
               {
                 "type": "absolute",
-                "value": 0,
-                "action": "audit"
+                "value": 1000,
+                "action": "block"
               }
             ]
           },
@@ -122,8 +122,8 @@
                 },
                 {
                   "type": "absolute",
-                  "value": 0,
-                  "action": "audit"
+                  "value": 1000,
+                  "action": "block"
                 }
               ]
             },
@@ -197,8 +197,8 @@
                 },
                 {
                   "type": "absolute",
-                  "value": 0,
-                  "action": "audit"
+                  "value": 1000,
+                  "action": "block"
                 }
               ]
             },

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-09-15-preview/CostControl/createOrUpdate.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-09-15-preview/CostControl/createOrUpdate.json
@@ -43,7 +43,7 @@
               },
               {
                 "type": "absolute",
-                "value": 1000,
+                "value": 0,
                 "action": "audit"
               }
             ]
@@ -122,7 +122,7 @@
                 },
                 {
                   "type": "absolute",
-                  "value": 1000,
+                  "value": 0,
                   "action": "audit"
                 }
               ]
@@ -197,7 +197,7 @@
                 },
                 {
                   "type": "absolute",
-                  "value": 1000,
+                  "value": 0,
                   "action": "audit"
                 }
               ]

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-09-15-preview/CostControl/get.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-09-15-preview/CostControl/get.json
@@ -55,8 +55,8 @@
                 },
                 {
                   "type": "absolute",
-                  "value": 0,
-                  "action": "audit"
+                  "value": 1000,
+                  "action": "block"
                 }
               ]
             },

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-09-15-preview/CostControl/get.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-09-15-preview/CostControl/get.json
@@ -55,7 +55,7 @@
                 },
                 {
                   "type": "absolute",
-                  "value": 1000,
+                  "value": 0,
                   "action": "audit"
                 }
               ]

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-09-15-preview/CostControl/list.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-09-15-preview/CostControl/list.json
@@ -54,8 +54,8 @@
                     },
                     {
                       "type": "absolute",
-                      "value": 0,
-                      "action": "audit"
+                      "value": 1000,
+                      "action": "block"
                     }
                   ]
                 },

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-09-15-preview/CostControl/list.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-09-15-preview/CostControl/list.json
@@ -54,7 +54,7 @@
                     },
                     {
                       "type": "absolute",
-                      "value": 1000,
+                      "value": 0,
                       "action": "audit"
                     }
                   ]

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-09-15-preview/CostControl/update.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-09-15-preview/CostControl/update.json
@@ -43,8 +43,8 @@
               },
               {
                 "type": "absolute",
-                "value": 0,
-                "action": "audit"
+                "value": 1500,
+                "action": "block"
               }
             ]
           }
@@ -102,8 +102,8 @@
                 },
                 {
                   "type": "absolute",
-                  "value": 0,
-                  "action": "audit"
+                  "value": 1500,
+                  "action": "block"
                 }
               ]
             }

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-09-15-preview/CostControl/update.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-09-15-preview/CostControl/update.json
@@ -43,7 +43,7 @@
               },
               {
                 "type": "absolute",
-                "value": 1500,
+                "value": 0,
                 "action": "audit"
               }
             ]
@@ -102,7 +102,7 @@
                 },
                 {
                   "type": "absolute",
-                  "value": 1500,
+                  "value": 0,
                   "action": "audit"
                 }
               ]

--- a/specification/cognitiveservices/CognitiveServices.Management/models.tsp
+++ b/specification/cognitiveservices/CognitiveServices.Management/models.tsp
@@ -2053,7 +2053,7 @@ model AccountProperties {
   ]>[];
 
   /**
-   * The account-level connections used to publish cost control telemetry and events. Configure this property after account creation and before attaching cost controls.
+   * The account-level connections used to publish cost control telemetry and events. Application Insights is optional for attachment, accounting, and enforcement and can be configured later. Event Grid must be configured before attaching a cost control with an alert threshold.
    */
   #suppress "@azure-tools/typespec-azure-core/no-nullable" "The service distinguishes an omitted costControlConnections object from an explicit null in PATCH so callers can clear the value."
   @added(Versions.v2026_09_15_preview)

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-09-15-preview/cognitiveservices.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-09-15-preview/cognitiveservices.json
@@ -12976,7 +12976,7 @@
         },
         "costControlConnections": {
           "$ref": "#/definitions/CostControlConnections",
-          "description": "The account-level connections used to publish cost control telemetry and events. Configure this property after account creation and before attaching cost controls.",
+          "description": "The account-level connections used to publish cost control telemetry and events. Application Insights is optional for attachment, accounting, and enforcement and can be configured later. Event Grid must be configured before attaching a cost control with an alert threshold.",
           "x-nullable": true,
           "x-ms-mutability": [
             "read",
@@ -16421,7 +16421,7 @@
         "appInsightsConnectionId": {
           "type": "string",
           "format": "arm-id",
-          "description": "The full resource ID of the Application Insights connection used for cost control telemetry. This connection must be configured before a cost control can be attached and cannot be removed while any cost control remains attached.",
+          "description": "The full resource ID of the Application Insights connection used for cost control audit telemetry. This connection is optional for attachment, accounting, and enforcement, and can be configured later. Customer audit delivery requires this connection.",
           "x-nullable": true,
           "x-ms-arm-id-details": {
             "allowedResources": [
@@ -16754,21 +16754,19 @@
         },
         "thresholds": {
           "type": "array",
-          "description": "The actions evaluated as consumption approaches the configured amount.",
-          "minItems": 1,
+          "description": "The optional actions evaluated as consumption approaches the configured amount. Omitted, null, or empty thresholds define an audit-only rule. Explicit audit thresholds must use a value of zero. Only an explicit block threshold enforces a limit.",
           "maxItems": 10,
+          "x-nullable": true,
           "items": {
             "$ref": "#/definitions/CostControlThreshold"
-          },
-          "x-ms-identifiers": []
+          }
         }
       },
       "required": [
         "name",
         "counterKey",
         "unit",
-        "amount",
-        "thresholds"
+        "amount"
       ]
     },
     "CostControlThreshold": {
@@ -16782,16 +16780,17 @@
         "value": {
           "type": "number",
           "format": "double",
-          "description": "The threshold value. Percentage values range from 0 through 100, and absolute values cannot exceed the rule amount.",
+          "description": "The threshold value. Audit thresholds must use zero. Block and alert thresholds must be greater than zero. Percentage values cannot exceed 100, and absolute values cannot exceed the rule amount.",
           "minimum": 0
         },
         "action": {
           "type": "string",
-          "description": "The action taken when the threshold is reached. The default is audit.",
+          "description": "The action taken when the threshold is reached. Omitted actions default to audit and therefore require a value of zero.",
           "default": "audit",
           "enum": [
             "audit",
-            "alert"
+            "alert",
+            "block"
           ],
           "x-ms-enum": {
             "name": "CostControlThresholdAction",
@@ -16800,12 +16799,17 @@
               {
                 "name": "Audit",
                 "value": "audit",
-                "description": "Records the threshold crossing without notifying the customer or blocking requests."
+                "description": "Audits every applied usage update. Authored audit thresholds must use zero. This action is retained in the current preview for compatibility; audit-only rules may omit thresholds."
               },
               {
                 "name": "Alert",
                 "value": "alert",
                 "description": "Emits a customer-facing alert without blocking requests."
+              },
+              {
+                "name": "Block",
+                "value": "block",
+                "description": "Blocks the request without emitting a customer-facing alert."
               }
             ]
           }
@@ -16821,7 +16825,8 @@
       "description": "The supported actions when a threshold is reached.",
       "enum": [
         "audit",
-        "alert"
+        "alert",
+        "block"
       ],
       "x-ms-enum": {
         "name": "CostControlThresholdAction",
@@ -16830,12 +16835,17 @@
           {
             "name": "Audit",
             "value": "audit",
-            "description": "Records the threshold crossing without notifying the customer or blocking requests."
+            "description": "Audits every applied usage update. Authored audit thresholds must use zero. This action is retained in the current preview for compatibility; audit-only rules may omit thresholds."
           },
           {
             "name": "Alert",
             "value": "alert",
             "description": "Emits a customer-facing alert without blocking requests."
+          },
+          {
+            "name": "Block",
+            "value": "block",
+            "description": "Blocks the request without emitting a customer-facing alert."
           }
         ]
       }

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-09-15-preview/examples/CostControl/createOrUpdate.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-09-15-preview/examples/CostControl/createOrUpdate.json
@@ -43,8 +43,8 @@
               },
               {
                 "type": "absolute",
-                "value": 0,
-                "action": "audit"
+                "value": 1000,
+                "action": "block"
               }
             ]
           },
@@ -122,8 +122,8 @@
                 },
                 {
                   "type": "absolute",
-                  "value": 0,
-                  "action": "audit"
+                  "value": 1000,
+                  "action": "block"
                 }
               ]
             },
@@ -197,8 +197,8 @@
                 },
                 {
                   "type": "absolute",
-                  "value": 0,
-                  "action": "audit"
+                  "value": 1000,
+                  "action": "block"
                 }
               ]
             },

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-09-15-preview/examples/CostControl/createOrUpdate.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-09-15-preview/examples/CostControl/createOrUpdate.json
@@ -43,7 +43,7 @@
               },
               {
                 "type": "absolute",
-                "value": 1000,
+                "value": 0,
                 "action": "audit"
               }
             ]
@@ -122,7 +122,7 @@
                 },
                 {
                   "type": "absolute",
-                  "value": 1000,
+                  "value": 0,
                   "action": "audit"
                 }
               ]
@@ -197,7 +197,7 @@
                 },
                 {
                   "type": "absolute",
-                  "value": 1000,
+                  "value": 0,
                   "action": "audit"
                 }
               ]

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-09-15-preview/examples/CostControl/get.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-09-15-preview/examples/CostControl/get.json
@@ -55,8 +55,8 @@
                 },
                 {
                   "type": "absolute",
-                  "value": 0,
-                  "action": "audit"
+                  "value": 1000,
+                  "action": "block"
                 }
               ]
             },

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-09-15-preview/examples/CostControl/get.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-09-15-preview/examples/CostControl/get.json
@@ -55,7 +55,7 @@
                 },
                 {
                   "type": "absolute",
-                  "value": 1000,
+                  "value": 0,
                   "action": "audit"
                 }
               ]

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-09-15-preview/examples/CostControl/list.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-09-15-preview/examples/CostControl/list.json
@@ -54,8 +54,8 @@
                     },
                     {
                       "type": "absolute",
-                      "value": 0,
-                      "action": "audit"
+                      "value": 1000,
+                      "action": "block"
                     }
                   ]
                 },

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-09-15-preview/examples/CostControl/list.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-09-15-preview/examples/CostControl/list.json
@@ -54,7 +54,7 @@
                     },
                     {
                       "type": "absolute",
-                      "value": 1000,
+                      "value": 0,
                       "action": "audit"
                     }
                   ]

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-09-15-preview/examples/CostControl/update.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-09-15-preview/examples/CostControl/update.json
@@ -43,8 +43,8 @@
               },
               {
                 "type": "absolute",
-                "value": 0,
-                "action": "audit"
+                "value": 1500,
+                "action": "block"
               }
             ]
           }
@@ -102,8 +102,8 @@
                 },
                 {
                   "type": "absolute",
-                  "value": 0,
-                  "action": "audit"
+                  "value": 1500,
+                  "action": "block"
                 }
               ]
             }

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-09-15-preview/examples/CostControl/update.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-09-15-preview/examples/CostControl/update.json
@@ -43,7 +43,7 @@
               },
               {
                 "type": "absolute",
-                "value": 1500,
+                "value": 0,
                 "action": "audit"
               }
             ]
@@ -102,7 +102,7 @@
                 },
                 {
                   "type": "absolute",
-                  "value": 1500,
+                  "value": 0,
                   "action": "audit"
                 }
               ]


### PR DESCRIPTION
Implemented the Cost Control contract changes proposed in [Platform-ResourceProvider PR 17090378](https://msazure.visualstudio.com/Cognitive%20Services/_git/Platform-ResourceProvider/pullrequest/17090378).

## Changes

- Updated `CostControl.tsp`:
  - `thresholds` now accepts omitted, `null`, or empty arrays for audit-only rules.
  - Explicit audit thresholds are documented as requiring value `0`.
  - Omitted actions default to audit and therefore require value `0`.
  - Added the missing `block` action.
  - Clarified that only explicit block thresholds enforce limits.
  - Made Application Insights optional for attachment, accounting, and enforcement.
- Updated the account connection description in `models.tsp`. The related account and deployment properties are defined there rather than directly in `main.tsp`.
- Preserved the original nonzero absolute threshold values in the Cost Control examples and changed their actions from `audit` to `block`, keeping the examples valid under the updated contract.
- Regenerated the checked-in `2026-09-15-preview` OpenAPI and corresponding examples.

## Validation

- `npx tsp compile . --warn-as-error` passed.
- Verified the emitted schema:
  - `thresholds` is optional and `x-nullable: true`.
  - `maxItems: 10` is retained.
  - Actions are `audit`, `alert`, and `block`.
  - The audit-compatible minimum remains `0`.
- All Cost Control examples parse as valid JSON.
- Original absolute threshold values (`1000` and `1500`) are preserved and use the `block` action.
- `git diff --check` passed; only line-ending warnings were reported.

The dedicated Azure SDK TypeSpec validation MCP command was not exposed in this session, so validation used the repository's TypeSpec compiler directly with warnings treated as errors.

## References

- [Platform-ResourceProvider PR 17090378](https://msazure.visualstudio.com/Cognitive%20Services/_git/Platform-ResourceProvider/pullrequest/17090378)
- [Evolving APIs with TypeSpec](https://azure.github.io/typespec-azure/docs/howtos/versioning/06-evolving-apis/)
- [TypeSpec optional model properties](https://typespec.io/docs/language-basics/models/#optional-properties)