### PR TITLE
Fix skill eval environment setup

### DIFF
--- a/.github/skills/.vally.yaml
+++ b/.github/skills/.vally.yaml
@@ -5,13 +5,8 @@
 # environments), pared down to the skill folders that exist in this repo.
 
 paths:
-  # "." is the root for skill *discovery*, which vally only performs when `--skill-dir` is passed
-  # on the command line -- `paths.skills` alone does not load anything. Neither the local runner
-  # (evals/arm-api-reviewer/run-evals.ps1) nor the CI shard runner
-  # (eng/common/scripts/eval/invoke-eval-shard.ts) passes `--skill-dir`, so every eval file here
-  # declares the skill it exercises via `environment.skills` -- once at the file root, which vally
-  # merges into each of its stimuli (fail-loud: vally aborts when a declared skill directory has
-  # no SKILL.md).
+  # "." is the root for skill discovery. The runners do not pass `--skill-dir`, so named
+  # environments below mount each eval file's owning skill through `environment.skills`.
   skills: "."
   evals:
     - azsdk-common-apiview-feedback-resolution/evals/
@@ -37,15 +32,19 @@ environments:
       azure-sdk-mcp:
         type: stdio
         command: dotnet
+        cwd: .
         args: ["../../artifacts/mcp/cli/azsdk.dll", "start"]
         timeout: "60s"
         env:
           AZSDKTOOLS_AGENT_TESTING: "true"
           AZSDKTOOLS_COLLECT_TELEMETRY: "false"
   azsdk-mcp-mock:
+    # Eval paths resolve relative to each eval file, so ".." mounts that file's owning skill.
+    skills: [".."]
     mcpServers:
       azure-sdk-mcp:
         type: stdio
         command: dotnet
+        cwd: .
         args: ["../../artifacts/mcp/mock/azsdk-mock.dll"]
         timeout: "60s"


### PR DESCRIPTION
## Summary

- anchor the live and mock MCP child processes to the Vally project root with `cwd: .`
- mount each eval file's owning skill through the shared mock environment

## Why

The `azure-rest-api-specs - eval-skills` pipeline runs Vally trials in isolated temporary workspaces. Without an MCP working directory, the relative `../../artifacts/mcp/...` path resolves from the trial workspace and the mock server closes during `initialize`.

The plain capability suites also rely on the named mock environment and do not declare per-stimulus skill environments, so their owning skills were not loaded.

Affected build: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6803604

## Validation

- parsed `.github/skills/.vally.yaml` and verified both MCP `cwd` values and the owning-skill mount
- pipeline-analysis routing stimulus: 100%, 0 execution errors, owning skill invoked
- generate-sdk-locally metadata stimulus: 100%, 0 execution errors, mock MCP tool invoked
- `git diff --check`