### PR TITLE
Add back TypeSpec metadata emitter dependency removed by mistake

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@azure-tools/typespec-client-generator-cli": "0.33.1",
         "@azure-tools/typespec-client-generator-core": "0.72.0",
         "@azure-tools/typespec-liftr-base": "0.13.0",
+        "@azure-tools/typespec-metadata": "0.4.0",
         "@azure/avocado": "0.12.1",
         "@azure/oad": "0.12.4",
         "@microsoft.azure/openapi-validator": "2.2.4",
@@ -1296,6 +1297,25 @@
       "resolved": "https://registry.npmjs.org/@azure-tools/typespec-liftr-base/-/typespec-liftr-base-0.13.0.tgz",
       "integrity": "sha512-MF40K/IHwyy3N606DTZSPhFSwA/84ekR9RqvmtJXsXD0SdYcQSoAHOJp4o5qw8OAPSC+aKZ5A+TXRx333V/3PQ==",
       "dev": true
+    },
+    "node_modules/@azure-tools/typespec-metadata": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-metadata/-/typespec-metadata-0.4.0.tgz",
+      "integrity": "sha512-YFTBouDY1Q5E2cHcg5uTt87jhN+PE+l+qPb37gT2woNil8QxwMNHfwE8Rdc4DYJ8Ctb16Bs855YuDO1SYCV33w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yaml": "^2.9.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "@azure-tools/typespec-azure-core": "^0.72.0",
+        "@azure-tools/typespec-client-generator-core": "^0.72.0",
+        "@typespec/compiler": "^1.16.0",
+        "@typespec/versioning": "^0.86.0"
+      }
     },
     "node_modules/@azure-tools/typespec-migration-validation": {
       "resolved": "eng/tools/typespec-migration-validation",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@azure-tools/typespec-client-generator-cli": "0.33.1",
     "@azure-tools/typespec-client-generator-core": "0.72.0",
     "@azure-tools/typespec-liftr-base": "0.13.0",
+    "@azure-tools/typespec-metadata": "0.4.0",
     "@azure/avocado": "0.12.1",
     "@azure/oad": "0.12.4",
     "@microsoft.azure/openapi-validator": "2.2.4",


### PR DESCRIPTION
PR https://github.com/Azure/azure-rest-api-specs/pull/46261 removed by mistake(package wasn't published like the others)