### PR TITLE
[DRAFT][2026-09-01] ContainerService: add LocalDNS failfastAllUnhealthyUpstreams and healthCheck

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/AgentPoolModels.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/AgentPoolModels.tsp
@@ -1287,6 +1287,34 @@ model LocalDNSOverride {
    * Policy for serving stale data. See [cache plugin](https://coredns.io/plugins/cache) for more information.
    */
   serveStale?: LocalDNSServeStale = LocalDNSServeStale.Immediate;
+
+  /**
+   * Determines the handling of requests when all upstream DNS servers are unhealthy. When true, localDNS immediately returns SERVFAIL instead of forwarding the query and waiting for a timeout. See [forward plugin](https://coredns.io/plugins/forward) for more information.
+   */
+  @added(Versions.v2026_09_01)
+  failfastAllUnhealthyUpstreams?: boolean;
+
+  /**
+   * Configures active health checking of upstream DNS servers by localDNS. See [forward plugin](https://coredns.io/plugins/forward) for more information.
+   */
+  @added(Versions.v2026_09_01)
+  healthCheck?: LocalDNSHealthCheck;
+}
+
+/**
+ * Active upstream health check settings for localDNS. See [forward plugin](https://coredns.io/plugins/forward) for more information.
+ */
+@added(Versions.v2026_09_01)
+model LocalDNSHealthCheck {
+  /**
+   * The health check interval as a duration string, for example "500ms" or "1s". See [forward plugin](https://coredns.io/plugins/forward) for more information.
+   */
+  duration?: string;
+
+  /**
+   * When true, sets the RecursionDesired bit to false on health check queries. See [forward plugin](https://coredns.io/plugins/forward) for more information.
+   */
+  noRec?: boolean;
 }
 
 /**


### PR DESCRIPTION
> **⚠️ DRAFT — early review only.** The target API version is **2026-09-01**, but the
> `dev-containerservice-Microsoft.ContainerService-2026-09` branch has not been cut yet
> (per the AKS API release train, swagger dev branches are created after the 2026-08 API
> release completes). This PR is temporarily based on the **2026-07** dev branch so the
> change can be reviewed early. It will be **retargeted to the 2026-09 dev branch** once it
> exists, at which point the `@added(Versions.v2026_09_01)` gate will compile.
> Please review the **model change only**; CI will not be green against this temporary base
> because `Versions.v2026_09_01` does not exist on the 2026-07 branch.

## Summary

Adds the CoreDNS forward-plugin health knobs to the AKS `LocalDNSOverride` model for the **2026-09-01** API version:

- `failfastAllUnhealthyUpstreams?: boolean` — when true, localDNS returns SERVFAIL immediately once all upstream DNS servers are unhealthy, instead of forwarding the query and waiting for a timeout.
- `healthCheck?: LocalDNSHealthCheck` — active upstream health checking:
  - `duration?: string` — health check interval as a duration string (e.g. `"500ms"`, `"1s"`).
  - `noRec?: boolean` — sets the RecursionDesired bit to false on health check queries.

These let customers configure the forward-plugin health behavior directly through the localDNS API payload, instead of enabling them out-of-band via a DaemonSet.

## Versioning

All new members are gated with `@added(Versions.v2026_09_01)`, so they appear only in `2026-09-01` and later. Earlier API versions are unchanged — no retroactive enablement.

## Related

- **aks-rp** datamodel + converters (ADO PR 17105774): adds the same fields to the `v20260901` frontend datamodel and wires them to the existing HCP proto fields and the agentbaker/nodeprovisioner paths.
- **agentbaker** (follow-up): emit `health_check` and `failfast_all_unhealthy_upstreams` inside the `forward` block of the localdns corefile templates.

## Remaining before this can merge

- [ ] Retarget onto `dev-containerservice-Microsoft.ContainerService-2026-09` (once cut).
- [ ] `tsp compile` + regenerate swagger on that base.
- [ ] Add/update a localdns example under `aks/examples/2026-09-01/` covering the new fields.
