### PR TITLE
Use ResourceIdentifier for StorageMover cross-tenant endpoint

### DIFF
--- a/specification/storagemover/resource-manager/Microsoft.StorageMover/StorageMover/client.tsp
+++ b/specification/storagemover/resource-manager/Microsoft.StorageMover/StorageMover/client.tsp
@@ -107,7 +107,7 @@ using Azure.Core;
 );
 @@alternateType(
   JobDefinitionProperties.crossTenantEndpointResourceId,
-  string,
+  armResourceIdentifier,
   "csharp"
 );
 @@clientName(

--- a/specification/storagemover/resource-manager/Microsoft.StorageMover/StorageMover/client.tsp
+++ b/specification/storagemover/resource-manager/Microsoft.StorageMover/StorageMover/client.tsp
@@ -111,6 +111,16 @@ using Azure.Core;
   "csharp"
 );
 @@clientName(
+  JobDefinitionProperties.moverSyncedUntil,
+  "MoverSyncedOn",
+  "csharp"
+);
+@@clientName(
+  JobDefinitionUpdateProperties.moverSyncedUntil,
+  "MoverSyncedOn",
+  "csharp"
+);
+@@clientName(
   AzureKeyVaultSmbCredentials.passwordUri,
   "PasswordUriString",
   "csharp"

--- a/specification/storagemover/resource-manager/Microsoft.StorageMover/StorageMover/client.tsp
+++ b/specification/storagemover/resource-manager/Microsoft.StorageMover/StorageMover/client.tsp
@@ -111,16 +111,6 @@ using Azure.Core;
   "csharp"
 );
 @@clientName(
-  JobDefinitionProperties.moverSyncedUntil,
-  "MoverSyncedOn",
-  "csharp"
-);
-@@clientName(
-  JobDefinitionUpdateProperties.moverSyncedUntil,
-  "MoverSyncedOn",
-  "csharp"
-);
-@@clientName(
   AzureKeyVaultSmbCredentials.passwordUri,
   "PasswordUriString",
   "csharp"


### PR DESCRIPTION
Addresses the .NET management SDK review feedback from Azure/azure-sdk-for-net#61273 by mapping \JobDefinitionProperties.crossTenantEndpointResourceId\ to \rmResourceIdentifier\ for C#.\n\nOnly \client.tsp\ is changed.