### PR TITLE
[Foundry] Require connection and scalar source for outbound telephony

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/README.md
+++ b/specification/ai-foundry/data-plane/Foundry/README.md
@@ -2,13 +2,6 @@
 
 This folder contains the TypeSpec for all data-plane REST APIs of the Foundry service.
 
-## Telephony connection names
-
-Telephony bindings, outbound call jobs, and outbound campaigns use `connection_name` to reference
-a Foundry connection by its `name`, not its service-generated `id`. These are distinct fields in
-the [Connection model](src/connections/models.tsp). Use the [Connections list and get APIs](src/connections/routes.tsp)
-(`GET /connections` and `GET /connections/{name}`) to discover the connection name.
-
 ## Contributing
 
 ### Adding preview features

--- a/specification/ai-foundry/data-plane/Foundry/README.md
+++ b/specification/ai-foundry/data-plane/Foundry/README.md
@@ -2,6 +2,13 @@
 
 This folder contains the TypeSpec for all data-plane REST APIs of the Foundry service.
 
+## Telephony connection names
+
+Telephony bindings, outbound call jobs, and outbound campaigns use `connection_name` to reference
+a Foundry connection by its `name`, not its service-generated `id`. These are distinct fields in
+the [Connection model](src/connections/models.tsp). Use the [Connections list and get APIs](src/connections/routes.tsp)
+(`GET /connections` and `GET /connections/{name}`) to discover the connection name.
+
 ## Contributing
 
 ### Adding preview features
@@ -76,4 +83,3 @@ If you want to emit Python SDK from latest TypeSpec in this folder do the follow
   - `tsp-client update` to use the TypeSpec commit mentioned in the local tsp-location.yaml file
 - After the code was emitted, run the script `post-emitter-fixes.cmd`
 - To review your changes, send a PR for merging your topic branch into branch `feature/azure-ai-projects/2.0.0b1`
-

--- a/specification/ai-foundry/data-plane/Foundry/examples/v1/AgentTelephony_ClearTeamsBindingMetadata.json
+++ b/specification/ai-foundry/data-plane/Foundry/examples/v1/AgentTelephony_ClearTeamsBindingMetadata.json
@@ -20,7 +20,7 @@
       "body": {
         "id": "binding_support_teams",
         "provider": "teams_phone_extension",
-        "connection": "teams-phone-connection-secondary",
+        "connection_name": "teams-phone-connection-secondary",
         "resource_account_object_id": "11111111-2222-3333-8444-555555555555",
         "status": "suspended",
         "incoming_call_url": "https://contoso.services.ai.azure.com/agents/support-agent/endpoint/protocols/voice/telephony/teams_phone_extension/callbacks/incoming_call"

--- a/specification/ai-foundry/data-plane/Foundry/examples/v1/AgentTelephony_CreateTeamsPhoneExtensionBinding.json
+++ b/specification/ai-foundry/data-plane/Foundry/examples/v1/AgentTelephony_CreateTeamsPhoneExtensionBinding.json
@@ -7,7 +7,7 @@
     "agent_name": "support-agent",
     "body": {
       "provider": "teams_phone_extension",
-      "connection": "teams-phone-connection",
+      "connection_name": "teams-phone-connection",
       "phone_number": "+14255550100",
       "label": "Customer support",
       "resource_account_object_id": "11111111-2222-3333-8444-555555555555"
@@ -21,7 +21,7 @@
       "body": {
         "id": "binding_support_teams",
         "provider": "teams_phone_extension",
-        "connection": "teams-phone-connection",
+        "connection_name": "teams-phone-connection",
         "phone_number": "+14255550100",
         "label": "Customer support",
         "resource_account_object_id": "11111111-2222-3333-8444-555555555555",

--- a/specification/ai-foundry/data-plane/Foundry/examples/v1/AgentTelephony_CreateTwilioBinding.json
+++ b/specification/ai-foundry/data-plane/Foundry/examples/v1/AgentTelephony_CreateTwilioBinding.json
@@ -7,7 +7,7 @@
     "agent_name": "support-agent",
     "body": {
       "provider": "twilio",
-      "connection": "twilio-support-connection",
+      "connection_name": "twilio-support-connection",
       "phone_number": "+14255550123",
       "label": "Customer support"
     }
@@ -20,7 +20,7 @@
       "body": {
         "id": "binding_support_twilio",
         "provider": "twilio",
-        "connection": "twilio-support-connection",
+        "connection_name": "twilio-support-connection",
         "phone_number": "+14255550123",
         "label": "Customer support",
         "status": "active",

--- a/specification/ai-foundry/data-plane/Foundry/examples/v1/AgentTelephony_GetBinding.json
+++ b/specification/ai-foundry/data-plane/Foundry/examples/v1/AgentTelephony_GetBinding.json
@@ -15,7 +15,7 @@
       "body": {
         "id": "binding_support_twilio",
         "provider": "twilio",
-        "connection": "twilio-support-connection",
+        "connection_name": "twilio-support-connection",
         "phone_number": "+14255550123",
         "label": "Customer support",
         "status": "active",

--- a/specification/ai-foundry/data-plane/Foundry/examples/v1/AgentTelephony_ListBindings.json
+++ b/specification/ai-foundry/data-plane/Foundry/examples/v1/AgentTelephony_ListBindings.json
@@ -16,7 +16,7 @@
           {
             "id": "binding_support_twilio",
             "provider": "twilio",
-            "connection": "twilio-support-connection",
+            "connection_name": "twilio-support-connection",
             "phone_number": "+14255550123",
             "label": "Customer support",
             "status": "active",

--- a/specification/ai-foundry/data-plane/Foundry/examples/v1/AgentTelephony_UpdateBinding.json
+++ b/specification/ai-foundry/data-plane/Foundry/examples/v1/AgentTelephony_UpdateBinding.json
@@ -20,7 +20,7 @@
       "body": {
         "id": "binding_support_twilio",
         "provider": "twilio",
-        "connection": "twilio-support-connection",
+        "connection_name": "twilio-support-connection",
         "phone_number": "+14255550123",
         "label": "Customer support maintenance",
         "status": "suspended",

--- a/specification/ai-foundry/data-plane/Foundry/examples/v1/AgentTelephony_UpdateTeamsBindingMaximum.json
+++ b/specification/ai-foundry/data-plane/Foundry/examples/v1/AgentTelephony_UpdateTeamsBindingMaximum.json
@@ -9,7 +9,7 @@
     "If-Match": "\"binding-etag-1\"",
     "body": {
       "status": "suspended",
-      "connection": "teams-phone-connection-secondary",
+      "connection_name": "teams-phone-connection-secondary",
       "phone_number": "+14255550101",
       "label": "Customer support maintenance"
     }
@@ -22,7 +22,7 @@
       "body": {
         "id": "binding_support_teams",
         "provider": "teams_phone_extension",
-        "connection": "teams-phone-connection-secondary",
+        "connection_name": "teams-phone-connection-secondary",
         "phone_number": "+14255550101",
         "label": "Customer support maintenance",
         "resource_account_object_id": "11111111-2222-3333-8444-555555555555",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -38100,11 +38100,11 @@
           "connection": {
             "type": "string",
             "minLength": 1,
-            "maxLength": 128,
+            "maxLength": 256,
             "description": "The Foundry connection name in the current project used to originate the call. Its category selects Twilio or Azure Communication Services / Teams Phone Extension. No inbound telephony binding is required."
           },
           "source": {
-            "type": "string",
+            "$ref": "#/components/schemas/TelephonyOutboundSource",
             "minLength": 1,
             "description": "The caller identity used to originate the call. For a Twilio connection, provide an authorized E.164 phone number. For an Azure Communication Services / Teams Phone Extension connection, provide the Teams Resource Account object ID. The identity type is inferred from the connection category; originating does not change inbound routing."
           },
@@ -38168,11 +38168,11 @@
           "connection": {
             "type": "string",
             "minLength": 1,
-            "maxLength": 128,
+            "maxLength": 256,
             "description": "The Foundry connection name in the current project used to originate campaign calls. Its category selects Twilio or Azure Communication Services / Teams Phone Extension. No inbound telephony binding is required."
           },
           "source": {
-            "type": "string",
+            "$ref": "#/components/schemas/TelephonyOutboundSource",
             "minLength": 1,
             "description": "The caller identity used to originate campaign calls. For a Twilio connection, provide an authorized E.164 phone number. For an Azure Communication Services / Teams Phone Extension connection, provide the Teams Resource Account object ID. The identity type is inferred from the connection category; originating does not change inbound routing."
           },
@@ -87453,11 +87453,11 @@
           "connection": {
             "type": "string",
             "minLength": 1,
-            "maxLength": 128,
+            "maxLength": 256,
             "description": "The Foundry connection name in the current project used to originate the call. Its category selects Twilio or Azure Communication Services / Teams Phone Extension. No inbound telephony binding is required."
           },
           "source": {
-            "type": "string",
+            "$ref": "#/components/schemas/TelephonyOutboundSource",
             "minLength": 1,
             "description": "The caller identity used to originate the call. For a Twilio connection, provide an authorized E.164 phone number. For an Azure Communication Services / Teams Phone Extension connection, provide the Teams Resource Account object ID. The identity type is inferred from the connection category; originating does not change inbound routing."
           },
@@ -88254,11 +88254,11 @@
           "connection": {
             "type": "string",
             "minLength": 1,
-            "maxLength": 128,
+            "maxLength": 256,
             "description": "The Foundry connection name in the current project used to originate campaign calls. Its category selects Twilio or Azure Communication Services / Teams Phone Extension. No inbound telephony binding is required."
           },
           "source": {
-            "type": "string",
+            "$ref": "#/components/schemas/TelephonyOutboundSource",
             "minLength": 1,
             "description": "The caller identity used to originate campaign calls. For a Twilio connection, provide an authorized E.164 phone number. For an Azure Communication Services / Teams Phone Extension connection, provide the Teams Resource Account object ID. The identity type is inferred from the connection category; originating does not change inbound routing."
           },
@@ -89071,6 +89071,18 @@
           }
         ],
         "description": "The retry strategy for an outbound call.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "VoiceAgents=V1Preview"
+          ]
+        }
+      },
+      "TelephonyOutboundSource": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 36,
+        "pattern": "^(?:\\+[1-9][0-9]{1,14}|(?!00000000-0000-0000-0000-000000000000$)[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$",
+        "description": "An outbound caller identity: an E.164 phone number or a non-empty Teams Resource Account UUID. The connection category determines which form is accepted.",
         "x-ms-foundry-meta": {
           "required_previews": [
             "VoiceAgents=V1Preview"

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -38052,14 +38052,14 @@
         "type": "object",
         "required": [
           "provider",
-          "connection"
+          "connection_name"
         ],
         "properties": {
           "provider": {
             "$ref": "#/components/schemas/TelephonyProvider",
             "description": "The telephony provider."
           },
-          "connection": {
+          "connection_name": {
             "type": "string",
             "minLength": 1,
             "maxLength": 256,
@@ -38089,7 +38089,7 @@
         "type": "object",
         "required": [
           "destination",
-          "connection",
+          "connection_name",
           "source"
         ],
         "properties": {
@@ -38097,7 +38097,7 @@
             "$ref": "#/components/schemas/TelephonyOutboundDestination",
             "description": "The phone destination to call."
           },
-          "connection": {
+          "connection_name": {
             "type": "string",
             "minLength": 1,
             "maxLength": 256,
@@ -38130,7 +38130,7 @@
         "description": "A request to create one durable direct outbound call job.",
         "examples": [
           {
-            "connection": "telephony-acs",
+            "connection_name": "telephony-acs",
             "source": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
             "destination": {
               "type": "phone_number",
@@ -38138,7 +38138,7 @@
             }
           },
           {
-            "connection": "telephony-twilio",
+            "connection_name": "telephony-twilio",
             "source": "+14255550100",
             "destination": {
               "type": "phone_number",
@@ -38156,7 +38156,7 @@
         "type": "object",
         "required": [
           "display_name",
-          "connection",
+          "connection_name",
           "source"
         ],
         "properties": {
@@ -38165,7 +38165,7 @@
             "minLength": 1,
             "description": "A customer-visible name for the campaign."
           },
-          "connection": {
+          "connection_name": {
             "type": "string",
             "minLength": 1,
             "maxLength": 256,
@@ -38194,12 +38194,12 @@
         "examples": [
           {
             "display_name": "Teams Phone renewal reminders",
-            "connection": "telephony-acs",
+            "connection_name": "telephony-acs",
             "source": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
           },
           {
             "display_name": "Twilio renewal reminders",
-            "connection": "telephony-twilio",
+            "connection_name": "telephony-twilio",
             "source": "+14255550100"
           }
         ],
@@ -87270,7 +87270,7 @@
         "required": [
           "id",
           "provider",
-          "connection",
+          "connection_name",
           "status",
           "incoming_call_url"
         ],
@@ -87283,7 +87283,7 @@
             "$ref": "#/components/schemas/TelephonyProvider",
             "description": "The telephony provider."
           },
-          "connection": {
+          "connection_name": {
             "type": "string",
             "minLength": 1,
             "maxLength": 256,
@@ -87329,7 +87329,7 @@
         "required": [
           "id",
           "provider",
-          "connection",
+          "connection_name",
           "status",
           "incoming_call_url",
           "etag"
@@ -87343,7 +87343,7 @@
             "$ref": "#/components/schemas/TelephonyProvider",
             "description": "The telephony provider."
           },
-          "connection": {
+          "connection_name": {
             "type": "string",
             "minLength": 1,
             "maxLength": 256,
@@ -87433,7 +87433,7 @@
         "type": "object",
         "required": [
           "destination",
-          "connection",
+          "connection_name",
           "source",
           "id",
           "object",
@@ -87450,7 +87450,7 @@
             "$ref": "#/components/schemas/TelephonyOutboundDestination",
             "description": "The phone destination to call."
           },
-          "connection": {
+          "connection_name": {
             "type": "string",
             "minLength": 1,
             "maxLength": 256,
@@ -88233,7 +88233,7 @@
         "type": "object",
         "required": [
           "display_name",
-          "connection",
+          "connection_name",
           "source",
           "id",
           "object",
@@ -88251,7 +88251,7 @@
             "minLength": 1,
             "description": "A customer-visible name for the campaign."
           },
-          "connection": {
+          "connection_name": {
             "type": "string",
             "minLength": 1,
             "maxLength": 256,
@@ -90378,7 +90378,7 @@
             "maxLength": 128,
             "description": "The replacement display label. Omit it to preserve the current value; use null to clear it."
           },
-          "connection": {
+          "connection_name": {
             "type": "string",
             "minLength": 1,
             "maxLength": 256,

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -38089,16 +38089,24 @@
         "type": "object",
         "required": [
           "destination",
-          "telephony_binding_id"
+          "connection",
+          "source"
         ],
         "properties": {
           "destination": {
             "$ref": "#/components/schemas/TelephonyOutboundDestination",
             "description": "The phone destination to call."
           },
-          "telephony_binding_id": {
-            "$ref": "#/components/schemas/TelephonyBindingId",
-            "description": "The active agent telephony binding used to originate the call."
+          "connection": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 128,
+            "description": "The Foundry connection name in the current project used to originate the call. Its category selects Twilio or Azure Communication Services / Teams Phone Extension. No inbound telephony binding is required."
+          },
+          "source": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The caller identity used to originate the call. For a Twilio connection, provide an authorized E.164 phone number. For an Azure Communication Services / Teams Phone Extension connection, provide the Teams Resource Account object ID. The identity type is inferred from the connection category; originating does not change inbound routing."
           },
           "purpose": {
             "type": "string",
@@ -38120,6 +38128,24 @@
           }
         },
         "description": "A request to create one durable direct outbound call job.",
+        "examples": [
+          {
+            "connection": "telephony-acs",
+            "source": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "destination": {
+              "type": "phone_number",
+              "value": "+14255550123"
+            }
+          },
+          {
+            "connection": "telephony-twilio",
+            "source": "+14255550100",
+            "destination": {
+              "type": "phone_number",
+              "value": "+14255550123"
+            }
+          }
+        ],
         "x-ms-foundry-meta": {
           "required_previews": [
             "VoiceAgents=V1Preview"
@@ -38130,7 +38156,8 @@
         "type": "object",
         "required": [
           "display_name",
-          "telephony_binding_id"
+          "connection",
+          "source"
         ],
         "properties": {
           "display_name": {
@@ -38138,9 +38165,16 @@
             "minLength": 1,
             "description": "A customer-visible name for the campaign."
           },
-          "telephony_binding_id": {
-            "$ref": "#/components/schemas/TelephonyBindingId",
-            "description": "The active agent telephony binding used to originate campaign calls."
+          "connection": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 128,
+            "description": "The Foundry connection name in the current project used to originate campaign calls. Its category selects Twilio or Azure Communication Services / Teams Phone Extension. No inbound telephony binding is required."
+          },
+          "source": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The caller identity used to originate campaign calls. For a Twilio connection, provide an authorized E.164 phone number. For an Azure Communication Services / Teams Phone Extension connection, provide the Teams Resource Account object ID. The identity type is inferred from the connection category; originating does not change inbound routing."
           },
           "purpose": {
             "type": "string",
@@ -38157,6 +38191,18 @@
           }
         },
         "description": "A request to create a draft outbound campaign.",
+        "examples": [
+          {
+            "display_name": "Teams Phone renewal reminders",
+            "connection": "telephony-acs",
+            "source": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+          },
+          {
+            "display_name": "Twilio renewal reminders",
+            "connection": "telephony-twilio",
+            "source": "+14255550100"
+          }
+        ],
         "x-ms-foundry-meta": {
           "required_previews": [
             "VoiceAgents=V1Preview"
@@ -87387,7 +87433,8 @@
         "type": "object",
         "required": [
           "destination",
-          "telephony_binding_id",
+          "connection",
+          "source",
           "id",
           "object",
           "agent_name",
@@ -87403,9 +87450,16 @@
             "$ref": "#/components/schemas/TelephonyOutboundDestination",
             "description": "The phone destination to call."
           },
-          "telephony_binding_id": {
-            "$ref": "#/components/schemas/TelephonyBindingId",
-            "description": "The active agent telephony binding used to originate the call."
+          "connection": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 128,
+            "description": "The Foundry connection name in the current project used to originate the call. Its category selects Twilio or Azure Communication Services / Teams Phone Extension. No inbound telephony binding is required."
+          },
+          "source": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The caller identity used to originate the call. For a Twilio connection, provide an authorized E.164 phone number. For an Azure Communication Services / Teams Phone Extension connection, provide the Teams Resource Account object ID. The identity type is inferred from the connection category; originating does not change inbound routing."
           },
           "purpose": {
             "type": "string",
@@ -88179,7 +88233,8 @@
         "type": "object",
         "required": [
           "display_name",
-          "telephony_binding_id",
+          "connection",
+          "source",
           "id",
           "object",
           "agent_name",
@@ -88196,9 +88251,16 @@
             "minLength": 1,
             "description": "A customer-visible name for the campaign."
           },
-          "telephony_binding_id": {
-            "$ref": "#/components/schemas/TelephonyBindingId",
-            "description": "The active agent telephony binding used to originate campaign calls."
+          "connection": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 128,
+            "description": "The Foundry connection name in the current project used to originate campaign calls. Its category selects Twilio or Azure Communication Services / Teams Phone Extension. No inbound telephony binding is required."
+          },
+          "source": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The caller identity used to originate campaign calls. For a Twilio connection, provide an authorized E.164 phone number. For an Azure Communication Services / Teams Phone Extension connection, provide the Teams Resource Account object ID. The identity type is inferred from the connection category; originating does not change inbound routing."
           },
           "purpose": {
             "type": "string",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -46068,12 +46068,12 @@ components:
       type: object
       required:
         - provider
-        - connection
+        - connection_name
       properties:
         provider:
           $ref: '#/components/schemas/TelephonyProvider'
           description: The telephony provider.
-        connection:
+        connection_name:
           type: string
           minLength: 1
           maxLength: 256
@@ -46095,13 +46095,13 @@ components:
       type: object
       required:
         - destination
-        - connection
+        - connection_name
         - source
       properties:
         destination:
           $ref: '#/components/schemas/TelephonyOutboundDestination'
           description: The phone destination to call.
-        connection:
+        connection_name:
           type: string
           minLength: 1
           maxLength: 256
@@ -46126,12 +46126,12 @@ components:
           description: The provider-attempt retry policy. Omit it for one attempt with no retry delay.
       description: A request to create one durable direct outbound call job.
       examples:
-        - connection: telephony-acs
+        - connection_name: telephony-acs
           source: aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa
           destination:
             type: phone_number
             value: '+14255550123'
-        - connection: telephony-twilio
+        - connection_name: telephony-twilio
           source: '+14255550100'
           destination:
             type: phone_number
@@ -46143,14 +46143,14 @@ components:
       type: object
       required:
         - display_name
-        - connection
+        - connection_name
         - source
       properties:
         display_name:
           type: string
           minLength: 1
           description: A customer-visible name for the campaign.
-        connection:
+        connection_name:
           type: string
           minLength: 1
           maxLength: 256
@@ -46172,10 +46172,10 @@ components:
       description: A request to create a draft outbound campaign.
       examples:
         - display_name: Teams Phone renewal reminders
-          connection: telephony-acs
+          connection_name: telephony-acs
           source: aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa
         - display_name: Twilio renewal reminders
-          connection: telephony-twilio
+          connection_name: telephony-twilio
           source: '+14255550100'
       x-ms-foundry-meta:
         required_previews:
@@ -81693,7 +81693,7 @@ components:
       required:
         - id
         - provider
-        - connection
+        - connection_name
         - status
         - incoming_call_url
       properties:
@@ -81703,7 +81703,7 @@ components:
         provider:
           $ref: '#/components/schemas/TelephonyProvider'
           description: The telephony provider.
-        connection:
+        connection_name:
           type: string
           minLength: 1
           maxLength: 256
@@ -81738,7 +81738,7 @@ components:
       required:
         - id
         - provider
-        - connection
+        - connection_name
         - status
         - incoming_call_url
         - etag
@@ -81749,7 +81749,7 @@ components:
         provider:
           $ref: '#/components/schemas/TelephonyProvider'
           description: The telephony provider.
-        connection:
+        connection_name:
           type: string
           minLength: 1
           maxLength: 256
@@ -81809,7 +81809,7 @@ components:
       type: object
       required:
         - destination
-        - connection
+        - connection_name
         - source
         - id
         - object
@@ -81824,7 +81824,7 @@ components:
         destination:
           $ref: '#/components/schemas/TelephonyOutboundDestination'
           description: The phone destination to call.
-        connection:
+        connection_name:
           type: string
           minLength: 1
           maxLength: 256
@@ -82387,7 +82387,7 @@ components:
       type: object
       required:
         - display_name
-        - connection
+        - connection_name
         - source
         - id
         - object
@@ -82403,7 +82403,7 @@ components:
           type: string
           minLength: 1
           description: A customer-visible name for the campaign.
-        connection:
+        connection_name:
           type: string
           minLength: 1
           maxLength: 256
@@ -83882,7 +83882,7 @@ components:
             - type: 'null'
           maxLength: 128
           description: The replacement display label. Omit it to preserve the current value; use null to clear it.
-        connection:
+        connection_name:
           type: string
           minLength: 1
           maxLength: 256

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -46104,10 +46104,10 @@ components:
         connection:
           type: string
           minLength: 1
-          maxLength: 128
+          maxLength: 256
           description: The Foundry connection name in the current project used to originate the call. Its category selects Twilio or Azure Communication Services / Teams Phone Extension. No inbound telephony binding is required.
         source:
-          type: string
+          $ref: '#/components/schemas/TelephonyOutboundSource'
           minLength: 1
           description: The caller identity used to originate the call. For a Twilio connection, provide an authorized E.164 phone number. For an Azure Communication Services / Teams Phone Extension connection, provide the Teams Resource Account object ID. The identity type is inferred from the connection category; originating does not change inbound routing.
         purpose:
@@ -46153,10 +46153,10 @@ components:
         connection:
           type: string
           minLength: 1
-          maxLength: 128
+          maxLength: 256
           description: The Foundry connection name in the current project used to originate campaign calls. Its category selects Twilio or Azure Communication Services / Teams Phone Extension. No inbound telephony binding is required.
         source:
-          type: string
+          $ref: '#/components/schemas/TelephonyOutboundSource'
           minLength: 1
           description: The caller identity used to originate campaign calls. For a Twilio connection, provide an authorized E.164 phone number. For an Azure Communication Services / Teams Phone Extension connection, provide the Teams Resource Account object ID. The identity type is inferred from the connection category; originating does not change inbound routing.
         purpose:
@@ -81827,10 +81827,10 @@ components:
         connection:
           type: string
           minLength: 1
-          maxLength: 128
+          maxLength: 256
           description: The Foundry connection name in the current project used to originate the call. Its category selects Twilio or Azure Communication Services / Teams Phone Extension. No inbound telephony binding is required.
         source:
-          type: string
+          $ref: '#/components/schemas/TelephonyOutboundSource'
           minLength: 1
           description: The caller identity used to originate the call. For a Twilio connection, provide an authorized E.164 phone number. For an Azure Communication Services / Teams Phone Extension connection, provide the Teams Resource Account object ID. The identity type is inferred from the connection category; originating does not change inbound routing.
         purpose:
@@ -82406,10 +82406,10 @@ components:
         connection:
           type: string
           minLength: 1
-          maxLength: 128
+          maxLength: 256
           description: The Foundry connection name in the current project used to originate campaign calls. Its category selects Twilio or Azure Communication Services / Teams Phone Extension. No inbound telephony binding is required.
         source:
-          type: string
+          $ref: '#/components/schemas/TelephonyOutboundSource'
           minLength: 1
           description: The caller identity used to originate campaign calls. For a Twilio connection, provide an authorized E.164 phone number. For an Azure Communication Services / Teams Phone Extension connection, provide the Teams Resource Account object ID. The identity type is inferred from the connection category; originating does not change inbound routing.
         purpose:
@@ -82958,6 +82958,15 @@ components:
           enum:
             - fixed_interval
       description: The retry strategy for an outbound call.
+      x-ms-foundry-meta:
+        required_previews:
+          - VoiceAgents=V1Preview
+    TelephonyOutboundSource:
+      type: string
+      minLength: 1
+      maxLength: 36
+      pattern: ^(?:\+[1-9][0-9]{1,14}|(?!00000000-0000-0000-0000-000000000000$)[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$
+      description: 'An outbound caller identity: an E.164 phone number or a non-empty Teams Resource Account UUID. The connection category determines which form is accepted.'
       x-ms-foundry-meta:
         required_previews:
           - VoiceAgents=V1Preview

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -46095,14 +46095,21 @@ components:
       type: object
       required:
         - destination
-        - telephony_binding_id
+        - connection
+        - source
       properties:
         destination:
           $ref: '#/components/schemas/TelephonyOutboundDestination'
           description: The phone destination to call.
-        telephony_binding_id:
-          $ref: '#/components/schemas/TelephonyBindingId'
-          description: The active agent telephony binding used to originate the call.
+        connection:
+          type: string
+          minLength: 1
+          maxLength: 128
+          description: The Foundry connection name in the current project used to originate the call. Its category selects Twilio or Azure Communication Services / Teams Phone Extension. No inbound telephony binding is required.
+        source:
+          type: string
+          minLength: 1
+          description: The caller identity used to originate the call. For a Twilio connection, provide an authorized E.164 phone number. For an Azure Communication Services / Teams Phone Extension connection, provide the Teams Resource Account object ID. The identity type is inferred from the connection category; originating does not change inbound routing.
         purpose:
           type: string
           minLength: 1
@@ -46118,6 +46125,17 @@ components:
           $ref: '#/components/schemas/TelephonyOutboundRetryPolicy'
           description: The provider-attempt retry policy. Omit it for one attempt with no retry delay.
       description: A request to create one durable direct outbound call job.
+      examples:
+        - connection: telephony-acs
+          source: aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa
+          destination:
+            type: phone_number
+            value: '+14255550123'
+        - connection: telephony-twilio
+          source: '+14255550100'
+          destination:
+            type: phone_number
+            value: '+14255550123'
       x-ms-foundry-meta:
         required_previews:
           - VoiceAgents=V1Preview
@@ -46125,15 +46143,22 @@ components:
       type: object
       required:
         - display_name
-        - telephony_binding_id
+        - connection
+        - source
       properties:
         display_name:
           type: string
           minLength: 1
           description: A customer-visible name for the campaign.
-        telephony_binding_id:
-          $ref: '#/components/schemas/TelephonyBindingId'
-          description: The active agent telephony binding used to originate campaign calls.
+        connection:
+          type: string
+          minLength: 1
+          maxLength: 128
+          description: The Foundry connection name in the current project used to originate campaign calls. Its category selects Twilio or Azure Communication Services / Teams Phone Extension. No inbound telephony binding is required.
+        source:
+          type: string
+          minLength: 1
+          description: The caller identity used to originate campaign calls. For a Twilio connection, provide an authorized E.164 phone number. For an Azure Communication Services / Teams Phone Extension connection, provide the Teams Resource Account object ID. The identity type is inferred from the connection category; originating does not change inbound routing.
         purpose:
           type: string
           minLength: 1
@@ -46145,6 +46170,13 @@ components:
           $ref: '#/components/schemas/TelephonyOutboundRetryPolicy'
           description: The provider-attempt retry policy inherited by every materialized call job.
       description: A request to create a draft outbound campaign.
+      examples:
+        - display_name: Teams Phone renewal reminders
+          connection: telephony-acs
+          source: aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa
+        - display_name: Twilio renewal reminders
+          connection: telephony-twilio
+          source: '+14255550100'
       x-ms-foundry-meta:
         required_previews:
           - VoiceAgents=V1Preview
@@ -81777,7 +81809,8 @@ components:
       type: object
       required:
         - destination
-        - telephony_binding_id
+        - connection
+        - source
         - id
         - object
         - agent_name
@@ -81791,9 +81824,15 @@ components:
         destination:
           $ref: '#/components/schemas/TelephonyOutboundDestination'
           description: The phone destination to call.
-        telephony_binding_id:
-          $ref: '#/components/schemas/TelephonyBindingId'
-          description: The active agent telephony binding used to originate the call.
+        connection:
+          type: string
+          minLength: 1
+          maxLength: 128
+          description: The Foundry connection name in the current project used to originate the call. Its category selects Twilio or Azure Communication Services / Teams Phone Extension. No inbound telephony binding is required.
+        source:
+          type: string
+          minLength: 1
+          description: The caller identity used to originate the call. For a Twilio connection, provide an authorized E.164 phone number. For an Azure Communication Services / Teams Phone Extension connection, provide the Teams Resource Account object ID. The identity type is inferred from the connection category; originating does not change inbound routing.
         purpose:
           type: string
           minLength: 1
@@ -82348,7 +82387,8 @@ components:
       type: object
       required:
         - display_name
-        - telephony_binding_id
+        - connection
+        - source
         - id
         - object
         - agent_name
@@ -82363,9 +82403,15 @@ components:
           type: string
           minLength: 1
           description: A customer-visible name for the campaign.
-        telephony_binding_id:
-          $ref: '#/components/schemas/TelephonyBindingId'
-          description: The active agent telephony binding used to originate campaign calls.
+        connection:
+          type: string
+          minLength: 1
+          maxLength: 128
+          description: The Foundry connection name in the current project used to originate campaign calls. Its category selects Twilio or Azure Communication Services / Teams Phone Extension. No inbound telephony binding is required.
+        source:
+          type: string
+          minLength: 1
+          description: The caller identity used to originate campaign calls. For a Twilio connection, provide an authorized E.164 phone number. For an Azure Communication Services / Teams Phone Extension connection, provide the Teams Resource Account object ID. The identity type is inferred from the connection category; originating does not change inbound routing.
         purpose:
           type: string
           minLength: 1

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -42555,16 +42555,24 @@
         "type": "object",
         "required": [
           "destination",
-          "telephony_binding_id"
+          "connection",
+          "source"
         ],
         "properties": {
           "destination": {
             "$ref": "#/components/schemas/TelephonyOutboundDestination",
             "description": "The phone destination to call."
           },
-          "telephony_binding_id": {
-            "$ref": "#/components/schemas/TelephonyBindingId",
-            "description": "The active agent telephony binding used to originate the call."
+          "connection": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 128,
+            "description": "The Foundry connection name in the current project used to originate the call. Its category selects Twilio or Azure Communication Services / Teams Phone Extension. No inbound telephony binding is required."
+          },
+          "source": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The caller identity used to originate the call. For a Twilio connection, provide an authorized E.164 phone number. For an Azure Communication Services / Teams Phone Extension connection, provide the Teams Resource Account object ID. The identity type is inferred from the connection category; originating does not change inbound routing."
           },
           "purpose": {
             "type": "string",
@@ -42586,6 +42594,24 @@
           }
         },
         "description": "A request to create one durable direct outbound call job.",
+        "examples": [
+          {
+            "connection": "telephony-acs",
+            "source": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "destination": {
+              "type": "phone_number",
+              "value": "+14255550123"
+            }
+          },
+          {
+            "connection": "telephony-twilio",
+            "source": "+14255550100",
+            "destination": {
+              "type": "phone_number",
+              "value": "+14255550123"
+            }
+          }
+        ],
         "x-ms-foundry-meta": {
           "required_previews": [
             "VoiceAgents=V1Preview"
@@ -42596,7 +42622,8 @@
         "type": "object",
         "required": [
           "display_name",
-          "telephony_binding_id"
+          "connection",
+          "source"
         ],
         "properties": {
           "display_name": {
@@ -42604,9 +42631,16 @@
             "minLength": 1,
             "description": "A customer-visible name for the campaign."
           },
-          "telephony_binding_id": {
-            "$ref": "#/components/schemas/TelephonyBindingId",
-            "description": "The active agent telephony binding used to originate campaign calls."
+          "connection": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 128,
+            "description": "The Foundry connection name in the current project used to originate campaign calls. Its category selects Twilio or Azure Communication Services / Teams Phone Extension. No inbound telephony binding is required."
+          },
+          "source": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The caller identity used to originate campaign calls. For a Twilio connection, provide an authorized E.164 phone number. For an Azure Communication Services / Teams Phone Extension connection, provide the Teams Resource Account object ID. The identity type is inferred from the connection category; originating does not change inbound routing."
           },
           "purpose": {
             "type": "string",
@@ -42623,6 +42657,18 @@
           }
         },
         "description": "A request to create a draft outbound campaign.",
+        "examples": [
+          {
+            "display_name": "Teams Phone renewal reminders",
+            "connection": "telephony-acs",
+            "source": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+          },
+          {
+            "display_name": "Twilio renewal reminders",
+            "connection": "telephony-twilio",
+            "source": "+14255550100"
+          }
+        ],
         "x-ms-foundry-meta": {
           "required_previews": [
             "VoiceAgents=V1Preview"
@@ -93011,7 +93057,8 @@
         "type": "object",
         "required": [
           "destination",
-          "telephony_binding_id",
+          "connection",
+          "source",
           "id",
           "object",
           "agent_name",
@@ -93027,9 +93074,16 @@
             "$ref": "#/components/schemas/TelephonyOutboundDestination",
             "description": "The phone destination to call."
           },
-          "telephony_binding_id": {
-            "$ref": "#/components/schemas/TelephonyBindingId",
-            "description": "The active agent telephony binding used to originate the call."
+          "connection": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 128,
+            "description": "The Foundry connection name in the current project used to originate the call. Its category selects Twilio or Azure Communication Services / Teams Phone Extension. No inbound telephony binding is required."
+          },
+          "source": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The caller identity used to originate the call. For a Twilio connection, provide an authorized E.164 phone number. For an Azure Communication Services / Teams Phone Extension connection, provide the Teams Resource Account object ID. The identity type is inferred from the connection category; originating does not change inbound routing."
           },
           "purpose": {
             "type": "string",
@@ -93803,7 +93857,8 @@
         "type": "object",
         "required": [
           "display_name",
-          "telephony_binding_id",
+          "connection",
+          "source",
           "id",
           "object",
           "agent_name",
@@ -93820,9 +93875,16 @@
             "minLength": 1,
             "description": "A customer-visible name for the campaign."
           },
-          "telephony_binding_id": {
-            "$ref": "#/components/schemas/TelephonyBindingId",
-            "description": "The active agent telephony binding used to originate campaign calls."
+          "connection": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 128,
+            "description": "The Foundry connection name in the current project used to originate campaign calls. Its category selects Twilio or Azure Communication Services / Teams Phone Extension. No inbound telephony binding is required."
+          },
+          "source": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The caller identity used to originate campaign calls. For a Twilio connection, provide an authorized E.164 phone number. For an Azure Communication Services / Teams Phone Extension connection, provide the Teams Resource Account object ID. The identity type is inferred from the connection category; originating does not change inbound routing."
           },
           "purpose": {
             "type": "string",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -42518,14 +42518,14 @@
         "type": "object",
         "required": [
           "provider",
-          "connection"
+          "connection_name"
         ],
         "properties": {
           "provider": {
             "$ref": "#/components/schemas/TelephonyProvider",
             "description": "The telephony provider."
           },
-          "connection": {
+          "connection_name": {
             "type": "string",
             "minLength": 1,
             "maxLength": 256,
@@ -42555,7 +42555,7 @@
         "type": "object",
         "required": [
           "destination",
-          "connection",
+          "connection_name",
           "source"
         ],
         "properties": {
@@ -42563,7 +42563,7 @@
             "$ref": "#/components/schemas/TelephonyOutboundDestination",
             "description": "The phone destination to call."
           },
-          "connection": {
+          "connection_name": {
             "type": "string",
             "minLength": 1,
             "maxLength": 256,
@@ -42596,7 +42596,7 @@
         "description": "A request to create one durable direct outbound call job.",
         "examples": [
           {
-            "connection": "telephony-acs",
+            "connection_name": "telephony-acs",
             "source": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
             "destination": {
               "type": "phone_number",
@@ -42604,7 +42604,7 @@
             }
           },
           {
-            "connection": "telephony-twilio",
+            "connection_name": "telephony-twilio",
             "source": "+14255550100",
             "destination": {
               "type": "phone_number",
@@ -42622,7 +42622,7 @@
         "type": "object",
         "required": [
           "display_name",
-          "connection",
+          "connection_name",
           "source"
         ],
         "properties": {
@@ -42631,7 +42631,7 @@
             "minLength": 1,
             "description": "A customer-visible name for the campaign."
           },
-          "connection": {
+          "connection_name": {
             "type": "string",
             "minLength": 1,
             "maxLength": 256,
@@ -42660,12 +42660,12 @@
         "examples": [
           {
             "display_name": "Teams Phone renewal reminders",
-            "connection": "telephony-acs",
+            "connection_name": "telephony-acs",
             "source": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
           },
           {
             "display_name": "Twilio renewal reminders",
-            "connection": "telephony-twilio",
+            "connection_name": "telephony-twilio",
             "source": "+14255550100"
           }
         ],
@@ -92894,7 +92894,7 @@
         "required": [
           "id",
           "provider",
-          "connection",
+          "connection_name",
           "status",
           "incoming_call_url"
         ],
@@ -92907,7 +92907,7 @@
             "$ref": "#/components/schemas/TelephonyProvider",
             "description": "The telephony provider."
           },
-          "connection": {
+          "connection_name": {
             "type": "string",
             "minLength": 1,
             "maxLength": 256,
@@ -92953,7 +92953,7 @@
         "required": [
           "id",
           "provider",
-          "connection",
+          "connection_name",
           "status",
           "incoming_call_url",
           "etag"
@@ -92967,7 +92967,7 @@
             "$ref": "#/components/schemas/TelephonyProvider",
             "description": "The telephony provider."
           },
-          "connection": {
+          "connection_name": {
             "type": "string",
             "minLength": 1,
             "maxLength": 256,
@@ -93057,7 +93057,7 @@
         "type": "object",
         "required": [
           "destination",
-          "connection",
+          "connection_name",
           "source",
           "id",
           "object",
@@ -93074,7 +93074,7 @@
             "$ref": "#/components/schemas/TelephonyOutboundDestination",
             "description": "The phone destination to call."
           },
-          "connection": {
+          "connection_name": {
             "type": "string",
             "minLength": 1,
             "maxLength": 256,
@@ -93857,7 +93857,7 @@
         "type": "object",
         "required": [
           "display_name",
-          "connection",
+          "connection_name",
           "source",
           "id",
           "object",
@@ -93875,7 +93875,7 @@
             "minLength": 1,
             "description": "A customer-visible name for the campaign."
           },
-          "connection": {
+          "connection_name": {
             "type": "string",
             "minLength": 1,
             "maxLength": 256,
@@ -96053,7 +96053,7 @@
             "maxLength": 128,
             "description": "The replacement display label. Omit it to preserve the current value; use null to clear it."
           },
-          "connection": {
+          "connection_name": {
             "type": "string",
             "minLength": 1,
             "maxLength": 256,

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -42566,11 +42566,11 @@
           "connection": {
             "type": "string",
             "minLength": 1,
-            "maxLength": 128,
+            "maxLength": 256,
             "description": "The Foundry connection name in the current project used to originate the call. Its category selects Twilio or Azure Communication Services / Teams Phone Extension. No inbound telephony binding is required."
           },
           "source": {
-            "type": "string",
+            "$ref": "#/components/schemas/TelephonyOutboundSource",
             "minLength": 1,
             "description": "The caller identity used to originate the call. For a Twilio connection, provide an authorized E.164 phone number. For an Azure Communication Services / Teams Phone Extension connection, provide the Teams Resource Account object ID. The identity type is inferred from the connection category; originating does not change inbound routing."
           },
@@ -42634,11 +42634,11 @@
           "connection": {
             "type": "string",
             "minLength": 1,
-            "maxLength": 128,
+            "maxLength": 256,
             "description": "The Foundry connection name in the current project used to originate campaign calls. Its category selects Twilio or Azure Communication Services / Teams Phone Extension. No inbound telephony binding is required."
           },
           "source": {
-            "type": "string",
+            "$ref": "#/components/schemas/TelephonyOutboundSource",
             "minLength": 1,
             "description": "The caller identity used to originate campaign calls. For a Twilio connection, provide an authorized E.164 phone number. For an Azure Communication Services / Teams Phone Extension connection, provide the Teams Resource Account object ID. The identity type is inferred from the connection category; originating does not change inbound routing."
           },
@@ -93077,11 +93077,11 @@
           "connection": {
             "type": "string",
             "minLength": 1,
-            "maxLength": 128,
+            "maxLength": 256,
             "description": "The Foundry connection name in the current project used to originate the call. Its category selects Twilio or Azure Communication Services / Teams Phone Extension. No inbound telephony binding is required."
           },
           "source": {
-            "type": "string",
+            "$ref": "#/components/schemas/TelephonyOutboundSource",
             "minLength": 1,
             "description": "The caller identity used to originate the call. For a Twilio connection, provide an authorized E.164 phone number. For an Azure Communication Services / Teams Phone Extension connection, provide the Teams Resource Account object ID. The identity type is inferred from the connection category; originating does not change inbound routing."
           },
@@ -93878,11 +93878,11 @@
           "connection": {
             "type": "string",
             "minLength": 1,
-            "maxLength": 128,
+            "maxLength": 256,
             "description": "The Foundry connection name in the current project used to originate campaign calls. Its category selects Twilio or Azure Communication Services / Teams Phone Extension. No inbound telephony binding is required."
           },
           "source": {
-            "type": "string",
+            "$ref": "#/components/schemas/TelephonyOutboundSource",
             "minLength": 1,
             "description": "The caller identity used to originate campaign calls. For a Twilio connection, provide an authorized E.164 phone number. For an Azure Communication Services / Teams Phone Extension connection, provide the Teams Resource Account object ID. The identity type is inferred from the connection category; originating does not change inbound routing."
           },
@@ -94695,6 +94695,18 @@
           }
         ],
         "description": "The retry strategy for an outbound call.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "VoiceAgents=V1Preview"
+          ]
+        }
+      },
+      "TelephonyOutboundSource": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 36,
+        "pattern": "^(?:\\+[1-9][0-9]{1,14}|(?!00000000-0000-0000-0000-000000000000$)[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$",
+        "description": "An outbound caller identity: an E.164 phone number or a non-empty Teams Resource Account UUID. The connection category determines which form is accepted.",
         "x-ms-foundry-meta": {
           "required_previews": [
             "VoiceAgents=V1Preview"

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -49091,12 +49091,12 @@ components:
       type: object
       required:
         - provider
-        - connection
+        - connection_name
       properties:
         provider:
           $ref: '#/components/schemas/TelephonyProvider'
           description: The telephony provider.
-        connection:
+        connection_name:
           type: string
           minLength: 1
           maxLength: 256
@@ -49118,13 +49118,13 @@ components:
       type: object
       required:
         - destination
-        - connection
+        - connection_name
         - source
       properties:
         destination:
           $ref: '#/components/schemas/TelephonyOutboundDestination'
           description: The phone destination to call.
-        connection:
+        connection_name:
           type: string
           minLength: 1
           maxLength: 256
@@ -49149,12 +49149,12 @@ components:
           description: The provider-attempt retry policy. Omit it for one attempt with no retry delay.
       description: A request to create one durable direct outbound call job.
       examples:
-        - connection: telephony-acs
+        - connection_name: telephony-acs
           source: aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa
           destination:
             type: phone_number
             value: '+14255550123'
-        - connection: telephony-twilio
+        - connection_name: telephony-twilio
           source: '+14255550100'
           destination:
             type: phone_number
@@ -49166,14 +49166,14 @@ components:
       type: object
       required:
         - display_name
-        - connection
+        - connection_name
         - source
       properties:
         display_name:
           type: string
           minLength: 1
           description: A customer-visible name for the campaign.
-        connection:
+        connection_name:
           type: string
           minLength: 1
           maxLength: 256
@@ -49195,10 +49195,10 @@ components:
       description: A request to create a draft outbound campaign.
       examples:
         - display_name: Teams Phone renewal reminders
-          connection: telephony-acs
+          connection_name: telephony-acs
           source: aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa
         - display_name: Twilio renewal reminders
-          connection: telephony-twilio
+          connection_name: telephony-twilio
           source: '+14255550100'
       x-ms-foundry-meta:
         required_previews:
@@ -85565,7 +85565,7 @@ components:
       required:
         - id
         - provider
-        - connection
+        - connection_name
         - status
         - incoming_call_url
       properties:
@@ -85575,7 +85575,7 @@ components:
         provider:
           $ref: '#/components/schemas/TelephonyProvider'
           description: The telephony provider.
-        connection:
+        connection_name:
           type: string
           minLength: 1
           maxLength: 256
@@ -85610,7 +85610,7 @@ components:
       required:
         - id
         - provider
-        - connection
+        - connection_name
         - status
         - incoming_call_url
         - etag
@@ -85621,7 +85621,7 @@ components:
         provider:
           $ref: '#/components/schemas/TelephonyProvider'
           description: The telephony provider.
-        connection:
+        connection_name:
           type: string
           minLength: 1
           maxLength: 256
@@ -85681,7 +85681,7 @@ components:
       type: object
       required:
         - destination
-        - connection
+        - connection_name
         - source
         - id
         - object
@@ -85696,7 +85696,7 @@ components:
         destination:
           $ref: '#/components/schemas/TelephonyOutboundDestination'
           description: The phone destination to call.
-        connection:
+        connection_name:
           type: string
           minLength: 1
           maxLength: 256
@@ -86259,7 +86259,7 @@ components:
       type: object
       required:
         - display_name
-        - connection
+        - connection_name
         - source
         - id
         - object
@@ -86275,7 +86275,7 @@ components:
           type: string
           minLength: 1
           description: A customer-visible name for the campaign.
-        connection:
+        connection_name:
           type: string
           minLength: 1
           maxLength: 256
@@ -87789,7 +87789,7 @@ components:
             - type: 'null'
           maxLength: 128
           description: The replacement display label. Omit it to preserve the current value; use null to clear it.
-        connection:
+        connection_name:
           type: string
           minLength: 1
           maxLength: 256

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -49127,10 +49127,10 @@ components:
         connection:
           type: string
           minLength: 1
-          maxLength: 128
+          maxLength: 256
           description: The Foundry connection name in the current project used to originate the call. Its category selects Twilio or Azure Communication Services / Teams Phone Extension. No inbound telephony binding is required.
         source:
-          type: string
+          $ref: '#/components/schemas/TelephonyOutboundSource'
           minLength: 1
           description: The caller identity used to originate the call. For a Twilio connection, provide an authorized E.164 phone number. For an Azure Communication Services / Teams Phone Extension connection, provide the Teams Resource Account object ID. The identity type is inferred from the connection category; originating does not change inbound routing.
         purpose:
@@ -49176,10 +49176,10 @@ components:
         connection:
           type: string
           minLength: 1
-          maxLength: 128
+          maxLength: 256
           description: The Foundry connection name in the current project used to originate campaign calls. Its category selects Twilio or Azure Communication Services / Teams Phone Extension. No inbound telephony binding is required.
         source:
-          type: string
+          $ref: '#/components/schemas/TelephonyOutboundSource'
           minLength: 1
           description: The caller identity used to originate campaign calls. For a Twilio connection, provide an authorized E.164 phone number. For an Azure Communication Services / Teams Phone Extension connection, provide the Teams Resource Account object ID. The identity type is inferred from the connection category; originating does not change inbound routing.
         purpose:
@@ -85699,10 +85699,10 @@ components:
         connection:
           type: string
           minLength: 1
-          maxLength: 128
+          maxLength: 256
           description: The Foundry connection name in the current project used to originate the call. Its category selects Twilio or Azure Communication Services / Teams Phone Extension. No inbound telephony binding is required.
         source:
-          type: string
+          $ref: '#/components/schemas/TelephonyOutboundSource'
           minLength: 1
           description: The caller identity used to originate the call. For a Twilio connection, provide an authorized E.164 phone number. For an Azure Communication Services / Teams Phone Extension connection, provide the Teams Resource Account object ID. The identity type is inferred from the connection category; originating does not change inbound routing.
         purpose:
@@ -86278,10 +86278,10 @@ components:
         connection:
           type: string
           minLength: 1
-          maxLength: 128
+          maxLength: 256
           description: The Foundry connection name in the current project used to originate campaign calls. Its category selects Twilio or Azure Communication Services / Teams Phone Extension. No inbound telephony binding is required.
         source:
-          type: string
+          $ref: '#/components/schemas/TelephonyOutboundSource'
           minLength: 1
           description: The caller identity used to originate campaign calls. For a Twilio connection, provide an authorized E.164 phone number. For an Azure Communication Services / Teams Phone Extension connection, provide the Teams Resource Account object ID. The identity type is inferred from the connection category; originating does not change inbound routing.
         purpose:
@@ -86830,6 +86830,15 @@ components:
           enum:
             - fixed_interval
       description: The retry strategy for an outbound call.
+      x-ms-foundry-meta:
+        required_previews:
+          - VoiceAgents=V1Preview
+    TelephonyOutboundSource:
+      type: string
+      minLength: 1
+      maxLength: 36
+      pattern: ^(?:\+[1-9][0-9]{1,14}|(?!00000000-0000-0000-0000-000000000000$)[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$
+      description: 'An outbound caller identity: an E.164 phone number or a non-empty Teams Resource Account UUID. The connection category determines which form is accepted.'
       x-ms-foundry-meta:
         required_previews:
           - VoiceAgents=V1Preview

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -49118,14 +49118,21 @@ components:
       type: object
       required:
         - destination
-        - telephony_binding_id
+        - connection
+        - source
       properties:
         destination:
           $ref: '#/components/schemas/TelephonyOutboundDestination'
           description: The phone destination to call.
-        telephony_binding_id:
-          $ref: '#/components/schemas/TelephonyBindingId'
-          description: The active agent telephony binding used to originate the call.
+        connection:
+          type: string
+          minLength: 1
+          maxLength: 128
+          description: The Foundry connection name in the current project used to originate the call. Its category selects Twilio or Azure Communication Services / Teams Phone Extension. No inbound telephony binding is required.
+        source:
+          type: string
+          minLength: 1
+          description: The caller identity used to originate the call. For a Twilio connection, provide an authorized E.164 phone number. For an Azure Communication Services / Teams Phone Extension connection, provide the Teams Resource Account object ID. The identity type is inferred from the connection category; originating does not change inbound routing.
         purpose:
           type: string
           minLength: 1
@@ -49141,6 +49148,17 @@ components:
           $ref: '#/components/schemas/TelephonyOutboundRetryPolicy'
           description: The provider-attempt retry policy. Omit it for one attempt with no retry delay.
       description: A request to create one durable direct outbound call job.
+      examples:
+        - connection: telephony-acs
+          source: aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa
+          destination:
+            type: phone_number
+            value: '+14255550123'
+        - connection: telephony-twilio
+          source: '+14255550100'
+          destination:
+            type: phone_number
+            value: '+14255550123'
       x-ms-foundry-meta:
         required_previews:
           - VoiceAgents=V1Preview
@@ -49148,15 +49166,22 @@ components:
       type: object
       required:
         - display_name
-        - telephony_binding_id
+        - connection
+        - source
       properties:
         display_name:
           type: string
           minLength: 1
           description: A customer-visible name for the campaign.
-        telephony_binding_id:
-          $ref: '#/components/schemas/TelephonyBindingId'
-          description: The active agent telephony binding used to originate campaign calls.
+        connection:
+          type: string
+          minLength: 1
+          maxLength: 128
+          description: The Foundry connection name in the current project used to originate campaign calls. Its category selects Twilio or Azure Communication Services / Teams Phone Extension. No inbound telephony binding is required.
+        source:
+          type: string
+          minLength: 1
+          description: The caller identity used to originate campaign calls. For a Twilio connection, provide an authorized E.164 phone number. For an Azure Communication Services / Teams Phone Extension connection, provide the Teams Resource Account object ID. The identity type is inferred from the connection category; originating does not change inbound routing.
         purpose:
           type: string
           minLength: 1
@@ -49168,6 +49193,13 @@ components:
           $ref: '#/components/schemas/TelephonyOutboundRetryPolicy'
           description: The provider-attempt retry policy inherited by every materialized call job.
       description: A request to create a draft outbound campaign.
+      examples:
+        - display_name: Teams Phone renewal reminders
+          connection: telephony-acs
+          source: aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa
+        - display_name: Twilio renewal reminders
+          connection: telephony-twilio
+          source: '+14255550100'
       x-ms-foundry-meta:
         required_previews:
           - VoiceAgents=V1Preview
@@ -85649,7 +85681,8 @@ components:
       type: object
       required:
         - destination
-        - telephony_binding_id
+        - connection
+        - source
         - id
         - object
         - agent_name
@@ -85663,9 +85696,15 @@ components:
         destination:
           $ref: '#/components/schemas/TelephonyOutboundDestination'
           description: The phone destination to call.
-        telephony_binding_id:
-          $ref: '#/components/schemas/TelephonyBindingId'
-          description: The active agent telephony binding used to originate the call.
+        connection:
+          type: string
+          minLength: 1
+          maxLength: 128
+          description: The Foundry connection name in the current project used to originate the call. Its category selects Twilio or Azure Communication Services / Teams Phone Extension. No inbound telephony binding is required.
+        source:
+          type: string
+          minLength: 1
+          description: The caller identity used to originate the call. For a Twilio connection, provide an authorized E.164 phone number. For an Azure Communication Services / Teams Phone Extension connection, provide the Teams Resource Account object ID. The identity type is inferred from the connection category; originating does not change inbound routing.
         purpose:
           type: string
           minLength: 1
@@ -86220,7 +86259,8 @@ components:
       type: object
       required:
         - display_name
-        - telephony_binding_id
+        - connection
+        - source
         - id
         - object
         - agent_name
@@ -86235,9 +86275,15 @@ components:
           type: string
           minLength: 1
           description: A customer-visible name for the campaign.
-        telephony_binding_id:
-          $ref: '#/components/schemas/TelephonyBindingId'
-          description: The active agent telephony binding used to originate campaign calls.
+        connection:
+          type: string
+          minLength: 1
+          maxLength: 128
+          description: The Foundry connection name in the current project used to originate campaign calls. Its category selects Twilio or Azure Communication Services / Teams Phone Extension. No inbound telephony binding is required.
+        source:
+          type: string
+          minLength: 1
+          description: The caller identity used to originate campaign calls. For a Twilio connection, provide an authorized E.164 phone number. For an Azure Communication Services / Teams Phone Extension connection, provide the Teams Resource Account object ID. The identity type is inferred from the connection category; originating does not change inbound routing.
         purpose:
           type: string
           minLength: 1

--- a/specification/ai-foundry/data-plane/Foundry/src/voice-agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/voice-agents/models.tsp
@@ -1267,8 +1267,14 @@ model TelephonyCallJobConfiguration {
   @doc("The phone destination to call.")
   destination: TelephonyOutboundDestination;
 
-  @doc("The active agent telephony binding used to originate the call.")
-  telephony_binding_id: TelephonyBindingId;
+  @doc("The Foundry connection name in the current project used to originate the call. Its category selects Twilio or Azure Communication Services / Teams Phone Extension. No inbound telephony binding is required.")
+  @minLength(1)
+  @maxLength(128)
+  connection: string;
+
+  @doc("The caller identity used to originate the call. For a Twilio connection, provide an authorized E.164 phone number. For an Azure Communication Services / Teams Phone Extension connection, provide the Teams Resource Account object ID. The identity type is inferred from the connection category; originating does not change inbound routing.")
+  @minLength(1)
+  source: string;
 
   @doc("An optional customer-declared purpose for placing the call.")
   @minLength(1)
@@ -1284,6 +1290,16 @@ model TelephonyCallJobConfiguration {
 @doc("A request to create one durable direct outbound call job.")
 @extension("x-ms-foundry-meta", VoiceAgentRequiredPreview)
 @clientName("CreateTelephonyCallJobContent", "csharp")
+@example(#{
+  connection: "telephony-twilio",
+  source: "+14255550100",
+  destination: #{ type: "phone_number", value: "+14255550123" },
+})
+@example(#{
+  connection: "telephony-acs",
+  source: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+  destination: #{ type: "phone_number", value: "+14255550123" },
+})
 model CreateTelephonyCallJobRequest {
   ...TelephonyCallJobConfiguration;
 
@@ -1409,8 +1425,14 @@ model TelephonyCampaignConfiguration {
   @minLength(1)
   display_name: string;
 
-  @doc("The active agent telephony binding used to originate campaign calls.")
-  telephony_binding_id: TelephonyBindingId;
+  @doc("The Foundry connection name in the current project used to originate campaign calls. Its category selects Twilio or Azure Communication Services / Teams Phone Extension. No inbound telephony binding is required.")
+  @minLength(1)
+  @maxLength(128)
+  connection: string;
+
+  @doc("The caller identity used to originate campaign calls. For a Twilio connection, provide an authorized E.164 phone number. For an Azure Communication Services / Teams Phone Extension connection, provide the Teams Resource Account object ID. The identity type is inferred from the connection category; originating does not change inbound routing.")
+  @minLength(1)
+  source: string;
 
   @doc("An optional customer-declared purpose for campaign calls.")
   @minLength(1)
@@ -1423,6 +1445,16 @@ model TelephonyCampaignConfiguration {
 @doc("A request to create a draft outbound campaign.")
 @extension("x-ms-foundry-meta", VoiceAgentRequiredPreview)
 @clientName("CreateTelephonyCampaignContent", "csharp")
+@example(#{
+  display_name: "Twilio renewal reminders",
+  connection: "telephony-twilio",
+  source: "+14255550100",
+})
+@example(#{
+  display_name: "Teams Phone renewal reminders",
+  connection: "telephony-acs",
+  source: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+})
 model CreateTelephonyCampaignRequest {
   ...TelephonyCampaignConfiguration;
 

--- a/specification/ai-foundry/data-plane/Foundry/src/voice-agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/voice-agents/models.tsp
@@ -553,7 +553,7 @@ model CreateTelephonyBindingRequest {
   @doc("The Foundry connection name for the telephony provider.")
   @minLength(1)
   @maxLength(256)
-  connection: string;
+  connection_name: string;
 
   @doc("An optional display label for the binding.")
   @maxLength(128)
@@ -603,7 +603,7 @@ model UpdateTelephonyBindingRequest {
   @doc("The replacement Foundry connection name. This property is valid only for a Teams Phone Extension binding; a Twilio binding's connection is immutable.")
   @minLength(1)
   @maxLength(256)
-  connection?: string;
+  connection_name?: string;
 
   @doc("The replacement Teams Phone Extension display phone number. Omit it to preserve the current value; use null to clear it. This property is valid only for a Teams Phone Extension binding.")
   @maxLength(64)
@@ -623,7 +623,7 @@ model TelephonyBinding {
   @doc("The Foundry connection name for the telephony provider.")
   @minLength(1)
   @maxLength(256)
-  connection: string;
+  connection_name: string;
 
   @doc("The optional display label for the binding.")
   @maxLength(128)
@@ -674,7 +674,7 @@ model TelephonyBindingListItem {
   @doc("The Foundry connection name for the telephony provider.")
   @minLength(1)
   @maxLength(256)
-  connection: string;
+  connection_name: string;
 
   @doc("The optional display label for the binding.")
   @maxLength(128)
@@ -1277,7 +1277,7 @@ model TelephonyCallJobConfiguration {
   @doc("The Foundry connection name in the current project used to originate the call. Its category selects Twilio or Azure Communication Services / Teams Phone Extension. No inbound telephony binding is required.")
   @minLength(1)
   @maxLength(256)
-  connection: string;
+  connection_name: string;
 
   @doc("The caller identity used to originate the call. For a Twilio connection, provide an authorized E.164 phone number. For an Azure Communication Services / Teams Phone Extension connection, provide the Teams Resource Account object ID. The identity type is inferred from the connection category; originating does not change inbound routing.")
   @minLength(1)
@@ -1298,12 +1298,12 @@ model TelephonyCallJobConfiguration {
 @extension("x-ms-foundry-meta", VoiceAgentRequiredPreview)
 @clientName("CreateTelephonyCallJobContent", "csharp")
 @example(#{
-  connection: "telephony-twilio",
+  connection_name: "telephony-twilio",
   source: "+14255550100",
   destination: #{ type: "phone_number", value: "+14255550123" },
 })
 @example(#{
-  connection: "telephony-acs",
+  connection_name: "telephony-acs",
   source: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
   destination: #{ type: "phone_number", value: "+14255550123" },
 })
@@ -1435,7 +1435,7 @@ model TelephonyCampaignConfiguration {
   @doc("The Foundry connection name in the current project used to originate campaign calls. Its category selects Twilio or Azure Communication Services / Teams Phone Extension. No inbound telephony binding is required.")
   @minLength(1)
   @maxLength(256)
-  connection: string;
+  connection_name: string;
 
   @doc("The caller identity used to originate campaign calls. For a Twilio connection, provide an authorized E.164 phone number. For an Azure Communication Services / Teams Phone Extension connection, provide the Teams Resource Account object ID. The identity type is inferred from the connection category; originating does not change inbound routing.")
   @minLength(1)
@@ -1454,12 +1454,12 @@ model TelephonyCampaignConfiguration {
 @clientName("CreateTelephonyCampaignContent", "csharp")
 @example(#{
   display_name: "Twilio renewal reminders",
-  connection: "telephony-twilio",
+  connection_name: "telephony-twilio",
   source: "+14255550100",
 })
 @example(#{
   display_name: "Teams Phone renewal reminders",
-  connection: "telephony-acs",
+  connection_name: "telephony-acs",
   source: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
 })
 model CreateTelephonyCampaignRequest {

--- a/specification/ai-foundry/data-plane/Foundry/src/voice-agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/voice-agents/models.tsp
@@ -1261,6 +1261,13 @@ model TelephonyCallJobSchedule {
   expires_at?: FoundryTimestamp;
 }
 
+@doc("An outbound caller identity: an E.164 phone number or a non-empty Teams Resource Account UUID. The connection category determines which form is accepted.")
+@extension("x-ms-foundry-meta", VoiceAgentRequiredPreview)
+@minLength(1)
+@maxLength(36)
+@pattern("^(?:\\+[1-9][0-9]{1,14}|(?!00000000-0000-0000-0000-000000000000$)[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$")
+scalar TelephonyOutboundSource extends string;
+
 @doc("Customer-controlled configuration shared by direct and campaign-created call jobs.")
 @extension("x-ms-foundry-meta", VoiceAgentRequiredPreview)
 model TelephonyCallJobConfiguration {
@@ -1269,12 +1276,12 @@ model TelephonyCallJobConfiguration {
 
   @doc("The Foundry connection name in the current project used to originate the call. Its category selects Twilio or Azure Communication Services / Teams Phone Extension. No inbound telephony binding is required.")
   @minLength(1)
-  @maxLength(128)
+  @maxLength(256)
   connection: string;
 
   @doc("The caller identity used to originate the call. For a Twilio connection, provide an authorized E.164 phone number. For an Azure Communication Services / Teams Phone Extension connection, provide the Teams Resource Account object ID. The identity type is inferred from the connection category; originating does not change inbound routing.")
   @minLength(1)
-  source: string;
+  source: TelephonyOutboundSource;
 
   @doc("An optional customer-declared purpose for placing the call.")
   @minLength(1)
@@ -1427,12 +1434,12 @@ model TelephonyCampaignConfiguration {
 
   @doc("The Foundry connection name in the current project used to originate campaign calls. Its category selects Twilio or Azure Communication Services / Teams Phone Extension. No inbound telephony binding is required.")
   @minLength(1)
-  @maxLength(128)
+  @maxLength(256)
   connection: string;
 
   @doc("The caller identity used to originate campaign calls. For a Twilio connection, provide an authorized E.164 phone number. For an Azure Communication Services / Teams Phone Extension connection, provide the Teams Resource Account object ID. The identity type is inferred from the connection category; originating does not change inbound routing.")
   @minLength(1)
-  source: string;
+  source: TelephonyOutboundSource;
 
   @doc("An optional customer-declared purpose for campaign calls.")
   @minLength(1)


### PR DESCRIPTION
# Data Plane API Specification Update

## Summary

Replace the outbound `telephony_binding_id` property with **required** `connection` and **required string** `source` properties for CallJobs and Campaigns. Outbound transport selection must not require moving a phone number's inbound routing to the Agent making the call.

The connection category determines the provider and the source identity type:

- Twilio: `source` is an authorized E.164 caller ID.
- Azure Communication Services / Teams Phone Extension: `source` is a Teams Resource Account object ID.

There is no `source.type` or `source.value` wrapper. The connection name resolves in the current project, and the Agent remains the one selected by the resource route.

## Examples

Twilio CallJob:

```json
{
  "connection": "telephony-twilio",
  "source": "+14255550100",
  "destination": { "type": "phone_number", "value": "+14255550123" }
}
```

ACS/TPE Campaign:

```json
{
  "display_name": "Renewal reminders",
  "connection": "telephony-acs",
  "source": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
}
```

## Change scope

- Base: `feature/foundry-release`, which contains the outbound contract merged through #46049 and #45852. `main` does not yet contain these outbound models.
- Update shared `TelephonyCallJobConfiguration` and `TelephonyCampaignConfiguration`. Requiredness propagates to both create requests and returned resources.
- Regenerate JSON and YAML OpenAPI for `v1` and `virtual-public-preview`.
- Add compiler-checked Twilio and ACS/TPE examples to both create request models.
- Use the established 256-character connection-name limit and a shared string scalar constrained to E.164 or a canonical non-zero UUID.
- Leave inbound binding APIs, destination shape, scheduling, retry, structured inputs, and routes unchanged.

## API Info / Compatibility

- [x] Public preview feature, gated by `VoiceAgents=V1Preview`.
- This intentionally changes the existing **preview** outbound contract: `telephony_binding_id` is removed and both replacement fields are required. It is not an optional additive alias.
- Existing binding resources still use `TelephonyBindingId`; that scalar and inbound routing are unchanged.
- Coordinate service rollout and SDK adoption. A runtime may retain legacy binding requests for migration, but they are not part of this new public contract. Returned resources consumed through this contract must supply `connection` and `source`, including migrated legacy resources.
- No claim of deployment or generated language-SDK validation is made by this specification PR.

## Validation

- TypeSpec 1.15.0 compilation with the repository dependencies and Node 24: passed.
- TypeSpec formatting and Prettier with the TypeSpec plugin: passed.
- Generated-schema checks across both API versions: **344 positive/negative cases passed**, covering requiredness, string types, empty/null/object/array/numeric/boolean rejection, and the full generated request examples.
- Semantic comparison against the base: only the four outbound create/resource schemas and their shared constrained source scalar change; unrelated schemas and paths are identical.
- Repeated compilation produces identical generated output.
- `git diff --check`: passed.

The transport field negative tests use the emitted property schemas; full request examples are validated against the generated schemas and their references. Provider-specific phone/RA compatibility is documented here and enforced by the service, since connection category is resolved at runtime.
