### PR TITLE
Consolidate CodeTransparency operation names across API versions

### DIFF
--- a/specification/confidentialledger/Microsoft.CodeTransparency/client.tsp
+++ b/specification/confidentialledger/Microsoft.CodeTransparency/client.tsp
@@ -33,16 +33,6 @@ using Azure.ClientGenerator.Core;
   "csharp"
 );
 
-@@clientName(
-  Microsoft.CodeTransparency.getPublicKeys,
-  "getPublicKeysPreview",
-  "csharp"
-);
-@@clientName(
-  Microsoft.CodeTransparency.getPublicKeysV09,
-  "getPublicKeys",
-  "csharp"
-);
-@@convenientAPI(Microsoft.CodeTransparency.getPublicKeysV09, false, "csharp");
+@@convenientAPI(Microsoft.CodeTransparency.getPublicKeys, false, "csharp");
 @@convenientAPI(Microsoft.CodeTransparency.listScittKeys, false, "csharp");
 @@convenientAPI(Microsoft.CodeTransparency.getScittKey, false, "csharp");

--- a/specification/confidentialledger/Microsoft.CodeTransparency/main.tsp
+++ b/specification/confidentialledger/Microsoft.CodeTransparency/main.tsp
@@ -1,14 +1,12 @@
 import "@typespec/http";
 import "@typespec/rest";
 import "@typespec/versioning";
-import "@typespec/openapi";
 import "@azure-tools/typespec-azure-core";
 import "./client.tsp";
 
 using TypeSpec.Http;
 using TypeSpec.Rest;
 using TypeSpec.Versioning;
-using TypeSpec.OpenAPI;
 using Azure.Core;
 using Azure.Core.Foundations;
 using Azure.Core.Traits;
@@ -54,28 +52,11 @@ op getTransparencyConfigCbor is Foundations.Operation<
 #suppress "@azure-tools/typespec-azure-core/response-schema-problem" "cannot assign error to directive to cbor binary responses"
 #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "IETF SCITT/SCRAPI operation exchanges raw COSE/CBOR binary payloads and does not map to Azure.Core standard resource operations."
 @added(Versions.`2025-01-31-preview`)
-@removed(Versions.`2026-03-26`)
-@sharedRoute
 @doc("Get the public keys used by the service to sign receipts, mentioned in IETF SCITT draft as part of jwks_uri implementation")
 @route("/jwks")
 op getPublicKeys is Foundations.Operation<
   {},
-  JwksDocument,
-  ServiceTraits,
-  AnyCborError
->;
-
-#suppress "@azure-tools/typespec-azure-core/response-schema-problem" "cannot assign error to directive to cbor binary responses"
-#suppress "@azure-tools/typespec-azure-core/use-standard-operations" "IETF SCITT/SCRAPI operation exchanges raw COSE/CBOR binary payloads and does not map to Azure.Core standard resource operations."
-#suppress "@azure-tools/typespec-azure-core/no-openapi" "Preserving canonical GetPublicKeys operationId across versions"
-@added(Versions.`2026-03-26`)
-@operationId("GetPublicKeys")
-@sharedRoute
-@doc("Get the public keys used by the service to sign receipts, mentioned in IETF SCITT draft as part of jwks_uri implementation")
-@route("/jwks")
-op getPublicKeysV09 is Foundations.Operation<
-  {},
-  GetPublicKeysResponse,
+  PublicKeysResult,
   ServiceTraits,
   AnyCborError
 >;
@@ -107,114 +88,90 @@ op getScittKey is Foundations.Operation<
 
 #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "IETF SCITT/SCRAPI operation exchanges raw COSE/CBOR binary payloads and does not map to Azure.Core standard resource operations."
 @added(Versions.`2025-01-31-preview`)
-@removed(Versions.`2026-03-26`)
-@sharedRoute
 @doc("Post an entry to be registered on the CodeTransparency instance, mandatory in IETF SCITT draft")
 @post
 @route("/entries")
 op createEntry is Foundations.Operation<
-  SignedStatement & AcceptCoseOrCborHeader,
-  CreateEntryCreated | CreateEntryPending,
-  ServiceTraits,
-  AnyCborError
->;
-
-#suppress "@azure-tools/typespec-azure-core/use-standard-operations" "IETF SCITT/SCRAPI operation exchanges raw COSE/CBOR binary payloads and does not map to Azure.Core standard resource operations."
-#suppress "@azure-tools/typespec-azure-core/no-openapi" "Preserving canonical CreateEntry operationId across versions"
-@added(Versions.`2026-03-26`)
-@operationId("CreateEntry")
-@sharedRoute
-@doc("Post an entry to be registered on the CodeTransparency instance, mandatory in IETF SCITT draft")
-@post
-@route("/entries")
-op createEntryV09 is Foundations.Operation<
   SignedStatement & AcceptCoseOrCborHeader & WaitForCommitParameter,
-  CreateEntryCreated | CreateEntrySeeOther,
+  CreateEntryResult,
   ServiceTraits,
-  AnyCborErrorV09
+  VersionedCborError
 >;
 
 #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "IETF SCITT/SCRAPI operation exchanges raw COSE/CBOR binary payloads and does not map to Azure.Core standard resource operations."
+#deprecated "The /operations/{operationId} endpoint is deprecated in SCRAPI v09 (api-version=2026-03-26). Clients should poll /entries/{entryId} directly. Behavior is unchanged for backward compatibility."
 @added(Versions.`2025-01-31-preview`)
-@removed(Versions.`2026-03-26`)
-@sharedRoute
-@doc("Get status of the long running registration operation, mandatory in IETF SCITT draft")
+@doc("Get status of the long running registration operation. Deprecated starting with api-version=2026-03-26 (SCRAPI v09) but retained unchanged for backward compatibility; clients using that version should poll /entries/{entryId} directly.")
 @route("/operations/{operationId}")
 op getOperation is Foundations.Operation<
   OperationIdParameter & AcceptCborHeader,
   OperationStatusComplete | OperationStatusPending,
   ServiceTraits,
-  AnyCborError
->;
-
-#suppress "@azure-tools/typespec-azure-core/use-standard-operations" "IETF SCITT/SCRAPI operation exchanges raw COSE/CBOR binary payloads and does not map to Azure.Core standard resource operations."
-#suppress "@azure-tools/typespec-azure-core/no-openapi" "Preserving canonical GetOperation operationId across versions"
-#deprecated "The /operations/{operationId} endpoint is deprecated in SCRAPI v09 (api-version=2026-03-26). Clients should poll /entries/{entryId} directly. Behavior is unchanged for backward compatibility."
-@added(Versions.`2026-03-26`)
-@operationId("GetOperation")
-@sharedRoute
-@doc("Get status of the long running registration operation. Deprecated in SCRAPI v09 but retained unchanged for backward compatibility; clients should poll /entries/{entryId} directly.")
-@route("/operations/{operationId}")
-op getOperationV09 is Foundations.Operation<
-  OperationIdParameter & AcceptCborHeader,
-  OperationStatusComplete | OperationStatusPending,
-  ServiceTraits,
-  AnyCborErrorV09
+  VersionedCborError
 >;
 
 #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "IETF SCITT/SCRAPI operation exchanges raw COSE/CBOR binary payloads and does not map to Azure.Core standard resource operations."
 @added(Versions.`2025-01-31-preview`)
-@removed(Versions.`2026-03-26`)
-@sharedRoute
 @doc("Get receipt")
 @route("/entries/{entryId}")
 op getEntry is Foundations.Operation<
-  EntryIdParameter & AcceptCoseHeader,
-  ReceiptEntry,
-  ServiceTraits,
-  AnyCborError
->;
-
-#suppress "@azure-tools/typespec-azure-core/use-standard-operations" "IETF SCITT/SCRAPI operation exchanges raw COSE/CBOR binary payloads and does not map to Azure.Core standard resource operations."
-#suppress "@azure-tools/typespec-azure-core/no-openapi" "Preserving canonical GetEntry operationId across versions"
-@added(Versions.`2026-03-26`)
-@operationId("GetEntry")
-@sharedRoute
-@doc("Get receipt")
-@route("/entries/{entryId}")
-op getEntryV09 is Foundations.Operation<
   EntryIdParameter & AcceptScittReceiptHeader,
-  ReceiptEntry | ReceiptEntryPending,
+  ReceiptEntryResult,
   ServiceTraits,
-  AnyCborErrorV09
+  VersionedCborError
 >;
 
 #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "IETF SCITT/SCRAPI operation exchanges raw COSE/CBOR binary payloads and does not map to Azure.Core standard resource operations."
 @added(Versions.`2025-01-31-preview`)
-@removed(Versions.`2026-03-26`)
-@sharedRoute
 @doc("Get the transparent statement consisting of the signed statement and the receipt embedded in the header")
 @route("/entries/{entryId}/statement")
 op getEntryStatement is Foundations.Operation<
-  EntryIdParameter & AcceptCoseHeader,
-  TransparentStatement,
-  ServiceTraits,
-  AnyCborError
->;
-
-#suppress "@azure-tools/typespec-azure-core/use-standard-operations" "IETF SCITT/SCRAPI operation exchanges raw COSE/CBOR binary payloads and does not map to Azure.Core standard resource operations."
-#suppress "@azure-tools/typespec-azure-core/no-openapi" "Preserving canonical GetEntryStatement operationId across versions"
-@added(Versions.`2026-03-26`)
-@operationId("GetEntryStatement")
-@sharedRoute
-@doc("Get the transparent statement consisting of the signed statement and the receipt embedded in the header")
-@route("/entries/{entryId}/statement")
-op getEntryStatementV09 is Foundations.Operation<
   EntryIdParameter & AcceptScittStatementHeader,
   TransparentStatement,
   ServiceTraits,
-  AnyCborErrorV09
+  VersionedCborError
 >;
+
+@doc("The public key response for each supported API version.")
+union PublicKeysResult {
+  @removed(Versions.`2026-03-26`)
+  JwksDocument,
+
+  @added(Versions.`2026-03-26`)
+  GetPublicKeysResponse,
+}
+
+@doc("The immediate or pending result of registering an entry.")
+union CreateEntryResult {
+  CreateEntryCreated,
+
+  @removed(Versions.`2026-03-26`)
+  CreateEntryPending,
+
+  @added(Versions.`2026-03-26`)
+  CreateEntrySeeOther,
+}
+
+@doc("The receipt or, starting with SCRAPI v09, a redirect while it is pending.")
+union ReceiptEntryResult {
+  ReceiptEntry,
+
+  @added(Versions.`2026-03-26`)
+  ReceiptEntryPending,
+}
+
+@doc("CBOR errors, including authentication failures starting with SCRAPI v09.")
+union VersionedCborError {
+  Response400Cbor,
+
+  @added(Versions.`2026-03-26`)
+  Response401Cbor,
+
+  Response404Cbor,
+  Response429Cbor,
+  Response500Cbor,
+  Response503Cbor,
+}
 
 @added(Versions.`2025-01-31-preview`)
 @doc("Response of entry submission if the response can be served immediately, mandatory in IETF SCITT draft")
@@ -439,9 +396,9 @@ model KidParameter {
 }
 
 @doc("WaitForCommit query parameter for synchronous registration")
-@added(Versions.`2026-03-26`)
 model WaitForCommitParameter {
   @doc("If true, waits for the entry to be committed before returning. Returns 201 with receipt or 503 on rollback.")
+  @added(Versions.`2026-03-26`)
   @query
   waitForCommit?: boolean;
 }
@@ -453,25 +410,18 @@ model AcceptCoseOrCborHeader {
   accept: "application/cose; application/cbor";
 }
 
-@doc("Accept application/cose header")
-model AcceptCoseHeader {
-  @doc("Accept header")
-  @header
-  accept: "application/cose";
-}
-
 @doc("Accept application/scitt-statement+cose header")
-@added(Versions.`2026-03-26`)
 model AcceptScittStatementHeader {
   @doc("Accept header")
+  @typeChangedFrom(Versions.`2026-03-26`, "application/cose")
   @header
   accept: "application/scitt-statement+cose";
 }
 
 @doc("Accept application/scitt-receipt+cose header")
-@added(Versions.`2026-03-26`)
 model AcceptScittReceiptHeader {
   @doc("Accept header")
+  @typeChangedFrom(Versions.`2026-03-26`, "application/cose")
   @header
   accept: "application/scitt-receipt+cose";
 }

--- a/specification/confidentialledger/Microsoft.CodeTransparency/test/2025-01-31-preview.snap
+++ b/specification/confidentialledger/Microsoft.CodeTransparency/test/2025-01-31-preview.snap
@@ -1,0 +1,1851 @@
+[
+  {
+    "path": "/.well-known/transparency-configuration",
+    "verb": "get",
+    "parameters": [
+      {
+        "name": "api-version",
+        "location": "query",
+        "optional": false,
+        "type": "string"
+      },
+      {
+        "name": "accept",
+        "location": "header",
+        "optional": false,
+        "type": "application/cbor"
+      }
+    ],
+    "responses": [
+      {
+        "status": 200,
+        "type": {
+          "name": "TransparencyConfigurationCbor",
+          "properties": [
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/cbor"
+            },
+            {
+              "name": "body",
+              "wire": "body",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [],
+            "body": {
+              "contentTypes": [
+                "application/cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 500,
+        "type": {
+          "name": "Response500Cbor",
+          "properties": [
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 500
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 503,
+        "type": {
+          "name": "Response503Cbor",
+          "properties": [
+            {
+              "name": "retryAfter",
+              "wire": "retryAfter",
+              "optional": true,
+              "type": "int32"
+            },
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 503
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [
+              {
+                "name": "Retry-After",
+                "optional": true,
+                "type": "int32"
+              }
+            ],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      }
+    ],
+    "name": "getTransparencyConfigCbor"
+  },
+  {
+    "path": "/entries",
+    "verb": "post",
+    "parameters": [
+      {
+        "name": "api-version",
+        "location": "query",
+        "optional": false,
+        "type": "string"
+      },
+      {
+        "name": "Content-Type",
+        "location": "header",
+        "optional": false,
+        "type": "application/cose"
+      },
+      {
+        "name": "accept",
+        "location": "header",
+        "optional": false,
+        "type": "application/cose; application/cbor"
+      }
+    ],
+    "body": {
+      "contentTypes": [
+        "application/cose"
+      ],
+      "type": "bytes"
+    },
+    "responses": [
+      {
+        "status": 201,
+        "type": {
+          "name": "CreateEntryCreated",
+          "properties": [
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 201
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/cose"
+            },
+            {
+              "name": "location",
+              "wire": "location",
+              "optional": true,
+              "type": "string"
+            },
+            {
+              "name": "body",
+              "wire": "body",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [
+              {
+                "name": "Location",
+                "optional": true,
+                "type": "string"
+              }
+            ],
+            "body": {
+              "contentTypes": [
+                "application/cose"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 202,
+        "type": {
+          "name": "CreateEntryPending",
+          "properties": [
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 202
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/cbor"
+            },
+            {
+              "name": "location",
+              "wire": "location",
+              "optional": true,
+              "type": "string"
+            },
+            {
+              "name": "retryAfter",
+              "wire": "retryAfter",
+              "optional": true,
+              "type": "int32"
+            },
+            {
+              "name": "body",
+              "wire": "body",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [
+              {
+                "name": "Location",
+                "optional": true,
+                "type": "string"
+              },
+              {
+                "name": "Retry-After",
+                "optional": true,
+                "type": "int32"
+              }
+            ],
+            "body": {
+              "contentTypes": [
+                "application/cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 400,
+        "type": {
+          "name": "Response400Cbor",
+          "properties": [
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 400
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 404,
+        "type": {
+          "name": "Response404Cbor",
+          "properties": [
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 404
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 429,
+        "type": {
+          "name": "Response429Cbor",
+          "properties": [
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 429
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "retryAfter",
+              "wire": "retryAfter",
+              "optional": true,
+              "type": "int32"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [
+              {
+                "name": "Retry-After",
+                "optional": true,
+                "type": "int32"
+              }
+            ],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 500,
+        "type": {
+          "name": "Response500Cbor",
+          "properties": [
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 500
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 503,
+        "type": {
+          "name": "Response503Cbor",
+          "properties": [
+            {
+              "name": "retryAfter",
+              "wire": "retryAfter",
+              "optional": true,
+              "type": "int32"
+            },
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 503
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [
+              {
+                "name": "Retry-After",
+                "optional": true,
+                "type": "int32"
+              }
+            ],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      }
+    ],
+    "name": "createEntry"
+  },
+  {
+    "path": "/entries/{entryId}",
+    "verb": "get",
+    "parameters": [
+      {
+        "name": "api-version",
+        "location": "query",
+        "optional": false,
+        "type": "string"
+      },
+      {
+        "name": "entryId",
+        "location": "path",
+        "optional": false,
+        "type": "string"
+      },
+      {
+        "name": "accept",
+        "location": "header",
+        "optional": false,
+        "type": "application/cose"
+      }
+    ],
+    "responses": [
+      {
+        "status": 200,
+        "type": {
+          "name": "ReceiptEntry",
+          "properties": [
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/cose"
+            },
+            {
+              "name": "location",
+              "wire": "location",
+              "optional": true,
+              "type": "string"
+            },
+            {
+              "name": "body",
+              "wire": "body",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [
+              {
+                "name": "Location",
+                "optional": true,
+                "type": "string"
+              }
+            ],
+            "body": {
+              "contentTypes": [
+                "application/cose"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 400,
+        "type": {
+          "name": "Response400Cbor",
+          "properties": [
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 400
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 404,
+        "type": {
+          "name": "Response404Cbor",
+          "properties": [
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 404
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 429,
+        "type": {
+          "name": "Response429Cbor",
+          "properties": [
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 429
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "retryAfter",
+              "wire": "retryAfter",
+              "optional": true,
+              "type": "int32"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [
+              {
+                "name": "Retry-After",
+                "optional": true,
+                "type": "int32"
+              }
+            ],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 500,
+        "type": {
+          "name": "Response500Cbor",
+          "properties": [
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 500
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 503,
+        "type": {
+          "name": "Response503Cbor",
+          "properties": [
+            {
+              "name": "retryAfter",
+              "wire": "retryAfter",
+              "optional": true,
+              "type": "int32"
+            },
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 503
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [
+              {
+                "name": "Retry-After",
+                "optional": true,
+                "type": "int32"
+              }
+            ],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      }
+    ],
+    "name": "getEntry"
+  },
+  {
+    "path": "/entries/{entryId}/statement",
+    "verb": "get",
+    "parameters": [
+      {
+        "name": "api-version",
+        "location": "query",
+        "optional": false,
+        "type": "string"
+      },
+      {
+        "name": "entryId",
+        "location": "path",
+        "optional": false,
+        "type": "string"
+      },
+      {
+        "name": "accept",
+        "location": "header",
+        "optional": false,
+        "type": "application/cose"
+      }
+    ],
+    "responses": [
+      {
+        "status": 200,
+        "type": {
+          "name": "TransparentStatement",
+          "properties": [
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/cose"
+            },
+            {
+              "name": "body",
+              "wire": "body",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [],
+            "body": {
+              "contentTypes": [
+                "application/cose"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 400,
+        "type": {
+          "name": "Response400Cbor",
+          "properties": [
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 400
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 404,
+        "type": {
+          "name": "Response404Cbor",
+          "properties": [
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 404
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 429,
+        "type": {
+          "name": "Response429Cbor",
+          "properties": [
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 429
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "retryAfter",
+              "wire": "retryAfter",
+              "optional": true,
+              "type": "int32"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [
+              {
+                "name": "Retry-After",
+                "optional": true,
+                "type": "int32"
+              }
+            ],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 500,
+        "type": {
+          "name": "Response500Cbor",
+          "properties": [
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 500
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 503,
+        "type": {
+          "name": "Response503Cbor",
+          "properties": [
+            {
+              "name": "retryAfter",
+              "wire": "retryAfter",
+              "optional": true,
+              "type": "int32"
+            },
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 503
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [
+              {
+                "name": "Retry-After",
+                "optional": true,
+                "type": "int32"
+              }
+            ],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      }
+    ],
+    "name": "getEntryStatement"
+  },
+  {
+    "path": "/jwks",
+    "verb": "get",
+    "parameters": [
+      {
+        "name": "api-version",
+        "location": "query",
+        "optional": false,
+        "type": "string"
+      }
+    ],
+    "responses": [
+      {
+        "status": 200,
+        "type": {
+          "name": "JwksDocument",
+          "properties": [
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/json"
+            },
+            {
+              "name": "keys",
+              "wire": "keys",
+              "optional": false,
+              "type": {
+                "name": "Array",
+                "indexer": {
+                  "name": "JsonWebKey",
+                  "properties": [
+                    {
+                      "name": "alg",
+                      "wire": "alg",
+                      "optional": true,
+                      "type": "string"
+                    },
+                    {
+                      "name": "crv",
+                      "wire": "crv",
+                      "optional": true,
+                      "type": "string"
+                    },
+                    {
+                      "name": "d",
+                      "wire": "d",
+                      "optional": true,
+                      "type": "string"
+                    },
+                    {
+                      "name": "dp",
+                      "wire": "dp",
+                      "optional": true,
+                      "type": "string"
+                    },
+                    {
+                      "name": "dq",
+                      "wire": "dq",
+                      "optional": true,
+                      "type": "string"
+                    },
+                    {
+                      "name": "e",
+                      "wire": "e",
+                      "optional": true,
+                      "type": "string"
+                    },
+                    {
+                      "name": "k",
+                      "wire": "k",
+                      "optional": true,
+                      "type": "string"
+                    },
+                    {
+                      "name": "kid",
+                      "wire": "kid",
+                      "optional": true,
+                      "type": "string"
+                    },
+                    {
+                      "name": "kty",
+                      "wire": "kty",
+                      "optional": false,
+                      "type": "string"
+                    },
+                    {
+                      "name": "n",
+                      "wire": "n",
+                      "optional": true,
+                      "type": "string"
+                    },
+                    {
+                      "name": "p",
+                      "wire": "p",
+                      "optional": true,
+                      "type": "string"
+                    },
+                    {
+                      "name": "q",
+                      "wire": "q",
+                      "optional": true,
+                      "type": "string"
+                    },
+                    {
+                      "name": "qi",
+                      "wire": "qi",
+                      "optional": true,
+                      "type": "string"
+                    },
+                    {
+                      "name": "use",
+                      "wire": "use",
+                      "optional": true,
+                      "type": "string"
+                    },
+                    {
+                      "name": "x",
+                      "wire": "x",
+                      "optional": true,
+                      "type": "string"
+                    },
+                    {
+                      "name": "x5c",
+                      "wire": "x5c",
+                      "optional": true,
+                      "type": {
+                        "name": "Array",
+                        "indexer": "string",
+                        "properties": []
+                      }
+                    },
+                    {
+                      "name": "y",
+                      "wire": "y",
+                      "optional": true,
+                      "type": "string"
+                    }
+                  ]
+                },
+                "properties": []
+              }
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [],
+            "body": {
+              "contentTypes": [
+                "application/json"
+              ],
+              "type": {
+                "name": "",
+                "properties": [
+                  {
+                    "name": "keys",
+                    "wire": "keys",
+                    "optional": false,
+                    "type": {
+                      "name": "Array",
+                      "indexer": {
+                        "name": "JsonWebKey",
+                        "properties": [
+                          {
+                            "name": "alg",
+                            "wire": "alg",
+                            "optional": true,
+                            "type": "string"
+                          },
+                          {
+                            "name": "crv",
+                            "wire": "crv",
+                            "optional": true,
+                            "type": "string"
+                          },
+                          {
+                            "name": "d",
+                            "wire": "d",
+                            "optional": true,
+                            "type": "string"
+                          },
+                          {
+                            "name": "dp",
+                            "wire": "dp",
+                            "optional": true,
+                            "type": "string"
+                          },
+                          {
+                            "name": "dq",
+                            "wire": "dq",
+                            "optional": true,
+                            "type": "string"
+                          },
+                          {
+                            "name": "e",
+                            "wire": "e",
+                            "optional": true,
+                            "type": "string"
+                          },
+                          {
+                            "name": "k",
+                            "wire": "k",
+                            "optional": true,
+                            "type": "string"
+                          },
+                          {
+                            "name": "kid",
+                            "wire": "kid",
+                            "optional": true,
+                            "type": "string"
+                          },
+                          {
+                            "name": "kty",
+                            "wire": "kty",
+                            "optional": false,
+                            "type": "string"
+                          },
+                          {
+                            "name": "n",
+                            "wire": "n",
+                            "optional": true,
+                            "type": "string"
+                          },
+                          {
+                            "name": "p",
+                            "wire": "p",
+                            "optional": true,
+                            "type": "string"
+                          },
+                          {
+                            "name": "q",
+                            "wire": "q",
+                            "optional": true,
+                            "type": "string"
+                          },
+                          {
+                            "name": "qi",
+                            "wire": "qi",
+                            "optional": true,
+                            "type": "string"
+                          },
+                          {
+                            "name": "use",
+                            "wire": "use",
+                            "optional": true,
+                            "type": "string"
+                          },
+                          {
+                            "name": "x",
+                            "wire": "x",
+                            "optional": true,
+                            "type": "string"
+                          },
+                          {
+                            "name": "x5c",
+                            "wire": "x5c",
+                            "optional": true,
+                            "type": {
+                              "name": "Array",
+                              "indexer": "string",
+                              "properties": []
+                            }
+                          },
+                          {
+                            "name": "y",
+                            "wire": "y",
+                            "optional": true,
+                            "type": "string"
+                          }
+                        ]
+                      },
+                      "properties": []
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      },
+      {
+        "status": 400,
+        "type": {
+          "name": "Response400Cbor",
+          "properties": [
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 400
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 404,
+        "type": {
+          "name": "Response404Cbor",
+          "properties": [
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 404
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 429,
+        "type": {
+          "name": "Response429Cbor",
+          "properties": [
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 429
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "retryAfter",
+              "wire": "retryAfter",
+              "optional": true,
+              "type": "int32"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [
+              {
+                "name": "Retry-After",
+                "optional": true,
+                "type": "int32"
+              }
+            ],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 500,
+        "type": {
+          "name": "Response500Cbor",
+          "properties": [
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 500
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 503,
+        "type": {
+          "name": "Response503Cbor",
+          "properties": [
+            {
+              "name": "retryAfter",
+              "wire": "retryAfter",
+              "optional": true,
+              "type": "int32"
+            },
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 503
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [
+              {
+                "name": "Retry-After",
+                "optional": true,
+                "type": "int32"
+              }
+            ],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      }
+    ],
+    "name": "getPublicKeys"
+  },
+  {
+    "path": "/operations/{operationId}",
+    "verb": "get",
+    "parameters": [
+      {
+        "name": "api-version",
+        "location": "query",
+        "optional": false,
+        "type": "string"
+      },
+      {
+        "name": "operationId",
+        "location": "path",
+        "optional": false,
+        "type": "string"
+      },
+      {
+        "name": "accept",
+        "location": "header",
+        "optional": false,
+        "type": "application/cbor"
+      }
+    ],
+    "responses": [
+      {
+        "status": 200,
+        "type": {
+          "name": "OperationStatusComplete",
+          "properties": [
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/cbor"
+            },
+            {
+              "name": "location",
+              "wire": "location",
+              "optional": true,
+              "type": "string"
+            },
+            {
+              "name": "body",
+              "wire": "body",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [
+              {
+                "name": "Location",
+                "optional": true,
+                "type": "string"
+              }
+            ],
+            "body": {
+              "contentTypes": [
+                "application/cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 202,
+        "type": {
+          "name": "OperationStatusPending",
+          "properties": [
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 202
+            },
+            {
+              "name": "location",
+              "wire": "location",
+              "optional": true,
+              "type": "string"
+            },
+            {
+              "name": "retryAfter",
+              "wire": "retryAfter",
+              "optional": true,
+              "type": "int32"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [
+              {
+                "name": "Location",
+                "optional": true,
+                "type": "string"
+              },
+              {
+                "name": "Retry-After",
+                "optional": true,
+                "type": "int32"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "status": 400,
+        "type": {
+          "name": "Response400Cbor",
+          "properties": [
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 400
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 404,
+        "type": {
+          "name": "Response404Cbor",
+          "properties": [
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 404
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 429,
+        "type": {
+          "name": "Response429Cbor",
+          "properties": [
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 429
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "retryAfter",
+              "wire": "retryAfter",
+              "optional": true,
+              "type": "int32"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [
+              {
+                "name": "Retry-After",
+                "optional": true,
+                "type": "int32"
+              }
+            ],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 500,
+        "type": {
+          "name": "Response500Cbor",
+          "properties": [
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 500
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 503,
+        "type": {
+          "name": "Response503Cbor",
+          "properties": [
+            {
+              "name": "retryAfter",
+              "wire": "retryAfter",
+              "optional": true,
+              "type": "int32"
+            },
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 503
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [
+              {
+                "name": "Retry-After",
+                "optional": true,
+                "type": "int32"
+              }
+            ],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      }
+    ],
+    "name": "getOperation"
+  }
+]

--- a/specification/confidentialledger/Microsoft.CodeTransparency/test/2026-03-26.snap
+++ b/specification/confidentialledger/Microsoft.CodeTransparency/test/2026-03-26.snap
@@ -1,0 +1,2656 @@
+[
+  {
+    "path": "/.well-known/scitt-keys",
+    "verb": "get",
+    "parameters": [
+      {
+        "name": "api-version",
+        "location": "query",
+        "optional": false,
+        "type": "string"
+      },
+      {
+        "name": "accept",
+        "location": "header",
+        "optional": false,
+        "type": "application/cbor"
+      }
+    ],
+    "responses": [
+      {
+        "status": 200,
+        "type": {
+          "name": "ScittKeysResponse",
+          "properties": [
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/cbor"
+            },
+            {
+              "name": "body",
+              "wire": "body",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [],
+            "body": {
+              "contentTypes": [
+                "application/cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 400,
+        "type": {
+          "name": "Response400Cbor",
+          "properties": [
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 400
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 401,
+        "type": {
+          "name": "Response401Cbor",
+          "properties": [
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 401
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 404,
+        "type": {
+          "name": "Response404Cbor",
+          "properties": [
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 404
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 429,
+        "type": {
+          "name": "Response429Cbor",
+          "properties": [
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 429
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "retryAfter",
+              "wire": "retryAfter",
+              "optional": true,
+              "type": "int32"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [
+              {
+                "name": "Retry-After",
+                "optional": true,
+                "type": "int32"
+              }
+            ],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 500,
+        "type": {
+          "name": "Response500Cbor",
+          "properties": [
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 500
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 503,
+        "type": {
+          "name": "Response503Cbor",
+          "properties": [
+            {
+              "name": "retryAfter",
+              "wire": "retryAfter",
+              "optional": true,
+              "type": "int32"
+            },
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 503
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "transactionId",
+              "wire": "transactionId",
+              "optional": true,
+              "type": "string"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [
+              {
+                "name": "Retry-After",
+                "optional": true,
+                "type": "int32"
+              },
+              {
+                "name": "x-ms-ccf-transaction-id",
+                "optional": true,
+                "type": "string"
+              }
+            ],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      }
+    ],
+    "name": "listScittKeys"
+  },
+  {
+    "path": "/.well-known/scitt-keys/{kid}",
+    "verb": "get",
+    "parameters": [
+      {
+        "name": "api-version",
+        "location": "query",
+        "optional": false,
+        "type": "string"
+      },
+      {
+        "name": "kid",
+        "location": "path",
+        "optional": false,
+        "type": "string"
+      },
+      {
+        "name": "accept",
+        "location": "header",
+        "optional": false,
+        "type": "application/cbor"
+      }
+    ],
+    "responses": [
+      {
+        "status": 200,
+        "type": {
+          "name": "ScittKeyResponse",
+          "properties": [
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/cbor"
+            },
+            {
+              "name": "body",
+              "wire": "body",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [],
+            "body": {
+              "contentTypes": [
+                "application/cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 400,
+        "type": {
+          "name": "Response400Cbor",
+          "properties": [
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 400
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 401,
+        "type": {
+          "name": "Response401Cbor",
+          "properties": [
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 401
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 404,
+        "type": {
+          "name": "Response404Cbor",
+          "properties": [
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 404
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 429,
+        "type": {
+          "name": "Response429Cbor",
+          "properties": [
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 429
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "retryAfter",
+              "wire": "retryAfter",
+              "optional": true,
+              "type": "int32"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [
+              {
+                "name": "Retry-After",
+                "optional": true,
+                "type": "int32"
+              }
+            ],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 500,
+        "type": {
+          "name": "Response500Cbor",
+          "properties": [
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 500
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 503,
+        "type": {
+          "name": "Response503Cbor",
+          "properties": [
+            {
+              "name": "retryAfter",
+              "wire": "retryAfter",
+              "optional": true,
+              "type": "int32"
+            },
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 503
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "transactionId",
+              "wire": "transactionId",
+              "optional": true,
+              "type": "string"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [
+              {
+                "name": "Retry-After",
+                "optional": true,
+                "type": "int32"
+              },
+              {
+                "name": "x-ms-ccf-transaction-id",
+                "optional": true,
+                "type": "string"
+              }
+            ],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      }
+    ],
+    "name": "getScittKey"
+  },
+  {
+    "path": "/.well-known/transparency-configuration",
+    "verb": "get",
+    "parameters": [
+      {
+        "name": "api-version",
+        "location": "query",
+        "optional": false,
+        "type": "string"
+      },
+      {
+        "name": "accept",
+        "location": "header",
+        "optional": false,
+        "type": "application/cbor"
+      }
+    ],
+    "responses": [
+      {
+        "status": 200,
+        "type": {
+          "name": "TransparencyConfigurationCbor",
+          "properties": [
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/cbor"
+            },
+            {
+              "name": "body",
+              "wire": "body",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [],
+            "body": {
+              "contentTypes": [
+                "application/cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 500,
+        "type": {
+          "name": "Response500Cbor",
+          "properties": [
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 500
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 503,
+        "type": {
+          "name": "Response503Cbor",
+          "properties": [
+            {
+              "name": "retryAfter",
+              "wire": "retryAfter",
+              "optional": true,
+              "type": "int32"
+            },
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 503
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "transactionId",
+              "wire": "transactionId",
+              "optional": true,
+              "type": "string"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [
+              {
+                "name": "Retry-After",
+                "optional": true,
+                "type": "int32"
+              },
+              {
+                "name": "x-ms-ccf-transaction-id",
+                "optional": true,
+                "type": "string"
+              }
+            ],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      }
+    ],
+    "name": "getTransparencyConfigCbor"
+  },
+  {
+    "path": "/entries",
+    "verb": "post",
+    "parameters": [
+      {
+        "name": "api-version",
+        "location": "query",
+        "optional": false,
+        "type": "string"
+      },
+      {
+        "name": "Content-Type",
+        "location": "header",
+        "optional": false,
+        "type": "application/cose"
+      },
+      {
+        "name": "accept",
+        "location": "header",
+        "optional": false,
+        "type": "application/cose; application/cbor"
+      },
+      {
+        "name": "waitForCommit",
+        "location": "query",
+        "optional": true,
+        "type": "boolean"
+      }
+    ],
+    "body": {
+      "contentTypes": [
+        "application/cose"
+      ],
+      "type": "bytes"
+    },
+    "responses": [
+      {
+        "status": 201,
+        "type": {
+          "name": "CreateEntryCreated",
+          "properties": [
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 201
+            },
+            {
+              "name": "contentTypeV09",
+              "wire": "contentTypeV09",
+              "optional": false,
+              "type": "application/scitt-receipt+cose"
+            },
+            {
+              "name": "location",
+              "wire": "location",
+              "optional": true,
+              "type": "string"
+            },
+            {
+              "name": "transactionId",
+              "wire": "transactionId",
+              "optional": true,
+              "type": "string"
+            },
+            {
+              "name": "body",
+              "wire": "body",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [
+              {
+                "name": "Location",
+                "optional": true,
+                "type": "string"
+              },
+              {
+                "name": "x-ms-ccf-transaction-id",
+                "optional": true,
+                "type": "string"
+              }
+            ],
+            "body": {
+              "contentTypes": [
+                "application/scitt-receipt+cose"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 303,
+        "type": {
+          "name": "CreateEntrySeeOther",
+          "properties": [
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 303
+            },
+            {
+              "name": "location",
+              "wire": "location",
+              "optional": false,
+              "type": "string"
+            },
+            {
+              "name": "transactionId",
+              "wire": "transactionId",
+              "optional": false,
+              "type": "string"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [
+              {
+                "name": "Location",
+                "optional": false,
+                "type": "string"
+              },
+              {
+                "name": "x-ms-ccf-transaction-id",
+                "optional": false,
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "status": 400,
+        "type": {
+          "name": "Response400Cbor",
+          "properties": [
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 400
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 401,
+        "type": {
+          "name": "Response401Cbor",
+          "properties": [
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 401
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 404,
+        "type": {
+          "name": "Response404Cbor",
+          "properties": [
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 404
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 429,
+        "type": {
+          "name": "Response429Cbor",
+          "properties": [
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 429
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "retryAfter",
+              "wire": "retryAfter",
+              "optional": true,
+              "type": "int32"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [
+              {
+                "name": "Retry-After",
+                "optional": true,
+                "type": "int32"
+              }
+            ],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 500,
+        "type": {
+          "name": "Response500Cbor",
+          "properties": [
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 500
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 503,
+        "type": {
+          "name": "Response503Cbor",
+          "properties": [
+            {
+              "name": "retryAfter",
+              "wire": "retryAfter",
+              "optional": true,
+              "type": "int32"
+            },
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 503
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "transactionId",
+              "wire": "transactionId",
+              "optional": true,
+              "type": "string"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [
+              {
+                "name": "Retry-After",
+                "optional": true,
+                "type": "int32"
+              },
+              {
+                "name": "x-ms-ccf-transaction-id",
+                "optional": true,
+                "type": "string"
+              }
+            ],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      }
+    ],
+    "name": "createEntry"
+  },
+  {
+    "path": "/entries/{entryId}",
+    "verb": "get",
+    "parameters": [
+      {
+        "name": "api-version",
+        "location": "query",
+        "optional": false,
+        "type": "string"
+      },
+      {
+        "name": "entryId",
+        "location": "path",
+        "optional": false,
+        "type": "string"
+      },
+      {
+        "name": "accept",
+        "location": "header",
+        "optional": false,
+        "type": "application/scitt-receipt+cose"
+      }
+    ],
+    "responses": [
+      {
+        "status": 200,
+        "type": {
+          "name": "ReceiptEntry",
+          "properties": [
+            {
+              "name": "contentTypeV09",
+              "wire": "contentTypeV09",
+              "optional": false,
+              "type": "application/scitt-receipt+cose"
+            },
+            {
+              "name": "location",
+              "wire": "location",
+              "optional": true,
+              "type": "string"
+            },
+            {
+              "name": "body",
+              "wire": "body",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [
+              {
+                "name": "Location",
+                "optional": true,
+                "type": "string"
+              }
+            ],
+            "body": {
+              "contentTypes": [
+                "application/scitt-receipt+cose"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 302,
+        "type": {
+          "name": "ReceiptEntryPending",
+          "properties": [
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 302
+            },
+            {
+              "name": "location",
+              "wire": "location",
+              "optional": false,
+              "type": "string"
+            },
+            {
+              "name": "retryAfter",
+              "wire": "retryAfter",
+              "optional": true,
+              "type": "int32"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [
+              {
+                "name": "Location",
+                "optional": false,
+                "type": "string"
+              },
+              {
+                "name": "Retry-After",
+                "optional": true,
+                "type": "int32"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "status": 400,
+        "type": {
+          "name": "Response400Cbor",
+          "properties": [
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 400
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 401,
+        "type": {
+          "name": "Response401Cbor",
+          "properties": [
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 401
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 404,
+        "type": {
+          "name": "Response404Cbor",
+          "properties": [
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 404
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 429,
+        "type": {
+          "name": "Response429Cbor",
+          "properties": [
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 429
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "retryAfter",
+              "wire": "retryAfter",
+              "optional": true,
+              "type": "int32"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [
+              {
+                "name": "Retry-After",
+                "optional": true,
+                "type": "int32"
+              }
+            ],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 500,
+        "type": {
+          "name": "Response500Cbor",
+          "properties": [
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 500
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 503,
+        "type": {
+          "name": "Response503Cbor",
+          "properties": [
+            {
+              "name": "retryAfter",
+              "wire": "retryAfter",
+              "optional": true,
+              "type": "int32"
+            },
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 503
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "transactionId",
+              "wire": "transactionId",
+              "optional": true,
+              "type": "string"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [
+              {
+                "name": "Retry-After",
+                "optional": true,
+                "type": "int32"
+              },
+              {
+                "name": "x-ms-ccf-transaction-id",
+                "optional": true,
+                "type": "string"
+              }
+            ],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      }
+    ],
+    "name": "getEntry"
+  },
+  {
+    "path": "/entries/{entryId}/statement",
+    "verb": "get",
+    "parameters": [
+      {
+        "name": "api-version",
+        "location": "query",
+        "optional": false,
+        "type": "string"
+      },
+      {
+        "name": "entryId",
+        "location": "path",
+        "optional": false,
+        "type": "string"
+      },
+      {
+        "name": "accept",
+        "location": "header",
+        "optional": false,
+        "type": "application/scitt-statement+cose"
+      }
+    ],
+    "responses": [
+      {
+        "status": 200,
+        "type": {
+          "name": "TransparentStatement",
+          "properties": [
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/scitt-statement+cose"
+            },
+            {
+              "name": "body",
+              "wire": "body",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [],
+            "body": {
+              "contentTypes": [
+                "application/scitt-statement+cose"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 400,
+        "type": {
+          "name": "Response400Cbor",
+          "properties": [
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 400
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 401,
+        "type": {
+          "name": "Response401Cbor",
+          "properties": [
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 401
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 404,
+        "type": {
+          "name": "Response404Cbor",
+          "properties": [
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 404
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 429,
+        "type": {
+          "name": "Response429Cbor",
+          "properties": [
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 429
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "retryAfter",
+              "wire": "retryAfter",
+              "optional": true,
+              "type": "int32"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [
+              {
+                "name": "Retry-After",
+                "optional": true,
+                "type": "int32"
+              }
+            ],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 500,
+        "type": {
+          "name": "Response500Cbor",
+          "properties": [
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 500
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 503,
+        "type": {
+          "name": "Response503Cbor",
+          "properties": [
+            {
+              "name": "retryAfter",
+              "wire": "retryAfter",
+              "optional": true,
+              "type": "int32"
+            },
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 503
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "transactionId",
+              "wire": "transactionId",
+              "optional": true,
+              "type": "string"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [
+              {
+                "name": "Retry-After",
+                "optional": true,
+                "type": "int32"
+              },
+              {
+                "name": "x-ms-ccf-transaction-id",
+                "optional": true,
+                "type": "string"
+              }
+            ],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      }
+    ],
+    "name": "getEntryStatement"
+  },
+  {
+    "path": "/jwks",
+    "verb": "get",
+    "parameters": [
+      {
+        "name": "api-version",
+        "location": "query",
+        "optional": false,
+        "type": "string"
+      }
+    ],
+    "responses": [
+      {
+        "status": 200,
+        "type": {
+          "name": "GetPublicKeysResponse",
+          "properties": [
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/json"
+            },
+            {
+              "name": "body",
+              "wire": "body",
+              "optional": false,
+              "type": {
+                "name": "JsonWebKeySet",
+                "properties": [
+                  {
+                    "name": "keys",
+                    "wire": "keys",
+                    "optional": false,
+                    "type": {
+                      "name": "Array",
+                      "indexer": {
+                        "name": "PublicJsonWebKey",
+                        "properties": [
+                          {
+                            "name": "keyType",
+                            "wire": "kty",
+                            "optional": false,
+                            "type": "string"
+                          },
+                          {
+                            "name": "keyId",
+                            "wire": "kid",
+                            "optional": false,
+                            "type": "string"
+                          },
+                          {
+                            "name": "algorithm",
+                            "wire": "alg",
+                            "optional": true,
+                            "type": "string"
+                          },
+                          {
+                            "name": "publicKeyUse",
+                            "wire": "use",
+                            "optional": true,
+                            "type": "string"
+                          },
+                          {
+                            "name": "curveName",
+                            "wire": "crv",
+                            "optional": true,
+                            "type": "string"
+                          },
+                          {
+                            "name": "xCoordinate",
+                            "wire": "x",
+                            "optional": true,
+                            "type": "string"
+                          },
+                          {
+                            "name": "yCoordinate",
+                            "wire": "y",
+                            "optional": true,
+                            "type": "string"
+                          },
+                          {
+                            "name": "modulus",
+                            "wire": "n",
+                            "optional": true,
+                            "type": "string"
+                          },
+                          {
+                            "name": "exponent",
+                            "wire": "e",
+                            "optional": true,
+                            "type": "string"
+                          },
+                          {
+                            "name": "certificateChain",
+                            "wire": "x5c",
+                            "optional": true,
+                            "type": {
+                              "name": "Array",
+                              "indexer": "string",
+                              "properties": []
+                            }
+                          }
+                        ]
+                      },
+                      "properties": []
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [],
+            "body": {
+              "contentTypes": [
+                "application/json"
+              ],
+              "type": {
+                "name": "JsonWebKeySet",
+                "properties": [
+                  {
+                    "name": "keys",
+                    "wire": "keys",
+                    "optional": false,
+                    "type": {
+                      "name": "Array",
+                      "indexer": {
+                        "name": "PublicJsonWebKey",
+                        "properties": [
+                          {
+                            "name": "keyType",
+                            "wire": "kty",
+                            "optional": false,
+                            "type": "string"
+                          },
+                          {
+                            "name": "keyId",
+                            "wire": "kid",
+                            "optional": false,
+                            "type": "string"
+                          },
+                          {
+                            "name": "algorithm",
+                            "wire": "alg",
+                            "optional": true,
+                            "type": "string"
+                          },
+                          {
+                            "name": "publicKeyUse",
+                            "wire": "use",
+                            "optional": true,
+                            "type": "string"
+                          },
+                          {
+                            "name": "curveName",
+                            "wire": "crv",
+                            "optional": true,
+                            "type": "string"
+                          },
+                          {
+                            "name": "xCoordinate",
+                            "wire": "x",
+                            "optional": true,
+                            "type": "string"
+                          },
+                          {
+                            "name": "yCoordinate",
+                            "wire": "y",
+                            "optional": true,
+                            "type": "string"
+                          },
+                          {
+                            "name": "modulus",
+                            "wire": "n",
+                            "optional": true,
+                            "type": "string"
+                          },
+                          {
+                            "name": "exponent",
+                            "wire": "e",
+                            "optional": true,
+                            "type": "string"
+                          },
+                          {
+                            "name": "certificateChain",
+                            "wire": "x5c",
+                            "optional": true,
+                            "type": {
+                              "name": "Array",
+                              "indexer": "string",
+                              "properties": []
+                            }
+                          }
+                        ]
+                      },
+                      "properties": []
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      },
+      {
+        "status": 400,
+        "type": {
+          "name": "Response400Cbor",
+          "properties": [
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 400
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 404,
+        "type": {
+          "name": "Response404Cbor",
+          "properties": [
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 404
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 429,
+        "type": {
+          "name": "Response429Cbor",
+          "properties": [
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 429
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "retryAfter",
+              "wire": "retryAfter",
+              "optional": true,
+              "type": "int32"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [
+              {
+                "name": "Retry-After",
+                "optional": true,
+                "type": "int32"
+              }
+            ],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 500,
+        "type": {
+          "name": "Response500Cbor",
+          "properties": [
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 500
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 503,
+        "type": {
+          "name": "Response503Cbor",
+          "properties": [
+            {
+              "name": "retryAfter",
+              "wire": "retryAfter",
+              "optional": true,
+              "type": "int32"
+            },
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 503
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "transactionId",
+              "wire": "transactionId",
+              "optional": true,
+              "type": "string"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [
+              {
+                "name": "Retry-After",
+                "optional": true,
+                "type": "int32"
+              },
+              {
+                "name": "x-ms-ccf-transaction-id",
+                "optional": true,
+                "type": "string"
+              }
+            ],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      }
+    ],
+    "name": "getPublicKeys"
+  },
+  {
+    "path": "/operations/{operationId}",
+    "verb": "get",
+    "parameters": [
+      {
+        "name": "api-version",
+        "location": "query",
+        "optional": false,
+        "type": "string"
+      },
+      {
+        "name": "operationId",
+        "location": "path",
+        "optional": false,
+        "type": "string"
+      },
+      {
+        "name": "accept",
+        "location": "header",
+        "optional": false,
+        "type": "application/cbor"
+      }
+    ],
+    "responses": [
+      {
+        "status": 200,
+        "type": {
+          "name": "OperationStatusComplete",
+          "properties": [
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/cbor"
+            },
+            {
+              "name": "location",
+              "wire": "location",
+              "optional": true,
+              "type": "string"
+            },
+            {
+              "name": "body",
+              "wire": "body",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [
+              {
+                "name": "Location",
+                "optional": true,
+                "type": "string"
+              }
+            ],
+            "body": {
+              "contentTypes": [
+                "application/cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 202,
+        "type": {
+          "name": "OperationStatusPending",
+          "properties": [
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 202
+            },
+            {
+              "name": "location",
+              "wire": "location",
+              "optional": true,
+              "type": "string"
+            },
+            {
+              "name": "retryAfter",
+              "wire": "retryAfter",
+              "optional": true,
+              "type": "int32"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [
+              {
+                "name": "Location",
+                "optional": true,
+                "type": "string"
+              },
+              {
+                "name": "Retry-After",
+                "optional": true,
+                "type": "int32"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "status": 400,
+        "type": {
+          "name": "Response400Cbor",
+          "properties": [
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 400
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 401,
+        "type": {
+          "name": "Response401Cbor",
+          "properties": [
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 401
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 404,
+        "type": {
+          "name": "Response404Cbor",
+          "properties": [
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 404
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 429,
+        "type": {
+          "name": "Response429Cbor",
+          "properties": [
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 429
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "retryAfter",
+              "wire": "retryAfter",
+              "optional": true,
+              "type": "int32"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [
+              {
+                "name": "Retry-After",
+                "optional": true,
+                "type": "int32"
+              }
+            ],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 500,
+        "type": {
+          "name": "Response500Cbor",
+          "properties": [
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 500
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      },
+      {
+        "status": 503,
+        "type": {
+          "name": "Response503Cbor",
+          "properties": [
+            {
+              "name": "retryAfter",
+              "wire": "retryAfter",
+              "optional": true,
+              "type": "int32"
+            },
+            {
+              "name": "statusCode",
+              "wire": "statusCode",
+              "optional": false,
+              "type": 503
+            },
+            {
+              "name": "contentType",
+              "wire": "contentType",
+              "optional": false,
+              "type": "application/concise-problem-details+cbor"
+            },
+            {
+              "name": "transactionId",
+              "wire": "transactionId",
+              "optional": true,
+              "type": "string"
+            },
+            {
+              "name": "error",
+              "wire": "error",
+              "optional": false,
+              "type": "bytes"
+            }
+          ]
+        },
+        "content": [
+          {
+            "headers": [
+              {
+                "name": "Retry-After",
+                "optional": true,
+                "type": "int32"
+              },
+              {
+                "name": "x-ms-ccf-transaction-id",
+                "optional": true,
+                "type": "string"
+              }
+            ],
+            "body": {
+              "contentTypes": [
+                "application/concise-problem-details+cbor"
+              ],
+              "type": "bytes"
+            }
+          }
+        ]
+      }
+    ],
+    "name": "getOperation"
+  }
+]

--- a/specification/confidentialledger/Microsoft.CodeTransparency/test/README.md
+++ b/specification/confidentialledger/Microsoft.CodeTransparency/test/README.md
@@ -1,0 +1,17 @@
+# CodeTransparency contract regressions
+
+From the repository root, after the normal `npm ci`, run the existing Vitest runner and configuration:
+
+```powershell
+npx vitest run --config eng\tools\typespec-validation\vitest.config.js --dir specification\confidentialledger\Microsoft.CodeTransparency\test
+```
+
+The tests compile the real project, check both HTTP version projections against pre-consolidation snapshots, compare emitted OpenAPI with the checked-in files, and inspect C#, Java, Python, and JavaScript client-generator metadata. They do not generate SDK packages or introduce a new test framework.
+
+The snapshots were captured before consolidating the duplicate operations, using the repository's TypeSpec 1.16.0 and Azure libraries 0.72.0. Only the operation names were normalized to their stable names. They preserve each version's routes, methods, parameters, response codes, binary bodies, media types, headers, model properties, JWK encoded names, and requiredness. Descriptions and deprecation metadata are excluded from the wire snapshots and tested separately where relevant.
+
+The shared `getOperation` declaration carries a version-qualified deprecation message. TypeSpec's `#deprecated` directive is not versioned, so both projections expose the annotation even though the message explicitly dates deprecation to `2026-03-26`. The endpoint remains available in both versions.
+
+AutoRest omits unreachable schemas so the version-selection unions are not emitted as unsupported OpenAPI 2 payload definitions. This also prunes previously unused envelope definitions; all referenced JSON payload definitions and binary HTTP contracts are preserved.
+
+These service-local tests are explicitly invoked with the command above; no workflow or global test-discovery configuration is changed. Snapshot updates require reviewing both API-version wire contracts, not merely accepting output from `--update`.

--- a/specification/confidentialledger/Microsoft.CodeTransparency/test/contracts.test.ts
+++ b/specification/confidentialledger/Microsoft.CodeTransparency/test/contracts.test.ts
@@ -1,0 +1,411 @@
+import {
+  getAllServicesAtAllVersions,
+  resolveAutorestOptions,
+} from "@azure-tools/typespec-autorest";
+import { createSdkContext, getAccessOverride } from "@azure-tools/typespec-client-generator-core";
+import {
+  compile,
+  getDeprecationDetails,
+  getDoc,
+  getMaxLength,
+  listServices,
+  NodeHost,
+  resolveCompilerOptions,
+  resolveEncodedName,
+  type Namespace,
+  type Program,
+  type Type,
+} from "@typespec/compiler";
+import { unsafe_mutateSubgraphWithNamespace } from "@typespec/compiler/experimental";
+import { createPerfReporter } from "@typespec/compiler/utils";
+import {
+  getHttpService,
+  isSharedRoute,
+  type HttpOperation,
+  type HttpService,
+} from "@typespec/http";
+import { getVersioningMutators } from "@typespec/versioning";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { beforeAll, describe, expect, it } from "vitest";
+
+const project = resolve(import.meta.dirname, "..");
+const versions = ["2025-01-31-preview", "2026-03-26"] as const;
+const originalNames = [
+  "getTransparencyConfigCbor",
+  "getPublicKeys",
+  "createEntry",
+  "getOperation",
+  "getEntry",
+  "getEntryStatement",
+];
+const scittNames = ["listScittKeys", "getScittKey"];
+let program: Program;
+let namespace: Namespace;
+const httpServices = new Map<string, HttpService>();
+
+type Json = string | number | boolean | Json[] | { [key: string]: Json };
+
+function typeShape(type: Type, seen = new Set<Type>()): Json {
+  if (type.kind === "String" || type.kind === "Number" || type.kind === "Boolean") {
+    return type.value;
+  }
+  if (type.kind === "Union") {
+    return [...type.variants.values()].map((variant) => typeShape(variant.type, seen));
+  }
+  if (type.kind !== "Model") {
+    return "name" in type && typeof type.name === "string" ? type.name : type.kind;
+  }
+  if (seen.has(type)) return { ref: type.name };
+  const next = new Set([...seen, type]);
+  return {
+    name: type.name,
+    ...(type.indexer ? { indexer: typeShape(type.indexer.value, next) } : {}),
+    properties: [...type.properties.values()].map((property) => ({
+      name: property.name,
+      wire: resolveEncodedName(program, property, "application/json"),
+      optional: property.optional,
+      type: typeShape(property.type, next),
+    })),
+    ...(type.baseModel ? { base: typeShape(type.baseModel, next) } : {}),
+  };
+}
+
+function httpContract(operations: HttpOperation[]) {
+  return operations
+    .map((operation) => ({
+      path: operation.path,
+      verb: operation.verb,
+      parameters: operation.parameters.parameters.map((parameter) => ({
+        name: parameter.name,
+        location: parameter.type,
+        optional: parameter.param.optional,
+        type: typeShape(parameter.param.type),
+      })),
+      body: operation.parameters.body && {
+        contentTypes: operation.parameters.body.contentTypes,
+        type: typeShape(operation.parameters.body.type),
+      },
+      responses: operation.responses
+        .map((response) => ({
+          status: response.statusCodes,
+          type: typeShape(response.type),
+          content: response.responses.map((content) => ({
+            headers: Object.entries(content.headers ?? {}).map(([name, property]) => ({
+              name,
+              optional: property.optional,
+              type: typeShape(property.type),
+            })),
+            body: content.body && {
+              contentTypes: content.body.contentTypes,
+              type: typeShape(content.body.type),
+            },
+          })),
+        }))
+        .sort((a, b) => Number(a.status) - Number(b.status)),
+      name: operation.operation.name,
+    }))
+    .sort((a, b) => a.path.localeCompare(b.path));
+}
+
+function service(version: string) {
+  const result = httpServices.get(version);
+  assert.ok(result, `Missing HTTP projection for ${version}`);
+  return result;
+}
+
+function operation(version: string, name: string) {
+  const result = service(version).operations.find((op) => op.operation.name === name);
+  assert.ok(result, `Missing ${name} in ${version}`);
+  return result;
+}
+
+function response(version: string, name: string, status: number) {
+  const result = operation(version, name).responses.find((r) => r.statusCodes === status);
+  assert.ok(result, `Missing ${status} response for ${name} in ${version}`);
+  expect(result.responses).toHaveLength(1);
+  return result.responses[0];
+}
+
+beforeAll(async () => {
+  const [options, diagnostics] = await resolveCompilerOptions(NodeHost, {
+    entrypoint: resolve(project, "main.tsp"),
+    cwd: project,
+  });
+  expect(diagnostics).toEqual([]);
+  program = await compile(NodeHost, resolve(project, "main.tsp"), {
+    ...options,
+    noEmit: true,
+  });
+  expect(program.diagnostics).toEqual([]);
+  namespace = listServices(program)[0].type;
+  const mutations = getVersioningMutators(program, namespace);
+  assert.equal(mutations?.kind, "versioned");
+  expect(mutations.snapshots.map((snapshot) => snapshot.version.value)).toEqual(versions);
+  for (const snapshot of mutations.snapshots) {
+    const { type } = unsafe_mutateSubgraphWithNamespace(program, [snapshot.mutator], namespace);
+    assert.equal(type.kind, "Namespace");
+    const [http, httpDiagnostics] = getHttpService(program, type);
+    expect(httpDiagnostics).toEqual([]);
+    httpServices.set(snapshot.version.value, http);
+  }
+}, 30_000);
+
+it("declares one stable operation per endpoint without shared-route aliases", () => {
+  expect([...namespace.operations.keys()].sort()).toEqual([...originalNames, ...scittNames].sort());
+  for (const op of namespace.operations.values()) {
+    expect(isSharedRoute(program, op)).toBe(false);
+  }
+});
+
+it("keeps both checked-in OpenAPI projections synchronized with the TypeSpec config", async () => {
+  const [options] = await resolveCompilerOptions(NodeHost, {
+    entrypoint: resolve(project, "main.tsp"),
+    cwd: project,
+  });
+  const autorest = options.options?.["@azure-tools/typespec-autorest"];
+  assert.ok(autorest, "AutoRest configuration must exist");
+  assert.ok(typeof autorest["output-file"] === "string");
+  const records = await getAllServicesAtAllVersions(
+    program,
+    resolveAutorestOptions(program, resolve(project, ".."), {
+      ...autorest,
+      "output-file": autorest["output-file"],
+    }),
+  );
+  expect(program.diagnostics).toEqual([]);
+  expect(records).toHaveLength(1);
+  assert.ok(records[0].versioned);
+  for (const record of records[0].versions) {
+    const checkedIn: unknown = JSON.parse(await readFile(record.outputFile, "utf8"));
+    expect(JSON.parse(JSON.stringify(record.document))).toEqual(checkedIn);
+  }
+});
+
+describe.each(versions)("%s REST contract", (version) => {
+  const latest = version === "2026-03-26";
+
+  it("matches the pre-consolidation HTTP and model baseline", async () => {
+    // Only baseline operation names were normalized. Documentation/deprecation are
+    // asserted separately; wire names, optionality, types, media and headers are not.
+    await expect(
+      JSON.stringify(httpContract(service(version).operations), null, 2) + "\n",
+    ).toMatchFileSnapshot(resolve(import.meta.dirname, `${version}.snap`));
+  });
+
+  it("retains the correct endpoint set and bearer authentication", () => {
+    const http = service(version);
+    expect(http.operations.map((op) => op.operation.name).sort()).toEqual(
+      [...originalNames, ...(latest ? scittNames : [])].sort(),
+    );
+    expect(http.authentication).toMatchObject({
+      options: [{ schemes: [{ type: "http", scheme: "Bearer" }] }],
+    });
+  });
+
+  it("versions the spread waitForCommit property, not just its container", () => {
+    const create = operation(version, "createEntry");
+    const wait = create.parameters.parameters.find(
+      (parameter) => parameter.name === "waitForCommit",
+    );
+    if (latest) {
+      expect(wait).toMatchObject({
+        type: "query",
+        param: { optional: true, type: { kind: "Scalar", name: "boolean" } },
+      });
+    } else {
+      expect(wait).toBeUndefined();
+      expect(create.operation.parameters.properties.has("waitForCommit")).toBe(false);
+    }
+    expect(create.parameters.body).toMatchObject({
+      contentTypes: ["application/cose"],
+      type: { kind: "Scalar", name: "bytes" },
+    });
+  });
+
+  it.each([
+    ["getEntry", "application/scitt-receipt+cose"],
+    ["getEntryStatement", "application/scitt-statement+cose"],
+  ])("versions %s request and response media", (name, currentMedia) => {
+    const accept = operation(version, name).parameters.parameters.find((p) => p.name === "accept");
+    expect(accept).toMatchObject({
+      type: "header",
+      param: {
+        optional: false,
+        type: { kind: "String", value: latest ? currentMedia : "application/cose" },
+      },
+    });
+    expect(response(version, name, 200).body?.contentTypes).toEqual([
+      latest ? currentMedia : "application/cose",
+    ]);
+  });
+
+  it("retains entry submission statuses, body shape and header requiredness", () => {
+    const created = response(version, "createEntry", 201);
+    expect(created.body?.contentTypes).toEqual([
+      latest ? "application/scitt-receipt+cose" : "application/cose",
+    ]);
+    expect(created.headers?.Location?.optional).toBe(true);
+    expect(created.headers?.["x-ms-ccf-transaction-id"]?.optional).toBe(latest ? true : undefined);
+    const pending = response(version, "createEntry", latest ? 303 : 202);
+    expect(pending.headers?.Location?.optional).toBe(!latest);
+    if (latest) {
+      expect(pending.body).toBeUndefined();
+      expect(pending.headers?.["x-ms-ccf-transaction-id"]?.optional).toBe(false);
+    } else {
+      expect(pending.body).toMatchObject({
+        contentTypes: ["application/cbor"],
+        type: { name: "bytes" },
+      });
+      expect(pending.headers?.["Retry-After"]?.optional).toBe(true);
+    }
+  });
+
+  it("keeps the legacy JWKS and public-only current JWKS distinct", () => {
+    const body = response(version, "getPublicKeys", 200).body;
+    assert.ok(body);
+    expect(body.contentTypes).toEqual(["application/json"]);
+    assert.equal(body.type.kind, "Model");
+    const keys = body.type.properties.get("keys");
+    assert.ok(keys);
+    expect(keys.optional).toBe(false);
+    assert.equal(keys.type.kind, "Model");
+    const key = keys.type.indexer?.value;
+    assert.equal(key?.kind, "Model");
+    const properties = [...key.properties.values()];
+    const wireNames = properties.map((p) => resolveEncodedName(program, p, "application/json"));
+    expect(wireNames.sort()).toEqual(
+      (latest
+        ? ["kty", "kid", "alg", "use", "crv", "x", "y", "n", "e", "x5c"]
+        : [
+            "alg",
+            "crv",
+            "d",
+            "dp",
+            "dq",
+            "e",
+            "k",
+            "kid",
+            "kty",
+            "n",
+            "p",
+            "q",
+            "qi",
+            "use",
+            "x",
+            "x5c",
+            "y",
+          ]
+      ).sort(),
+    );
+    expect(
+      properties
+        .filter((p) => !p.optional)
+        .map((p) => resolveEncodedName(program, p, "application/json"))
+        .sort(),
+    ).toEqual(latest ? ["kid", "kty"] : ["kty"]);
+  });
+
+  it("only adds the receipt polling redirect in the current version", () => {
+    const op = operation(version, "getEntry");
+    expect(op.responses.some((r) => r.statusCodes === 302)).toBe(latest);
+    if (latest) {
+      const pending = response(version, "getEntry", 302);
+      expect(pending.body).toBeUndefined();
+      expect(pending.headers?.Location?.optional).toBe(false);
+      expect(pending.headers?.["Retry-After"]?.optional).toBe(true);
+    }
+  });
+
+  it("keeps the operations endpoint and version-qualified deprecation guidance", () => {
+    const op = operation(version, "getOperation");
+    expect(op.path).toBe("/operations/{operationId}");
+    expect(getDoc(program, op.operation)).toContain("starting with api-version=2026-03-26");
+    expect(getDeprecationDetails(program, op.operation)?.message).toContain(
+      "api-version=2026-03-26",
+    );
+    expect(response(version, "getOperation", 200).body?.contentTypes).toEqual(["application/cbor"]);
+    expect(response(version, "getOperation", 202).body).toBeUndefined();
+  });
+
+  it("only adds 401 to entry operations, never to JWKS", () => {
+    for (const name of [
+      "createEntry",
+      "getOperation",
+      "getEntry",
+      "getEntryStatement",
+      "getPublicKeys",
+    ]) {
+      const codes = operation(version, name).responses.map((r) => r.statusCodes);
+      expect(codes.includes(401)).toBe(latest && name !== "getPublicKeys");
+      for (const code of [400, 404, 429, 500, 503]) {
+        expect(response(version, name, code).body?.contentTypes).toEqual([
+          "application/concise-problem-details+cbor",
+        ]);
+      }
+      const unavailable = response(version, name, 503);
+      expect(unavailable.headers?.["Retry-After"]?.optional).toBe(true);
+      expect(unavailable.headers?.["x-ms-ccf-transaction-id"]?.optional).toBe(
+        latest ? true : undefined,
+      );
+    }
+  });
+
+  it("keeps path identifier constraints and required API-version parameters", () => {
+    for (const op of service(version).operations) {
+      const apiVersion = op.parameters.parameters.find((p) => p.name === "api-version");
+      expect(apiVersion).toMatchObject({ type: "query", param: { optional: false } });
+      for (const parameter of op.parameters.parameters) {
+        if (["entryId", "operationId"].includes(parameter.name)) {
+          expect(parameter.param.optional).toBe(false);
+          expect(getMaxLength(program, parameter.param)).toBe(100);
+        }
+      }
+    }
+  });
+
+  it.each(["csharp", "java", "python", "javascript"])(
+    "uses stable %s SDK names and customizations",
+    async (language) => {
+      const context = await createSdkContext(
+        {
+          program,
+          emitterOutputDir: project,
+          options: { "api-version": version },
+          perf: createPerfReporter(),
+        },
+        `@azure-tools/typespec-${language}`,
+        { exportTCGCoutput: false },
+      );
+      expect(context.diagnostics.filter((diagnostic) => diagnostic.severity === "error")).toEqual(
+        [],
+      );
+      const methods = context.sdkPackage.clients.flatMap((client) => client.methods);
+      expect(methods.map((method) => method.name).sort()).toEqual(
+        [...originalNames, ...(latest ? scittNames : [])].sort(),
+      );
+      expect(methods.every((method) => method.kind === "basic")).toBe(true);
+      expect(methods.every((method) => method.apiVersions.includes(version))).toBe(true);
+      expect(methods.find((method) => method.name === "getPublicKeys")?.generateConvenient).toBe(
+        language !== "csharp",
+      );
+      if (latest && language === "csharp") {
+        for (const name of scittNames) {
+          expect(methods.find((method) => method.name === name)?.generateConvenient).toBe(false);
+        }
+        for (const name of ["GetPublicKeysResponse", "JsonWebKeySet", "PublicJsonWebKey"]) {
+          const model = namespace.models.get(name);
+          assert.ok(model);
+          expect(getAccessOverride(context, model)).toBe("internal");
+        }
+      }
+      const create = methods.find((method) => method.name === "createEntry");
+      assert.ok(create);
+      expect(create.operation.bodyParam?.type.kind).toBe(
+        language === "javascript" ? "string" : "bytes",
+      );
+    },
+    30_000,
+  );
+});

--- a/specification/confidentialledger/Microsoft.CodeTransparency/tspconfig.yaml
+++ b/specification/confidentialledger/Microsoft.CodeTransparency/tspconfig.yaml
@@ -8,6 +8,7 @@ emit:
 options:
   "@azure-tools/typespec-autorest":
     emit-lro-options: "none"
+    omit-unreachable-types: true
     azure-resource-provider-folder: "./data-plane"
     emitter-output-dir: "{project-root}/.."
     output-file: "{azure-resource-provider-folder}/{service-name}/{version-status}/{version}/cts.json"

--- a/specification/confidentialledger/data-plane/Microsoft.CodeTransparency/preview/2025-01-31-preview/cts.json
+++ b/specification/confidentialledger/data-plane/Microsoft.CodeTransparency/preview/2025-01-31-preview/cts.json
@@ -109,7 +109,7 @@
         ],
         "responses": {
           "201": {
-            "description": "Response of entry submission if the response can be served immediately, mandatory in IETF SCITT draft",
+            "description": "The immediate or pending result of registering an entry.",
             "schema": {
               "type": "file"
             },
@@ -121,7 +121,7 @@
             }
           },
           "202": {
-            "description": "Response of entry submission containing the operation id, mandatory in IETF SCITT draft",
+            "description": "The immediate or pending result of registering an entry.",
             "schema": {
               "type": "file"
             },
@@ -138,19 +138,19 @@
             }
           },
           "400": {
-            "description": "Validation error response",
+            "description": "CBOR errors, including authentication failures starting with SCRAPI v09.",
             "schema": {
               "type": "file"
             }
           },
           "404": {
-            "description": "Not found error response",
+            "description": "CBOR errors, including authentication failures starting with SCRAPI v09.",
             "schema": {
               "type": "file"
             }
           },
           "429": {
-            "description": "Not found error response",
+            "description": "CBOR errors, including authentication failures starting with SCRAPI v09.",
             "schema": {
               "type": "file"
             },
@@ -163,13 +163,13 @@
             }
           },
           "500": {
-            "description": "Server error response",
+            "description": "CBOR errors, including authentication failures starting with SCRAPI v09.",
             "schema": {
               "type": "file"
             }
           },
           "503": {
-            "description": "Service unavailable error response",
+            "description": "CBOR errors, including authentication failures starting with SCRAPI v09.",
             "schema": {
               "type": "file"
             },
@@ -205,12 +205,12 @@
             "$ref": "#/parameters/EntryIdParameter"
           },
           {
-            "$ref": "#/parameters/AcceptCoseHeader"
+            "$ref": "#/parameters/AcceptScittReceiptHeader"
           }
         ],
         "responses": {
           "200": {
-            "description": "A ledger receipt, see IETF SCITT draft",
+            "description": "The receipt or, starting with SCRAPI v09, a redirect while it is pending.",
             "schema": {
               "type": "file"
             },
@@ -222,19 +222,19 @@
             }
           },
           "400": {
-            "description": "Validation error response",
+            "description": "CBOR errors, including authentication failures starting with SCRAPI v09.",
             "schema": {
               "type": "file"
             }
           },
           "404": {
-            "description": "Not found error response",
+            "description": "CBOR errors, including authentication failures starting with SCRAPI v09.",
             "schema": {
               "type": "file"
             }
           },
           "429": {
-            "description": "Not found error response",
+            "description": "CBOR errors, including authentication failures starting with SCRAPI v09.",
             "schema": {
               "type": "file"
             },
@@ -247,13 +247,13 @@
             }
           },
           "500": {
-            "description": "Server error response",
+            "description": "CBOR errors, including authentication failures starting with SCRAPI v09.",
             "schema": {
               "type": "file"
             }
           },
           "503": {
-            "description": "Service unavailable error response",
+            "description": "CBOR errors, including authentication failures starting with SCRAPI v09.",
             "schema": {
               "type": "file"
             },
@@ -289,7 +289,7 @@
             "$ref": "#/parameters/EntryIdParameter"
           },
           {
-            "$ref": "#/parameters/AcceptCoseHeader"
+            "$ref": "#/parameters/AcceptScittStatementHeader"
           }
         ],
         "responses": {
@@ -300,19 +300,19 @@
             }
           },
           "400": {
-            "description": "Validation error response",
+            "description": "CBOR errors, including authentication failures starting with SCRAPI v09.",
             "schema": {
               "type": "file"
             }
           },
           "404": {
-            "description": "Not found error response",
+            "description": "CBOR errors, including authentication failures starting with SCRAPI v09.",
             "schema": {
               "type": "file"
             }
           },
           "429": {
-            "description": "Not found error response",
+            "description": "CBOR errors, including authentication failures starting with SCRAPI v09.",
             "schema": {
               "type": "file"
             },
@@ -325,13 +325,13 @@
             }
           },
           "500": {
-            "description": "Server error response",
+            "description": "CBOR errors, including authentication failures starting with SCRAPI v09.",
             "schema": {
               "type": "file"
             }
           },
           "503": {
-            "description": "Service unavailable error response",
+            "description": "CBOR errors, including authentication failures starting with SCRAPI v09.",
             "schema": {
               "type": "file"
             },
@@ -366,7 +366,7 @@
         ],
         "responses": {
           "200": {
-            "description": "The request has succeeded.",
+            "description": "The public key response for each supported API version.",
             "schema": {
               "$ref": "#/definitions/JwksDocument"
             }
@@ -426,7 +426,7 @@
     "/operations/{operationId}": {
       "get": {
         "operationId": "GetOperation",
-        "description": "Get status of the long running registration operation, mandatory in IETF SCITT draft",
+        "description": "Get status of the long running registration operation. Deprecated starting with api-version=2026-03-26 (SCRAPI v09) but retained unchanged for backward compatibility; clients using that version should poll /entries/{entryId} directly.",
         "produces": [
           "application/cbor",
           "application/concise-problem-details+cbor"
@@ -470,19 +470,19 @@
             }
           },
           "400": {
-            "description": "Validation error response",
+            "description": "CBOR errors, including authentication failures starting with SCRAPI v09.",
             "schema": {
               "type": "file"
             }
           },
           "404": {
-            "description": "Not found error response",
+            "description": "CBOR errors, including authentication failures starting with SCRAPI v09.",
             "schema": {
               "type": "file"
             }
           },
           "429": {
-            "description": "Not found error response",
+            "description": "CBOR errors, including authentication failures starting with SCRAPI v09.",
             "schema": {
               "type": "file"
             },
@@ -495,13 +495,13 @@
             }
           },
           "500": {
-            "description": "Server error response",
+            "description": "CBOR errors, including authentication failures starting with SCRAPI v09.",
             "schema": {
               "type": "file"
             }
           },
           "503": {
-            "description": "Service unavailable error response",
+            "description": "CBOR errors, including authentication failures starting with SCRAPI v09.",
             "schema": {
               "type": "file"
             },
@@ -514,6 +514,7 @@
             }
           }
         },
+        "deprecated": true,
         "x-ms-examples": {
           "GetOperation": {
             "$ref": "./examples/GetOperation.json"
@@ -523,34 +524,6 @@
     }
   },
   "definitions": {
-    "CreateEntryCreated": {
-      "type": "object",
-      "description": "Response of entry submission if the response can be served immediately, mandatory in IETF SCITT draft",
-      "properties": {
-        "body": {
-          "type": "string",
-          "format": "byte",
-          "description": "Receipt body in COSE format"
-        }
-      },
-      "required": [
-        "body"
-      ]
-    },
-    "CreateEntryPending": {
-      "type": "object",
-      "description": "Response of entry submission containing the operation id, mandatory in IETF SCITT draft",
-      "properties": {
-        "body": {
-          "type": "string",
-          "format": "byte",
-          "description": "Operation status response"
-        }
-      },
-      "required": [
-        "body"
-      ]
-    },
     "JsonWebKey": {
       "type": "object",
       "description": "rfc7517 JSON Web Key representation adapted from a shared swagger definition in the common types",
@@ -646,136 +619,6 @@
       "required": [
         "keys"
       ]
-    },
-    "OperationStatusComplete": {
-      "type": "object",
-      "description": "Provides status details for long running operation, mandatory in IETF SCITT draft",
-      "properties": {
-        "body": {
-          "type": "string",
-          "format": "byte",
-          "description": "Operation status response"
-        }
-      },
-      "required": [
-        "body"
-      ]
-    },
-    "OperationStatusPending": {
-      "type": "object",
-      "description": "Pending response if the operation was not complete, mandatory in IETF SCITT draft"
-    },
-    "ReceiptEntry": {
-      "type": "object",
-      "description": "A ledger receipt, see IETF SCITT draft",
-      "properties": {
-        "body": {
-          "type": "string",
-          "format": "byte",
-          "description": "A receipt structure in COSE format"
-        }
-      },
-      "required": [
-        "body"
-      ]
-    },
-    "Response400Cbor": {
-      "type": "object",
-      "description": "Validation error response",
-      "properties": {
-        "error": {
-          "type": "string",
-          "format": "byte",
-          "description": "CBOR content of the error object"
-        }
-      },
-      "required": [
-        "error"
-      ]
-    },
-    "Response404Cbor": {
-      "type": "object",
-      "description": "Not found error response",
-      "properties": {
-        "error": {
-          "type": "string",
-          "format": "byte",
-          "description": "CBOR content of the error object"
-        }
-      },
-      "required": [
-        "error"
-      ]
-    },
-    "Response429Cbor": {
-      "type": "object",
-      "description": "Not found error response",
-      "properties": {
-        "error": {
-          "type": "string",
-          "format": "byte",
-          "description": "CBOR content of the error object"
-        }
-      },
-      "required": [
-        "error"
-      ]
-    },
-    "Response500Cbor": {
-      "type": "object",
-      "description": "Server error response",
-      "properties": {
-        "error": {
-          "type": "string",
-          "format": "byte",
-          "description": "CBOR content of the error object"
-        }
-      },
-      "required": [
-        "error"
-      ]
-    },
-    "Response503Cbor": {
-      "type": "object",
-      "description": "Service unavailable error response",
-      "properties": {
-        "error": {
-          "type": "string",
-          "format": "byte",
-          "description": "CBOR content of the error object"
-        }
-      },
-      "required": [
-        "error"
-      ]
-    },
-    "TransparencyConfigurationCbor": {
-      "type": "object",
-      "description": "Transparency configuration, see IETF SCITT draft.",
-      "properties": {
-        "body": {
-          "type": "string",
-          "format": "byte",
-          "description": "CBOR content of the configuration object"
-        }
-      },
-      "required": [
-        "body"
-      ]
-    },
-    "TransparentStatement": {
-      "type": "object",
-      "description": "Transparent statement",
-      "properties": {
-        "body": {
-          "type": "string",
-          "format": "byte",
-          "description": "CoseSign1 signature envelope with the receipt embedded in the unprotected header"
-        }
-      },
-      "required": [
-        "body"
-      ]
     }
   },
   "parameters": {
@@ -793,7 +636,21 @@
       },
       "x-ms-parameter-location": "method"
     },
-    "AcceptCoseHeader": {
+    "AcceptCoseOrCborHeader": {
+      "name": "accept",
+      "in": "header",
+      "description": "Accept header",
+      "required": true,
+      "type": "string",
+      "enum": [
+        "application/cose; application/cbor"
+      ],
+      "x-ms-enum": {
+        "modelAsString": false
+      },
+      "x-ms-parameter-location": "method"
+    },
+    "AcceptScittReceiptHeader": {
       "name": "accept",
       "in": "header",
       "description": "Accept header",
@@ -807,14 +664,14 @@
       },
       "x-ms-parameter-location": "method"
     },
-    "AcceptCoseOrCborHeader": {
+    "AcceptScittStatementHeader": {
       "name": "accept",
       "in": "header",
       "description": "Accept header",
       "required": true,
       "type": "string",
       "enum": [
-        "application/cose; application/cbor"
+        "application/cose"
       ],
       "x-ms-enum": {
         "modelAsString": false

--- a/specification/confidentialledger/data-plane/Microsoft.CodeTransparency/stable/2026-03-26/cts.json
+++ b/specification/confidentialledger/data-plane/Microsoft.CodeTransparency/stable/2026-03-26/cts.json
@@ -288,7 +288,7 @@
         ],
         "responses": {
           "201": {
-            "description": "Response of entry submission if the response can be served immediately, mandatory in IETF SCITT draft",
+            "description": "The immediate or pending result of registering an entry.",
             "schema": {
               "type": "file"
             },
@@ -304,7 +304,7 @@
             }
           },
           "303": {
-            "description": "Response for async entry submission in SCRAPI v09, returns 303 See Other with empty body",
+            "description": "The immediate or pending result of registering an entry.",
             "headers": {
               "Location": {
                 "type": "string",
@@ -317,25 +317,25 @@
             }
           },
           "400": {
-            "description": "Validation error response",
+            "description": "CBOR errors, including authentication failures starting with SCRAPI v09.",
             "schema": {
               "type": "file"
             }
           },
           "401": {
-            "description": "Unauthorized error response, returned when JWT authentication is required and the request fails authentication.",
+            "description": "CBOR errors, including authentication failures starting with SCRAPI v09.",
             "schema": {
               "type": "file"
             }
           },
           "404": {
-            "description": "Not found error response",
+            "description": "CBOR errors, including authentication failures starting with SCRAPI v09.",
             "schema": {
               "type": "file"
             }
           },
           "429": {
-            "description": "Not found error response",
+            "description": "CBOR errors, including authentication failures starting with SCRAPI v09.",
             "schema": {
               "type": "file"
             },
@@ -348,13 +348,13 @@
             }
           },
           "500": {
-            "description": "Server error response",
+            "description": "CBOR errors, including authentication failures starting with SCRAPI v09.",
             "schema": {
               "type": "file"
             }
           },
           "503": {
-            "description": "Service unavailable error response",
+            "description": "CBOR errors, including authentication failures starting with SCRAPI v09.",
             "schema": {
               "type": "file"
             },
@@ -399,7 +399,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A ledger receipt, see IETF SCITT draft",
+            "description": "The receipt or, starting with SCRAPI v09, a redirect while it is pending.",
             "schema": {
               "type": "file"
             },
@@ -411,7 +411,7 @@
             }
           },
           "302": {
-            "description": "Pending response for entry query in SCRAPI v09, returns 302 Found",
+            "description": "The receipt or, starting with SCRAPI v09, a redirect while it is pending.",
             "headers": {
               "Location": {
                 "type": "string",
@@ -425,25 +425,25 @@
             }
           },
           "400": {
-            "description": "Validation error response",
+            "description": "CBOR errors, including authentication failures starting with SCRAPI v09.",
             "schema": {
               "type": "file"
             }
           },
           "401": {
-            "description": "Unauthorized error response, returned when JWT authentication is required and the request fails authentication.",
+            "description": "CBOR errors, including authentication failures starting with SCRAPI v09.",
             "schema": {
               "type": "file"
             }
           },
           "404": {
-            "description": "Not found error response",
+            "description": "CBOR errors, including authentication failures starting with SCRAPI v09.",
             "schema": {
               "type": "file"
             }
           },
           "429": {
-            "description": "Not found error response",
+            "description": "CBOR errors, including authentication failures starting with SCRAPI v09.",
             "schema": {
               "type": "file"
             },
@@ -456,13 +456,13 @@
             }
           },
           "500": {
-            "description": "Server error response",
+            "description": "CBOR errors, including authentication failures starting with SCRAPI v09.",
             "schema": {
               "type": "file"
             }
           },
           "503": {
-            "description": "Service unavailable error response",
+            "description": "CBOR errors, including authentication failures starting with SCRAPI v09.",
             "schema": {
               "type": "file"
             },
@@ -513,25 +513,25 @@
             }
           },
           "400": {
-            "description": "Validation error response",
+            "description": "CBOR errors, including authentication failures starting with SCRAPI v09.",
             "schema": {
               "type": "file"
             }
           },
           "401": {
-            "description": "Unauthorized error response, returned when JWT authentication is required and the request fails authentication.",
+            "description": "CBOR errors, including authentication failures starting with SCRAPI v09.",
             "schema": {
               "type": "file"
             }
           },
           "404": {
-            "description": "Not found error response",
+            "description": "CBOR errors, including authentication failures starting with SCRAPI v09.",
             "schema": {
               "type": "file"
             }
           },
           "429": {
-            "description": "Not found error response",
+            "description": "CBOR errors, including authentication failures starting with SCRAPI v09.",
             "schema": {
               "type": "file"
             },
@@ -544,13 +544,13 @@
             }
           },
           "500": {
-            "description": "Server error response",
+            "description": "CBOR errors, including authentication failures starting with SCRAPI v09.",
             "schema": {
               "type": "file"
             }
           },
           "503": {
-            "description": "Service unavailable error response",
+            "description": "CBOR errors, including authentication failures starting with SCRAPI v09.",
             "schema": {
               "type": "file"
             },
@@ -589,7 +589,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Response containing the service public keys used to verify receipts.",
+            "description": "The public key response for each supported API version.",
             "schema": {
               "$ref": "#/definitions/JsonWebKeySet"
             }
@@ -653,7 +653,7 @@
     "/operations/{operationId}": {
       "get": {
         "operationId": "GetOperation",
-        "description": "Get status of the long running registration operation. Deprecated in SCRAPI v09 but retained unchanged for backward compatibility; clients should poll /entries/{entryId} directly.",
+        "description": "Get status of the long running registration operation. Deprecated starting with api-version=2026-03-26 (SCRAPI v09) but retained unchanged for backward compatibility; clients using that version should poll /entries/{entryId} directly.",
         "produces": [
           "application/cbor",
           "application/concise-problem-details+cbor"
@@ -697,25 +697,25 @@
             }
           },
           "400": {
-            "description": "Validation error response",
+            "description": "CBOR errors, including authentication failures starting with SCRAPI v09.",
             "schema": {
               "type": "file"
             }
           },
           "401": {
-            "description": "Unauthorized error response, returned when JWT authentication is required and the request fails authentication.",
+            "description": "CBOR errors, including authentication failures starting with SCRAPI v09.",
             "schema": {
               "type": "file"
             }
           },
           "404": {
-            "description": "Not found error response",
+            "description": "CBOR errors, including authentication failures starting with SCRAPI v09.",
             "schema": {
               "type": "file"
             }
           },
           "429": {
-            "description": "Not found error response",
+            "description": "CBOR errors, including authentication failures starting with SCRAPI v09.",
             "schema": {
               "type": "file"
             },
@@ -728,13 +728,13 @@
             }
           },
           "500": {
-            "description": "Server error response",
+            "description": "CBOR errors, including authentication failures starting with SCRAPI v09.",
             "schema": {
               "type": "file"
             }
           },
           "503": {
-            "description": "Service unavailable error response",
+            "description": "CBOR errors, including authentication failures starting with SCRAPI v09.",
             "schema": {
               "type": "file"
             },
@@ -761,41 +761,6 @@
     }
   },
   "definitions": {
-    "AcceptCoseHeader": {
-      "type": "object",
-      "description": "Accept application/cose header"
-    },
-    "CreateEntryCreated": {
-      "type": "object",
-      "description": "Response of entry submission if the response can be served immediately, mandatory in IETF SCITT draft",
-      "properties": {
-        "body": {
-          "type": "string",
-          "format": "byte",
-          "description": "Receipt body in COSE format"
-        }
-      },
-      "required": [
-        "body"
-      ]
-    },
-    "CreateEntrySeeOther": {
-      "type": "object",
-      "description": "Response for async entry submission in SCRAPI v09, returns 303 See Other with empty body"
-    },
-    "GetPublicKeysResponse": {
-      "type": "object",
-      "description": "Response containing the service public keys used to verify receipts.",
-      "properties": {
-        "body": {
-          "$ref": "#/definitions/JsonWebKeySet",
-          "description": "The JSON Web Key Set response body."
-        }
-      },
-      "required": [
-        "body"
-      ]
-    },
     "JsonWebKeySet": {
       "type": "object",
       "description": "A JSON Web Key Set containing service receipt-verification keys.",
@@ -811,24 +776,6 @@
       "required": [
         "keys"
       ]
-    },
-    "OperationStatusComplete": {
-      "type": "object",
-      "description": "Provides status details for long running operation, mandatory in IETF SCITT draft",
-      "properties": {
-        "body": {
-          "type": "string",
-          "format": "byte",
-          "description": "Operation status response"
-        }
-      },
-      "required": [
-        "body"
-      ]
-    },
-    "OperationStatusPending": {
-      "type": "object",
-      "description": "Pending response if the operation was not complete, mandatory in IETF SCITT draft"
     },
     "PublicJsonWebKey": {
       "type": "object",
@@ -891,164 +838,6 @@
       "required": [
         "kty",
         "kid"
-      ]
-    },
-    "ReceiptEntry": {
-      "type": "object",
-      "description": "A ledger receipt, see IETF SCITT draft",
-      "properties": {
-        "body": {
-          "type": "string",
-          "format": "byte",
-          "description": "A receipt structure in COSE format"
-        }
-      },
-      "required": [
-        "body"
-      ]
-    },
-    "ReceiptEntryPending": {
-      "type": "object",
-      "description": "Pending response for entry query in SCRAPI v09, returns 302 Found"
-    },
-    "Response400Cbor": {
-      "type": "object",
-      "description": "Validation error response",
-      "properties": {
-        "error": {
-          "type": "string",
-          "format": "byte",
-          "description": "CBOR content of the error object"
-        }
-      },
-      "required": [
-        "error"
-      ]
-    },
-    "Response401Cbor": {
-      "type": "object",
-      "description": "Unauthorized error response, returned when JWT authentication is required and the request fails authentication.",
-      "properties": {
-        "error": {
-          "type": "string",
-          "format": "byte",
-          "description": "CBOR content of the error object"
-        }
-      },
-      "required": [
-        "error"
-      ]
-    },
-    "Response404Cbor": {
-      "type": "object",
-      "description": "Not found error response",
-      "properties": {
-        "error": {
-          "type": "string",
-          "format": "byte",
-          "description": "CBOR content of the error object"
-        }
-      },
-      "required": [
-        "error"
-      ]
-    },
-    "Response429Cbor": {
-      "type": "object",
-      "description": "Not found error response",
-      "properties": {
-        "error": {
-          "type": "string",
-          "format": "byte",
-          "description": "CBOR content of the error object"
-        }
-      },
-      "required": [
-        "error"
-      ]
-    },
-    "Response500Cbor": {
-      "type": "object",
-      "description": "Server error response",
-      "properties": {
-        "error": {
-          "type": "string",
-          "format": "byte",
-          "description": "CBOR content of the error object"
-        }
-      },
-      "required": [
-        "error"
-      ]
-    },
-    "Response503Cbor": {
-      "type": "object",
-      "description": "Service unavailable error response",
-      "properties": {
-        "error": {
-          "type": "string",
-          "format": "byte",
-          "description": "CBOR content of the error object"
-        }
-      },
-      "required": [
-        "error"
-      ]
-    },
-    "ScittKeyResponse": {
-      "type": "object",
-      "description": "Response containing a single COSE_Key (map, not array) in CBOR format",
-      "properties": {
-        "body": {
-          "type": "string",
-          "format": "byte",
-          "description": "Single COSE_Key as CBOR map"
-        }
-      },
-      "required": [
-        "body"
-      ]
-    },
-    "ScittKeysResponse": {
-      "type": "object",
-      "description": "Response containing COSE_Key_Set (array of COSE_Key maps) in CBOR format",
-      "properties": {
-        "body": {
-          "type": "string",
-          "format": "byte",
-          "description": "COSE_Key_Set as CBOR array of COSE_Key maps"
-        }
-      },
-      "required": [
-        "body"
-      ]
-    },
-    "TransparencyConfigurationCbor": {
-      "type": "object",
-      "description": "Transparency configuration, see IETF SCITT draft.",
-      "properties": {
-        "body": {
-          "type": "string",
-          "format": "byte",
-          "description": "CBOR content of the configuration object"
-        }
-      },
-      "required": [
-        "body"
-      ]
-    },
-    "TransparentStatement": {
-      "type": "object",
-      "description": "Transparent statement",
-      "properties": {
-        "body": {
-          "type": "string",
-          "format": "byte",
-          "description": "CoseSign1 signature envelope with the receipt embedded in the unprotected header"
-        }
-      },
-      "required": [
-        "body"
       ]
     }
   },


### PR DESCRIPTION
# Data Plane API Specification Update Pull Request

Consolidate CodeTransparency's five version-specific operation pairs into the original stable TypeSpec names: `getPublicKeys`, `createEntry`, `getOperation`, `getEntry`, and `getEntryStatement`. Preserve the REST wire contracts of both `2025-01-31-preview` and `2026-03-26`.

The response unions use versioned variants, and the spread `waitForCommit` and Accept-header properties are versioned individually. This preserves the distinct JWKS schemas, registration/polling statuses, binary media types, error responses, and header requiredness. In particular, `waitForCommit` and 401 responses do not leak into the preview version, and `/jwks` continues to omit 401 in both versions.

Remove the redundant `*V09` operation declarations, shared routes, explicit OpenAPI operation IDs, and associated suppressions. Keep the existing JavaScript binary-body customization and C# internal-model/protocol-only customizations. The two SCITT-key operations and the transparency-configuration operation keep their wire contracts.

## Intentional SDK and metadata effects

| Surface | Effect |
| --- | --- |
| .NET | Intentional generated API breaks are approved. Latest `CreateEntryV09`, `GetOperationV09`, `GetEntryV09`, and `GetEntryStatementV09` metadata becomes the original stable names. Preview `getPublicKeysPreview` becomes `getPublicKeys`, and JWKS convenience generation is disabled on the unified operation. No compatibility aliases are retained; downstream SDK customizations will need updating when regenerated. |
| Other TypeSpec SDK emitters | Latest-version `*V09` method metadata also becomes stable names, including `getPublicKeysV09`. Preview method names outside C# remain unchanged. This PR does not claim generated SDK API compatibility. |
| OpenAPI operation IDs and wire schemas | Operation IDs and all dereferenced operation contracts are unchanged, excluding descriptions and deprecation metadata. Referenced JWKS definitions remain identical. |
| Deprecation | `getOperation` remains at `/operations/{operationId}` in both versions. TypeSpec's `#deprecated` directive cannot be versioned, so both projections expose the annotation; its text explicitly dates deprecation to `2026-03-26` and directs those callers to `/entries/{entryId}`. |
| Unreachable OpenAPI definitions | `omit-unreachable-types: true` prevents the response-selection unions from being emitted as unsupported OpenAPI 2 payload schemas. It also prunes unused envelope definitions: 14 to 2 definitions in preview, 20 to 2 in stable. No referenced payload definition is removed. Preview Accept parameter component names split without changing their wire shapes. |

No .NET repository files, SDK generators, LRO support, unrelated services, or workflows are changed.

## Validation

- [x] Compile the real TypeSpec project with TypeSpec 1.16.0 / Azure libraries 0.72.0: no compiler or linter diagnostics; regenerate both checked-in OpenAPI files.
- [x] Run 32 service-local regressions with the existing Vitest 4.1.9 runner/configuration. Both HTTP snapshots were captured before edits; only operation names were normalized. Coverage includes methods, paths, version projections, spread parameters, statuses, bytes/media, header requiredness, complete reachable model metadata and JWK encoded names/requiredness, errors, deprecation guidance, and four-language SDK names/customizations. SDK metadata assertions reject error-severity diagnostics.
- [x] Compare both same-toolchain pre/post HTTP/model projections and dereferenced OpenAPI paths. Wire contracts match. The untouched baseline compiler output also matched the original checked-in Swagger files.
- [x] Strictly type-check the regression source with the existing TypeScript compiler, check formatting, and inspect the final scoped diff.
- [ ] Full repository dependency restore / `azsdk tsp validate` wrapper: environment-limited. The configured npm proxy lacks the unrelated pinned `@azure-tools/typespec-metadata@0.4.0`; direct npmjs access failed TLS. The local Azure SDK validation wrapper was attempted but reported `npm error could not determine executable to run`. The targeted compiler/test dependencies were restored at the repository's pinned versions in session-local storage; no repository manifest, lockfile, or global npm configuration was changed.

TCGC metadata inspection retains existing `example-value-no-mapping` and C# `conflict-access-override` warnings, not errors. The renamed preview C# JWKS operation now matches its existing example and reports one additional example-mapping warning. Language SDK packages were not generated or built in this specs-only change.

Run the regressions from the repository root after the normal dependency restore:

```powershell
npx vitest run --config eng\tools\typespec-validation\vitest.config.js --dir specification\confidentialledger\Microsoft.CodeTransparency\test
```

See `specification/confidentialledger/Microsoft.CodeTransparency/test/README.md` for snapshot provenance and limitations.

### TypeSpec references

- [Evolving APIs and versioning spread properties](https://azure.github.io/typespec-azure/docs/howtos/versioning/06-evolving-apis/)
- [Versioning decorators and union-variant support](https://typespec.io/docs/libraries/versioning/reference/decorators/)

## PR review workflow diagram

Please understand this diagram before proceeding. It explains how to get your PR approved & merged.

![spec_pr_review_workflow_diagram](https://github.com/Azure/azure-rest-api-specs/assets/4429827/5bb5e7ce-8aff-4dbb-a3f8-0d9b68fef5b1)

## API Info: The Basics

Most of the information about your service should be captured in the issue that serves as your [*API Spec engagement record*](https://aka.ms/azsdk/onboarding/restapischedule).

* Link to API Spec engagement record issue: N/A - refactoring existing API-version declarations; no new REST API version or endpoint.

Is this review for (select one):

- [ ] a private preview
- [ ] a public preview
- [ ] GA release

This change preserves the existing public preview and GA version contracts; it does not introduce a release.

### Change Scope

* Design Document: TypeSpec versioning references above.
* Previous API Spec Doc: [Baseline CodeTransparency TypeSpec](https://github.com/Azure/azure-rest-api-specs/blob/f2047bbdf9d14adf4655663e889be86e4b94db6b/specification/confidentialledger/Microsoft.CodeTransparency/main.tsp).
* Updated paths: `specification/confidentialledger/Microsoft.CodeTransparency/{main.tsp,client.tsp,tspconfig.yaml,test/}` and the two generated CodeTransparency `cts.json` files.

### Viewing API changes

For convenient view of the API changes made by this PR, refer to the URLs provided in the table
in the `Generated ApiView` comment added to this PR. You can use ApiView to show API versions diff.

### Suppressing failures

If one or multiple validation error/warning suppression(s) is detected in your PR, please follow the
[Swagger-Suppression-Process](https://aka.ms/pr-suppressions)
to get approval.

No new TypeSpec suppressions are added.

### Release planner

A [release plan](https://aka.ms/azsdkdocs/release-plans) should have been created. If not, please create one as it will help guide you through the REST API and SDK creation process.

N/A - existing-version specification refactoring; no SDK release is performed by this PR.

## ❔Got questions? Need additional info?? We are here to help!

<details>
  <summary> Contact us!</summary>

The [Azure API Review Board](https://aka.ms/azsdk/onboarding/restapischedule) is dedicated to helping you create amazing APIs. You can read about our mission and learn more about our process on our [wiki](https://aka.ms/azsdk/onboarding/restapischedule).
* 💬 [Teams Channel](https://teams.microsoft.com/l/channel/19%3a3ebb18fded0e47938f998e196a52952f%40thread.tacv2/General?groupId=1a10b50c-e870-4fe0-8483-bf5542a8d2d8&tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47)
* 💌 [email](mailto://azureapirbcore@microsoft.com)

</details>

<details>
  <summary>Click here for links to tools, specs, guidelines & other good stuff</summary>

### Tooling

 * [Open API validation tools](https://aka.ms/swaggertools) were run on this PR. Go here to see [how to fix errors](https://aka.ms/ci-fix)
 * [Spectral Linting](https://github.com/Azure/azure-api-style-guide/blob/main/README.md)

### Guidelines & Specifications

 * [Azure REST API Guidelines](https://aka.ms/azapi/guidelines)
 * [OpenAPI Style Guidelines](https://aka.ms/azapi/style)
 * [Azure Breaking Change Policy](https://aka.ms/AzBreakingChangesPolicy)

### Helpful Links

 * [Schedule a data plane REST API spec review](https://aka.ms/azsdk/onboarding/restapischedule)

</details>

## Getting help

- First, please carefully read through this PR description, from top to bottom.
- If you don't have permissions to remove or add labels to the PR, request `write access` per [aka.ms/azsdk/access#request-access-to-rest-api-or-sdk-repositories](https://aka.ms/azsdk/access#request-access-to-rest-api-or-sdk-repositories)
- To understand what you must do next to merge this PR, see the `Next Steps to Merge` comment. It will appear within few minutes of submitting this PR and will continue to be up-to-date with current PR state.
- For guidance on fixing this PR CI check failures, see the hyperlinks provided in given failure and https://aka.ms/ci-fix.
- If the PR CI checks appear to be stuck in `queued` state, please add a comment with contents `/azp run`.
  This should result in a new comment denoting a `PR validation pipeline` has started and the checks should be updated after few minutes.
- If the help provided by the previous points is not enough, post to https://aka.ms/azsdk/support/specreview-channel and link to this PR.