### PR TITLE
Fix Relay .NET management SDK review comments

### DIFF
--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/client.tsp
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/client.tsp
@@ -66,6 +66,9 @@ using Microsoft.Relay;
 @@clientName(UnavailableReason, "RelayNameUnavailableReason", "csharp");
 @@clientName(KeyType, "RelayAccessKeyType", "csharp");
 @@clientName(HybridConnection, "RelayHybridConnection", "csharp");
+@@clientName(RelayClusterSkuUpdate, "RelayClusterSkuPatch", "csharp");
+@@clientName(RelayClusterProperties.zoneRedundant, "IsZoneRedundant", "csharp");
+@@clientName(TlsVersion, "RelayTlsVersion", "csharp");
 
 // Acronym mapping: Ip -> IP (directive + acronym-mapping from autorest.md)
 @@clientName(NWRuleSetIpRules, "RelayNetworkRuleSetIPRule", "csharp");
@@ -86,6 +89,11 @@ using Microsoft.Relay;
 
 // Back-compat: location properties were AzureLocation? in the old autorest SDK
 @@alternateType(AuthorizationRule.location, Azure.Core.azureLocation, "csharp");
+@@alternateType(
+  AvailableRelayClusterRegion.location,
+  Azure.Core.azureLocation,
+  "csharp"
+);
 @@alternateType(HybridConnection.location, Azure.Core.azureLocation, "csharp");
 @@alternateType(
   PrivateEndpointConnection.location,


### PR DESCRIPTION
## Summary
- rename `RelayClusterSkuUpdate` to `RelayClusterSkuPatch` for C#
- rename `RelayClusterProperties.zoneRedundant` to `IsZoneRedundant` for C#
- rename `TlsVersion` to `RelayTlsVersion` for C#
- map `AvailableRelayClusterRegion.location` to `AzureLocation` for C#

Addresses the management SDK review feedback on Azure/azure-sdk-for-net#61732.

## Validation
`npx tsp compile specification\relay\resource-manager\Microsoft.Relay\Relay --warn-as-error` validates the new references, then stops on the existing `unknown-rule-set` error for the repository's `client-sdk` ruleset.