### PR TITLE
Align user conversation simulation contracts

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/examples/2025-11-15-preview/Evals_createEvalRun_UserConversationSimulation.json
+++ b/specification/ai-foundry/data-plane/Foundry/examples/2025-11-15-preview/Evals_createEvalRun_UserConversationSimulation.json
@@ -22,7 +22,9 @@
         "default_simulation_configuration": {
           "max_num_turns": 5,
           "conversation_repetitions": 3,
-          "desired_num_turns": 4
+          "desired_num_turns": 4,
+          "enable_conversation_dataset_generation": true,
+          "output_conversation_dataset_name": "conversation-eval-output"
         },
         "data_mapping": {
           "test_case_description": "test_case_description",
@@ -33,8 +35,7 @@
           "type": "azure_ai_agent",
           "name": "my-support-agent",
           "version": "2"
-        },
-        "enable_conversation_dataset_generation": true
+        }
       }
     }
   },
@@ -72,7 +73,9 @@
           "default_simulation_configuration": {
             "max_num_turns": 5,
             "conversation_repetitions": 3,
-            "desired_num_turns": 4
+            "desired_num_turns": 4,
+            "enable_conversation_dataset_generation": true,
+            "output_conversation_dataset_name": "conversation-eval-output"
           },
           "data_mapping": {
             "test_case_description": "test_case_description",
@@ -83,8 +86,7 @@
             "type": "azure_ai_agent",
             "name": "my-support-agent",
             "version": "2"
-          },
-          "enable_conversation_dataset_generation": true
+          }
         },
         "error": null,
         "metadata": {}

--- a/specification/ai-foundry/data-plane/Foundry/examples/2025-11-15-preview/Evals_getEvalRun_UserConversationSimulation.json
+++ b/specification/ai-foundry/data-plane/Foundry/examples/2025-11-15-preview/Evals_getEvalRun_UserConversationSimulation.json
@@ -57,7 +57,9 @@
           "default_simulation_configuration": {
             "max_num_turns": 5,
             "conversation_repetitions": 3,
-            "desired_num_turns": 4
+            "desired_num_turns": 4,
+            "enable_conversation_dataset_generation": true,
+            "output_conversation_dataset_name": "conversation-eval-output"
           },
           "data_mapping": {
             "test_case_description": "test_case_description",
@@ -68,14 +70,18 @@
             "type": "azure_ai_agent",
             "name": "my-support-agent",
             "version": "2"
-          },
-          "enable_conversation_dataset_generation": true
+          }
         },
-        "output_dataset": {
-          "id": "dataset_123",
-          "name": "conversation-eval-output",
-          "version": "1"
-        },
+        "output_datasets": [
+          {
+            "type": "simulated_user_conversations",
+            "dataset": {
+              "id": "dataset_123",
+              "name": "conversation-eval-output",
+              "version": "1"
+            }
+          }
+        ],
         "error": null,
         "metadata": {}
       }

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -39824,13 +39824,16 @@
             "description": "The level at which evaluation is performed. Defaults to 'turn' if not specified.",
             "default": "turn"
           },
-          "output_dataset": {
-            "$ref": "#/components/schemas/EvaluationDataset",
-            "description": "Dataset produced by the evaluation run. Present when the run creates a versioned Foundry dataset; otherwise omitted.",
+          "output_datasets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EvaluationOutputDataset"
+            },
+            "description": "Preview-only. Datasets produced by the evaluation run. Omitted when no datasets were generated. This field may change in a future API version.",
             "readOnly": true
           }
         },
-        "description": "An evaluation run, including Foundry-specific metadata and optional output dataset information.",
+        "description": "An evaluation run, including Foundry-specific metadata and generated output datasets.",
         "title": "EvalRun",
         "x-oaiMeta": {
           "name": "The eval run object",
@@ -40187,61 +40190,6 @@
           ]
         }
       },
-      "EvaluationAudioTranscriptionModel": {
-        "anyOf": [
-          {
-            "type": "string"
-          },
-          {
-            "type": "string",
-            "enum": [
-              "mai-transcribe-1",
-              "azure-speech"
-            ]
-          }
-        ],
-        "description": "Supported speech-to-text transcription models. The union is extensible for additional models."
-      },
-      "EvaluationAudioTranscriptionModelConfiguration": {
-        "type": "object",
-        "required": [
-          "model"
-        ],
-        "properties": {
-          "model": {
-            "$ref": "#/components/schemas/EvaluationAudioTranscriptionModel",
-            "description": "The transcription model."
-          }
-        },
-        "description": "Configuration for speech-to-text transcription used during evaluation."
-      },
-      "EvaluationAzureRealtimeNativeVoiceModelConfiguration": {
-        "type": "object",
-        "required": [
-          "type"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "azure-realtime-native"
-            ],
-            "description": "The voice kind. Always `azure-realtime-native`."
-          },
-          "name": {
-            "type": "string",
-            "minLength": 1,
-            "description": "The Azure realtime-native voice name. When omitted, the service defaults to `ava`.",
-            "default": "ava"
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/EvaluationVoiceModelConfiguration"
-          }
-        ],
-        "description": "Configures an Azure realtime-native voice for evaluation."
-      },
       "EvaluationAzureStandardVoiceModelConfiguration": {
         "type": "object",
         "required": [
@@ -40274,7 +40222,7 @@
             "$ref": "#/components/schemas/EvaluationVoiceModelConfiguration"
           }
         ],
-        "description": "Configures an Azure standard neural voice for evaluation."
+        "description": "Configures an Azure standard neural voice used to convert text to speech for evaluation through the Voice Live endpoint."
       },
       "EvaluationComparisonInsightRequest": {
         "type": "object",
@@ -40411,43 +40359,44 @@
             "$ref": "#/components/schemas/ModelSamplingParams",
             "description": "Sampling parameters applied when the simulation model produces user turns."
           },
-          "transcription_model": {
-            "$ref": "#/components/schemas/EvaluationAudioTranscriptionModelConfiguration",
-            "description": "Transcription model configuration used to convert simulated user speech to text. Omit for text-only simulation."
-          },
           "voice_model": {
             "$ref": "#/components/schemas/EvaluationVoiceModelConfiguration",
-            "description": "Voice model configuration used to convert simulated user text to speech. Omit for text-only simulation."
+            "description": "Voice configuration used to convert simulated user text to speech. Currently, only Azure standard voices are supported. Omit for text-only simulation."
           }
         },
         "description": "Configures the model that plays the simulated user. This model is separate from the evaluated `target`."
       },
-      "EvaluationOpenAIVoiceModelConfiguration": {
+      "EvaluationOutputDataset": {
         "type": "object",
         "required": [
           "type",
-          "name"
+          "dataset"
         ],
         "properties": {
           "type": {
-            "type": "string",
-            "enum": [
-              "openai"
-            ],
-            "description": "The voice kind. Always `openai`."
+            "$ref": "#/components/schemas/EvaluationOutputDatasetType",
+            "description": "Purpose of the generated dataset."
           },
-          "name": {
-            "type": "string",
-            "minLength": 1,
-            "description": "The OpenAI built-in voice name."
+          "dataset": {
+            "$ref": "#/components/schemas/EvaluationDataset",
+            "description": "Generated dataset reference."
           }
         },
-        "allOf": [
+        "description": "A typed reference to a dataset produced by an evaluation run."
+      },
+      "EvaluationOutputDatasetType": {
+        "anyOf": [
           {
-            "$ref": "#/components/schemas/EvaluationVoiceModelConfiguration"
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "simulated_user_conversations"
+            ]
           }
         ],
-        "description": "Configures an OpenAI built-in voice for evaluation."
+        "description": "Purpose of a dataset produced by an evaluation run. The union is extensible for additional output types."
       },
       "EvaluationResultSample": {
         "type": "object",
@@ -40921,12 +40870,10 @@
         "discriminator": {
           "propertyName": "type",
           "mapping": {
-            "openai": "#/components/schemas/EvaluationOpenAIVoiceModelConfiguration",
-            "azure-standard": "#/components/schemas/EvaluationAzureStandardVoiceModelConfiguration",
-            "azure-realtime-native": "#/components/schemas/EvaluationAzureRealtimeNativeVoiceModelConfiguration"
+            "azure-standard": "#/components/schemas/EvaluationAzureStandardVoiceModelConfiguration"
           }
         },
-        "description": "Voice configuration used to convert text to speech for evaluation. All supported voice types use the Voice Live endpoint under the hood."
+        "description": "Voice configuration used to convert text to speech for evaluation through the Voice Live endpoint."
       },
       "EvaluatorCategory": {
         "anyOf": [
@@ -90415,6 +90362,50 @@
         },
         "description": "Configures the number, length, audio effects, and simulated user behavior of conversations."
       },
+      "UserConversationSimulationDefaultConfiguration": {
+        "type": "object",
+        "properties": {
+          "max_num_turns": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "description": "Hard limit on turns in each conversation. When omitted, the service defaults to 20.",
+            "default": 20
+          },
+          "conversation_repetitions": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "description": "Number of independent conversation repetitions for each test case. Defaults to 1 when not specified at either the data-source or test-case level.",
+            "default": 1
+          },
+          "desired_num_turns": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "description": "Target number of turns in each conversation. The effective value cannot exceed the effective `max_num_turns`. When omitted, no target is set and the simulation model determines the conversation length dynamically from the scenario."
+          },
+          "audio_effects": {
+            "$ref": "#/components/schemas/UserConversationSimulationAudioEffectsConfiguration",
+            "description": "Audio effects applied to voice conversation simulations. This property is ignored for text-only simulations."
+          },
+          "user_behavior": {
+            "$ref": "#/components/schemas/UserConversationSimulationUserBehaviorConfiguration",
+            "description": "Conversation behavior of the simulated user."
+          },
+          "enable_conversation_dataset_generation": {
+            "type": "boolean",
+            "description": "Whether to write all generated conversations to a versioned Foundry dataset. When enabled, the completed run includes a `simulated_user_conversations` entry in `output_datasets`. When omitted, the service defaults to `false`.",
+            "default": false
+          },
+          "output_conversation_dataset_name": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Name of the dataset to which generated conversations are written. This property is used only when `enable_conversation_dataset_generation` is `true`. When omitted, the service generates a dataset name."
+          }
+        },
+        "description": "Configures default conversation behavior and optional run-wide persistence of generated conversations."
+      },
       "UserConversationSimulationDefaultInterruptionConfiguration": {
         "type": "object",
         "required": [
@@ -90465,8 +90456,8 @@
             "description": "Model used to simulate the user side of each conversation by generating turns sent to the evaluated `target`."
           },
           "default_simulation_configuration": {
-            "$ref": "#/components/schemas/UserConversationSimulationConfiguration",
-            "description": "Default configuration for generating simulated user conversations. Properties in a test case's `simulation_configuration` override the corresponding defaults."
+            "$ref": "#/components/schemas/UserConversationSimulationDefaultConfiguration",
+            "description": "Default configuration for generating simulated user conversations and persisting their output. Conversation properties in a test case's `simulation_configuration` override the corresponding defaults."
           },
           "data_mapping": {
             "type": "object",
@@ -90474,11 +90465,6 @@
               "type": "string"
             },
             "description": "Maps JSONL dataset attributes to user conversation simulation inputs when their names differ from the defaults. The default attribute names are `test_case_id`, `test_case_category`, `test_case_description`, and `simulation_configuration`, matching `UserConversationSimulationTestCase`. Omit when the dataset uses these names or when using `inline_user_conversation_simulation`."
-          },
-          "enable_conversation_dataset_generation": {
-            "type": "boolean",
-            "description": "Whether to write all generated conversations to a file in a versioned Foundry dataset, providing visibility into the generated conversations. The dataset can be reused in future evaluation runs. When enabled, the completed run includes `output_dataset`. When omitted, the service defaults to `false`.",
-            "default": false
           }
         },
         "allOf": [

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -47321,11 +47321,13 @@ components:
           $ref: '#/components/schemas/EvaluationLevel'
           description: The level at which evaluation is performed. Defaults to 'turn' if not specified.
           default: turn
-        output_dataset:
-          $ref: '#/components/schemas/EvaluationDataset'
-          description: Dataset produced by the evaluation run. Present when the run creates a versioned Foundry dataset; otherwise omitted.
+        output_datasets:
+          type: array
+          items:
+            $ref: '#/components/schemas/EvaluationOutputDataset'
+          description: Preview-only. Datasets produced by the evaluation run. Omitted when no datasets were generated. This field may change in a future API version.
           readOnly: true
-      description: An evaluation run, including Foundry-specific metadata and optional output dataset information.
+      description: An evaluation run, including Foundry-specific metadata and generated output datasets.
       title: EvalRun
       x-oaiMeta:
         name: The eval run object
@@ -47819,41 +47821,6 @@ components:
       x-ms-foundry-meta:
         conditional_previews:
           - Insights=V1Preview
-    EvaluationAudioTranscriptionModel:
-      anyOf:
-        - type: string
-        - type: string
-          enum:
-            - mai-transcribe-1
-            - azure-speech
-      description: Supported speech-to-text transcription models. The union is extensible for additional models.
-    EvaluationAudioTranscriptionModelConfiguration:
-      type: object
-      required:
-        - model
-      properties:
-        model:
-          $ref: '#/components/schemas/EvaluationAudioTranscriptionModel'
-          description: The transcription model.
-      description: Configuration for speech-to-text transcription used during evaluation.
-    EvaluationAzureRealtimeNativeVoiceModelConfiguration:
-      type: object
-      required:
-        - type
-      properties:
-        type:
-          type: string
-          enum:
-            - azure-realtime-native
-          description: The voice kind. Always `azure-realtime-native`.
-        name:
-          type: string
-          minLength: 1
-          description: The Azure realtime-native voice name. When omitted, the service defaults to `ava`.
-          default: ava
-      allOf:
-        - $ref: '#/components/schemas/EvaluationVoiceModelConfiguration'
-      description: Configures an Azure realtime-native voice for evaluation.
     EvaluationAzureStandardVoiceModelConfiguration:
       type: object
       required:
@@ -47877,7 +47844,7 @@ components:
           description: The synthesis temperature, from 0 to 1. When omitted, the service defaults to the underlying voice model's default temperature.
       allOf:
         - $ref: '#/components/schemas/EvaluationVoiceModelConfiguration'
-      description: Configures an Azure standard neural voice for evaluation.
+      description: Configures an Azure standard neural voice used to convert text to speech for evaluation through the Voice Live endpoint.
     EvaluationComparisonInsightRequest:
       type: object
       required:
@@ -47970,31 +47937,30 @@ components:
         sampling_params:
           $ref: '#/components/schemas/ModelSamplingParams'
           description: Sampling parameters applied when the simulation model produces user turns.
-        transcription_model:
-          $ref: '#/components/schemas/EvaluationAudioTranscriptionModelConfiguration'
-          description: Transcription model configuration used to convert simulated user speech to text. Omit for text-only simulation.
         voice_model:
           $ref: '#/components/schemas/EvaluationVoiceModelConfiguration'
-          description: Voice model configuration used to convert simulated user text to speech. Omit for text-only simulation.
+          description: Voice configuration used to convert simulated user text to speech. Currently, only Azure standard voices are supported. Omit for text-only simulation.
       description: Configures the model that plays the simulated user. This model is separate from the evaluated `target`.
-    EvaluationOpenAIVoiceModelConfiguration:
+    EvaluationOutputDataset:
       type: object
       required:
         - type
-        - name
+        - dataset
       properties:
         type:
-          type: string
+          $ref: '#/components/schemas/EvaluationOutputDatasetType'
+          description: Purpose of the generated dataset.
+        dataset:
+          $ref: '#/components/schemas/EvaluationDataset'
+          description: Generated dataset reference.
+      description: A typed reference to a dataset produced by an evaluation run.
+    EvaluationOutputDatasetType:
+      anyOf:
+        - type: string
+        - type: string
           enum:
-            - openai
-          description: The voice kind. Always `openai`.
-        name:
-          type: string
-          minLength: 1
-          description: The OpenAI built-in voice name.
-      allOf:
-        - $ref: '#/components/schemas/EvaluationVoiceModelConfiguration'
-      description: Configures an OpenAI built-in voice for evaluation.
+            - simulated_user_conversations
+      description: Purpose of a dataset produced by an evaluation run. The union is extensible for additional output types.
     EvaluationResultSample:
       type: object
       required:
@@ -48315,10 +48281,8 @@ components:
       discriminator:
         propertyName: type
         mapping:
-          openai: '#/components/schemas/EvaluationOpenAIVoiceModelConfiguration'
           azure-standard: '#/components/schemas/EvaluationAzureStandardVoiceModelConfiguration'
-          azure-realtime-native: '#/components/schemas/EvaluationAzureRealtimeNativeVoiceModelConfiguration'
-      description: Voice configuration used to convert text to speech for evaluation. All supported voice types use the Voice Live endpoint under the hood.
+      description: Voice configuration used to convert text to speech for evaluation through the Voice Live endpoint.
     EvaluatorCategory:
       anyOf:
         - type: string
@@ -83904,6 +83868,41 @@ components:
           $ref: '#/components/schemas/UserConversationSimulationUserBehaviorConfiguration'
           description: Conversation behavior of the simulated user.
       description: Configures the number, length, audio effects, and simulated user behavior of conversations.
+    UserConversationSimulationDefaultConfiguration:
+      type: object
+      properties:
+        max_num_turns:
+          type: integer
+          format: int32
+          minimum: 1
+          description: Hard limit on turns in each conversation. When omitted, the service defaults to 20.
+          default: 20
+        conversation_repetitions:
+          type: integer
+          format: int32
+          minimum: 1
+          description: Number of independent conversation repetitions for each test case. Defaults to 1 when not specified at either the data-source or test-case level.
+          default: 1
+        desired_num_turns:
+          type: integer
+          format: int32
+          minimum: 1
+          description: Target number of turns in each conversation. The effective value cannot exceed the effective `max_num_turns`. When omitted, no target is set and the simulation model determines the conversation length dynamically from the scenario.
+        audio_effects:
+          $ref: '#/components/schemas/UserConversationSimulationAudioEffectsConfiguration'
+          description: Audio effects applied to voice conversation simulations. This property is ignored for text-only simulations.
+        user_behavior:
+          $ref: '#/components/schemas/UserConversationSimulationUserBehaviorConfiguration'
+          description: Conversation behavior of the simulated user.
+        enable_conversation_dataset_generation:
+          type: boolean
+          description: Whether to write all generated conversations to a versioned Foundry dataset. When enabled, the completed run includes a `simulated_user_conversations` entry in `output_datasets`. When omitted, the service defaults to `false`.
+          default: false
+        output_conversation_dataset_name:
+          type: string
+          minLength: 1
+          description: Name of the dataset to which generated conversations are written. This property is used only when `enable_conversation_dataset_generation` is `true`. When omitted, the service generates a dataset name.
+      description: Configures default conversation behavior and optional run-wide persistence of generated conversations.
     UserConversationSimulationDefaultInterruptionConfiguration:
       type: object
       required:
@@ -83940,17 +83939,13 @@ components:
           $ref: '#/components/schemas/EvaluationModelConfiguration'
           description: Model used to simulate the user side of each conversation by generating turns sent to the evaluated `target`.
         default_simulation_configuration:
-          $ref: '#/components/schemas/UserConversationSimulationConfiguration'
-          description: Default configuration for generating simulated user conversations. Properties in a test case's `simulation_configuration` override the corresponding defaults.
+          $ref: '#/components/schemas/UserConversationSimulationDefaultConfiguration'
+          description: Default configuration for generating simulated user conversations and persisting their output. Conversation properties in a test case's `simulation_configuration` override the corresponding defaults.
         data_mapping:
           type: object
           unevaluatedProperties:
             type: string
           description: Maps JSONL dataset attributes to user conversation simulation inputs when their names differ from the defaults. The default attribute names are `test_case_id`, `test_case_category`, `test_case_description`, and `simulation_configuration`, matching `UserConversationSimulationTestCase`. Omit when the dataset uses these names or when using `inline_user_conversation_simulation`.
-        enable_conversation_dataset_generation:
-          type: boolean
-          description: Whether to write all generated conversations to a file in a versioned Foundry dataset, providing visibility into the generated conversations. The dataset can be reused in future evaluation runs. When enabled, the completed run includes `output_dataset`. When omitted, the service defaults to `false`.
-          default: false
       allOf:
         - $ref: '#/components/schemas/EvalRunDataSource'
       description: |-

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -44368,13 +44368,16 @@
             "description": "The level at which evaluation is performed. Defaults to 'turn' if not specified.",
             "default": "turn"
           },
-          "output_dataset": {
-            "$ref": "#/components/schemas/EvaluationDataset",
-            "description": "Dataset produced by the evaluation run. Present when the run creates a versioned Foundry dataset; otherwise omitted.",
+          "output_datasets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EvaluationOutputDataset"
+            },
+            "description": "Preview-only. Datasets produced by the evaluation run. Omitted when no datasets were generated. This field may change in a future API version.",
             "readOnly": true
           }
         },
-        "description": "An evaluation run, including Foundry-specific metadata and optional output dataset information.",
+        "description": "An evaluation run, including Foundry-specific metadata and generated output datasets.",
         "title": "EvalRun",
         "x-oaiMeta": {
           "name": "The eval run object",
@@ -44789,61 +44792,6 @@
         },
         "description": "Evaluation Definition"
       },
-      "EvaluationAudioTranscriptionModel": {
-        "anyOf": [
-          {
-            "type": "string"
-          },
-          {
-            "type": "string",
-            "enum": [
-              "mai-transcribe-1",
-              "azure-speech"
-            ]
-          }
-        ],
-        "description": "Supported speech-to-text transcription models. The union is extensible for additional models."
-      },
-      "EvaluationAudioTranscriptionModelConfiguration": {
-        "type": "object",
-        "required": [
-          "model"
-        ],
-        "properties": {
-          "model": {
-            "$ref": "#/components/schemas/EvaluationAudioTranscriptionModel",
-            "description": "The transcription model."
-          }
-        },
-        "description": "Configuration for speech-to-text transcription used during evaluation."
-      },
-      "EvaluationAzureRealtimeNativeVoiceModelConfiguration": {
-        "type": "object",
-        "required": [
-          "type"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "azure-realtime-native"
-            ],
-            "description": "The voice kind. Always `azure-realtime-native`."
-          },
-          "name": {
-            "type": "string",
-            "minLength": 1,
-            "description": "The Azure realtime-native voice name. When omitted, the service defaults to `ava`.",
-            "default": "ava"
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/EvaluationVoiceModelConfiguration"
-          }
-        ],
-        "description": "Configures an Azure realtime-native voice for evaluation."
-      },
       "EvaluationAzureStandardVoiceModelConfiguration": {
         "type": "object",
         "required": [
@@ -44876,7 +44824,7 @@
             "$ref": "#/components/schemas/EvaluationVoiceModelConfiguration"
           }
         ],
-        "description": "Configures an Azure standard neural voice for evaluation."
+        "description": "Configures an Azure standard neural voice used to convert text to speech for evaluation through the Voice Live endpoint."
       },
       "EvaluationComparisonInsightRequest": {
         "type": "object",
@@ -45061,43 +45009,44 @@
             "$ref": "#/components/schemas/ModelSamplingParams",
             "description": "Sampling parameters applied when the simulation model produces user turns."
           },
-          "transcription_model": {
-            "$ref": "#/components/schemas/EvaluationAudioTranscriptionModelConfiguration",
-            "description": "Transcription model configuration used to convert simulated user speech to text. Omit for text-only simulation."
-          },
           "voice_model": {
             "$ref": "#/components/schemas/EvaluationVoiceModelConfiguration",
-            "description": "Voice model configuration used to convert simulated user text to speech. Omit for text-only simulation."
+            "description": "Voice configuration used to convert simulated user text to speech. Currently, only Azure standard voices are supported. Omit for text-only simulation."
           }
         },
         "description": "Configures the model that plays the simulated user. This model is separate from the evaluated `target`."
       },
-      "EvaluationOpenAIVoiceModelConfiguration": {
+      "EvaluationOutputDataset": {
         "type": "object",
         "required": [
           "type",
-          "name"
+          "dataset"
         ],
         "properties": {
           "type": {
-            "type": "string",
-            "enum": [
-              "openai"
-            ],
-            "description": "The voice kind. Always `openai`."
+            "$ref": "#/components/schemas/EvaluationOutputDatasetType",
+            "description": "Purpose of the generated dataset."
           },
-          "name": {
-            "type": "string",
-            "minLength": 1,
-            "description": "The OpenAI built-in voice name."
+          "dataset": {
+            "$ref": "#/components/schemas/EvaluationDataset",
+            "description": "Generated dataset reference."
           }
         },
-        "allOf": [
+        "description": "A typed reference to a dataset produced by an evaluation run."
+      },
+      "EvaluationOutputDatasetType": {
+        "anyOf": [
           {
-            "$ref": "#/components/schemas/EvaluationVoiceModelConfiguration"
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "simulated_user_conversations"
+            ]
           }
         ],
-        "description": "Configures an OpenAI built-in voice for evaluation."
+        "description": "Purpose of a dataset produced by an evaluation run. The union is extensible for additional output types."
       },
       "EvaluationResultSample": {
         "type": "object",
@@ -46218,12 +46167,10 @@
         "discriminator": {
           "propertyName": "type",
           "mapping": {
-            "openai": "#/components/schemas/EvaluationOpenAIVoiceModelConfiguration",
-            "azure-standard": "#/components/schemas/EvaluationAzureStandardVoiceModelConfiguration",
-            "azure-realtime-native": "#/components/schemas/EvaluationAzureRealtimeNativeVoiceModelConfiguration"
+            "azure-standard": "#/components/schemas/EvaluationAzureStandardVoiceModelConfiguration"
           }
         },
-        "description": "Voice configuration used to convert text to speech for evaluation. All supported voice types use the Voice Live endpoint under the hood."
+        "description": "Voice configuration used to convert text to speech for evaluation through the Voice Live endpoint."
       },
       "EvaluatorCategory": {
         "anyOf": [
@@ -96090,6 +96037,50 @@
         },
         "description": "Configures the number, length, audio effects, and simulated user behavior of conversations."
       },
+      "UserConversationSimulationDefaultConfiguration": {
+        "type": "object",
+        "properties": {
+          "max_num_turns": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "description": "Hard limit on turns in each conversation. When omitted, the service defaults to 20.",
+            "default": 20
+          },
+          "conversation_repetitions": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "description": "Number of independent conversation repetitions for each test case. Defaults to 1 when not specified at either the data-source or test-case level.",
+            "default": 1
+          },
+          "desired_num_turns": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "description": "Target number of turns in each conversation. The effective value cannot exceed the effective `max_num_turns`. When omitted, no target is set and the simulation model determines the conversation length dynamically from the scenario."
+          },
+          "audio_effects": {
+            "$ref": "#/components/schemas/UserConversationSimulationAudioEffectsConfiguration",
+            "description": "Audio effects applied to voice conversation simulations. This property is ignored for text-only simulations."
+          },
+          "user_behavior": {
+            "$ref": "#/components/schemas/UserConversationSimulationUserBehaviorConfiguration",
+            "description": "Conversation behavior of the simulated user."
+          },
+          "enable_conversation_dataset_generation": {
+            "type": "boolean",
+            "description": "Whether to write all generated conversations to a versioned Foundry dataset. When enabled, the completed run includes a `simulated_user_conversations` entry in `output_datasets`. When omitted, the service defaults to `false`.",
+            "default": false
+          },
+          "output_conversation_dataset_name": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Name of the dataset to which generated conversations are written. This property is used only when `enable_conversation_dataset_generation` is `true`. When omitted, the service generates a dataset name."
+          }
+        },
+        "description": "Configures default conversation behavior and optional run-wide persistence of generated conversations."
+      },
       "UserConversationSimulationDefaultInterruptionConfiguration": {
         "type": "object",
         "required": [
@@ -96140,8 +96131,8 @@
             "description": "Model used to simulate the user side of each conversation by generating turns sent to the evaluated `target`."
           },
           "default_simulation_configuration": {
-            "$ref": "#/components/schemas/UserConversationSimulationConfiguration",
-            "description": "Default configuration for generating simulated user conversations. Properties in a test case's `simulation_configuration` override the corresponding defaults."
+            "$ref": "#/components/schemas/UserConversationSimulationDefaultConfiguration",
+            "description": "Default configuration for generating simulated user conversations and persisting their output. Conversation properties in a test case's `simulation_configuration` override the corresponding defaults."
           },
           "data_mapping": {
             "type": "object",
@@ -96149,11 +96140,6 @@
               "type": "string"
             },
             "description": "Maps JSONL dataset attributes to user conversation simulation inputs when their names differ from the defaults. The default attribute names are `test_case_id`, `test_case_category`, `test_case_description`, and `simulation_configuration`, matching `UserConversationSimulationTestCase`. Omit when the dataset uses these names or when using `inline_user_conversation_simulation`."
-          },
-          "enable_conversation_dataset_generation": {
-            "type": "boolean",
-            "description": "Whether to write all generated conversations to a file in a versioned Foundry dataset, providing visibility into the generated conversations. The dataset can be reused in future evaluation runs. When enabled, the completed run includes `output_dataset`. When omitted, the service defaults to `false`.",
-            "default": false
           }
         },
         "allOf": [

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -50396,11 +50396,13 @@ components:
           $ref: '#/components/schemas/EvaluationLevel'
           description: The level at which evaluation is performed. Defaults to 'turn' if not specified.
           default: turn
-        output_dataset:
-          $ref: '#/components/schemas/EvaluationDataset'
-          description: Dataset produced by the evaluation run. Present when the run creates a versioned Foundry dataset; otherwise omitted.
+        output_datasets:
+          type: array
+          items:
+            $ref: '#/components/schemas/EvaluationOutputDataset'
+          description: Preview-only. Datasets produced by the evaluation run. Omitted when no datasets were generated. This field may change in a future API version.
           readOnly: true
-      description: An evaluation run, including Foundry-specific metadata and optional output dataset information.
+      description: An evaluation run, including Foundry-specific metadata and generated output datasets.
       title: EvalRun
       x-oaiMeta:
         name: The eval run object
@@ -50937,41 +50939,6 @@ components:
           $ref: '#/components/schemas/EvaluationTarget'
           description: Specifies the type and configuration of the entity used for this evaluation.
       description: Evaluation Definition
-    EvaluationAudioTranscriptionModel:
-      anyOf:
-        - type: string
-        - type: string
-          enum:
-            - mai-transcribe-1
-            - azure-speech
-      description: Supported speech-to-text transcription models. The union is extensible for additional models.
-    EvaluationAudioTranscriptionModelConfiguration:
-      type: object
-      required:
-        - model
-      properties:
-        model:
-          $ref: '#/components/schemas/EvaluationAudioTranscriptionModel'
-          description: The transcription model.
-      description: Configuration for speech-to-text transcription used during evaluation.
-    EvaluationAzureRealtimeNativeVoiceModelConfiguration:
-      type: object
-      required:
-        - type
-      properties:
-        type:
-          type: string
-          enum:
-            - azure-realtime-native
-          description: The voice kind. Always `azure-realtime-native`.
-        name:
-          type: string
-          minLength: 1
-          description: The Azure realtime-native voice name. When omitted, the service defaults to `ava`.
-          default: ava
-      allOf:
-        - $ref: '#/components/schemas/EvaluationVoiceModelConfiguration'
-      description: Configures an Azure realtime-native voice for evaluation.
     EvaluationAzureStandardVoiceModelConfiguration:
       type: object
       required:
@@ -50995,7 +50962,7 @@ components:
           description: The synthesis temperature, from 0 to 1. When omitted, the service defaults to the underlying voice model's default temperature.
       allOf:
         - $ref: '#/components/schemas/EvaluationVoiceModelConfiguration'
-      description: Configures an Azure standard neural voice for evaluation.
+      description: Configures an Azure standard neural voice used to convert text to speech for evaluation through the Voice Live endpoint.
     EvaluationComparisonInsightRequest:
       type: object
       required:
@@ -51122,31 +51089,30 @@ components:
         sampling_params:
           $ref: '#/components/schemas/ModelSamplingParams'
           description: Sampling parameters applied when the simulation model produces user turns.
-        transcription_model:
-          $ref: '#/components/schemas/EvaluationAudioTranscriptionModelConfiguration'
-          description: Transcription model configuration used to convert simulated user speech to text. Omit for text-only simulation.
         voice_model:
           $ref: '#/components/schemas/EvaluationVoiceModelConfiguration'
-          description: Voice model configuration used to convert simulated user text to speech. Omit for text-only simulation.
+          description: Voice configuration used to convert simulated user text to speech. Currently, only Azure standard voices are supported. Omit for text-only simulation.
       description: Configures the model that plays the simulated user. This model is separate from the evaluated `target`.
-    EvaluationOpenAIVoiceModelConfiguration:
+    EvaluationOutputDataset:
       type: object
       required:
         - type
-        - name
+        - dataset
       properties:
         type:
-          type: string
+          $ref: '#/components/schemas/EvaluationOutputDatasetType'
+          description: Purpose of the generated dataset.
+        dataset:
+          $ref: '#/components/schemas/EvaluationDataset'
+          description: Generated dataset reference.
+      description: A typed reference to a dataset produced by an evaluation run.
+    EvaluationOutputDatasetType:
+      anyOf:
+        - type: string
+        - type: string
           enum:
-            - openai
-          description: The voice kind. Always `openai`.
-        name:
-          type: string
-          minLength: 1
-          description: The OpenAI built-in voice name.
-      allOf:
-        - $ref: '#/components/schemas/EvaluationVoiceModelConfiguration'
-      description: Configures an OpenAI built-in voice for evaluation.
+            - simulated_user_conversations
+      description: Purpose of a dataset produced by an evaluation run. The union is extensible for additional output types.
     EvaluationResultSample:
       type: object
       required:
@@ -51957,10 +51923,8 @@ components:
       discriminator:
         propertyName: type
         mapping:
-          openai: '#/components/schemas/EvaluationOpenAIVoiceModelConfiguration'
           azure-standard: '#/components/schemas/EvaluationAzureStandardVoiceModelConfiguration'
-          azure-realtime-native: '#/components/schemas/EvaluationAzureRealtimeNativeVoiceModelConfiguration'
-      description: Voice configuration used to convert text to speech for evaluation. All supported voice types use the Voice Live endpoint under the hood.
+      description: Voice configuration used to convert text to speech for evaluation through the Voice Live endpoint.
     EvaluatorCategory:
       anyOf:
         - type: string
@@ -87811,6 +87775,41 @@ components:
           $ref: '#/components/schemas/UserConversationSimulationUserBehaviorConfiguration'
           description: Conversation behavior of the simulated user.
       description: Configures the number, length, audio effects, and simulated user behavior of conversations.
+    UserConversationSimulationDefaultConfiguration:
+      type: object
+      properties:
+        max_num_turns:
+          type: integer
+          format: int32
+          minimum: 1
+          description: Hard limit on turns in each conversation. When omitted, the service defaults to 20.
+          default: 20
+        conversation_repetitions:
+          type: integer
+          format: int32
+          minimum: 1
+          description: Number of independent conversation repetitions for each test case. Defaults to 1 when not specified at either the data-source or test-case level.
+          default: 1
+        desired_num_turns:
+          type: integer
+          format: int32
+          minimum: 1
+          description: Target number of turns in each conversation. The effective value cannot exceed the effective `max_num_turns`. When omitted, no target is set and the simulation model determines the conversation length dynamically from the scenario.
+        audio_effects:
+          $ref: '#/components/schemas/UserConversationSimulationAudioEffectsConfiguration'
+          description: Audio effects applied to voice conversation simulations. This property is ignored for text-only simulations.
+        user_behavior:
+          $ref: '#/components/schemas/UserConversationSimulationUserBehaviorConfiguration'
+          description: Conversation behavior of the simulated user.
+        enable_conversation_dataset_generation:
+          type: boolean
+          description: Whether to write all generated conversations to a versioned Foundry dataset. When enabled, the completed run includes a `simulated_user_conversations` entry in `output_datasets`. When omitted, the service defaults to `false`.
+          default: false
+        output_conversation_dataset_name:
+          type: string
+          minLength: 1
+          description: Name of the dataset to which generated conversations are written. This property is used only when `enable_conversation_dataset_generation` is `true`. When omitted, the service generates a dataset name.
+      description: Configures default conversation behavior and optional run-wide persistence of generated conversations.
     UserConversationSimulationDefaultInterruptionConfiguration:
       type: object
       required:
@@ -87847,17 +87846,13 @@ components:
           $ref: '#/components/schemas/EvaluationModelConfiguration'
           description: Model used to simulate the user side of each conversation by generating turns sent to the evaluated `target`.
         default_simulation_configuration:
-          $ref: '#/components/schemas/UserConversationSimulationConfiguration'
-          description: Default configuration for generating simulated user conversations. Properties in a test case's `simulation_configuration` override the corresponding defaults.
+          $ref: '#/components/schemas/UserConversationSimulationDefaultConfiguration'
+          description: Default configuration for generating simulated user conversations and persisting their output. Conversation properties in a test case's `simulation_configuration` override the corresponding defaults.
         data_mapping:
           type: object
           unevaluatedProperties:
             type: string
           description: Maps JSONL dataset attributes to user conversation simulation inputs when their names differ from the defaults. The default attribute names are `test_case_id`, `test_case_category`, `test_case_description`, and `simulation_configuration`, matching `UserConversationSimulationTestCase`. Omit when the dataset uses these names or when using `inline_user_conversation_simulation`.
-        enable_conversation_dataset_generation:
-          type: boolean
-          description: Whether to write all generated conversations to a file in a versioned Foundry dataset, providing visibility into the generated conversations. The dataset can be reused in future evaluation runs. When enabled, the completed run includes `output_dataset`. When omitted, the service defaults to `false`.
-          default: false
       allOf:
         - $ref: '#/components/schemas/EvalRunDataSource'
       description: |-

--- a/specification/ai-foundry/data-plane/Foundry/src/openai/evaluations/common.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/openai/evaluations/common.tsp
@@ -21,38 +21,29 @@ model EvaluationDataset {
   version: string;
 }
 
-/** Configuration for speech-to-text transcription used during evaluation. */
-model EvaluationAudioTranscriptionModelConfiguration {
-  /** The transcription model. */
-  `model`: EvaluationAudioTranscriptionModel;
-}
-
-/** Supported speech-to-text transcription models. The union is extensible for additional models. */
-union EvaluationAudioTranscriptionModel {
+/** Purpose of a dataset produced by an evaluation run. The union is extensible for additional output types. */
+union EvaluationOutputDatasetType {
   string,
-  mai_transcribe_1: "mai-transcribe-1",
-  azure_speech: "azure-speech",
+  simulatedUserConversations: "simulated_user_conversations",
 }
 
-/** Voice configuration used to convert text to speech for evaluation. All supported voice types use the Voice Live endpoint under the hood. */
+/** A typed reference to a dataset produced by an evaluation run. */
+model EvaluationOutputDataset {
+  /** Purpose of the generated dataset. */
+  type: EvaluationOutputDatasetType;
+
+  /** Generated dataset reference. */
+  dataset: EvaluationDataset;
+}
+
+/** Voice configuration used to convert text to speech for evaluation through the Voice Live endpoint. */
 @discriminator("type")
 model EvaluationVoiceModelConfiguration {
   /** The voice kind. */
   type: string;
 }
 
-/** Configures an OpenAI built-in voice for evaluation. */
-model EvaluationOpenAIVoiceModelConfiguration
-  extends EvaluationVoiceModelConfiguration {
-  /** The voice kind. Always `openai`. */
-  type: "openai";
-
-  /** The OpenAI built-in voice name. */
-  @minLength(1)
-  name: string;
-}
-
-/** Configures an Azure standard neural voice for evaluation. */
+/** Configures an Azure standard neural voice used to convert text to speech for evaluation through the Voice Live endpoint. */
 model EvaluationAzureStandardVoiceModelConfiguration
   extends EvaluationVoiceModelConfiguration {
   /** The voice kind. Always `azure-standard`. */
@@ -68,17 +59,6 @@ model EvaluationAzureStandardVoiceModelConfiguration
   temperature?: float32;
 }
 
-/** Configures an Azure realtime-native voice for evaluation. */
-model EvaluationAzureRealtimeNativeVoiceModelConfiguration
-  extends EvaluationVoiceModelConfiguration {
-  /** The voice kind. Always `azure-realtime-native`. */
-  type: "azure-realtime-native";
-
-  /** The Azure realtime-native voice name. When omitted, the service defaults to `ava`. */
-  @minLength(1)
-  name?: string = "ava";
-}
-
 /** Configures the model that plays the simulated user. This model is separate from the evaluated `target`. */
 model EvaluationModelConfiguration {
   /** Model deployment that generates simulated user turns, in the format `{connectionName}/modelDeploymentName`. */
@@ -87,9 +67,6 @@ model EvaluationModelConfiguration {
   /** Sampling parameters applied when the simulation model produces user turns. */
   sampling_params?: ModelSamplingParams;
 
-  /** Transcription model configuration used to convert simulated user speech to text. Omit for text-only simulation. */
-  transcription_model?: EvaluationAudioTranscriptionModelConfiguration;
-
-  /** Voice model configuration used to convert simulated user text to speech. Omit for text-only simulation. */
+  /** Voice configuration used to convert simulated user text to speech. Currently, only Azure standard voices are supported. Omit for text-only simulation. */
   voice_model?: EvaluationVoiceModelConfiguration;
 }

--- a/specification/ai-foundry/data-plane/Foundry/src/openai/evaluations/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/openai/evaluations/models.tsp
@@ -719,7 +719,7 @@ model AzureAIBenchmarkPreviewEvalRunDataSource extends EvalRunDataSource {
   }
 );
 
-/** An evaluation run, including Foundry-specific metadata and optional output dataset information. */
+/** An evaluation run, including Foundry-specific metadata and generated output datasets. */
 model EvalRun is OpenAI.EvalRun {
   /** Unix timestamp (in seconds) when the evaluation run was last modified. */
   #suppress "@azure-tools/typespec-azure-core/no-generic-numeric" "Auto-suppressed warnings non-applicable rules during import."
@@ -740,9 +740,9 @@ model EvalRun is OpenAI.EvalRun {
   /** The level at which evaluation is performed. Defaults to 'turn' if not specified. */
   evaluation_level?: EvaluationLevel = EvaluationLevel.turn;
 
-  /** Dataset produced by the evaluation run. Present when the run creates a versioned Foundry dataset; otherwise omitted. */
+  /** Preview-only. Datasets produced by the evaluation run. Omitted when no datasets were generated. This field may change in a future API version. */
   @visibility(Lifecycle.Read)
-  output_dataset?: EvaluationDataset;
+  output_datasets?: EvaluationOutputDataset[];
 }
 
 #suppress "@azure-tools/typespec-autorest/union-unsupported" "Imported from OpenAI spec."

--- a/specification/ai-foundry/data-plane/Foundry/src/openai/evaluations/user_conversation_simulation.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/openai/evaluations/user_conversation_simulation.tsp
@@ -20,14 +20,11 @@ model UserConversationSimulationEvalRunDataSource extends EvalRunDataSource {
   /** Model used to simulate the user side of each conversation by generating turns sent to the evaluated `target`. */
   model_configuration: EvaluationModelConfiguration;
 
-  /** Default configuration for generating simulated user conversations. Properties in a test case's `simulation_configuration` override the corresponding defaults. */
-  default_simulation_configuration?: UserConversationSimulationConfiguration;
+  /** Default configuration for generating simulated user conversations and persisting their output. Conversation properties in a test case's `simulation_configuration` override the corresponding defaults. */
+  default_simulation_configuration?: UserConversationSimulationDefaultConfiguration;
 
   /** Maps JSONL dataset attributes to user conversation simulation inputs when their names differ from the defaults. The default attribute names are `test_case_id`, `test_case_category`, `test_case_description`, and `simulation_configuration`, matching `UserConversationSimulationTestCase`. Omit when the dataset uses these names or when using `inline_user_conversation_simulation`. */
   data_mapping?: Record<string>;
-
-  /** Whether to write all generated conversations to a file in a versioned Foundry dataset, providing visibility into the generated conversations. The dataset can be reused in future evaluation runs. When enabled, the completed run includes `output_dataset`. When omitted, the service defaults to `false`. */
-  enable_conversation_dataset_generation?: boolean = false;
 }
 
 /** Sources supported by user conversation simulation. */
@@ -57,6 +54,18 @@ model UserConversationSimulationConfiguration {
 
   /** Conversation behavior of the simulated user. */
   user_behavior?: UserConversationSimulationUserBehaviorConfiguration;
+}
+
+/** Configures default conversation behavior and optional run-wide persistence of generated conversations. */
+model UserConversationSimulationDefaultConfiguration {
+  ...UserConversationSimulationConfiguration;
+
+  /** Whether to write all generated conversations to a versioned Foundry dataset. When enabled, the completed run includes a `simulated_user_conversations` entry in `output_datasets`. When omitted, the service defaults to `false`. */
+  enable_conversation_dataset_generation?: boolean = false;
+
+  /** Name of the dataset to which generated conversations are written. This property is used only when `enable_conversation_dataset_generation` is `true`. When omitted, the service generates a dataset name. */
+  @minLength(1)
+  output_conversation_dataset_name?: string;
 }
 
 /** Effect that can be applied to simulated conversation audio. The union is extensible for additional effects. */

--- a/specification/ai-foundry/data-plane/Foundry/src/sdk-common/ops-relocation-agents.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/sdk-common/ops-relocation-agents.tsp
@@ -176,7 +176,6 @@ namespace Azure.AI.Projects.Beta {
     VoiceAgentWebSocket
   );
 
-  interface AgentEndpointConversations {}
   @@clientLocation(
     Azure.AI.Projects.AgentEndpointConversations.listAgentConversations,
     AgentEndpointConversations


### PR DESCRIPTION
## Summary
- restrict evaluation text-to-speech configuration to Azure Standard voices
- add run-wide conversation dataset controls to the default simulation configuration, including an optional customer-provided dataset name
- return optional typed `output_datasets` entries using `simulated_user_conversations`
- update examples and generated OpenAPI artifacts

## Validation
- `npx tsv .`