### PR TITLE
DeviceRegistry: add @identifiers to GroupListMembersResult.members (TSP-ARRAY-IDENTIFIERS)

### DIFF
--- a/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/groups.tsp
+++ b/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/groups.tsp
@@ -67,6 +67,7 @@ model GroupListMembersRequest {
 @doc("Response for the list members operation.")
 model GroupListMembersResult {
   @doc("The group members returned in this page.")
+  @identifiers(#["id"])
   members: GroupListMember[];
 
   #suppress "@azure-tools/typespec-azure-resource-manager/secret-prop" "This is a paging cursor, not a credential or secret."

--- a/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/preview/2026-11-02-preview/deviceregistry.json
+++ b/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/preview/2026-11-02-preview/deviceregistry.json
@@ -9829,7 +9829,10 @@
           "description": "The group members returned in this page.",
           "items": {
             "$ref": "#/definitions/GroupListMember"
-          }
+          },
+          "x-ms-identifiers": [
+            "id"
+          ]
         },
         "skipToken": {
           "type": "string",


### PR DESCRIPTION
Addresses **TSP-ARRAY-IDENTIFIERS** ([#45288 review](https://github.com/Azure/azure-rest-api-specs/pull/45288#issuecomment-5592840791)).

Adds `@identifiers(#["id"])` to `GroupListMembersResult.members` in `groups.tsp` so ARM/x-ms-identifiers treats `id` as the list item identity instead of defaulting to array index. `Groups` is preview-only, so only the `2026-11-02-preview` swagger is regenerated (`x-ms-identifiers: ["id"]` added to the members array). No stable-version change.

Merges into `adr-vnext-specs-v2` (head of #45288).