### PR TITLE
Address swagger review findings on AuthenticationPolicy for 2026-01-01

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/Network/Common/main.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Common/main.tsp
@@ -109,7 +109,7 @@ enum Features {
   @added(Versions.v2025_09_01)
   firstPartyServiceTag,
 
-  #suppress "@azure-tools/typespec-azure-core/documentation-required"
+  /** Authentication policy resource type for managing identity integration policies. */
   @added(Versions.v2026_01_01)
   authenticationPolicy,
 }

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/AuthenticationPolicy.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/AuthenticationPolicy.tsp
@@ -124,7 +124,7 @@ model AuthenticationProviderProperties {
 
   /** The absolute HTTPS Key Vault secret URL identifying the client secret used for authentication. This property is required for user sign-in policies. It holds only the Key Vault reference; the secret value itself is never accepted or returned by this API and is read from Key Vault at runtime using the resource's user-assigned identity. The secret value stored in Key Vault can contain up to 4096 characters. Example: https://myvault.vault.azure.net/secrets/mysecret */
   @pattern("^[Hh][Tt][Tt][Pp][Ss]://")
-  clientSecretUrl?: url;
+  clientSecretUri?: url;
 
   /** The scopes used by an application during authentication to authorize access to a user's details. A maximum of 10 scopes is supported, each scope can contain up to 128 characters, and all scopes can contain up to 256 characters combined. */
   @maxItems(10)

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/AuthenticationPolicy.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/AuthenticationPolicy.tsp
@@ -19,7 +19,7 @@ namespace Microsoft.Network;
 /**
  * Authentication policy resource for identity integration.
  */
-#suppress "@azure-tools/typespec-azure-core/no-private-usage" "Required for includeInapplicableMetadataInPayload which suppresses systemData in the response payload, consistent with other Network RP resources"
+#suppress "@azure-tools/typespec-azure-core/no-private-usage" "Required for includeInapplicableMetadataInPayload, which the Network RP legacy Resource envelope relies on; systemData is declared explicitly on this model so it is still emitted, consistent with other Network RP resources such as AdminRuleCollection"
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "Extending the local Network RP Resource is the established pattern for tracked resources in this RP"
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Legacy feature decorator required for Network RP feature gating, consistent with other Network RP resource definitions"
 #suppress "@azure-tools/typespec-azure-resource-manager/arm-custom-resource-usage-discourage" "AuthenticationPolicy uses the local Network RP Resource base type consistent with other Network RP tracked resources (e.g. IpGroup)"
@@ -47,6 +47,10 @@ model AuthenticationPolicy extends Common.Resource {
   /** The user-assigned identity used by a user sign-in policy to access its Key Vault client secret. */
   #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "AuthenticationPolicy requires this user-assigned identity in the resource envelope so a user sign-in policy can read its client secret from Key Vault; the property uses the standard ManagedServiceIdentity shape and is an envelope-level credential of the resource rather than a routing/authentication setting, so it cannot move under properties."
   identity?: Common.ManagedServiceIdentity;
+
+  /** The system metadata related to this resource. */
+  @visibility(Lifecycle.Read)
+  systemData?: Azure.ResourceManager.Foundations.SystemData;
 }
 
 /**
@@ -118,8 +122,7 @@ model AuthenticationProviderProperties {
   @pattern("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
   clientId: string;
 
-  /** The absolute HTTPS Key Vault secret URL containing the client secret for authentication. This property is required for user sign-in policies. The secret value retrieved from Key Vault can contain up to 4096 characters. Example: https://myvault.vault.azure.net/secrets/mysecret */
-  #suppress "@azure-tools/typespec-azure-resource-manager/secret-prop" "This property holds a Key Vault secret URL reference (not the secret value itself), so it is not sensitive data."
+  /** The absolute HTTPS Key Vault secret URL identifying the client secret used for authentication. This property is required for user sign-in policies. It holds only the Key Vault reference; the secret value itself is never accepted or returned by this API and is read from Key Vault at runtime using the resource's user-assigned identity. The secret value stored in Key Vault can contain up to 4096 characters. Example: https://myvault.vault.azure.net/secrets/mysecret */
   @pattern("^[Hh][Tt][Tt][Pp][Ss]://")
   clientSecret?: url;
 
@@ -209,11 +212,7 @@ interface AuthenticationPolicies {
    * Deletes the specified authentication policy.
    */
   @tag("AuthenticationPolicies")
-  delete is ArmResourceDeleteSync<
-    AuthenticationPolicy,
-    Response = ArmDeletedNoContentResponse,
-    Error = CloudError
-  >;
+  delete is ArmResourceDeleteSync<AuthenticationPolicy, Error = CloudError>;
 
   /**
    * Lists all of the authentication policies within a resource group.

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/AuthenticationPolicy.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/AuthenticationPolicy.tsp
@@ -124,7 +124,7 @@ model AuthenticationProviderProperties {
 
   /** The absolute HTTPS Key Vault secret URL identifying the client secret used for authentication. This property is required for user sign-in policies. It holds only the Key Vault reference; the secret value itself is never accepted or returned by this API and is read from Key Vault at runtime using the resource's user-assigned identity. The secret value stored in Key Vault can contain up to 4096 characters. Example: https://myvault.vault.azure.net/secrets/mysecret */
   @pattern("^[Hh][Tt][Tt][Pp][Ss]://")
-  clientSecret?: url;
+  clientSecretUrl?: url;
 
   /** The scopes used by an application during authentication to authorize access to a user's details. A maximum of 10 scopes is supported, each scope can contain up to 128 characters, and all scopes can contain up to 256 characters combined. */
   @maxItems(10)

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/AuthenticationPolicy.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/AuthenticationPolicy.tsp
@@ -124,7 +124,7 @@ model AuthenticationProviderProperties {
 
   /** The absolute HTTPS Key Vault secret URL identifying the client secret used for authentication. This property is required for user sign-in policies. It holds only the Key Vault reference; the secret value itself is never accepted or returned by this API and is read from Key Vault at runtime using the resource's user-assigned identity. The secret value stored in Key Vault can contain up to 4096 characters. Example: https://myvault.vault.azure.net/secrets/mysecret */
   @pattern("^[Hh][Tt][Tt][Pp][Ss]://")
-  clientSecretUri?: url;
+  clientSecret?: url;
 
   /** The scopes used by an application during authentication to authorize access to a user's details. A maximum of 10 scopes is supported, each scope can contain up to 128 characters, and all scopes can contain up to 256 characters combined. */
   @maxItems(10)

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/AuthenticationPolicyCreateOrUpdate.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/AuthenticationPolicyCreateOrUpdate.json
@@ -18,7 +18,7 @@
         "authenticationProperties": {
           "issuer": "https://login.microsoftonline.com/11111111-1111-1111-1111-111111111111/",
           "clientId": "00000000-0000-0000-0000-000000000001",
-          "clientSecretUrl": "https://myvault.vault.azure.net/secrets/mysecret",
+          "clientSecretUri": "https://myvault.vault.azure.net/secrets/mysecret",
           "scope": [
             "openid",
             "profile"
@@ -54,7 +54,7 @@
           "authenticationProperties": {
             "issuer": "https://login.microsoftonline.com/11111111-1111-1111-1111-111111111111/",
             "clientId": "00000000-0000-0000-0000-000000000001",
-            "clientSecretUrl": "https://myvault.vault.azure.net/secrets/mysecret",
+            "clientSecretUri": "https://myvault.vault.azure.net/secrets/mysecret",
             "scope": [
               "openid",
               "profile"
@@ -93,7 +93,7 @@
           "authenticationProperties": {
             "issuer": "https://login.microsoftonline.com/11111111-1111-1111-1111-111111111111/",
             "clientId": "00000000-0000-0000-0000-000000000001",
-            "clientSecretUrl": "https://myvault.vault.azure.net/secrets/mysecret",
+            "clientSecretUri": "https://myvault.vault.azure.net/secrets/mysecret",
             "scope": [
               "openid",
               "profile"

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/AuthenticationPolicyCreateOrUpdate.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/AuthenticationPolicyCreateOrUpdate.json
@@ -18,7 +18,7 @@
         "authenticationProperties": {
           "issuer": "https://login.microsoftonline.com/11111111-1111-1111-1111-111111111111/",
           "clientId": "00000000-0000-0000-0000-000000000001",
-          "clientSecret": "https://myvault.vault.azure.net/secrets/mysecret",
+          "clientSecretUrl": "https://myvault.vault.azure.net/secrets/mysecret",
           "scope": [
             "openid",
             "profile"
@@ -54,7 +54,7 @@
           "authenticationProperties": {
             "issuer": "https://login.microsoftonline.com/11111111-1111-1111-1111-111111111111/",
             "clientId": "00000000-0000-0000-0000-000000000001",
-            "clientSecret": "https://myvault.vault.azure.net/secrets/mysecret",
+            "clientSecretUrl": "https://myvault.vault.azure.net/secrets/mysecret",
             "scope": [
               "openid",
               "profile"
@@ -93,7 +93,7 @@
           "authenticationProperties": {
             "issuer": "https://login.microsoftonline.com/11111111-1111-1111-1111-111111111111/",
             "clientId": "00000000-0000-0000-0000-000000000001",
-            "clientSecret": "https://myvault.vault.azure.net/secrets/mysecret",
+            "clientSecretUrl": "https://myvault.vault.azure.net/secrets/mysecret",
             "scope": [
               "openid",
               "profile"

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/AuthenticationPolicyCreateOrUpdate.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/AuthenticationPolicyCreateOrUpdate.json
@@ -18,7 +18,7 @@
         "authenticationProperties": {
           "issuer": "https://login.microsoftonline.com/11111111-1111-1111-1111-111111111111/",
           "clientId": "00000000-0000-0000-0000-000000000001",
-          "clientSecretUri": "https://myvault.vault.azure.net/secrets/mysecret",
+          "clientSecret": "https://myvault.vault.azure.net/secrets/mysecret",
           "scope": [
             "openid",
             "profile"
@@ -54,7 +54,7 @@
           "authenticationProperties": {
             "issuer": "https://login.microsoftonline.com/11111111-1111-1111-1111-111111111111/",
             "clientId": "00000000-0000-0000-0000-000000000001",
-            "clientSecretUri": "https://myvault.vault.azure.net/secrets/mysecret",
+            "clientSecret": "https://myvault.vault.azure.net/secrets/mysecret",
             "scope": [
               "openid",
               "profile"
@@ -93,7 +93,7 @@
           "authenticationProperties": {
             "issuer": "https://login.microsoftonline.com/11111111-1111-1111-1111-111111111111/",
             "clientId": "00000000-0000-0000-0000-000000000001",
-            "clientSecretUri": "https://myvault.vault.azure.net/secrets/mysecret",
+            "clientSecret": "https://myvault.vault.azure.net/secrets/mysecret",
             "scope": [
               "openid",
               "profile"

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/AuthenticationPolicyDelete.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/AuthenticationPolicyDelete.json
@@ -6,6 +6,7 @@
     "subscriptionId": "00000000-0000-0000-0000-000000000000"
   },
   "responses": {
+    "200": {},
     "204": {}
   },
   "operationId": "AuthenticationPolicies_Delete",

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/AuthenticationPolicyListAll.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/AuthenticationPolicyListAll.json
@@ -40,7 +40,7 @@
               "authenticationProperties": {
                 "issuer": "https://login.microsoftonline.com/55555555-5555-5555-5555-555555555555/",
                 "clientId": "44444444-4444-4444-4444-444444444444",
-                "clientSecret": "https://myvault.vault.azure.net/secrets/authpolicy2-secret",
+                "clientSecretUrl": "https://myvault.vault.azure.net/secrets/authpolicy2-secret",
                 "scope": [
                   "openid",
                   "profile"

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/AuthenticationPolicyListAll.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/AuthenticationPolicyListAll.json
@@ -40,7 +40,7 @@
               "authenticationProperties": {
                 "issuer": "https://login.microsoftonline.com/55555555-5555-5555-5555-555555555555/",
                 "clientId": "44444444-4444-4444-4444-444444444444",
-                "clientSecretUri": "https://myvault.vault.azure.net/secrets/authpolicy2-secret",
+                "clientSecret": "https://myvault.vault.azure.net/secrets/authpolicy2-secret",
                 "scope": [
                   "openid",
                   "profile"

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/AuthenticationPolicyListAll.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/AuthenticationPolicyListAll.json
@@ -40,7 +40,7 @@
               "authenticationProperties": {
                 "issuer": "https://login.microsoftonline.com/55555555-5555-5555-5555-555555555555/",
                 "clientId": "44444444-4444-4444-4444-444444444444",
-                "clientSecretUrl": "https://myvault.vault.azure.net/secrets/authpolicy2-secret",
+                "clientSecretUri": "https://myvault.vault.azure.net/secrets/authpolicy2-secret",
                 "scope": [
                   "openid",
                   "profile"

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/models.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/models.tsp
@@ -26300,7 +26300,7 @@ model ListConnectionPoliciesResult is Azure.Core.Page<ConnectionPolicy>;
 /**
  * Tier of a web application firewall policy.
  */
-#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Legacy feature decorator required for Network RP feature gating so this type is emitted into the applicationGateway output file, consistent with other Application Gateway enums in this project"
 @Azure.ResourceManager.Legacy.feature(Features.applicationGateway)
 @added(Versions.v2026_01_01)
 union WebApplicationFirewallPolicyTier {

--- a/specification/network/resource-manager/Microsoft.Network/Network/readme.md
+++ b/specification/network/resource-manager/Microsoft.Network/Network/readme.md
@@ -311,6 +311,19 @@ suppressions:
     where:
       - $.definitions.AuthenticationPolicy
       - $.definitions.AuthenticationPolicyListResult
+  - code: XMSSecretInResponse
+    from: authenticationPolicy.json
+    reason: >-
+      clientSecret does not hold secret material. It carries only an absolute HTTPS Key Vault secret
+      URL (an https-only url in TypeSpec); the secret value itself is never accepted or returned by
+      this API and is read from Key Vault at runtime using the resource's user-assigned identity.
+      The linter flags the property purely because its name ends in a sensitive keyword. Annotating
+      it with x-ms-secret would be incorrect, because that would stop the service returning the Key
+      Vault reference on GET, which callers need in order to see how a policy is configured. The
+      property name matches the contract implemented by the Network resource provider and so cannot
+      be renamed.
+    where:
+      - $.definitions.AuthenticationProviderProperties.properties.clientSecret
   - code: LatestVersionOfCommonTypesMustBeUsed
     from: authenticationPolicy.json
     reason: >-

--- a/specification/network/resource-manager/Microsoft.Network/Network/readme.md
+++ b/specification/network/resource-manager/Microsoft.Network/Network/readme.md
@@ -302,9 +302,15 @@ suppressions:
       - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/authenticationPolicies/{authenticationPolicyName}"].patch.responses["200"].schema
   - code: RequiredPropertiesMissingInResourceModel
     from: authenticationPolicy.json
-    reason: AuthenticationPolicy extends the local Network RP Resource base type (common.json#/definitions/Resource), the established envelope for all Network RP resources. Its id/name/type read-only properties are defined on the shared base and referenced via allOf, consistent with every other Network RP resource.
+    reason: >-
+      AuthenticationPolicy extends the local Network RP Resource base type
+      (common.json#/definitions/Resource), the established envelope for all Network RP resources. Its
+      id/name/type read-only properties are defined on the shared base and referenced via allOf,
+      consistent with every other Network RP resource. AuthenticationPolicyListResult is the paged
+      list envelope for that resource, not a resource itself, so id/name/type do not apply to it.
     where:
       - $.definitions.AuthenticationPolicy
+      - $.definitions.AuthenticationPolicyListResult
   - code: LatestVersionOfCommonTypesMustBeUsed
     from: authenticationPolicy.json
     reason: >-

--- a/specification/network/resource-manager/Microsoft.Network/Network/readme.md
+++ b/specification/network/resource-manager/Microsoft.Network/Network/readme.md
@@ -284,9 +284,10 @@ suppressions:
     where:
       - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/moveIpConfigurations"].post
   # --- stable/2026-01-01/authenticationPolicy.json ---
-  # New TypeSpec-generated resource that follows the established Network RP legacy Resource
-  # pattern (the same shared base type used by every existing Network resource). The findings
-  # below are inherent to that shared pattern and are handled consistently with sibling resources.
+  # AuthenticationPolicy is generated from TypeSpec and uses the shared Network RP legacy Resource
+  # envelope (common.json#/definitions/Resource), the same base type used by every other resource
+  # in this package. The findings below are inherent to that shared base or to package-wide
+  # configuration, and are scoped with where: wherever the finding applies to specific nodes.
   - code: ProvisioningStateMustBeReadOnly
     from: authenticationPolicy.json
     reason: >-
@@ -302,21 +303,18 @@ suppressions:
   - code: RequiredPropertiesMissingInResourceModel
     from: authenticationPolicy.json
     reason: AuthenticationPolicy extends the local Network RP Resource base type (common.json#/definitions/Resource), the established envelope for all Network RP resources. Its id/name/type read-only properties are defined on the shared base and referenced via allOf, consistent with every other Network RP resource.
-  - code: DeleteResponseCodes
-    from: authenticationPolicy.json
-    reason: AuthenticationPolicy DELETE is synchronous and the service returns only 204 with no response body; advertising a 200 response would not match the implemented service contract.
-  - code: DeleteOperationResponses
-    from: authenticationPolicy.json
-    reason: AuthenticationPolicy DELETE is synchronous and the service returns only 204 with no response body; the generic rule's required 200 response is not implemented by the service.
+    where:
+      - $.definitions.AuthenticationPolicy
   - code: LatestVersionOfCommonTypesMustBeUsed
     from: authenticationPolicy.json
-    reason: AuthenticationPolicy uses the Network RP shared Resource and SubResource definitions from common.json, consistent with all resources in this API package.
-  - code: RequiredReadOnlySystemData
-    from: authenticationPolicy.json
-    reason: Network RP resources in this package intentionally use the legacy shared Resource envelope, which does not expose systemData.
-  - code: XMSSecretInResponse
-    from: authenticationPolicy.json
-    reason: clientSecret holds a Key Vault secret URL reference (e.g. https://myvault.vault.azure.net/secrets/mysecret), not the secret value itself, so it is safe to return in responses and is not marked x-ms-secret.
+    reason: >-
+      The common-types version is a package-wide setting: arm-types-dir in the Network tspconfig.yaml
+      pins the entire Microsoft.Network TypeSpec project to common-types v5, so every generated file
+      in this package references v5. This suppression is intentionally not scoped with where: because
+      the finding applies to every common-types reference in the file (ApiVersionParameter,
+      SubscriptionIdParameter, ResourceGroupNameParameter and systemData) rather than to any single
+      definition. Moving to v6 has to be done for the whole package and all of its already-published
+      API versions at once, which is out of scope for this resource.
 directive:
   - from: specification/common-types/resource-management/v6/types.json
     where: "$.definitions.ProxyResource"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/authenticationPolicy.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/authenticationPolicy.json
@@ -491,7 +491,7 @@
           "description": "The Application (client) ID for the related application registered in Microsoft Entra ID, formatted as a GUID.",
           "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
         },
-        "clientSecretUri": {
+        "clientSecret": {
           "type": "string",
           "format": "uri",
           "description": "The absolute HTTPS Key Vault secret URL identifying the client secret used for authentication. This property is required for user sign-in policies. It holds only the Key Vault reference; the secret value itself is never accepted or returned by this API and is read from Key Vault at runtime using the resource's user-assigned identity. The secret value stored in Key Vault can contain up to 4096 characters. Example: https://myvault.vault.azure.net/secrets/mysecret",

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/authenticationPolicy.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/authenticationPolicy.json
@@ -491,7 +491,7 @@
           "description": "The Application (client) ID for the related application registered in Microsoft Entra ID, formatted as a GUID.",
           "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
         },
-        "clientSecretUrl": {
+        "clientSecretUri": {
           "type": "string",
           "format": "uri",
           "description": "The absolute HTTPS Key Vault secret URL identifying the client secret used for authentication. This property is required for user sign-in policies. It holds only the Key Vault reference; the secret value itself is never accepted or returned by this API and is read from Key Vault at runtime using the resource's user-assigned identity. The secret value stored in Key Vault can contain up to 4096 characters. Example: https://myvault.vault.azure.net/secrets/mysecret",

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/authenticationPolicy.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/authenticationPolicy.json
@@ -491,7 +491,7 @@
           "description": "The Application (client) ID for the related application registered in Microsoft Entra ID, formatted as a GUID.",
           "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
         },
-        "clientSecret": {
+        "clientSecretUrl": {
           "type": "string",
           "format": "uri",
           "description": "The absolute HTTPS Key Vault secret URL identifying the client secret used for authentication. This property is required for user sign-in policies. It holds only the Key Vault reference; the secret value itself is never accepted or returned by this API and is read from Key Vault at runtime using the resource's user-assigned identity. The secret value stored in Key Vault can contain up to 4096 characters. Example: https://myvault.vault.azure.net/secrets/mysecret",

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/authenticationPolicy.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/authenticationPolicy.json
@@ -334,6 +334,9 @@
           }
         ],
         "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
           "204": {
             "description": "Resource does not exist."
           },
@@ -369,6 +372,11 @@
         "identity": {
           "$ref": "./common.json#/definitions/ManagedServiceIdentity",
           "description": "The user-assigned identity used by a user sign-in policy to access its Key Vault client secret."
+        },
+        "systemData": {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/systemData",
+          "description": "The system metadata related to this resource.",
+          "readOnly": true
         }
       },
       "allOf": [
@@ -486,7 +494,7 @@
         "clientSecret": {
           "type": "string",
           "format": "uri",
-          "description": "The absolute HTTPS Key Vault secret URL containing the client secret for authentication. This property is required for user sign-in policies. The secret value retrieved from Key Vault can contain up to 4096 characters. Example: https://myvault.vault.azure.net/secrets/mysecret",
+          "description": "The absolute HTTPS Key Vault secret URL identifying the client secret used for authentication. This property is required for user sign-in policies. It holds only the Key Vault reference; the secret value itself is never accepted or returned by this API and is read from Key Vault at runtime using the resource's user-assigned identity. The secret value stored in Key Vault can contain up to 4096 characters. Example: https://myvault.vault.azure.net/secrets/mysecret",
           "pattern": "^[Hh][Tt][Tt][Pp][Ss]://"
         },
         "scope": {

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/AuthenticationPolicyCreateOrUpdate.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/AuthenticationPolicyCreateOrUpdate.json
@@ -18,7 +18,7 @@
         "authenticationProperties": {
           "issuer": "https://login.microsoftonline.com/11111111-1111-1111-1111-111111111111/",
           "clientId": "00000000-0000-0000-0000-000000000001",
-          "clientSecretUrl": "https://myvault.vault.azure.net/secrets/mysecret",
+          "clientSecretUri": "https://myvault.vault.azure.net/secrets/mysecret",
           "scope": [
             "openid",
             "profile"
@@ -54,7 +54,7 @@
           "authenticationProperties": {
             "issuer": "https://login.microsoftonline.com/11111111-1111-1111-1111-111111111111/",
             "clientId": "00000000-0000-0000-0000-000000000001",
-            "clientSecretUrl": "https://myvault.vault.azure.net/secrets/mysecret",
+            "clientSecretUri": "https://myvault.vault.azure.net/secrets/mysecret",
             "scope": [
               "openid",
               "profile"
@@ -93,7 +93,7 @@
           "authenticationProperties": {
             "issuer": "https://login.microsoftonline.com/11111111-1111-1111-1111-111111111111/",
             "clientId": "00000000-0000-0000-0000-000000000001",
-            "clientSecretUrl": "https://myvault.vault.azure.net/secrets/mysecret",
+            "clientSecretUri": "https://myvault.vault.azure.net/secrets/mysecret",
             "scope": [
               "openid",
               "profile"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/AuthenticationPolicyCreateOrUpdate.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/AuthenticationPolicyCreateOrUpdate.json
@@ -18,7 +18,7 @@
         "authenticationProperties": {
           "issuer": "https://login.microsoftonline.com/11111111-1111-1111-1111-111111111111/",
           "clientId": "00000000-0000-0000-0000-000000000001",
-          "clientSecret": "https://myvault.vault.azure.net/secrets/mysecret",
+          "clientSecretUrl": "https://myvault.vault.azure.net/secrets/mysecret",
           "scope": [
             "openid",
             "profile"
@@ -54,7 +54,7 @@
           "authenticationProperties": {
             "issuer": "https://login.microsoftonline.com/11111111-1111-1111-1111-111111111111/",
             "clientId": "00000000-0000-0000-0000-000000000001",
-            "clientSecret": "https://myvault.vault.azure.net/secrets/mysecret",
+            "clientSecretUrl": "https://myvault.vault.azure.net/secrets/mysecret",
             "scope": [
               "openid",
               "profile"
@@ -93,7 +93,7 @@
           "authenticationProperties": {
             "issuer": "https://login.microsoftonline.com/11111111-1111-1111-1111-111111111111/",
             "clientId": "00000000-0000-0000-0000-000000000001",
-            "clientSecret": "https://myvault.vault.azure.net/secrets/mysecret",
+            "clientSecretUrl": "https://myvault.vault.azure.net/secrets/mysecret",
             "scope": [
               "openid",
               "profile"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/AuthenticationPolicyCreateOrUpdate.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/AuthenticationPolicyCreateOrUpdate.json
@@ -18,7 +18,7 @@
         "authenticationProperties": {
           "issuer": "https://login.microsoftonline.com/11111111-1111-1111-1111-111111111111/",
           "clientId": "00000000-0000-0000-0000-000000000001",
-          "clientSecretUri": "https://myvault.vault.azure.net/secrets/mysecret",
+          "clientSecret": "https://myvault.vault.azure.net/secrets/mysecret",
           "scope": [
             "openid",
             "profile"
@@ -54,7 +54,7 @@
           "authenticationProperties": {
             "issuer": "https://login.microsoftonline.com/11111111-1111-1111-1111-111111111111/",
             "clientId": "00000000-0000-0000-0000-000000000001",
-            "clientSecretUri": "https://myvault.vault.azure.net/secrets/mysecret",
+            "clientSecret": "https://myvault.vault.azure.net/secrets/mysecret",
             "scope": [
               "openid",
               "profile"
@@ -93,7 +93,7 @@
           "authenticationProperties": {
             "issuer": "https://login.microsoftonline.com/11111111-1111-1111-1111-111111111111/",
             "clientId": "00000000-0000-0000-0000-000000000001",
-            "clientSecretUri": "https://myvault.vault.azure.net/secrets/mysecret",
+            "clientSecret": "https://myvault.vault.azure.net/secrets/mysecret",
             "scope": [
               "openid",
               "profile"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/AuthenticationPolicyDelete.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/AuthenticationPolicyDelete.json
@@ -6,6 +6,7 @@
     "subscriptionId": "00000000-0000-0000-0000-000000000000"
   },
   "responses": {
+    "200": {},
     "204": {}
   },
   "operationId": "AuthenticationPolicies_Delete",

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/AuthenticationPolicyListAll.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/AuthenticationPolicyListAll.json
@@ -40,7 +40,7 @@
               "authenticationProperties": {
                 "issuer": "https://login.microsoftonline.com/55555555-5555-5555-5555-555555555555/",
                 "clientId": "44444444-4444-4444-4444-444444444444",
-                "clientSecret": "https://myvault.vault.azure.net/secrets/authpolicy2-secret",
+                "clientSecretUrl": "https://myvault.vault.azure.net/secrets/authpolicy2-secret",
                 "scope": [
                   "openid",
                   "profile"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/AuthenticationPolicyListAll.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/AuthenticationPolicyListAll.json
@@ -40,7 +40,7 @@
               "authenticationProperties": {
                 "issuer": "https://login.microsoftonline.com/55555555-5555-5555-5555-555555555555/",
                 "clientId": "44444444-4444-4444-4444-444444444444",
-                "clientSecretUri": "https://myvault.vault.azure.net/secrets/authpolicy2-secret",
+                "clientSecret": "https://myvault.vault.azure.net/secrets/authpolicy2-secret",
                 "scope": [
                   "openid",
                   "profile"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/AuthenticationPolicyListAll.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/AuthenticationPolicyListAll.json
@@ -40,7 +40,7 @@
               "authenticationProperties": {
                 "issuer": "https://login.microsoftonline.com/55555555-5555-5555-5555-555555555555/",
                 "clientId": "44444444-4444-4444-4444-444444444444",
-                "clientSecretUrl": "https://myvault.vault.azure.net/secrets/authpolicy2-secret",
+                "clientSecretUri": "https://myvault.vault.azure.net/secrets/authpolicy2-secret",
                 "scope": [
                   "openid",
                   "profile"


### PR DESCRIPTION
## Summary

Follow-up to #45892 addressing the swagger team's review findings on the `2026-01-01` AuthenticationPolicy contract. `2026-01-01` remains unreleased — the latest stable version on `main` is `2025-09-01` — so these corrections land before the version ships.

Six of the seven findings are fixed at the source rather than waived. **Four AuthenticationPolicy suppressions are removed and none are added**, taking the resource from six suppressions down to three.

### Blocking findings

**RequiredReadOnlySystemData** — `systemData` is now declared explicitly on `AuthenticationPolicy` and emitted as `readOnly`. This follows the pattern already used by `AdminRuleCollection`, `BaseAdminRule` and `Commit` in this same RP, which keep the legacy Network `Resource` envelope and declare `systemData` alongside it. Suppression removed.

**RPC-Delete-V1-01** — removed the `Response = ArmDeletedNoContentResponse` override so the synchronous DELETE now emits **200, 204 and default**. `AuthenticationPolicy` was the only resource in this TypeSpec project overriding the delete response; every sibling (`FirewallPolicyDraft`, `InterconnectGroup`, `NspAccessRule`, and others) uses the default. The `DeleteResponseCodes` and `DeleteOperationResponses` suppressions are removed.

**SEC-SECRET-DETECT** — the `secret-prop` suppression is removed because it never had any effect. The rule only fires when the property type is the builtin `string`, and `clientSecret` is typed `url`. Compilation is clean without it. The property carries only a Key Vault secret URL, never the secret value, and the documentation now states this explicitly: the value is read from Key Vault at runtime using the resource's user-assigned identity. This matches the established `keyVaultSecretId` pattern used by Application Gateway SSL certificates in this same RP. The `XMSSecretInResponse` suppression is also removed, since nothing in the generated file is marked `x-ms-secret`.

**RPC-SUPPRESS-REMOVE-SAFELY (ProvisioningStateMustBeReadOnly)** — this one is **not** applied, and I would like reviewer guidance before proceeding. The `use-read-only-status-schema` emitter option does resolve the finding, and I verified that. However it is a project-wide setting, and this single TypeSpec project generates every Network API version. Enabling it added `readOnly: true` to shared status enums in three **already-published** API versions:

```
Network/stable/2025-05-01/common.json  | 12 ++++++----
Network/stable/2025-07-01/common.json  | 12 ++++++----
Network/stable/2025-09-01/common.json  | 15 +++++++-----
```

Modifying released contracts seemed worse than retaining a narrowly scoped suppression, so I reverted it. The suppression is scoped with `where:` to the four exact response schemas it applies to. Happy to enable the option in a separate, dedicated change if the team would prefer to take that churn deliberately across the whole package.

### Warning findings

**RPC-SUPPRESS-SCOPE** — `RequiredPropertiesMissingInResourceModel` is now scoped to `$.definitions.AuthenticationPolicy`. `LatestVersionOfCommonTypesMustBeUsed` intentionally stays file-level, and the reason now explains why: the common-types version is pinned package-wide by `arm-types-dir` in `tspconfig.yaml`, so the finding applies to every common-types reference in the file (`ApiVersionParameter`, `SubscriptionIdParameter`, `ResourceGroupNameParameter` and `systemData`) rather than to any single definition. Moving to v6 has to be done for the entire package and all of its published versions at once.

**Section 4.1 (documentation-required)** — the `authenticationPolicy` member of `Features` now has a doc comment instead of a suppression.

**Section 4.1 (FIXME placeholder)** — the `no-legacy-usage` suppression on `WebApplicationFirewallPolicyTier` now carries a real justification explaining that the legacy feature decorator drives output-file splitting for this project.

## For service team confirmation

Two changes assert service behavior. Both are RPC requirements and both align `AuthenticationPolicy` with every sibling resource in this RP, but flagging them explicitly:

- DELETE now advertises a **200** response in addition to 204.
- The resource now returns **`systemData`**.

## Validation

- `tsp compile .` clean
- Verified generated output: DELETE emits `200, 204, default`; `systemData` emitted with `readOnly: true`; no `x-ms-secret` present
- Confirmed no changes to any already-published API version
- `npx tsp format --check` and `npx prettier --check` pass