### PR TITLE
Splitting Clients + Rust

### DIFF
--- a/specification/appconfiguration/data-plane/AppConfiguration/client.tsp
+++ b/specification/appconfiguration/data-plane/AppConfiguration/client.tsp
@@ -22,7 +22,16 @@ namespace SdkCustomizations;
 @@access(SnapshotUpdateParameters, Access.public, "python");
 @@clientName(Azure.Core.Foundations.Error, "CommonError", "python");
 
-//
+// Hide feature-flag operations from the config-only package.
+@@scope(getFeatureFlags, "!(csharp, python, java, javascript, go, rust)");
+@@scope(checkFeatureFlags, "!(csharp, python, java, javascript, go, rust)");
+@@scope(getFeatureFlag, "!(csharp, python, java, javascript, go, rust)");
+@@scope(checkFeatureFlag, "!(csharp, python, java, javascript, go, rust)");
+@@scope(putFeatureFlag, "!(csharp, python, java, javascript, go, rust)");
+@@scope(deleteFeatureFlag, "!(csharp, python, java, javascript, go, rust)");
+@@scope(getFeatureFlagRevisions, "!(csharp, python, java, javascript, go, rust)");
+@@scope(checkFeatureFlagRevisions, "!(csharp, python, java, javascript, go, rust)");
+
 // .NET specific customizations
 
 // Method renames
@@ -45,35 +54,9 @@ namespace SdkCustomizations;
 @@access(getSnapshot, Access.internal, "csharp");
 @@access(updateSnapshot, Access.internal, "csharp");
 
-// Access changes feature flags
-@@access(getFeatureFlag, Access.internal, "csharp");
-@@access(checkFeatureFlag, Access.internal, "csharp");
-@@access(getFeatureFlags, Access.internal, "csharp");
-@@access(checkFeatureFlags, Access.internal, "csharp");
-@@access(putFeatureFlag, Access.internal, "csharp");
-@@access(deleteFeatureFlag, Access.internal, "csharp");
-@@access(getFeatureFlagRevisions, Access.internal, "csharp");
-@@access(checkFeatureFlagRevisions, Access.internal, "csharp");
-
-// Move feature flag operations into a dedicated FeatureFlagClient (all languages)
-@@clientLocation(getFeatureFlag, "FeatureFlagClient");
-@@clientLocation(checkFeatureFlag, "FeatureFlagClient");
-@@clientLocation(getFeatureFlags, "FeatureFlagClient");
-@@clientLocation(checkFeatureFlags, "FeatureFlagClient");
-@@clientLocation(putFeatureFlag, "FeatureFlagClient");
-@@clientLocation(deleteFeatureFlag, "FeatureFlagClient");
-@@clientLocation(getFeatureFlagRevisions, "FeatureFlagClient");
-@@clientLocation(checkFeatureFlagRevisions, "FeatureFlagClient");
-
 // Alternate types for select parameters
-@@alternateType(FeatureFlagRevisionsRequestParams.select, string[], "csharp");
-@@alternateType(FeatureFlagsRequestParams.select, string[], "csharp");
 @@alternateType(KeyValuesRequestParams.select, string[], "csharp");
 @@alternateType(RevisionsRequestParams.select, string[], "csharp");
-@@alternateType(FeatureFlagFilter.parameters, Record<string>, "csharp");
-
-// Surface the feature flag etag as Azure.ETag to match ConfigurationSetting.ETag
-@@alternateType(FeatureFlag.etag, Azure.Core.eTag, "csharp");
 
 // TypeScript specific customizations
 @@clientName(Snapshot.expires, "expiresOn", "javascript");

--- a/specification/appconfiguration/data-plane/AppConfiguration/main.tsp
+++ b/specification/appconfiguration/data-plane/AppConfiguration/main.tsp
@@ -2,7 +2,6 @@ import "@typespec/rest";
 import "@typespec/http";
 import "@typespec/versioning";
 import "./routes.tsp";
-import "./client.tsp";
 
 using TypeSpec.Http;
 using TypeSpec.Versioning;

--- a/specification/appconfiguration/data-plane/AppConfigurationFeatureFlag/client.tsp
+++ b/specification/appconfiguration/data-plane/AppConfigurationFeatureFlag/client.tsp
@@ -1,0 +1,50 @@
+import "../AppConfiguration/main.tsp";
+import "@azure-tools/typespec-client-generator-core";
+
+using Azure.Core;
+using Azure.ClientGenerator.Core;
+using AzureAppConfiguration;
+
+namespace SdkCustomizations;
+
+@@clientName(AzureAppConfiguration, "FeatureFlagClient");
+@@clientName(Azure.Core.Foundations.Error, "CommonError");
+
+// Hide configuration operations from the feature-flag-only package.
+@@scope(getKeys, "!(csharp, python, java, javascript, go, rust)");
+@@scope(checkKeys, "!(csharp, python, java, javascript, go, rust)");
+@@scope(getKeyValues, "!(csharp, python, java, javascript, go, rust)");
+@@scope(checkKeyValues, "!(csharp, python, java, javascript, go, rust)");
+@@scope(getKeyValue, "!(csharp, python, java, javascript, go, rust)");
+@@scope(putKeyValue, "!(csharp, python, java, javascript, go, rust)");
+@@scope(deleteKeyValue, "!(csharp, python, java, javascript, go, rust)");
+@@scope(checkKeyValue, "!(csharp, python, java, javascript, go, rust)");
+@@scope(getSnapshots, "!(csharp, python, java, javascript, go, rust)");
+@@scope(checkSnapshots, "!(csharp, python, java, javascript, go, rust)");
+@@scope(getSnapshot, "!(csharp, python, java, javascript, go, rust)");
+@@scope(createSnapshot, "!(csharp, python, java, javascript, go, rust)");
+@@scope(updateSnapshot, "!(csharp, python, java, javascript, go, rust)");
+@@scope(checkSnapshot, "!(csharp, python, java, javascript, go, rust)");
+@@scope(checkLabels, "!(csharp, python, java, javascript, go, rust)");
+@@scope(putLock, "!(csharp, python, java, javascript, go, rust)");
+@@scope(deleteLock, "!(csharp, python, java, javascript, go, rust)");
+@@scope(getRevisions, "!(csharp, python, java, javascript, go, rust)");
+@@scope(checkRevisions, "!(csharp, python, java, javascript, go, rust)");
+@@scope(getOperationDetails, "!(csharp, python, java, javascript, go, rust)");
+
+// .NET specific customizations
+@@access(getFeatureFlag, Access.internal, "csharp");
+@@access(checkFeatureFlag, Access.internal, "csharp");
+@@access(getFeatureFlags, Access.internal, "csharp");
+@@access(checkFeatureFlags, Access.internal, "csharp");
+@@access(putFeatureFlag, Access.internal, "csharp");
+@@access(deleteFeatureFlag, Access.internal, "csharp");
+@@access(getFeatureFlagRevisions, Access.internal, "csharp");
+@@access(checkFeatureFlagRevisions, Access.internal, "csharp");
+
+@@alternateType(FeatureFlagRevisionsRequestParams.select, string[], "csharp");
+@@alternateType(FeatureFlagsRequestParams.select, string[], "csharp");
+@@alternateType(FeatureFlagFilter.parameters, Record<string>, "csharp");
+
+// Surface the feature flag etag as Azure.ETag to match ConfigurationSetting.ETag.
+@@alternateType(FeatureFlag.etag, Azure.Core.eTag, "csharp");

--- a/specification/appconfiguration/data-plane/AppConfigurationFeatureFlag/tspconfig.yaml
+++ b/specification/appconfiguration/data-plane/AppConfigurationFeatureFlag/tspconfig.yaml
@@ -3,53 +3,50 @@ parameters:
     default: "sdk/appconfiguration"
   "dependencies":
     default: ""
-emit:
-  - "@azure-tools/typespec-autorest"
 options:
-  "@azure-tools/typespec-autorest":
-    emit-lro-options: "none"
-    emitter-output-dir: "{project-root}"
-    output-file: "{version-status}/{version}/appconfiguration.json"
   "@azure-tools/typespec-python":
-    emitter-output-dir: "{output-dir}/{service-dir}/azure-appconfiguration"
+    emitter-output-dir: "{output-dir}/{service-dir}/azure-appconfiguration-featureflag"
     generation-subdir: "_generated"
-    namespace: "azure.appconfiguration"
-    package-pprint-name: "App Configuration Data"
+    namespace: "azure.appconfiguration.featureflag"
+    package-name: "azure-appconfiguration-featureflag"
+    package-pprint-name: "App Configuration Feature Flag"
     package-mode: dataplane
     flavor: azure
-    generate-test: false
-    generate-sample: false
+    generate-test: true
+    generate-sample: true
   "@azure-typespec/http-client-csharp":
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
-    namespace: Azure.Data.AppConfiguration
+    namespace: Azure.Data.AppConfiguration.FeatureFlag
     model-namespace: false
   "@azure-tools/typespec-ts":
-    emitter-output-dir: "{output-dir}/{service-dir}/app-configuration"
+    emitter-output-dir: "{output-dir}/{service-dir}/app-configuration-feature-flag"
     generate-metadata: false
     is-modular-library: true
     package-details:
-      name: "@azure/app-configuration"
+      name: "@azure/app-configuration-feature-flag"
     flavor: azure
   "@azure-tools/typespec-java":
-    emitter-output-dir: "{output-dir}/{service-dir}/azure-data-appconfiguration"
-    namespace: com.azure.data.appconfiguration
+    emitter-output-dir: "{output-dir}/{service-dir}/azure-data-appconfiguration-featureflag"
+    namespace: com.azure.data.appconfiguration.featureflag
     models-subpackage: "implementation.models"
-    customization-class: "customization/src/main/java/AppConfigurationCustomizations.java"
     flavor: azure
     generate-tests: false
     generate-samples: false
   "@azure-tools/typespec-go":
-    containing-module: "github.com/Azure/azure-sdk-for-go/sdk/data/azappconfig"
+    containing-module: "github.com/Azure/azure-sdk-for-go/sdk/data/azappconfigfeatureflag"
     service-dir: "sdk/data"
-    emitter-output-dir: "{output-dir}/{service-dir}/azappconfig/internal/generated"
+    emitter-output-dir: "{output-dir}/{service-dir}/azappconfigfeatureflag/internal/generated"
     slice-elements-byval: true
     generate-fakes: false
     inject-spans: false
     file-prefix: "zz_"
   "@azure-tools/typespec-rust":
-    crate-name: "azure_app_configuration"
+    crate-name: "azure_app_configuration_feature_flag"
     crate-version: "0.1.0"
     emitter-output-dir: "{output-dir}/{service-dir}/{crate-name}"
+  "@azure-tools/typespec-client-generator-cli":
+    additionalDirectories:
+      - specification/appconfiguration/data-plane/AppConfiguration
 linter:
   extends:
     - "@azure-tools/typespec-azure-rulesets/data-plane"


### PR DESCRIPTION
# SDK configuration pull request

## Purpose of this PR

- [ ] Splits App Configuration Client with Feature Flags getting their own client
- [ ] Adds Rust SDK support

## Due diligence checklist

To merge this PR, you **must** go through the following checklist and confirm you understood
and followed the instructions by checking all the boxes:

- [ ] I confirm this PR is modifying only SDK configurations, and not API related specifications.
- [ ] I have reviewed and used the respective `tspconfig.yaml` templates:
  - [ARM tspconfig template](https://aka.ms/azsdk/tspconfig-sample-mpg)
  - [Data plane tspconfig template](https://aka.ms/azsdk/tspconfig-sample-dpg)

## Getting help

- First, carefully read through this PR description, from top to bottom. Fill out the `Purpose of this PR` and `Due diligence checklist`.
- If you don't have permissions to remove or add labels to the PR, request `write access` per [aka.ms/azsdk/access#request-access-to-rest-api-or-sdk-repositories](https://aka.ms/azsdk/access#request-access-to-rest-api-or-sdk-repositories)
- To understand what you must do next to merge this PR, see the `Next Steps to Merge` comment. It will appear within few minutes of submitting this PR and will continue to be up-to-date with current PR state.
- For guidance on fixing this PR CI check failures, see the hyperlinks provided in given failure and https://aka.ms/ci-fix.
- If the PR CI checks appear to be stuck in `queued` state, please add a comment with contents `/azp run`.
  This should result in a new comment denoting a `PR validation pipeline` has started and the checks should be updated after few minutes.
- If the help provided by the previous points is not enough, post to https://aka.ms/azsdk/support/specreview-channel and link to this PR.
