### PR TITLE
DeviceRegistry: fill arm-no-record suppression reasons (Section 4.1)

### DIFF
--- a/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/client.tsp
+++ b/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/client.tsp
@@ -278,7 +278,7 @@ model PolicyUpdateProperties {
 @removed(Versions.v2026_04_01)
 @doc("A Credential Policy")
 model PolicyUpdate {
-  #suppress "@azure-tools/typespec-azure-resource-manager/arm-no-record" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-no-record" "Standard ARM resource tags bag with customer-supplied string keys/values, so a Record<string> map is the required shape. PolicyUpdate is @removed as of 2026-04-01 and is not present in the versions shipped by this PR."
   @doc("Resource tags.")
   tags?: Record<string>;
 

--- a/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/schemaRegistries.tsp
+++ b/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/DeviceRegistry/schemaRegistries.tsp
@@ -114,7 +114,7 @@ model SchemaProperties {
   @visibility(Lifecycle.Read)
   provisioningState?: ProvisioningState;
 
-  #suppress "@azure-tools/typespec-azure-resource-manager/arm-no-record" ""
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-no-record" "Customer-defined schema tags: keys are arbitrary user-supplied strings that cannot be predefined, so a Record<string> map is required."
   @doc("Schema tags.")
   // Allowed scenario as per user-defined tags: https://github.com/Azure/azure-openapi-validator/blob/main/docs/avoid-additional-properties.md
   tags?: Record<string>;


### PR DESCRIPTION
Addresses two **Section 4.1** suppression-reason warnings from the ARM API Review ([#45288 review](https://github.com/Azure/azure-rest-api-specs/pull/45288#issuecomment-5618248449)):

- `schemaRegistries.tsp` (`SchemaProperties.tags`) — replaces the empty `arm-no-record` suppression reason with a factual justification (customer-defined schema tags; arbitrary string keys, so `Record<string>` is required).
- `client.tsp` (`PolicyUpdate.tags`) — replaces the `FIXME` placeholder reason with the real justification (standard ARM resource tags bag; note `PolicyUpdate` is `@removed` as of 2026-04-01 and is absent from the versions this PR ships).

Suppression-reason-only change — **no emitted swagger diff** (verified via `tsp compile`). Merges into `adr-vnext-specs-v2` (head of #45288).