### PR TITLE
[AzureResilienceManagement] Mark report download URL secret in 2026-08-31-preview

### DIFF
--- a/specification/azureresiliencemanagement/resource-manager/Microsoft.AzureResilienceManagement/AzureResilienceManagement/models/drill/drillRun.models.tsp
+++ b/specification/azureresiliencemanagement/resource-manager/Microsoft.AzureResilienceManagement/AzureResilienceManagement/models/drill/drillRun.models.tsp
@@ -166,6 +166,7 @@ model ListReportDownloadUrlResponse {
   @doc("Short-lived, read-only URL to download the report.")
   @added(Versions.v2026_08_31_preview)
   @visibility(Lifecycle.Read)
+  @secret
   downloadUrl?: url;
 
   @doc("Timestamp at which the download URL expires.")

--- a/specification/azureresiliencemanagement/resource-manager/Microsoft.AzureResilienceManagement/AzureResilienceManagement/preview/2026-08-31-preview/openapi.json
+++ b/specification/azureresiliencemanagement/resource-manager/Microsoft.AzureResilienceManagement/AzureResilienceManagement/preview/2026-08-31-preview/openapi.json
@@ -8751,9 +8751,10 @@
         },
         "downloadUrl": {
           "type": "string",
-          "format": "uri",
+          "format": "password",
           "description": "Short-lived, read-only URL to download the report.",
-          "readOnly": true
+          "readOnly": true,
+          "x-ms-secret": true
         },
         "expiryTimestamp": {
           "type": "string",


### PR DESCRIPTION
## Purpose of this PR
- [x] Other: correct secret metadata on an existing ARM preview API.

## Summary
Adds `@secret` to `ListReportDownloadUrlResponse.downloadUrl` for **2026-08-31-preview** and regenerates that version's OpenAPI.

The generated property gains `x-ms-secret: true`; the emitter also changes `format` from `uri` to `password`. It remains an optional, read-only string. No endpoints, request/response payload values, authorization, expiry behavior, or service implementation change.

## Scope and related PR
This is the August companion to #45819, where commit `64e433b4ba475bd7bf8756f6781500eead9a71ee` fixes **2026-09-30-preview only**. That commit deliberately leaves the August contract unchanged. This PR starts from `main`, which currently contains versions through August, and changes only the TypeSpec property and the August OpenAPI file.

The four older OpenAPI versions remain byte-identical. Please preserve both versions' secret metadata when merging these related source changes.

## Compatibility
This corrects metadata in an already published preview and needs the normal versioning/SDK-compatibility review. In particular, `uri` to `password` can affect OpenAPI-based SDK type generation. The annotation itself does not guarantee runtime log redaction, and no service-side change is required for it.

## Validation
- Azure SDK MCP TypeSpec validation succeeded.
- `npx --no-install tsp compile . --warn-as-error` succeeded.
- Exact comparison confirms only the intended `downloadUrl` metadata differs; all other definitions, operations, and earlier versions are unchanged.

## Due diligence
- [x] This PR modifies ARM specifications, not data-plane specifications.
- [ ] Service owner/reviewer confirms the applicable ARM contract and compatibility approvals.
- [ ] Release-plan requirements reviewed by the service owner.

## References
- [TypeSpec secret decorator](https://typespec.io/docs/standard-library/built-in-decorators/#secret)
- [Versioned API changes](https://azure.github.io/typespec-azure/docs/howtos/versioning/06-evolving-apis)
- [Type-change versioning guidance](https://azure.github.io/typespec-azure/docs/howtos/versioning/03-stable-after-preview)
- [TypeSpec for OpenAPI developers](https://typespec.io/docs/getting-started/typespec-for-openapi-dev)