### PR TITLE
Remove former Compute API reviewers from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -93,7 +93,7 @@
 
 
 # PRLabel: %Compute
-/specification/compute/ @xinzewang233 @ookoka @audreyttt @haagha @bilaakpan-ms @grizzlytheodore @mabhard @danielli90 @smotwani @ppatwa @vikramd-ms @yunusm @ZhidongPeng @nkuchta @maheshnemichand @najams @changov
+/specification/compute/ @audreyttt @haagha @bilaakpan-ms @mabhard @danielli90 @smotwani @ppatwa @vikramd-ms @yunusm @ZhidongPeng @nkuchta @maheshnemichand @najams @changov
 
 /specification/consumption/ @arusing @micahbresette
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -93,7 +93,7 @@
 
 
 # PRLabel: %Compute
-/specification/compute/ @audreyttt @haagha @bilaakpan-ms @danielli90 @smotwani @yunusm @ZhidongPeng @maheshnemichand
+/specification/compute/ @haagha @audreyttt
 
 /specification/consumption/ @arusing @micahbresette
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -93,7 +93,7 @@
 
 
 # PRLabel: %Compute
-/specification/compute/ @audreyttt @haagha @bilaakpan-ms @mabhard @danielli90 @smotwani @ppatwa @vikramd-ms @yunusm @ZhidongPeng @nkuchta @maheshnemichand @najams @changov
+/specification/compute/ @audreyttt @haagha @bilaakpan-ms @danielli90 @smotwani @yunusm @ZhidongPeng @maheshnemichand
 
 /specification/consumption/ @arusing @micahbresette
 


### PR DESCRIPTION
## What this PR does

Removes former reviewers from the Compute CODEOWNERS entry.

## Why

This prevents owners who are no longer serving as CPlat reviewers from receiving Compute API review requests. It also keeps the CODEOWNERS entry accurate for consumers such as the portal project, which uses this list to identify CPlat reviewers.