### PR TITLE
Add browser session recording API

### DIFF
--- a/specification/loadtestservice/data-plane/playwright/examples/2026-10-01-preview/AccessTokens_CreateOrReplace.json
+++ b/specification/loadtestservice/data-plane/playwright/examples/2026-10-01-preview/AccessTokens_CreateOrReplace.json
@@ -1,0 +1,35 @@
+{
+  "title": "AccessTokens_CreateOrReplace",
+  "operationId": "AccessTokens_CreateOrReplace",
+  "parameters": {
+    "api-version": "2026-10-01-preview",
+    "workspaceId": "00000000-0000-0000-0000-000000000000",
+    "accessTokenId": "00000000-0000-0000-0000-000000000000",
+    "resource": {
+      "name": "sampleAccessToken",
+      "expiryAt": "2022-09-28T12:32:33Z"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "00000000-0000-0000-0000-000000000000",
+        "name": "sampleAccessToken",
+        "jwtToken": "sampleJwtToken",
+        "createdAt": "2021-09-28T12:32:33Z",
+        "expiryAt": "2022-09-28T12:32:33Z",
+        "state": "Active"
+      }
+    },
+    "201": {
+      "body": {
+        "id": "00000000-0000-0000-0000-000000000000",
+        "name": "sampleAccessToken",
+        "jwtToken": "sampleJwtToken",
+        "createdAt": "2021-09-28T12:32:33Z",
+        "expiryAt": "2022-09-28T12:32:33Z",
+        "state": "Active"
+      }
+    }
+  }
+}

--- a/specification/loadtestservice/data-plane/playwright/examples/2026-10-01-preview/AccessTokens_Delete.json
+++ b/specification/loadtestservice/data-plane/playwright/examples/2026-10-01-preview/AccessTokens_Delete.json
@@ -1,0 +1,12 @@
+{
+  "title": "AccessTokens_Delete",
+  "operationId": "AccessTokens_Delete",
+  "parameters": {
+    "api-version": "2026-10-01-preview",
+    "workspaceId": "00000000-0000-0000-0000-000000000000",
+    "accessTokenId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "204": {}
+  }
+}

--- a/specification/loadtestservice/data-plane/playwright/examples/2026-10-01-preview/AccessTokens_Get.json
+++ b/specification/loadtestservice/data-plane/playwright/examples/2026-10-01-preview/AccessTokens_Get.json
@@ -1,0 +1,20 @@
+{
+  "title": "AccessTokens_Get",
+  "operationId": "AccessTokens_Get",
+  "parameters": {
+    "api-version": "2026-10-01-preview",
+    "workspaceId": "00000000-0000-0000-0000-000000000000",
+    "accessTokenId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "00000000-0000-0000-0000-000000000000",
+        "name": "sampleAccessToken",
+        "createdAt": "2021-09-28T12:32:33Z",
+        "expiryAt": "2022-09-28T12:32:33Z",
+        "state": "Active"
+      }
+    }
+  }
+}

--- a/specification/loadtestservice/data-plane/playwright/examples/2026-10-01-preview/AccessTokens_List.json
+++ b/specification/loadtestservice/data-plane/playwright/examples/2026-10-01-preview/AccessTokens_List.json
@@ -1,0 +1,24 @@
+{
+  "title": "AccessTokens_List",
+  "operationId": "AccessTokens_List",
+  "parameters": {
+    "api-version": "2026-10-01-preview",
+    "workspaceId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "00000000-0000-0000-0000-000000000000",
+            "name": "sampleAccessToken",
+            "createdAt": "2021-09-28T12:32:33Z",
+            "expiryAt": "2022-09-28T12:32:33Z",
+            "state": "Active"
+          }
+        ],
+        "nextLink": null
+      }
+    }
+  }
+}

--- a/specification/loadtestservice/data-plane/playwright/examples/2026-10-01-preview/BrowserSessions_Get.json
+++ b/specification/loadtestservice/data-plane/playwright/examples/2026-10-01-preview/BrowserSessions_Get.json
@@ -1,0 +1,39 @@
+{
+  "title": "BrowserSessions_Get",
+  "operationId": "BrowserSessions_Get",
+  "parameters": {
+    "api-version": "2026-10-01-preview",
+    "sessionId": "00000000-0000-0000-0000-000000000000",
+    "workspaceId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "00000000-0000-0000-0000-000000000000",
+        "displayName": "<BrowserSession_Timestamp>",
+        "creatorId": "string",
+        "source": {
+          "id": "00000000-0000-0000-0000-000000000000",
+          "type": "PlaywrightWorkspacesTestRun"
+        },
+        "startTime": "2025-06-06T11:43:28.954Z",
+        "endTime": "2025-06-06T11:43:28.954Z",
+        "durationInMilliseconds": 0,
+        "status": "Completed",
+        "browserType": "Chromium",
+        "operatingSystem": "Windows",
+        "recording": {
+          "enabled": true,
+          "artifacts": {
+            "containerUrl": "https://examplestorageaccount.blob.core.windows.net/browser-session-recordings/00000000-0000-0000-0000-000000000000",
+            "traceArtifacts": [
+              {
+                "url": "https://examplestorageaccount.blob.core.windows.net/browser-session-recordings/00000000-0000-0000-0000-000000000000/trace.zip"
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/loadtestservice/data-plane/playwright/examples/2026-10-01-preview/BrowserSessions_List.json
+++ b/specification/loadtestservice/data-plane/playwright/examples/2026-10-01-preview/BrowserSessions_List.json
@@ -1,0 +1,43 @@
+{
+  "title": "BrowserSessions_List",
+  "operationId": "BrowserSessions_List",
+  "parameters": {
+    "api-version": "2026-10-01-preview",
+    "workspaceId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "00000000-0000-0000-0000-000000000000",
+            "displayName": "<BrowserSession_Timestamp>",
+            "creatorId": "string",
+            "source": {
+              "id": "00000000-0000-0000-0000-000000000000",
+              "type": "PlaywrightWorkspacesTestRun"
+            },
+            "startTime": "2025-06-06T11:43:28.954Z",
+            "endTime": "2025-06-06T11:43:28.954Z",
+            "durationInMilliseconds": 0,
+            "status": "Completed",
+            "browserType": "Chromium",
+            "operatingSystem": "Windows",
+            "recording": {
+              "enabled": true,
+              "artifacts": {
+                "containerUrl": "https://examplestorageaccount.blob.core.windows.net/browser-session-recordings/00000000-0000-0000-0000-000000000000",
+                "traceArtifacts": [
+                  {
+                    "url": "https://examplestorageaccount.blob.core.windows.net/browser-session-recordings/00000000-0000-0000-0000-000000000000/trace.zip"
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        "nextLink": null
+      }
+    }
+  }
+}

--- a/specification/loadtestservice/data-plane/playwright/examples/2026-10-01-preview/BrowserSessions_Update.json
+++ b/specification/loadtestservice/data-plane/playwright/examples/2026-10-01-preview/BrowserSessions_Update.json
@@ -1,0 +1,34 @@
+{
+  "title": "BrowserSessions_Update",
+  "operationId": "BrowserSessions_Update",
+  "parameters": {
+    "api-version": "2026-10-01-preview",
+    "sessionId": "00000000-0000-0000-0000-000000000000",
+    "workspaceId": "00000000-0000-0000-0000-000000000000",
+    "resource": {
+      "recording": {
+        "enabled": true
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "00000000-0000-0000-0000-000000000000",
+        "displayName": "<BrowserSession_Timestamp>",
+        "creatorId": "string",
+        "source": {
+          "id": "00000000-0000-0000-0000-000000000000",
+          "type": "BrowserAutomationTool"
+        },
+        "startTime": "2025-06-06T11:43:28.954Z",
+        "status": "Active",
+        "browserType": "Chromium",
+        "operatingSystem": "Windows",
+        "recording": {
+          "enabled": true
+        }
+      }
+    }
+  }
+}

--- a/specification/loadtestservice/data-plane/playwright/examples/2026-10-01-preview/TestRuns_CreateOrUpdate.json
+++ b/specification/loadtestservice/data-plane/playwright/examples/2026-10-01-preview/TestRuns_CreateOrUpdate.json
@@ -1,0 +1,86 @@
+{
+  "title": "TestRuns_CreateOrUpdate",
+  "operationId": "TestRuns_CreateOrUpdate",
+  "parameters": {
+    "api-version": "2026-10-01-preview",
+    "workspaceId": "00000000-0000-0000-0000-000000000000",
+    "runId": "00000000-0000-0000-0000-000000000000",
+    "resource": {
+      "displayName": "sampleTestRun"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "00000000-0000-0000-0000-000000000000",
+        "displayName": "sampleTestRun",
+        "creatorId": "string",
+        "creatorName": "string",
+        "config": {
+          "framework": {
+            "name": "string",
+            "version": "string",
+            "runnerName": "string"
+          },
+          "sdkLanguage": "JAVASCRIPT",
+          "maxWorkers": 10
+        },
+        "ciConfig": {
+          "providerName": "string",
+          "branch": "string",
+          "author": "string",
+          "commitId": "string",
+          "revisionUrl": "string"
+        },
+        "summary": {
+          "status": "RUNNING",
+          "billableTime": 0,
+          "numBrowserSessions": 1,
+          "maxConcurrentBrowserSessions": 10,
+          "startTime": "2025-06-06T11:43:28.954Z",
+          "endTime": "2025-06-06T11:43:28.954Z",
+          "duration": 0,
+          "errorMessages": [
+            "string"
+          ]
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "id": "00000000-0000-0000-0000-000000000000",
+        "displayName": "sampleTestRun",
+        "creatorId": "string",
+        "creatorName": "string",
+        "config": {
+          "framework": {
+            "name": "string",
+            "version": "string",
+            "runnerName": "string"
+          },
+          "sdkLanguage": "JAVASCRIPT",
+          "maxWorkers": 10
+        },
+        "ciConfig": {
+          "providerName": "string",
+          "branch": "string",
+          "author": "string",
+          "commitId": "string",
+          "revisionUrl": "string"
+        },
+        "summary": {
+          "status": "RUNNING",
+          "billableTime": 0,
+          "numBrowserSessions": 1,
+          "maxConcurrentBrowserSessions": 10,
+          "startTime": "2025-06-06T11:43:28.954Z",
+          "endTime": "2025-06-06T11:43:28.954Z",
+          "duration": 0,
+          "errorMessages": [
+            "string"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/loadtestservice/data-plane/playwright/examples/2026-10-01-preview/TestRuns_Get.json
+++ b/specification/loadtestservice/data-plane/playwright/examples/2026-10-01-preview/TestRuns_Get.json
@@ -1,0 +1,47 @@
+{
+  "title": "TestRuns_Get",
+  "operationId": "TestRuns_Get",
+  "parameters": {
+    "api-version": "2026-10-01-preview",
+    "runId": "00000000-0000-0000-0000-000000000000",
+    "workspaceId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "00000000-0000-0000-0000-000000000000",
+        "displayName": "string",
+        "creatorId": "string",
+        "creatorName": "string",
+        "config": {
+          "framework": {
+            "name": "string",
+            "version": "string",
+            "runnerName": "string"
+          },
+          "sdkLanguage": "JAVASCRIPT",
+          "maxWorkers": 10
+        },
+        "ciConfig": {
+          "providerName": "string",
+          "branch": "string",
+          "author": "string",
+          "commitId": "string",
+          "revisionUrl": "string"
+        },
+        "summary": {
+          "status": "RUNNING",
+          "billableTime": 0,
+          "numBrowserSessions": 1,
+          "maxConcurrentBrowserSessions": 10,
+          "startTime": "2025-06-06T11:43:28.954Z",
+          "endTime": "2025-06-06T11:43:28.954Z",
+          "duration": 0,
+          "errorMessages": [
+            "string"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/loadtestservice/data-plane/playwright/examples/2026-10-01-preview/TestRuns_List.json
+++ b/specification/loadtestservice/data-plane/playwright/examples/2026-10-01-preview/TestRuns_List.json
@@ -1,0 +1,51 @@
+{
+  "title": "TestRuns_List",
+  "operationId": "TestRuns_List",
+  "parameters": {
+    "api-version": "2026-10-01-preview",
+    "workspaceId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "00000000-0000-0000-0000-000000000000",
+            "displayName": "string",
+            "creatorId": "string",
+            "creatorName": "string",
+            "config": {
+              "framework": {
+                "name": "string",
+                "version": "string",
+                "runnerName": "string"
+              },
+              "sdkLanguage": "JAVASCRIPT",
+              "maxWorkers": 10
+            },
+            "ciConfig": {
+              "providerName": "string",
+              "branch": "string",
+              "author": "string",
+              "commitId": "string",
+              "revisionUrl": "string"
+            },
+            "summary": {
+              "status": "RUNNING",
+              "billableTime": 0,
+              "numBrowserSessions": 1,
+              "maxConcurrentBrowserSessions": 10,
+              "startTime": "2025-06-06T11:43:28.954Z",
+              "endTime": "2025-06-06T11:43:28.954Z",
+              "duration": 0,
+              "errorMessages": [
+                "string"
+              ]
+            }
+          }
+        ],
+        "nextLink": null
+      }
+    }
+  }
+}

--- a/specification/loadtestservice/data-plane/playwright/examples/2026-10-01-preview/Workspaces_Get.json
+++ b/specification/loadtestservice/data-plane/playwright/examples/2026-10-01-preview/Workspaces_Get.json
@@ -1,0 +1,25 @@
+{
+  "title": "Workspaces_Get",
+  "operationId": "Workspaces_Get",
+  "parameters": {
+    "api-version": "2026-10-01-preview",
+    "workspaceId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "00000000-0000-0000-0000-000000000000",
+        "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/dummyrg/providers/Microsoft.LoadTestService/PlaywrightWorkspaces/myWorkspace",
+        "name": "myPlaywrightWorkspace",
+        "state": "Active",
+        "subscriptionId": "00000000-0000-0000-0000-000000000000",
+        "subscriptionState": "Registered",
+        "tenantId": "00000000-0000-0000-0000-000000000000",
+        "location": "westus3",
+        "regionalAffinity": "Enabled",
+        "localAuth": "Enabled",
+        "storageUri": "https://examplestorageaccount.blob.core.windows.net"
+      }
+    }
+  }
+}

--- a/specification/loadtestservice/data-plane/playwright/examples/2026-10-01-preview/Workspaces_GetBrowsers.json
+++ b/specification/loadtestservice/data-plane/playwright/examples/2026-10-01-preview/Workspaces_GetBrowsers.json
@@ -1,0 +1,16 @@
+{
+  "title": "Workspaces_GetBrowsers",
+  "operationId": "Workspaces_GetBrowsers",
+  "parameters": {
+    "api-version": "2026-10-01-preview",
+    "workspaceId": "00000000-0000-0000-0000-000000000000",
+    "os": "Linux"
+  },
+  "responses": {
+    "302": {
+      "headers": {
+        "location": "wss://{region}.api.playwright.microsoft.com/redirectURL?api-version=2026-10-01-preview&os=Linux"
+      }
+    }
+  }
+}

--- a/specification/loadtestservice/data-plane/playwright/main.tsp
+++ b/specification/loadtestservice/data-plane/playwright/main.tsp
@@ -60,4 +60,7 @@ enum Versions {
 
   @doc("Preview version 2026-04-01-preview with experimental features.")
   v2026_04_01_preview: "2026-04-01-preview",
+
+  @doc("Preview version 2026-10-01-preview with experimental features.")
+  v2026_10_01_preview: "2026-10-01-preview",
 }

--- a/specification/loadtestservice/data-plane/playwright/preview/2026-10-01-preview/examples/AccessTokens_CreateOrReplace.json
+++ b/specification/loadtestservice/data-plane/playwright/preview/2026-10-01-preview/examples/AccessTokens_CreateOrReplace.json
@@ -1,0 +1,35 @@
+{
+  "title": "AccessTokens_CreateOrReplace",
+  "operationId": "AccessTokens_CreateOrReplace",
+  "parameters": {
+    "api-version": "2026-10-01-preview",
+    "workspaceId": "00000000-0000-0000-0000-000000000000",
+    "accessTokenId": "00000000-0000-0000-0000-000000000000",
+    "resource": {
+      "name": "sampleAccessToken",
+      "expiryAt": "2022-09-28T12:32:33Z"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "00000000-0000-0000-0000-000000000000",
+        "name": "sampleAccessToken",
+        "jwtToken": "sampleJwtToken",
+        "createdAt": "2021-09-28T12:32:33Z",
+        "expiryAt": "2022-09-28T12:32:33Z",
+        "state": "Active"
+      }
+    },
+    "201": {
+      "body": {
+        "id": "00000000-0000-0000-0000-000000000000",
+        "name": "sampleAccessToken",
+        "jwtToken": "sampleJwtToken",
+        "createdAt": "2021-09-28T12:32:33Z",
+        "expiryAt": "2022-09-28T12:32:33Z",
+        "state": "Active"
+      }
+    }
+  }
+}

--- a/specification/loadtestservice/data-plane/playwright/preview/2026-10-01-preview/examples/AccessTokens_Delete.json
+++ b/specification/loadtestservice/data-plane/playwright/preview/2026-10-01-preview/examples/AccessTokens_Delete.json
@@ -1,0 +1,12 @@
+{
+  "title": "AccessTokens_Delete",
+  "operationId": "AccessTokens_Delete",
+  "parameters": {
+    "api-version": "2026-10-01-preview",
+    "workspaceId": "00000000-0000-0000-0000-000000000000",
+    "accessTokenId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "204": {}
+  }
+}

--- a/specification/loadtestservice/data-plane/playwright/preview/2026-10-01-preview/examples/AccessTokens_Get.json
+++ b/specification/loadtestservice/data-plane/playwright/preview/2026-10-01-preview/examples/AccessTokens_Get.json
@@ -1,0 +1,20 @@
+{
+  "title": "AccessTokens_Get",
+  "operationId": "AccessTokens_Get",
+  "parameters": {
+    "api-version": "2026-10-01-preview",
+    "workspaceId": "00000000-0000-0000-0000-000000000000",
+    "accessTokenId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "00000000-0000-0000-0000-000000000000",
+        "name": "sampleAccessToken",
+        "createdAt": "2021-09-28T12:32:33Z",
+        "expiryAt": "2022-09-28T12:32:33Z",
+        "state": "Active"
+      }
+    }
+  }
+}

--- a/specification/loadtestservice/data-plane/playwright/preview/2026-10-01-preview/examples/AccessTokens_List.json
+++ b/specification/loadtestservice/data-plane/playwright/preview/2026-10-01-preview/examples/AccessTokens_List.json
@@ -1,0 +1,24 @@
+{
+  "title": "AccessTokens_List",
+  "operationId": "AccessTokens_List",
+  "parameters": {
+    "api-version": "2026-10-01-preview",
+    "workspaceId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "00000000-0000-0000-0000-000000000000",
+            "name": "sampleAccessToken",
+            "createdAt": "2021-09-28T12:32:33Z",
+            "expiryAt": "2022-09-28T12:32:33Z",
+            "state": "Active"
+          }
+        ],
+        "nextLink": null
+      }
+    }
+  }
+}

--- a/specification/loadtestservice/data-plane/playwright/preview/2026-10-01-preview/examples/BrowserSessions_Get.json
+++ b/specification/loadtestservice/data-plane/playwright/preview/2026-10-01-preview/examples/BrowserSessions_Get.json
@@ -1,0 +1,39 @@
+{
+  "title": "BrowserSessions_Get",
+  "operationId": "BrowserSessions_Get",
+  "parameters": {
+    "api-version": "2026-10-01-preview",
+    "sessionId": "00000000-0000-0000-0000-000000000000",
+    "workspaceId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "00000000-0000-0000-0000-000000000000",
+        "displayName": "<BrowserSession_Timestamp>",
+        "creatorId": "string",
+        "source": {
+          "id": "00000000-0000-0000-0000-000000000000",
+          "type": "PlaywrightWorkspacesTestRun"
+        },
+        "startTime": "2025-06-06T11:43:28.954Z",
+        "endTime": "2025-06-06T11:43:28.954Z",
+        "durationInMilliseconds": 0,
+        "status": "Completed",
+        "browserType": "Chromium",
+        "operatingSystem": "Windows",
+        "recording": {
+          "enabled": true,
+          "artifacts": {
+            "containerUrl": "https://examplestorageaccount.blob.core.windows.net/browser-session-recordings/00000000-0000-0000-0000-000000000000",
+            "traceArtifacts": [
+              {
+                "url": "https://examplestorageaccount.blob.core.windows.net/browser-session-recordings/00000000-0000-0000-0000-000000000000/trace.zip"
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/loadtestservice/data-plane/playwright/preview/2026-10-01-preview/examples/BrowserSessions_List.json
+++ b/specification/loadtestservice/data-plane/playwright/preview/2026-10-01-preview/examples/BrowserSessions_List.json
@@ -1,0 +1,43 @@
+{
+  "title": "BrowserSessions_List",
+  "operationId": "BrowserSessions_List",
+  "parameters": {
+    "api-version": "2026-10-01-preview",
+    "workspaceId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "00000000-0000-0000-0000-000000000000",
+            "displayName": "<BrowserSession_Timestamp>",
+            "creatorId": "string",
+            "source": {
+              "id": "00000000-0000-0000-0000-000000000000",
+              "type": "PlaywrightWorkspacesTestRun"
+            },
+            "startTime": "2025-06-06T11:43:28.954Z",
+            "endTime": "2025-06-06T11:43:28.954Z",
+            "durationInMilliseconds": 0,
+            "status": "Completed",
+            "browserType": "Chromium",
+            "operatingSystem": "Windows",
+            "recording": {
+              "enabled": true,
+              "artifacts": {
+                "containerUrl": "https://examplestorageaccount.blob.core.windows.net/browser-session-recordings/00000000-0000-0000-0000-000000000000",
+                "traceArtifacts": [
+                  {
+                    "url": "https://examplestorageaccount.blob.core.windows.net/browser-session-recordings/00000000-0000-0000-0000-000000000000/trace.zip"
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        "nextLink": null
+      }
+    }
+  }
+}

--- a/specification/loadtestservice/data-plane/playwright/preview/2026-10-01-preview/examples/BrowserSessions_Update.json
+++ b/specification/loadtestservice/data-plane/playwright/preview/2026-10-01-preview/examples/BrowserSessions_Update.json
@@ -1,0 +1,34 @@
+{
+  "title": "BrowserSessions_Update",
+  "operationId": "BrowserSessions_Update",
+  "parameters": {
+    "api-version": "2026-10-01-preview",
+    "sessionId": "00000000-0000-0000-0000-000000000000",
+    "workspaceId": "00000000-0000-0000-0000-000000000000",
+    "resource": {
+      "recording": {
+        "enabled": true
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "00000000-0000-0000-0000-000000000000",
+        "displayName": "<BrowserSession_Timestamp>",
+        "creatorId": "string",
+        "source": {
+          "id": "00000000-0000-0000-0000-000000000000",
+          "type": "BrowserAutomationTool"
+        },
+        "startTime": "2025-06-06T11:43:28.954Z",
+        "status": "Active",
+        "browserType": "Chromium",
+        "operatingSystem": "Windows",
+        "recording": {
+          "enabled": true
+        }
+      }
+    }
+  }
+}

--- a/specification/loadtestservice/data-plane/playwright/preview/2026-10-01-preview/examples/TestRuns_CreateOrUpdate.json
+++ b/specification/loadtestservice/data-plane/playwright/preview/2026-10-01-preview/examples/TestRuns_CreateOrUpdate.json
@@ -1,0 +1,82 @@
+{
+  "title": "TestRuns_CreateOrUpdate",
+  "operationId": "TestRuns_CreateOrUpdate",
+  "parameters": {
+    "api-version": "2026-10-01-preview",
+    "workspaceId": "00000000-0000-0000-0000-000000000000",
+    "runId": "00000000-0000-0000-0000-000000000000",
+    "resource": {
+      "displayName": "sampleTestRun"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "00000000-0000-0000-0000-000000000000",
+        "displayName": "sampleTestRun",
+        "creatorId": "string",
+        "creatorName": "string",
+        "config": {
+          "framework": {
+            "name": "string",
+            "version": "string",
+            "runnerName": "string"
+          },
+          "sdkLanguage": "JAVASCRIPT",
+          "maxWorkers": 10
+        },
+        "ciConfig": {
+          "providerName": "string",
+          "branch": "string",
+          "author": "string",
+          "commitId": "string",
+          "revisionUrl": "string"
+        },
+        "summary": {
+          "status": "RUNNING",
+          "billableTime": 0,
+          "numBrowserSessions": 1,
+          "maxConcurrentBrowserSessions": 10,
+          "startTime": "2025-06-06T11:43:28.954Z",
+          "endTime": "2025-06-06T11:43:28.954Z",
+          "duration": 0,
+          "errorMessages": ["string"]
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "id": "00000000-0000-0000-0000-000000000000",
+        "displayName": "sampleTestRun",
+        "creatorId": "string",
+        "creatorName": "string",
+        "config": {
+          "framework": {
+            "name": "string",
+            "version": "string",
+            "runnerName": "string"
+          },
+          "sdkLanguage": "JAVASCRIPT",
+          "maxWorkers": 10
+        },
+        "ciConfig": {
+          "providerName": "string",
+          "branch": "string",
+          "author": "string",
+          "commitId": "string",
+          "revisionUrl": "string"
+        },
+        "summary": {
+          "status": "RUNNING",
+          "billableTime": 0,
+          "numBrowserSessions": 1,
+          "maxConcurrentBrowserSessions": 10,
+          "startTime": "2025-06-06T11:43:28.954Z",
+          "endTime": "2025-06-06T11:43:28.954Z",
+          "duration": 0,
+          "errorMessages": ["string"]
+        }
+      }
+    }
+  }
+}

--- a/specification/loadtestservice/data-plane/playwright/preview/2026-10-01-preview/examples/TestRuns_Get.json
+++ b/specification/loadtestservice/data-plane/playwright/preview/2026-10-01-preview/examples/TestRuns_Get.json
@@ -1,0 +1,45 @@
+{
+  "title": "TestRuns_Get",
+  "operationId": "TestRuns_Get",
+  "parameters": {
+    "api-version": "2026-10-01-preview",
+    "runId": "00000000-0000-0000-0000-000000000000",
+    "workspaceId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "00000000-0000-0000-0000-000000000000",
+        "displayName": "string",
+        "creatorId": "string",
+        "creatorName": "string",
+        "config": {
+          "framework": {
+            "name": "string",
+            "version": "string",
+            "runnerName": "string"
+          },
+          "sdkLanguage": "JAVASCRIPT",
+          "maxWorkers": 10
+        },
+        "ciConfig": {
+          "providerName": "string",
+          "branch": "string",
+          "author": "string",
+          "commitId": "string",
+          "revisionUrl": "string"
+        },
+        "summary": {
+          "status": "RUNNING",
+          "billableTime": 0,
+          "numBrowserSessions": 1,
+          "maxConcurrentBrowserSessions": 10,
+          "startTime": "2025-06-06T11:43:28.954Z",
+          "endTime": "2025-06-06T11:43:28.954Z",
+          "duration": 0,
+          "errorMessages": ["string"]
+        }
+      }
+    }
+  }
+}

--- a/specification/loadtestservice/data-plane/playwright/preview/2026-10-01-preview/examples/TestRuns_List.json
+++ b/specification/loadtestservice/data-plane/playwright/preview/2026-10-01-preview/examples/TestRuns_List.json
@@ -1,0 +1,49 @@
+{
+  "title": "TestRuns_List",
+  "operationId": "TestRuns_List",
+  "parameters": {
+    "api-version": "2026-10-01-preview",
+    "workspaceId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "00000000-0000-0000-0000-000000000000",
+            "displayName": "string",
+            "creatorId": "string",
+            "creatorName": "string",
+            "config": {
+              "framework": {
+                "name": "string",
+                "version": "string",
+                "runnerName": "string"
+              },
+              "sdkLanguage": "JAVASCRIPT",
+              "maxWorkers": 10
+            },
+            "ciConfig": {
+              "providerName": "string",
+              "branch": "string",
+              "author": "string",
+              "commitId": "string",
+              "revisionUrl": "string"
+            },
+            "summary": {
+              "status": "RUNNING",
+              "billableTime": 0,
+              "numBrowserSessions": 1,
+              "maxConcurrentBrowserSessions": 10,
+              "startTime": "2025-06-06T11:43:28.954Z",
+              "endTime": "2025-06-06T11:43:28.954Z",
+              "duration": 0,
+              "errorMessages": ["string"]
+            }
+          }
+        ],
+        "nextLink": null
+      }
+    }
+  }
+}

--- a/specification/loadtestservice/data-plane/playwright/preview/2026-10-01-preview/examples/Workspaces_Get.json
+++ b/specification/loadtestservice/data-plane/playwright/preview/2026-10-01-preview/examples/Workspaces_Get.json
@@ -1,0 +1,25 @@
+{
+  "title": "Workspaces_Get",
+  "operationId": "Workspaces_Get",
+  "parameters": {
+    "api-version": "2026-10-01-preview",
+    "workspaceId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "00000000-0000-0000-0000-000000000000",
+        "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/dummyrg/providers/Microsoft.LoadTestService/PlaywrightWorkspaces/myWorkspace",
+        "name": "myPlaywrightWorkspace",
+        "state": "Active",
+        "subscriptionId": "00000000-0000-0000-0000-000000000000",
+        "subscriptionState": "Registered",
+        "tenantId": "00000000-0000-0000-0000-000000000000",
+        "location": "westus3",
+        "regionalAffinity": "Enabled",
+        "localAuth": "Enabled",
+        "storageUri": "https://examplestorageaccount.blob.core.windows.net"
+      }
+    }
+  }
+}

--- a/specification/loadtestservice/data-plane/playwright/preview/2026-10-01-preview/examples/Workspaces_GetBrowsers.json
+++ b/specification/loadtestservice/data-plane/playwright/preview/2026-10-01-preview/examples/Workspaces_GetBrowsers.json
@@ -1,0 +1,16 @@
+{
+  "title": "Workspaces_GetBrowsers",
+  "operationId": "Workspaces_GetBrowsers",
+  "parameters": {
+    "api-version": "2026-10-01-preview",
+    "workspaceId": "00000000-0000-0000-0000-000000000000",
+    "os": "Linux"
+  },
+  "responses": {
+    "302": {
+      "headers": {
+        "location": "wss://{region}.api.playwright.microsoft.com/redirectURL?api-version=2026-10-01-preview&os=Linux"
+      }
+    }
+  }
+}

--- a/specification/loadtestservice/data-plane/playwright/preview/2026-10-01-preview/playwright.json
+++ b/specification/loadtestservice/data-plane/playwright/preview/2026-10-01-preview/playwright.json
@@ -1,0 +1,2029 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Playwright Service API",
+    "version": "2026-10-01-preview",
+    "x-typespec-generated": [
+      {
+        "emitter": "@azure-tools/typespec-autorest"
+      }
+    ]
+  },
+  "schemes": [
+    "https"
+  ],
+  "x-ms-parameterized-host": {
+    "hostTemplate": "{endpoint}",
+    "useSchemePrefix": false,
+    "parameters": [
+      {
+        "name": "endpoint",
+        "in": "path",
+        "description": "Playwright Service API endpoint (protocol and hostname) formatted as https://{region}.api.playwright.microsoft.com.\nThe region corresponds to your Azure Playwright workspace location. You can find this value in your Azure Playwright workspace properties under `dataplaneUri`.",
+        "required": true,
+        "type": "string",
+        "format": "uri",
+        "x-ms-skip-url-encoding": true
+      }
+    ]
+  },
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "OAuth2Auth": [
+        "https://playwright.microsoft.com/.default"
+      ],
+      "OAuth2Auth_": [
+        "https://playwright.microsoft.com/.default"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "OAuth2Auth": {
+      "type": "oauth2",
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "https://playwright.microsoft.com/.default": ""
+      }
+    },
+    "OAuth2Auth_": {
+      "type": "oauth2",
+      "flow": "accessCode",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "https://playwright.microsoft.com/.default": ""
+      },
+      "tokenUrl": "https://login.microsoftonline.com/common/v2.0/oauth2/token"
+    }
+  },
+  "tags": [],
+  "paths": {
+    "/playwrightworkspaces/{workspaceId}": {
+      "get": {
+        "operationId": "Workspaces_Get",
+        "description": "Get details of the Azure resource mapped to a workspace for the given workspace id. Authorization required is Bearer JWT Access token provided by EntraID.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "workspaceId",
+            "in": "path",
+            "description": "The workspace ID in GUID format.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 36,
+            "pattern": "[A-Za-z0-9]+(-[A-Za-z0-9]+)+"
+          },
+          {
+            "$ref": "#/parameters/Azure.Core.ClientRequestIdHeader"
+          },
+          {
+            "name": "x-ms-useragent",
+            "in": "header",
+            "description": "Optional header to specify additional client information when the standard 'User-Agent' header cannot be explicitly set, such as when using Playwright Client. The value should follow the standard 'User-Agent' header format.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/Workspace"
+            },
+            "headers": {
+              "x-ms-client-request-id": {
+                "type": "string",
+                "format": "uuid",
+                "description": "An opaque, globally-unique, client-generated string identifier for the request."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Workspaces_Get": {
+            "$ref": "./examples/Workspaces_Get.json"
+          }
+        }
+      }
+    },
+    "/playwrightworkspaces/{workspaceId}/access-tokens": {
+      "get": {
+        "operationId": "AccessTokens_List",
+        "description": "Lists access tokens for the specified workspace ID. Supports OData query parameters: $select, $filter, $orderby, $top, and $skip. Default page size is 10. Use nextLink in response to fetch additional results. Requires Bearer JWT access token provided by Entra ID.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "workspaceId",
+            "in": "path",
+            "description": "The workspace ID in GUID format.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 36,
+            "pattern": "[A-Za-z0-9]+(-[A-Za-z0-9]+)+"
+          },
+          {
+            "$ref": "#/parameters/Azure.Core.ClientRequestIdHeader"
+          },
+          {
+            "name": "x-ms-useragent",
+            "in": "header",
+            "description": "Optional header to specify additional client information when the standard 'User-Agent' header cannot be explicitly set, such as when using Playwright Client. The value should follow the standard 'User-Agent' header format.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/PagedAccessToken"
+            },
+            "headers": {
+              "x-ms-client-request-id": {
+                "type": "string",
+                "format": "uuid",
+                "description": "An opaque, globally-unique, client-generated string identifier for the request."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        },
+        "x-ms-examples": {
+          "AccessTokens_List": {
+            "$ref": "./examples/AccessTokens_List.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/playwrightworkspaces/{workspaceId}/access-tokens/{accessTokenId}": {
+      "get": {
+        "operationId": "AccessTokens_Get",
+        "description": "Gets an access token for the workspace with the specified access token ID. Requires Bearer JWT access token provided by Entra ID.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "workspaceId",
+            "in": "path",
+            "description": "The workspace ID in GUID format.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 36,
+            "pattern": "[A-Za-z0-9]+(-[A-Za-z0-9]+)+"
+          },
+          {
+            "name": "accessTokenId",
+            "in": "path",
+            "description": "The access token ID in GUID format.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 36,
+            "pattern": "[A-Za-z0-9]+(-[A-Za-z0-9]+)+"
+          },
+          {
+            "$ref": "#/parameters/Azure.Core.ClientRequestIdHeader"
+          },
+          {
+            "name": "x-ms-useragent",
+            "in": "header",
+            "description": "Optional header to specify additional client information when the standard 'User-Agent' header cannot be explicitly set, such as when using Playwright Client. The value should follow the standard 'User-Agent' header format.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/AccessToken"
+            },
+            "headers": {
+              "x-ms-client-request-id": {
+                "type": "string",
+                "format": "uuid",
+                "description": "An opaque, globally-unique, client-generated string identifier for the request."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        },
+        "x-ms-examples": {
+          "AccessTokens_Get": {
+            "$ref": "./examples/AccessTokens_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "AccessTokens_CreateOrReplace",
+        "description": "Creates an access token for the workspace with the specified access token ID and name. The ID and name must be unique among active access tokens for the user within a Playwright workspace. Requires Bearer JWT access token provided by Entra ID.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "workspaceId",
+            "in": "path",
+            "description": "The workspace ID in GUID format.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 36,
+            "pattern": "[A-Za-z0-9]+(-[A-Za-z0-9]+)+"
+          },
+          {
+            "name": "accessTokenId",
+            "in": "path",
+            "description": "The access token ID in GUID format.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 36,
+            "pattern": "[A-Za-z0-9]+(-[A-Za-z0-9]+)+"
+          },
+          {
+            "$ref": "#/parameters/Azure.Core.ClientRequestIdHeader"
+          },
+          {
+            "name": "x-ms-useragent",
+            "in": "header",
+            "description": "Optional header to specify additional client information when the standard 'User-Agent' header cannot be explicitly set, such as when using Playwright Client. The value should follow the standard 'User-Agent' header format.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "The resource instance.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/AccessToken"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/AccessToken"
+            },
+            "headers": {
+              "x-ms-client-request-id": {
+                "type": "string",
+                "format": "uuid",
+                "description": "An opaque, globally-unique, client-generated string identifier for the request."
+              }
+            }
+          },
+          "201": {
+            "description": "The request has succeeded and a new resource has been created as a result.",
+            "schema": {
+              "$ref": "#/definitions/AccessToken"
+            },
+            "headers": {
+              "x-ms-client-request-id": {
+                "type": "string",
+                "format": "uuid",
+                "description": "An opaque, globally-unique, client-generated string identifier for the request."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        },
+        "x-ms-examples": {
+          "AccessTokens_CreateOrReplace": {
+            "$ref": "./examples/AccessTokens_CreateOrReplace.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "AccessTokens_Delete",
+        "description": "Deletes an access token for the workspace with the specified access token ID. Requires Bearer JWT access token provided by Entra ID.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "workspaceId",
+            "in": "path",
+            "description": "The workspace ID in GUID format.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 36,
+            "pattern": "[A-Za-z0-9]+(-[A-Za-z0-9]+)+"
+          },
+          {
+            "name": "accessTokenId",
+            "in": "path",
+            "description": "The access token ID in GUID format.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 36,
+            "pattern": "[A-Za-z0-9]+(-[A-Za-z0-9]+)+"
+          },
+          {
+            "$ref": "#/parameters/Azure.Core.ClientRequestIdHeader"
+          },
+          {
+            "name": "x-ms-useragent",
+            "in": "header",
+            "description": "Optional header to specify additional client information when the standard 'User-Agent' header cannot be explicitly set, such as when using Playwright Client. The value should follow the standard 'User-Agent' header format.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "There is no content to send for this request, but the headers may be useful. ",
+            "headers": {
+              "x-ms-client-request-id": {
+                "type": "string",
+                "format": "uuid",
+                "description": "An opaque, globally-unique, client-generated string identifier for the request."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        },
+        "x-ms-examples": {
+          "AccessTokens_Delete": {
+            "$ref": "./examples/AccessTokens_Delete.json"
+          }
+        }
+      }
+    },
+    "/playwrightworkspaces/{workspaceId}/browser-sessions": {
+      "get": {
+        "operationId": "BrowserSessions_List",
+        "description": "Lists browser sessions for the specified workspace ID. Supports OData query parameters such as $filter and $top. Default page size is 10. Use nextLink in response to fetch additional results. Requires Bearer JWT access token provided by Entra ID.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "workspaceId",
+            "in": "path",
+            "description": "The workspace ID in GUID format.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 36,
+            "pattern": "[A-Za-z0-9]+(-[A-Za-z0-9]+)+"
+          },
+          {
+            "$ref": "#/parameters/Azure.Core.ClientRequestIdHeader"
+          },
+          {
+            "name": "x-ms-useragent",
+            "in": "header",
+            "description": "Optional header to specify additional client information when the standard 'User-Agent' header cannot be explicitly set, such as when using Playwright Client. The value should follow the standard 'User-Agent' header format.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/PagedBrowserSession"
+            },
+            "headers": {
+              "x-ms-client-request-id": {
+                "type": "string",
+                "format": "uuid",
+                "description": "An opaque, globally-unique, client-generated string identifier for the request."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        },
+        "x-ms-examples": {
+          "BrowserSessions_List": {
+            "$ref": "./examples/BrowserSessions_List.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/playwrightworkspaces/{workspaceId}/browser-sessions/{sessionId}": {
+      "get": {
+        "operationId": "BrowserSessions_Get",
+        "description": "Get a browser session for the specified session and workspace ID. Requires Bearer JWT access token provided by Entra ID.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "workspaceId",
+            "in": "path",
+            "description": "The workspace ID in GUID format.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 36,
+            "pattern": "[A-Za-z0-9]+(-[A-Za-z0-9]+)+"
+          },
+          {
+            "name": "sessionId",
+            "in": "path",
+            "description": "The browser session ID in GUID format.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 36,
+            "pattern": "[A-Za-z0-9]+(-[A-Za-z0-9]+)+"
+          },
+          {
+            "$ref": "#/parameters/Azure.Core.ClientRequestIdHeader"
+          },
+          {
+            "name": "x-ms-useragent",
+            "in": "header",
+            "description": "Optional header to specify additional client information when the standard 'User-Agent' header cannot be explicitly set, such as when using Playwright Client. The value should follow the standard 'User-Agent' header format.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/BrowserSession"
+            },
+            "headers": {
+              "x-ms-client-request-id": {
+                "type": "string",
+                "format": "uuid",
+                "description": "An opaque, globally-unique, client-generated string identifier for the request."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        },
+        "x-ms-examples": {
+          "BrowserSessions_Get": {
+            "$ref": "./examples/BrowserSessions_Get.json"
+          }
+        }
+      },
+      "patch": {
+        "operationId": "BrowserSessions_Update",
+        "description": "Updates the per-session recording setting for the specified browser session. Requires Bearer JWT access token provided by Entra ID.",
+        "consumes": [
+          "application/merge-patch+json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "workspaceId",
+            "in": "path",
+            "description": "The workspace ID in GUID format.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 36,
+            "pattern": "[A-Za-z0-9]+(-[A-Za-z0-9]+)+"
+          },
+          {
+            "name": "sessionId",
+            "in": "path",
+            "description": "The browser session ID in GUID format.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 36,
+            "pattern": "[A-Za-z0-9]+(-[A-Za-z0-9]+)+"
+          },
+          {
+            "$ref": "#/parameters/Azure.Core.ClientRequestIdHeader"
+          },
+          {
+            "name": "x-ms-useragent",
+            "in": "header",
+            "description": "Optional header to specify additional client information when the standard 'User-Agent' header cannot be explicitly set, such as when using Playwright Client. The value should follow the standard 'User-Agent' header format.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "The resource instance.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/BrowserSessionUpdate"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/BrowserSession"
+            },
+            "headers": {
+              "x-ms-client-request-id": {
+                "type": "string",
+                "format": "uuid",
+                "description": "An opaque, globally-unique, client-generated string identifier for the request."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        },
+        "x-ms-examples": {
+          "BrowserSessions_Update": {
+            "$ref": "./examples/BrowserSessions_Update.json"
+          }
+        }
+      }
+    },
+    "/playwrightworkspaces/{workspaceId}/browsers": {
+      "get": {
+        "operationId": "Workspaces_GetBrowsers",
+        "description": "Gets remote browsers for the specified workspace ID and redirects the client to execute Playwright scripts. Requires Bearer JWT access token provided by Entra ID or Playwright Service.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "workspaceId",
+            "in": "path",
+            "description": "The workspace ID in GUID format.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 36,
+            "pattern": "[A-Za-z0-9]+(-[A-Za-z0-9]+)+"
+          },
+          {
+            "name": "os",
+            "in": "query",
+            "description": "The operating system for remote script execution.",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "Linux",
+              "Windows"
+            ],
+            "x-ms-enum": {
+              "name": "OS",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "Linux",
+                  "value": "Linux",
+                  "description": "Linux operating system."
+                },
+                {
+                  "name": "Windows",
+                  "value": "Windows",
+                  "description": "Windows operating system."
+                }
+              ]
+            }
+          },
+          {
+            "name": "runId",
+            "in": "query",
+            "description": "The run ID in GUID format.",
+            "required": false,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 36,
+            "pattern": "[A-Za-z0-9]+(-[A-Za-z0-9]+)+"
+          },
+          {
+            "$ref": "#/parameters/Azure.Core.ClientRequestIdHeader"
+          },
+          {
+            "name": "x-ms-useragent",
+            "in": "header",
+            "description": "Optional header to specify additional client information when the standard 'User-Agent' header cannot be explicitly set, such as when using Playwright Client. The value should follow the standard 'User-Agent' header format.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "302": {
+            "description": "Redirection",
+            "headers": {
+              "location": {
+                "type": "string",
+                "description": "The redirect target URL for executing Playwright scripts on remote browsers."
+              },
+              "x-ms-client-request-id": {
+                "type": "string",
+                "format": "uuid",
+                "description": "An opaque, globally-unique, client-generated string identifier for the request."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Workspaces_GetBrowsers": {
+            "$ref": "./examples/Workspaces_GetBrowsers.json"
+          }
+        }
+      }
+    },
+    "/playwrightworkspaces/{workspaceId}/test-runs": {
+      "get": {
+        "operationId": "TestRuns_List",
+        "description": "Lists test runs for the specified workspace ID. Supports OData query parameters such as $filter and $top. Default page size is 10. Use nextLink in response to fetch additional results. Requires Bearer JWT access token provided by Entra ID or Playwright Service.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "workspaceId",
+            "in": "path",
+            "description": "The workspace ID in GUID format.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 36,
+            "pattern": "[A-Za-z0-9]+(-[A-Za-z0-9]+)+"
+          },
+          {
+            "$ref": "#/parameters/Azure.Core.ClientRequestIdHeader"
+          },
+          {
+            "name": "x-ms-useragent",
+            "in": "header",
+            "description": "Optional header to specify additional client information when the standard 'User-Agent' header cannot be explicitly set, such as when using Playwright Client. The value should follow the standard 'User-Agent' header format.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/PagedTestRun"
+            },
+            "headers": {
+              "x-ms-client-request-id": {
+                "type": "string",
+                "format": "uuid",
+                "description": "An opaque, globally-unique, client-generated string identifier for the request."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        },
+        "x-ms-examples": {
+          "TestRuns_List": {
+            "$ref": "./examples/TestRuns_List.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/playwrightworkspaces/{workspaceId}/test-runs/{runId}": {
+      "get": {
+        "operationId": "TestRuns_Get",
+        "description": "Gets a test run for the specified run and workspace ID. Requires Bearer JWT access token provided by Entra ID or Playwright Service.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "workspaceId",
+            "in": "path",
+            "description": "The workspace ID in GUID format.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 36,
+            "pattern": "[A-Za-z0-9]+(-[A-Za-z0-9]+)+"
+          },
+          {
+            "name": "runId",
+            "in": "path",
+            "description": "The test run ID in GUID format.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 36,
+            "pattern": "[A-Za-z0-9]+(-[A-Za-z0-9]+)+"
+          },
+          {
+            "$ref": "#/parameters/Azure.Core.ClientRequestIdHeader"
+          },
+          {
+            "name": "x-ms-useragent",
+            "in": "header",
+            "description": "Optional header to specify additional client information when the standard 'User-Agent' header cannot be explicitly set, such as when using Playwright Client. The value should follow the standard 'User-Agent' header format.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/TestRun"
+            },
+            "headers": {
+              "x-ms-client-request-id": {
+                "type": "string",
+                "format": "uuid",
+                "description": "An opaque, globally-unique, client-generated string identifier for the request."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        },
+        "x-ms-examples": {
+          "TestRuns_Get": {
+            "$ref": "./examples/TestRuns_Get.json"
+          }
+        }
+      },
+      "patch": {
+        "operationId": "TestRuns_CreateOrUpdate",
+        "description": "Creates or updates a test run for the workspace with the specified test run ID. Requires Bearer JWT access token provided by Entra ID or Playwright Service.",
+        "consumes": [
+          "application/merge-patch+json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "workspaceId",
+            "in": "path",
+            "description": "The workspace ID in GUID format.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 36,
+            "pattern": "[A-Za-z0-9]+(-[A-Za-z0-9]+)+"
+          },
+          {
+            "name": "runId",
+            "in": "path",
+            "description": "The test run ID in GUID format.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 36,
+            "pattern": "[A-Za-z0-9]+(-[A-Za-z0-9]+)+"
+          },
+          {
+            "$ref": "#/parameters/Azure.Core.ClientRequestIdHeader"
+          },
+          {
+            "name": "x-ms-useragent",
+            "in": "header",
+            "description": "Optional header to specify additional client information when the standard 'User-Agent' header cannot be explicitly set, such as when using Playwright Client. The value should follow the standard 'User-Agent' header format.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "The resource instance.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/TestRunCreateOrUpdate"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/TestRun"
+            },
+            "headers": {
+              "x-ms-client-request-id": {
+                "type": "string",
+                "format": "uuid",
+                "description": "An opaque, globally-unique, client-generated string identifier for the request."
+              }
+            }
+          },
+          "201": {
+            "description": "The request has succeeded and a new resource has been created as a result.",
+            "schema": {
+              "$ref": "#/definitions/TestRun"
+            },
+            "headers": {
+              "x-ms-client-request-id": {
+                "type": "string",
+                "format": "uuid",
+                "description": "An opaque, globally-unique, client-generated string identifier for the request."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Azure.Core.Foundations.ErrorResponse"
+            },
+            "headers": {
+              "x-ms-error-code": {
+                "type": "string",
+                "description": "String error code indicating what went wrong."
+              }
+            }
+          }
+        },
+        "x-ms-examples": {
+          "TestRuns_CreateOrUpdate": {
+            "$ref": "./examples/TestRuns_CreateOrUpdate.json"
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "AccessToken": {
+      "type": "object",
+      "description": "Model of an access token linked to a workspace.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The access token ID in GUID format.",
+          "minLength": 3,
+          "maxLength": 36,
+          "pattern": "[A-Za-z0-9]+(-[A-Za-z0-9]+)+",
+          "readOnly": true
+        },
+        "name": {
+          "type": "string",
+          "description": "The access token name.",
+          "minLength": 3,
+          "maxLength": 24,
+          "pattern": "^[a-zA-Z0-9-]{3,24}$",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "jwtToken": {
+          "type": "string",
+          "description": "The access token value in JWT format.",
+          "readOnly": true
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The access token creation timestamp in UTC.",
+          "readOnly": true
+        },
+        "expiryAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The access token expiration timestamp in UTC.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "state": {
+          "$ref": "#/definitions/AccessTokenState",
+          "description": "The access token state.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "id",
+        "name",
+        "createdAt",
+        "expiryAt",
+        "state"
+      ]
+    },
+    "AccessTokenState": {
+      "type": "string",
+      "description": "The access token state.",
+      "enum": [
+        "Active",
+        "Expired"
+      ],
+      "x-ms-enum": {
+        "name": "AccessTokenState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Active",
+            "value": "Active",
+            "description": "The access token is active and can be used for authentication."
+          },
+          {
+            "name": "Expired",
+            "value": "Expired",
+            "description": "The access token has expired and cannot be used for authentication."
+          }
+        ]
+      }
+    },
+    "Azure.Core.Foundations.Error": {
+      "type": "object",
+      "description": "The error object.",
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "One of a server-defined set of error codes."
+        },
+        "message": {
+          "type": "string",
+          "description": "A human-readable representation of the error."
+        },
+        "target": {
+          "type": "string",
+          "description": "The target of the error."
+        },
+        "details": {
+          "type": "array",
+          "description": "An array of details about specific errors that led to this reported error.",
+          "items": {
+            "$ref": "#/definitions/Azure.Core.Foundations.Error"
+          }
+        },
+        "innererror": {
+          "$ref": "#/definitions/Azure.Core.Foundations.InnerError",
+          "description": "An object containing more specific information than the current object about the error."
+        }
+      },
+      "required": [
+        "code",
+        "message"
+      ]
+    },
+    "Azure.Core.Foundations.ErrorResponse": {
+      "type": "object",
+      "description": "A response containing error details.",
+      "properties": {
+        "error": {
+          "$ref": "#/definitions/Azure.Core.Foundations.Error",
+          "description": "The error object."
+        }
+      },
+      "required": [
+        "error"
+      ]
+    },
+    "Azure.Core.Foundations.InnerError": {
+      "type": "object",
+      "description": "An object containing more specific information about the error. As per Azure REST API guidelines - https://aka.ms/AzureRestApiGuidelines#handling-errors.",
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "One of a server-defined set of error codes."
+        },
+        "innererror": {
+          "$ref": "#/definitions/Azure.Core.Foundations.InnerError",
+          "description": "Inner error."
+        }
+      }
+    },
+    "BrowserSession": {
+      "type": "object",
+      "description": "Model of a browser session used for tracking purposes.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The browser session ID in GUID format.",
+          "minLength": 3,
+          "maxLength": 36,
+          "pattern": "[A-Za-z0-9]+(-[A-Za-z0-9]+)+",
+          "readOnly": true
+        },
+        "displayName": {
+          "type": "string",
+          "description": "The browser session display name.",
+          "minLength": 1,
+          "maxLength": 200,
+          "readOnly": true
+        },
+        "creatorId": {
+          "type": "string",
+          "description": "The browser session creator's ID.",
+          "readOnly": true
+        },
+        "startTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The browser session start time in UTC.",
+          "readOnly": true
+        },
+        "endTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The browser session end time in UTC.",
+          "readOnly": true
+        },
+        "durationInMilliseconds": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The browser session duration in milliseconds.",
+          "readOnly": true
+        },
+        "status": {
+          "$ref": "#/definitions/BrowserSessionStatus",
+          "description": "The browser session status.",
+          "readOnly": true
+        },
+        "source": {
+          "$ref": "#/definitions/BrowserSessionSource",
+          "description": "The browser session source details.",
+          "readOnly": true
+        },
+        "browserType": {
+          "$ref": "#/definitions/BrowserType",
+          "description": "The browser session browser type.",
+          "readOnly": true
+        },
+        "operatingSystem": {
+          "$ref": "#/definitions/OS",
+          "description": "The browser session operating system.",
+          "readOnly": true
+        },
+        "recording": {
+          "$ref": "#/definitions/BrowserSessionRecording",
+          "description": "The recording configuration and artifacts for the browser session.",
+          "x-ms-mutability": [
+            "read",
+            "update"
+          ]
+        }
+      },
+      "required": [
+        "id",
+        "displayName",
+        "creatorId",
+        "status",
+        "source",
+        "browserType",
+        "operatingSystem"
+      ]
+    },
+    "BrowserSessionRecording": {
+      "type": "object",
+      "description": "The recording configuration and artifacts for a browser session.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Indicates whether recording is enabled for the browser session. When specified in an update request, this value overrides the workspace-level recording setting for the session.",
+          "x-ms-mutability": [
+            "read",
+            "update"
+          ]
+        },
+        "artifacts": {
+          "$ref": "#/definitions/BrowserSessionRecordingArtifacts",
+          "description": "The finalized recording artifacts uploaded for the browser session.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "enabled"
+      ]
+    },
+    "BrowserSessionRecordingArtifacts": {
+      "type": "object",
+      "description": "The finalized recording artifacts uploaded for a browser session.",
+      "properties": {
+        "containerUrl": {
+          "type": "string",
+          "format": "uri",
+          "description": "The URL of the blob container that stores the recording artifacts for the browser session.",
+          "readOnly": true
+        },
+        "traceArtifacts": {
+          "type": "array",
+          "description": "The trace artifacts uploaded for the browser session.",
+          "items": {
+            "$ref": "#/definitions/BrowserSessionTraceArtifact"
+          },
+          "readOnly": true
+        }
+      },
+      "required": [
+        "containerUrl"
+      ]
+    },
+    "BrowserSessionRecordingUpdate": {
+      "type": "object",
+      "description": "The recording configuration and artifacts for a browser session.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Indicates whether recording is enabled for the browser session. When specified in an update request, this value overrides the workspace-level recording setting for the session.",
+          "x-ms-mutability": [
+            "read",
+            "update"
+          ]
+        }
+      }
+    },
+    "BrowserSessionSource": {
+      "type": "object",
+      "description": "The browser session source details.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The browser session source ID, would be same as runId for test-runs.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "The browser session source type.",
+          "default": "Others",
+          "enum": [
+            "PlaywrightWorkspacesTestRun",
+            "BrowserAutomationTool",
+            "Others"
+          ],
+          "x-ms-enum": {
+            "name": "BrowserSessionSourceType",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "PlaywrightWorkspacesTestRun",
+                "value": "PlaywrightWorkspacesTestRun",
+                "description": "The browser session source is a Playwright Workspaces test run."
+              },
+              {
+                "name": "BrowserAutomationTool",
+                "value": "BrowserAutomationTool",
+                "description": "The browser session source is a browser automation tool."
+              },
+              {
+                "name": "Others",
+                "value": "Others",
+                "description": "The browser session source is of other types."
+              }
+            ]
+          },
+          "readOnly": true
+        }
+      },
+      "required": [
+        "id",
+        "type"
+      ]
+    },
+    "BrowserSessionStatus": {
+      "type": "string",
+      "description": "The browser session status.",
+      "enum": [
+        "Created",
+        "Active",
+        "Completed",
+        "Failed"
+      ],
+      "x-ms-enum": {
+        "name": "BrowserSessionStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Created",
+            "value": "Created",
+            "description": "The browser session is created."
+          },
+          {
+            "name": "Active",
+            "value": "Active",
+            "description": "The browser session is currently active."
+          },
+          {
+            "name": "Completed",
+            "value": "Completed",
+            "description": "The browser session has completed."
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "The browser session has failed."
+          }
+        ]
+      }
+    },
+    "BrowserSessionTraceArtifact": {
+      "type": "object",
+      "description": "A trace artifact uploaded for a browser session.",
+      "properties": {
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "description": "The URL of the uploaded trace artifact.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "url"
+      ]
+    },
+    "BrowserSessionUpdate": {
+      "type": "object",
+      "description": "Model of a browser session used for tracking purposes.",
+      "properties": {
+        "recording": {
+          "$ref": "#/definitions/BrowserSessionRecordingUpdate",
+          "description": "The recording configuration and artifacts for the browser session.",
+          "x-ms-mutability": [
+            "read",
+            "update"
+          ]
+        }
+      }
+    },
+    "BrowserType": {
+      "type": "string",
+      "description": "The browser type to configure for remote script execution.",
+      "enum": [
+        "Chromium",
+        "Firefox",
+        "Webkit"
+      ],
+      "x-ms-enum": {
+        "name": "BrowserType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Chromium",
+            "value": "Chromium",
+            "description": "Chromium browser type."
+          },
+          {
+            "name": "Firefox",
+            "value": "Firefox",
+            "description": "Firefox browser type."
+          },
+          {
+            "name": "Webkit",
+            "value": "Webkit",
+            "description": "WebKit browser type."
+          }
+        ]
+      }
+    },
+    "CiConfig": {
+      "type": "object",
+      "description": "The test run CI configuration.",
+      "properties": {
+        "providerName": {
+          "type": "string",
+          "description": "The CI provider name.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "branch": {
+          "type": "string",
+          "description": "The CI branch name.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "author": {
+          "type": "string",
+          "description": "The CI commit author.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "commitId": {
+          "type": "string",
+          "description": "The CI commit ID.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "revisionUrl": {
+          "type": "string",
+          "description": "The CI revision URL.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        }
+      }
+    },
+    "OS": {
+      "type": "string",
+      "description": "The operating system to configure for remote script execution.",
+      "enum": [
+        "Linux",
+        "Windows"
+      ],
+      "x-ms-enum": {
+        "name": "OS",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Linux",
+            "value": "Linux",
+            "description": "Linux operating system."
+          },
+          {
+            "name": "Windows",
+            "value": "Windows",
+            "description": "Windows operating system."
+          }
+        ]
+      }
+    },
+    "PagedAccessToken": {
+      "type": "object",
+      "description": "Paged collection of AccessToken items",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The AccessToken items on this page",
+          "items": {
+            "$ref": "#/definitions/AccessToken"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "PagedBrowserSession": {
+      "type": "object",
+      "description": "Paged collection of BrowserSession items",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The BrowserSession items on this page",
+          "items": {
+            "$ref": "#/definitions/BrowserSession"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "PagedTestRun": {
+      "type": "object",
+      "description": "Paged collection of TestRun items",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The TestRun items on this page",
+          "items": {
+            "$ref": "#/definitions/TestRun"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "RunConfig": {
+      "type": "object",
+      "description": "The run configuration.",
+      "properties": {
+        "framework": {
+          "$ref": "#/definitions/RunFramework",
+          "description": "The framework used for the test run.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "sdkLanguage": {
+          "$ref": "#/definitions/SDKLanguage",
+          "description": "The SDK language used for the test run.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "maxWorkers": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The maximum number of workers required for the test run.",
+          "minimum": 1,
+          "maximum": 500,
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        }
+      }
+    },
+    "RunFramework": {
+      "type": "object",
+      "description": "The test run framework information.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The framework name.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "version": {
+          "type": "string",
+          "description": "The framework version.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "runnerName": {
+          "type": "string",
+          "description": "The framework runner name.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        }
+      }
+    },
+    "RunStatus": {
+      "type": "string",
+      "description": "The test run status.",
+      "enum": [
+        "RUNNING",
+        "CLIENT_COMPLETE",
+        "SERVER_COMPLETE"
+      ],
+      "x-ms-enum": {
+        "name": "RunStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "RUNNING",
+            "value": "RUNNING",
+            "description": "The test run is currently running."
+          },
+          {
+            "name": "CLIENT_COMPLETE",
+            "value": "CLIENT_COMPLETE",
+            "description": "The test run has completed on the client side."
+          },
+          {
+            "name": "SERVER_COMPLETE",
+            "value": "SERVER_COMPLETE",
+            "description": "The test run has completed on the server side."
+          }
+        ]
+      }
+    },
+    "RunSummary": {
+      "type": "object",
+      "description": "The test run summary.",
+      "properties": {
+        "status": {
+          "$ref": "#/definitions/RunStatus",
+          "description": "The test run status.",
+          "readOnly": true
+        },
+        "billableTime": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The test run billable time in milliseconds.",
+          "readOnly": true
+        },
+        "numBrowserSessions": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The total number of browser sessions allocated to the test run.",
+          "readOnly": true
+        },
+        "maxConcurrentBrowserSessions": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The highest number of browser sessions that were running concurrently during the test run.",
+          "readOnly": true
+        },
+        "startTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The test run start time in UTC.",
+          "readOnly": true
+        },
+        "endTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The test run end time in UTC.",
+          "readOnly": true
+        },
+        "duration": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The test run duration in milliseconds.",
+          "readOnly": true
+        },
+        "errorMessages": {
+          "type": "array",
+          "description": "The list of error messages corresponding to the test run.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        }
+      },
+      "required": [
+        "status",
+        "startTime"
+      ]
+    },
+    "SDKLanguage": {
+      "type": "string",
+      "description": "The SDK language used for the test run.",
+      "enum": [
+        "JAVASCRIPT",
+        "TYPESCRIPT",
+        "CSHARP"
+      ],
+      "x-ms-enum": {
+        "name": "SDKLanguage",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "JAVASCRIPT",
+            "value": "JAVASCRIPT",
+            "description": "JavaScript SDK"
+          },
+          {
+            "name": "TYPESCRIPT",
+            "value": "TYPESCRIPT",
+            "description": "TypeScript SDK"
+          },
+          {
+            "name": "CSHARP",
+            "value": "CSHARP",
+            "description": "C# SDK"
+          }
+        ]
+      }
+    },
+    "SubscriptionState": {
+      "type": "string",
+      "description": "The Azure subscription state.",
+      "enum": [
+        "Registered",
+        "Warned",
+        "Suspended",
+        "Deleted",
+        "Unregistered"
+      ],
+      "x-ms-enum": {
+        "name": "SubscriptionState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Registered",
+            "value": "Registered",
+            "description": "The subscription state is Registered."
+          },
+          {
+            "name": "Warned",
+            "value": "Warned",
+            "description": "The subscription state is Warned."
+          },
+          {
+            "name": "Suspended",
+            "value": "Suspended",
+            "description": "The subscription state is Suspended."
+          },
+          {
+            "name": "Deleted",
+            "value": "Deleted",
+            "description": "The subscription state is Deleted."
+          },
+          {
+            "name": "Unregistered",
+            "value": "Unregistered",
+            "description": "The subscription state is Unregistered."
+          }
+        ]
+      }
+    },
+    "TestRun": {
+      "type": "object",
+      "description": "Model of a test run used for tracking purposes.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The test run ID in GUID format.",
+          "minLength": 3,
+          "maxLength": 36,
+          "pattern": "[A-Za-z0-9]+(-[A-Za-z0-9]+)+",
+          "readOnly": true
+        },
+        "displayName": {
+          "type": "string",
+          "description": "The test run display name.",
+          "minLength": 1,
+          "maxLength": 200,
+          "x-ms-mutability": [
+            "read",
+            "update",
+            "create"
+          ]
+        },
+        "creatorId": {
+          "type": "string",
+          "description": "The test run creator's ID.",
+          "readOnly": true
+        },
+        "creatorName": {
+          "type": "string",
+          "description": "The test run creator's name.",
+          "readOnly": true
+        },
+        "config": {
+          "$ref": "#/definitions/RunConfig",
+          "description": "The test run configuration.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "ciConfig": {
+          "$ref": "#/definitions/CiConfig",
+          "description": "The test run CI configuration.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "summary": {
+          "$ref": "#/definitions/RunSummary",
+          "description": "The test run summary.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "id",
+        "displayName",
+        "creatorId",
+        "summary"
+      ]
+    },
+    "TestRunCreateOrUpdate": {
+      "type": "object",
+      "description": "Model of a test run used for tracking purposes.",
+      "properties": {
+        "displayName": {
+          "type": "string",
+          "description": "The test run display name.",
+          "minLength": 1,
+          "maxLength": 200,
+          "x-ms-mutability": [
+            "read",
+            "update",
+            "create"
+          ]
+        },
+        "config": {
+          "$ref": "#/definitions/RunConfig",
+          "description": "The test run configuration.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "ciConfig": {
+          "$ref": "#/definitions/CiConfig",
+          "description": "The test run CI configuration.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        }
+      }
+    },
+    "Workspace": {
+      "type": "object",
+      "description": "Playwright workspace is the parent resource for most of the other service resources.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The workspace ID in GUID format.",
+          "minLength": 3,
+          "maxLength": 36,
+          "pattern": "[A-Za-z0-9]+(-[A-Za-z0-9]+)+",
+          "readOnly": true
+        },
+        "resourceId": {
+          "type": "string",
+          "description": "The fully-qualified Azure resource id for the workspace.",
+          "readOnly": true
+        },
+        "name": {
+          "type": "string",
+          "description": "The workspace name.",
+          "readOnly": true
+        },
+        "state": {
+          "$ref": "#/definitions/WorkspaceState",
+          "description": "The state of workspace - Active | Inactive",
+          "readOnly": true
+        },
+        "subscriptionId": {
+          "type": "string",
+          "description": "The Azure subscription id in GUID format for the workspace.",
+          "readOnly": true
+        },
+        "subscriptionState": {
+          "$ref": "#/definitions/SubscriptionState",
+          "description": "The Azure subscription state - Registered | Unregistered | Warned | Suspended | Deleted",
+          "readOnly": true
+        },
+        "tenantId": {
+          "type": "string",
+          "description": "The Azure tenant id in GUID format for the workspace.",
+          "readOnly": true
+        },
+        "location": {
+          "type": "string",
+          "description": "The workspace resource location in Azure, for eg. eastus, southeastasia.",
+          "readOnly": true
+        },
+        "regionalAffinity": {
+          "type": "string",
+          "description": "This property sets the connection region for Playwright client workers to cloud-hosted browsers. If enabled, workers connect to browsers in the closest Azure region, ensuring lower latency. If disabled, workers connect to browsers in the Azure region in which the workspace was initially created.",
+          "default": "Enabled",
+          "enum": [
+            "Enabled",
+            "Disabled"
+          ],
+          "x-ms-enum": {
+            "name": "EnablementStatus",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "Enabled",
+                "value": "Enabled",
+                "description": "The feature is Enabled."
+              },
+              {
+                "name": "Disabled",
+                "value": "Disabled",
+                "description": "The feature is Disabled."
+              }
+            ]
+          },
+          "readOnly": true
+        },
+        "localAuth": {
+          "type": "string",
+          "description": "When enabled, this feature allows the workspace to use local auth (through service access token) for executing operations.",
+          "default": "Disabled",
+          "enum": [
+            "Enabled",
+            "Disabled"
+          ],
+          "x-ms-enum": {
+            "name": "EnablementStatus",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "Enabled",
+                "value": "Enabled",
+                "description": "The feature is Enabled."
+              },
+              {
+                "name": "Disabled",
+                "value": "Disabled",
+                "description": "The feature is Disabled."
+              }
+            ]
+          },
+          "readOnly": true
+        },
+        "storageUri": {
+          "type": "string",
+          "format": "uri",
+          "description": "When set on Playwright workspace resource, it provides the URI of the Azure storage account used to store workspace artifacts, test results, and reports.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "id",
+        "resourceId",
+        "name",
+        "state",
+        "subscriptionId",
+        "subscriptionState",
+        "tenantId",
+        "location"
+      ]
+    },
+    "WorkspaceState": {
+      "type": "string",
+      "description": "The Playwright workspace state.",
+      "enum": [
+        "Active",
+        "Inactive"
+      ],
+      "x-ms-enum": {
+        "name": "WorkspaceState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Active",
+            "value": "Active",
+            "description": "The workspace is Active."
+          },
+          {
+            "name": "Inactive",
+            "value": "Inactive",
+            "description": "The workspace is Inactive."
+          }
+        ]
+      }
+    }
+  },
+  "parameters": {
+    "Azure.Core.ClientRequestIdHeader": {
+      "name": "x-ms-client-request-id",
+      "in": "header",
+      "description": "An opaque, globally-unique, client-generated string identifier for the request.",
+      "required": false,
+      "type": "string",
+      "format": "uuid",
+      "x-ms-parameter-location": "method",
+      "x-ms-client-name": "clientRequestId"
+    },
+    "Azure.Core.Foundations.ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "description": "The API version to use for this operation.",
+      "required": true,
+      "type": "string",
+      "minLength": 1,
+      "x-ms-parameter-location": "method",
+      "x-ms-client-name": "apiVersion"
+    }
+  }
+}

--- a/specification/loadtestservice/data-plane/playwright/readme.md
+++ b/specification/loadtestservice/data-plane/playwright/readme.md
@@ -30,6 +30,20 @@ description: Microsoft Playwright Service Client
 openapi-type: data-plane
 tag: package-2025-09-01
 ```
+### Tag: package-2026-10-01-preview
+These settings apply only when `--tag=2026-10-01-preview` is specified on the command line.
+
+```yaml $(tag) == 'package-2026-10-01-preview'
+input-file:
+  - preview/2026-10-01-preview/playwright.json
+suppressions:
+  - code: ValidResponseCodeRequired
+    from: playwright.json
+    reason: Need 302 response code as a product requirement to redirect the client for script execution on remote browsers provided by the service.
+    where:
+      - $.paths["/playwrightworkspaces/{workspaceId}/browsers"].get.responses
+```
+
 ### Tag: package-2026-04-01-preview
 These settings apply only when `--tag=2026-04-01-preview` is specified on the command line.
 

--- a/specification/loadtestservice/data-plane/playwright/service.yaml
+++ b/specification/loadtestservice/data-plane/playwright/service.yaml
@@ -15,3 +15,7 @@ versions:
     source: typespec
     swagger-files:
       - preview/2026-04-01-preview/playwright.json
+  - version: 2026-10-01-preview
+    source: typespec
+    swagger-files:
+      - preview/2026-10-01-preview/playwright.json

--- a/specification/loadtestservice/data-plane/playwright/typespec/browsersessions.tsp
+++ b/specification/loadtestservice/data-plane/playwright/typespec/browsersessions.tsp
@@ -56,6 +56,43 @@ model BrowserSession {
   @doc("The browser session operating system.")
   @visibility(Lifecycle.Read)
   operatingSystem: OS;
+
+  @added(Versions.v2026_10_01_preview)
+  @doc("The recording configuration and artifacts for the browser session.")
+  @visibility(Lifecycle.Read, Lifecycle.Update)
+  recording?: BrowserSessionRecording;
+}
+
+@added(Versions.v2026_10_01_preview)
+@doc("The recording configuration and artifacts for a browser session.")
+model BrowserSessionRecording {
+  @doc("Indicates whether recording is enabled for the browser session. When specified in an update request, this value overrides the workspace-level recording setting for the session.")
+  @visibility(Lifecycle.Read, Lifecycle.Update)
+  enabled: boolean;
+
+  @doc("The finalized recording artifacts uploaded for the browser session.")
+  @visibility(Lifecycle.Read)
+  artifacts?: BrowserSessionRecordingArtifacts;
+}
+
+@added(Versions.v2026_10_01_preview)
+@doc("The finalized recording artifacts uploaded for a browser session.")
+model BrowserSessionRecordingArtifacts {
+  @doc("The URL of the blob container that stores the recording artifacts for the browser session.")
+  @visibility(Lifecycle.Read)
+  containerUrl: url;
+
+  @doc("The trace artifacts uploaded for the browser session.")
+  @visibility(Lifecycle.Read)
+  traceArtifacts?: BrowserSessionTraceArtifact[];
+}
+
+@added(Versions.v2026_10_01_preview)
+@doc("A trace artifact uploaded for a browser session.")
+model BrowserSessionTraceArtifact {
+  @doc("The URL of the uploaded trace artifact.")
+  @visibility(Lifecycle.Read)
+  url: url;
 }
 
 @doc("The browser session source details.")
@@ -107,6 +144,10 @@ interface BrowserSessions {
   @added(Versions.v2026_04_01_preview)
   @doc("Get a browser session for the specified session and workspace ID. Requires Bearer JWT access token provided by Entra ID.")
   get is Operations.ResourceRead<BrowserSession>;
+
+  @added(Versions.v2026_10_01_preview)
+  @doc("Updates the per-session recording setting for the specified browser session. Requires Bearer JWT access token provided by Entra ID.")
+  update is Operations.ResourceUpdate<BrowserSession>;
 
   @added(Versions.v2026_04_01_preview)
   @doc("Lists browser sessions for the specified workspace ID. Supports OData query parameters such as $filter and $top. Default page size is 10. Use nextLink in response to fetch additional results. Requires Bearer JWT access token provided by Entra ID.")


### PR DESCRIPTION
## Summary

Adds the `2026-10-01-preview` Playwright Service data-plane API version with customer-facing browser-session recording support.

- Adds `PATCH /playwrightworkspaces/{workspaceId}/browser-sessions/{sessionId}` for a per-session `recording.enabled` override.
- Extends browser-session GET and list responses with recording status and finalized artifact locations.
- Models the artifact container URL and trace artifact URLs as read-only response data.
- Adds source and generated examples for the new version.
- Registers the version in the service and AutoRest configuration.

The internal administrative PATCH used by FES to persist artifact metadata is intentionally not part of this public specification. Workspace recording defaults and upload identity remain in the Resource Provider API.

## Validation

- TypeSpec compilation passed.
- OpenAPI semantic validation passed.
- OpenAPI example validation passed.
- TypeSpec formatting and Git whitespace checks passed.