### PR TITLE
[Foundry] Expose known telephony reason codes as extensible unions

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -87377,6 +87377,54 @@
           ]
         }
       },
+      "TelephonyCallEndReason": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "invalid_webhook_payload",
+              "webhook_validation_failed",
+              "binding_not_found",
+              "binding_suspended",
+              "admission_rejected",
+              "admission_check_failed",
+              "route_agent_mismatch",
+              "invalid_binding_configuration",
+              "credential_resolution_failed",
+              "provider_resource_mismatch",
+              "endpoint_resolution_failed",
+              "ingress_setup_failed",
+              "live_call_conflict",
+              "live_call_persistence_failed",
+              "answer_failed",
+              "provider_disconnected",
+              "provider_busy",
+              "provider_no_answer",
+              "provider_cancelled",
+              "provider_failed",
+              "provider_stream_error",
+              "provider_stream_stopped",
+              "agent_session_connect_failed",
+              "media_stream_ended",
+              "bridge_cancelled",
+              "bridge_failed",
+              "managed_hangup",
+              "managed_transfer",
+              "manage_hangup_failed",
+              "manage_transfer_failed"
+            ]
+          }
+        ],
+        "description": "Known service-generated reasons that one telephony call ended, rather than reasons for an overall outbound call job. Additional string codes may be returned.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "VoiceAgents=V1Preview"
+          ]
+        }
+      },
       "TelephonyCallId": {
         "type": "string",
         "minLength": 1,
@@ -87459,8 +87507,8 @@
             "description": "The Unix timestamp in seconds at which the next retry becomes eligible."
           },
           "terminal_reason": {
-            "type": "string",
-            "description": "The stable reason for the terminal status, when available."
+            "$ref": "#/components/schemas/TelephonyCallJobTerminalReason",
+            "description": "The stable service-generated reason for the overall outbound call job, which can span multiple provider attempts, when available. Interpret this with `status`: a queued job can retain a temporary dispatch-deferral reason. Additional string codes may be returned."
           },
           "revision": {
             "type": "integer",
@@ -87577,6 +87625,45 @@
           ]
         }
       },
+      "TelephonyCallJobTerminalReason": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "no_answer",
+              "no_answer_timeout",
+              "answer_failed",
+              "bridge_cancelled",
+              "bridge_failed",
+              "voice_session_configuration_invalid",
+              "connection_project_mismatch",
+              "outbound_connection_changed",
+              "outbound_connection_unavailable",
+              "telephony_binding_invalid",
+              "telephony_binding_not_found",
+              "telephony_binding_inactive",
+              "telephony_binding_changed",
+              "campaign_not_found",
+              "campaign_cancelled",
+              "campaign_completed",
+              "campaign_failed",
+              "origination_fence_not_recorded",
+              "origination_reconciliation_timeout",
+              "cancellation_reconciliation_timeout",
+              "provider_callback_timeout_cancellation_reconciliation_timeout"
+            ]
+          }
+        ],
+        "description": "Known terminal reasons for an overall outbound call job, which can span multiple provider attempts. These are distinct from individual call lifecycle reasons. Additional string codes may be returned.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "VoiceAgents=V1Preview"
+          ]
+        }
+      },
       "TelephonyCallLifecycleEvent": {
         "type": "object",
         "required": [
@@ -87620,9 +87707,9 @@
             "description": "The source of the event timestamp."
           },
           "reason": {
-            "type": "string",
+            "$ref": "#/components/schemas/TelephonyCallLifecycleEventReason",
             "maxLength": 128,
-            "description": "A stable service-generated reason associated with the event."
+            "description": "A stable service-generated reason associated with this lifecycle event, not necessarily the final outcome of the call. Additional string codes may be returned."
           },
           "provider_event_id": {
             "type": "string",
@@ -87702,6 +87789,54 @@
           }
         ],
         "description": "The outcome of one telephony lifecycle observation.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "VoiceAgents=V1Preview"
+          ]
+        }
+      },
+      "TelephonyCallLifecycleEventReason": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "invalid_webhook_payload",
+              "webhook_validation_failed",
+              "binding_not_found",
+              "binding_suspended",
+              "admission_rejected",
+              "admission_check_failed",
+              "route_agent_mismatch",
+              "invalid_binding_configuration",
+              "credential_resolution_failed",
+              "provider_resource_mismatch",
+              "endpoint_resolution_failed",
+              "ingress_setup_failed",
+              "live_call_conflict",
+              "live_call_persistence_failed",
+              "answer_failed",
+              "provider_disconnected",
+              "provider_busy",
+              "provider_no_answer",
+              "provider_cancelled",
+              "provider_failed",
+              "provider_stream_error",
+              "provider_stream_stopped",
+              "agent_session_connect_failed",
+              "media_stream_ended",
+              "bridge_cancelled",
+              "bridge_failed",
+              "managed_hangup",
+              "managed_transfer",
+              "manage_hangup_failed",
+              "manage_transfer_failed"
+            ]
+          }
+        ],
+        "description": "Known service-generated reasons for a telephony lifecycle event. An event reason does not necessarily describe the final outcome of the call. Additional string codes may be returned.",
         "x-ms-foundry-meta": {
           "required_previews": [
             "VoiceAgents=V1Preview"
@@ -87829,9 +87964,9 @@
             "description": "The call duration."
           },
           "end_reason": {
-            "type": "string",
+            "$ref": "#/components/schemas/TelephonyCallEndReason",
             "maxLength": 128,
-            "description": "The service-generated reason that the call ended."
+            "description": "The service-generated reason that this single call ended, rather than the outcome of an overall outbound call job. Additional string codes may be returned."
           },
           "provider_status_code": {
             "type": "integer",
@@ -87964,9 +88099,9 @@
             "description": "The call duration."
           },
           "end_reason": {
-            "type": "string",
+            "$ref": "#/components/schemas/TelephonyCallEndReason",
             "maxLength": 128,
-            "description": "The service-generated reason that the call ended."
+            "description": "The service-generated reason that this single call ended, rather than the outcome of an overall outbound call job. Additional string codes may be returned."
           },
           "provider_status_code": {
             "type": "integer",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -81768,6 +81768,45 @@ components:
       x-ms-foundry-meta:
         required_previews:
           - VoiceAgents=V1Preview
+    TelephonyCallEndReason:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - invalid_webhook_payload
+            - webhook_validation_failed
+            - binding_not_found
+            - binding_suspended
+            - admission_rejected
+            - admission_check_failed
+            - route_agent_mismatch
+            - invalid_binding_configuration
+            - credential_resolution_failed
+            - provider_resource_mismatch
+            - endpoint_resolution_failed
+            - ingress_setup_failed
+            - live_call_conflict
+            - live_call_persistence_failed
+            - answer_failed
+            - provider_disconnected
+            - provider_busy
+            - provider_no_answer
+            - provider_cancelled
+            - provider_failed
+            - provider_stream_error
+            - provider_stream_stopped
+            - agent_session_connect_failed
+            - media_stream_ended
+            - bridge_cancelled
+            - bridge_failed
+            - managed_hangup
+            - managed_transfer
+            - manage_hangup_failed
+            - manage_transfer_failed
+      description: Known service-generated reasons that one telephony call ended, rather than reasons for an overall outbound call job. Additional string codes may be returned.
+      x-ms-foundry-meta:
+        required_previews:
+          - VoiceAgents=V1Preview
     TelephonyCallId:
       type: string
       minLength: 1
@@ -81834,8 +81873,8 @@ components:
           $ref: '#/components/schemas/FoundryTimestamp'
           description: The Unix timestamp in seconds at which the next retry becomes eligible.
         terminal_reason:
-          type: string
-          description: The stable reason for the terminal status, when available.
+          $ref: '#/components/schemas/TelephonyCallJobTerminalReason'
+          description: 'The stable service-generated reason for the overall outbound call job, which can span multiple provider attempts, when available. Interpret this with `status`: a queued job can retain a temporary dispatch-deferral reason. Additional string codes may be returned.'
         revision:
           type: integer
           format: int64
@@ -81917,6 +81956,36 @@ components:
       x-ms-foundry-meta:
         required_previews:
           - VoiceAgents=V1Preview
+    TelephonyCallJobTerminalReason:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - no_answer
+            - no_answer_timeout
+            - answer_failed
+            - bridge_cancelled
+            - bridge_failed
+            - voice_session_configuration_invalid
+            - connection_project_mismatch
+            - outbound_connection_changed
+            - outbound_connection_unavailable
+            - telephony_binding_invalid
+            - telephony_binding_not_found
+            - telephony_binding_inactive
+            - telephony_binding_changed
+            - campaign_not_found
+            - campaign_cancelled
+            - campaign_completed
+            - campaign_failed
+            - origination_fence_not_recorded
+            - origination_reconciliation_timeout
+            - cancellation_reconciliation_timeout
+            - provider_callback_timeout_cancellation_reconciliation_timeout
+      description: Known terminal reasons for an overall outbound call job, which can span multiple provider attempts. These are distinct from individual call lifecycle reasons. Additional string codes may be returned.
+      x-ms-foundry-meta:
+        required_previews:
+          - VoiceAgents=V1Preview
     TelephonyCallLifecycleEvent:
       type: object
       required:
@@ -81952,9 +82021,9 @@ components:
           $ref: '#/components/schemas/TelephonyCallTimestampSource'
           description: The source of the event timestamp.
         reason:
-          type: string
+          $ref: '#/components/schemas/TelephonyCallLifecycleEventReason'
           maxLength: 128
-          description: A stable service-generated reason associated with the event.
+          description: A stable service-generated reason associated with this lifecycle event, not necessarily the final outcome of the call. Additional string codes may be returned.
         provider_event_id:
           type: string
           maxLength: 256
@@ -82010,6 +82079,45 @@ components:
             - rejected
             - cancelled
       description: The outcome of one telephony lifecycle observation.
+      x-ms-foundry-meta:
+        required_previews:
+          - VoiceAgents=V1Preview
+    TelephonyCallLifecycleEventReason:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - invalid_webhook_payload
+            - webhook_validation_failed
+            - binding_not_found
+            - binding_suspended
+            - admission_rejected
+            - admission_check_failed
+            - route_agent_mismatch
+            - invalid_binding_configuration
+            - credential_resolution_failed
+            - provider_resource_mismatch
+            - endpoint_resolution_failed
+            - ingress_setup_failed
+            - live_call_conflict
+            - live_call_persistence_failed
+            - answer_failed
+            - provider_disconnected
+            - provider_busy
+            - provider_no_answer
+            - provider_cancelled
+            - provider_failed
+            - provider_stream_error
+            - provider_stream_stopped
+            - agent_session_connect_failed
+            - media_stream_ended
+            - bridge_cancelled
+            - bridge_failed
+            - managed_hangup
+            - managed_transfer
+            - manage_hangup_failed
+            - manage_transfer_failed
+      description: Known service-generated reasons for a telephony lifecycle event. An event reason does not necessarily describe the final outcome of the call. Additional string codes may be returned.
       x-ms-foundry-meta:
         required_previews:
           - VoiceAgents=V1Preview
@@ -82102,9 +82210,9 @@ components:
           $ref: '#/components/schemas/FoundryDurationMilliseconds'
           description: The call duration.
         end_reason:
-          type: string
+          $ref: '#/components/schemas/TelephonyCallEndReason'
           maxLength: 128
-          description: The service-generated reason that the call ended.
+          description: The service-generated reason that this single call ended, rather than the outcome of an overall outbound call job. Additional string codes may be returned.
         provider_status_code:
           type: integer
           format: int32
@@ -82201,9 +82309,9 @@ components:
           $ref: '#/components/schemas/FoundryDurationMilliseconds'
           description: The call duration.
         end_reason:
-          type: string
+          $ref: '#/components/schemas/TelephonyCallEndReason'
           maxLength: 128
-          description: The service-generated reason that the call ended.
+          description: The service-generated reason that this single call ended, rather than the outcome of an overall outbound call job. Additional string codes may be returned.
         provider_status_code:
           type: integer
           format: int32

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -93001,6 +93001,54 @@
           ]
         }
       },
+      "TelephonyCallEndReason": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "invalid_webhook_payload",
+              "webhook_validation_failed",
+              "binding_not_found",
+              "binding_suspended",
+              "admission_rejected",
+              "admission_check_failed",
+              "route_agent_mismatch",
+              "invalid_binding_configuration",
+              "credential_resolution_failed",
+              "provider_resource_mismatch",
+              "endpoint_resolution_failed",
+              "ingress_setup_failed",
+              "live_call_conflict",
+              "live_call_persistence_failed",
+              "answer_failed",
+              "provider_disconnected",
+              "provider_busy",
+              "provider_no_answer",
+              "provider_cancelled",
+              "provider_failed",
+              "provider_stream_error",
+              "provider_stream_stopped",
+              "agent_session_connect_failed",
+              "media_stream_ended",
+              "bridge_cancelled",
+              "bridge_failed",
+              "managed_hangup",
+              "managed_transfer",
+              "manage_hangup_failed",
+              "manage_transfer_failed"
+            ]
+          }
+        ],
+        "description": "Known service-generated reasons that one telephony call ended, rather than reasons for an overall outbound call job. Additional string codes may be returned.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "VoiceAgents=V1Preview"
+          ]
+        }
+      },
       "TelephonyCallId": {
         "type": "string",
         "minLength": 1,
@@ -93083,8 +93131,8 @@
             "description": "The Unix timestamp in seconds at which the next retry becomes eligible."
           },
           "terminal_reason": {
-            "type": "string",
-            "description": "The stable reason for the terminal status, when available."
+            "$ref": "#/components/schemas/TelephonyCallJobTerminalReason",
+            "description": "The stable service-generated reason for the overall outbound call job, which can span multiple provider attempts, when available. Interpret this with `status`: a queued job can retain a temporary dispatch-deferral reason. Additional string codes may be returned."
           },
           "revision": {
             "type": "integer",
@@ -93201,6 +93249,45 @@
           ]
         }
       },
+      "TelephonyCallJobTerminalReason": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "no_answer",
+              "no_answer_timeout",
+              "answer_failed",
+              "bridge_cancelled",
+              "bridge_failed",
+              "voice_session_configuration_invalid",
+              "connection_project_mismatch",
+              "outbound_connection_changed",
+              "outbound_connection_unavailable",
+              "telephony_binding_invalid",
+              "telephony_binding_not_found",
+              "telephony_binding_inactive",
+              "telephony_binding_changed",
+              "campaign_not_found",
+              "campaign_cancelled",
+              "campaign_completed",
+              "campaign_failed",
+              "origination_fence_not_recorded",
+              "origination_reconciliation_timeout",
+              "cancellation_reconciliation_timeout",
+              "provider_callback_timeout_cancellation_reconciliation_timeout"
+            ]
+          }
+        ],
+        "description": "Known terminal reasons for an overall outbound call job, which can span multiple provider attempts. These are distinct from individual call lifecycle reasons. Additional string codes may be returned.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "VoiceAgents=V1Preview"
+          ]
+        }
+      },
       "TelephonyCallLifecycleEvent": {
         "type": "object",
         "required": [
@@ -93244,9 +93331,9 @@
             "description": "The source of the event timestamp."
           },
           "reason": {
-            "type": "string",
+            "$ref": "#/components/schemas/TelephonyCallLifecycleEventReason",
             "maxLength": 128,
-            "description": "A stable service-generated reason associated with the event."
+            "description": "A stable service-generated reason associated with this lifecycle event, not necessarily the final outcome of the call. Additional string codes may be returned."
           },
           "provider_event_id": {
             "type": "string",
@@ -93326,6 +93413,54 @@
           }
         ],
         "description": "The outcome of one telephony lifecycle observation.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "VoiceAgents=V1Preview"
+          ]
+        }
+      },
+      "TelephonyCallLifecycleEventReason": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "invalid_webhook_payload",
+              "webhook_validation_failed",
+              "binding_not_found",
+              "binding_suspended",
+              "admission_rejected",
+              "admission_check_failed",
+              "route_agent_mismatch",
+              "invalid_binding_configuration",
+              "credential_resolution_failed",
+              "provider_resource_mismatch",
+              "endpoint_resolution_failed",
+              "ingress_setup_failed",
+              "live_call_conflict",
+              "live_call_persistence_failed",
+              "answer_failed",
+              "provider_disconnected",
+              "provider_busy",
+              "provider_no_answer",
+              "provider_cancelled",
+              "provider_failed",
+              "provider_stream_error",
+              "provider_stream_stopped",
+              "agent_session_connect_failed",
+              "media_stream_ended",
+              "bridge_cancelled",
+              "bridge_failed",
+              "managed_hangup",
+              "managed_transfer",
+              "manage_hangup_failed",
+              "manage_transfer_failed"
+            ]
+          }
+        ],
+        "description": "Known service-generated reasons for a telephony lifecycle event. An event reason does not necessarily describe the final outcome of the call. Additional string codes may be returned.",
         "x-ms-foundry-meta": {
           "required_previews": [
             "VoiceAgents=V1Preview"
@@ -93453,9 +93588,9 @@
             "description": "The call duration."
           },
           "end_reason": {
-            "type": "string",
+            "$ref": "#/components/schemas/TelephonyCallEndReason",
             "maxLength": 128,
-            "description": "The service-generated reason that the call ended."
+            "description": "The service-generated reason that this single call ended, rather than the outcome of an overall outbound call job. Additional string codes may be returned."
           },
           "provider_status_code": {
             "type": "integer",
@@ -93588,9 +93723,9 @@
             "description": "The call duration."
           },
           "end_reason": {
-            "type": "string",
+            "$ref": "#/components/schemas/TelephonyCallEndReason",
             "maxLength": 128,
-            "description": "The service-generated reason that the call ended."
+            "description": "The service-generated reason that this single call ended, rather than the outcome of an overall outbound call job. Additional string codes may be returned."
           },
           "provider_status_code": {
             "type": "integer",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -85640,6 +85640,45 @@ components:
       x-ms-foundry-meta:
         required_previews:
           - VoiceAgents=V1Preview
+    TelephonyCallEndReason:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - invalid_webhook_payload
+            - webhook_validation_failed
+            - binding_not_found
+            - binding_suspended
+            - admission_rejected
+            - admission_check_failed
+            - route_agent_mismatch
+            - invalid_binding_configuration
+            - credential_resolution_failed
+            - provider_resource_mismatch
+            - endpoint_resolution_failed
+            - ingress_setup_failed
+            - live_call_conflict
+            - live_call_persistence_failed
+            - answer_failed
+            - provider_disconnected
+            - provider_busy
+            - provider_no_answer
+            - provider_cancelled
+            - provider_failed
+            - provider_stream_error
+            - provider_stream_stopped
+            - agent_session_connect_failed
+            - media_stream_ended
+            - bridge_cancelled
+            - bridge_failed
+            - managed_hangup
+            - managed_transfer
+            - manage_hangup_failed
+            - manage_transfer_failed
+      description: Known service-generated reasons that one telephony call ended, rather than reasons for an overall outbound call job. Additional string codes may be returned.
+      x-ms-foundry-meta:
+        required_previews:
+          - VoiceAgents=V1Preview
     TelephonyCallId:
       type: string
       minLength: 1
@@ -85706,8 +85745,8 @@ components:
           $ref: '#/components/schemas/FoundryTimestamp'
           description: The Unix timestamp in seconds at which the next retry becomes eligible.
         terminal_reason:
-          type: string
-          description: The stable reason for the terminal status, when available.
+          $ref: '#/components/schemas/TelephonyCallJobTerminalReason'
+          description: 'The stable service-generated reason for the overall outbound call job, which can span multiple provider attempts, when available. Interpret this with `status`: a queued job can retain a temporary dispatch-deferral reason. Additional string codes may be returned.'
         revision:
           type: integer
           format: int64
@@ -85789,6 +85828,36 @@ components:
       x-ms-foundry-meta:
         required_previews:
           - VoiceAgents=V1Preview
+    TelephonyCallJobTerminalReason:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - no_answer
+            - no_answer_timeout
+            - answer_failed
+            - bridge_cancelled
+            - bridge_failed
+            - voice_session_configuration_invalid
+            - connection_project_mismatch
+            - outbound_connection_changed
+            - outbound_connection_unavailable
+            - telephony_binding_invalid
+            - telephony_binding_not_found
+            - telephony_binding_inactive
+            - telephony_binding_changed
+            - campaign_not_found
+            - campaign_cancelled
+            - campaign_completed
+            - campaign_failed
+            - origination_fence_not_recorded
+            - origination_reconciliation_timeout
+            - cancellation_reconciliation_timeout
+            - provider_callback_timeout_cancellation_reconciliation_timeout
+      description: Known terminal reasons for an overall outbound call job, which can span multiple provider attempts. These are distinct from individual call lifecycle reasons. Additional string codes may be returned.
+      x-ms-foundry-meta:
+        required_previews:
+          - VoiceAgents=V1Preview
     TelephonyCallLifecycleEvent:
       type: object
       required:
@@ -85824,9 +85893,9 @@ components:
           $ref: '#/components/schemas/TelephonyCallTimestampSource'
           description: The source of the event timestamp.
         reason:
-          type: string
+          $ref: '#/components/schemas/TelephonyCallLifecycleEventReason'
           maxLength: 128
-          description: A stable service-generated reason associated with the event.
+          description: A stable service-generated reason associated with this lifecycle event, not necessarily the final outcome of the call. Additional string codes may be returned.
         provider_event_id:
           type: string
           maxLength: 256
@@ -85882,6 +85951,45 @@ components:
             - rejected
             - cancelled
       description: The outcome of one telephony lifecycle observation.
+      x-ms-foundry-meta:
+        required_previews:
+          - VoiceAgents=V1Preview
+    TelephonyCallLifecycleEventReason:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - invalid_webhook_payload
+            - webhook_validation_failed
+            - binding_not_found
+            - binding_suspended
+            - admission_rejected
+            - admission_check_failed
+            - route_agent_mismatch
+            - invalid_binding_configuration
+            - credential_resolution_failed
+            - provider_resource_mismatch
+            - endpoint_resolution_failed
+            - ingress_setup_failed
+            - live_call_conflict
+            - live_call_persistence_failed
+            - answer_failed
+            - provider_disconnected
+            - provider_busy
+            - provider_no_answer
+            - provider_cancelled
+            - provider_failed
+            - provider_stream_error
+            - provider_stream_stopped
+            - agent_session_connect_failed
+            - media_stream_ended
+            - bridge_cancelled
+            - bridge_failed
+            - managed_hangup
+            - managed_transfer
+            - manage_hangup_failed
+            - manage_transfer_failed
+      description: Known service-generated reasons for a telephony lifecycle event. An event reason does not necessarily describe the final outcome of the call. Additional string codes may be returned.
       x-ms-foundry-meta:
         required_previews:
           - VoiceAgents=V1Preview
@@ -85974,9 +86082,9 @@ components:
           $ref: '#/components/schemas/FoundryDurationMilliseconds'
           description: The call duration.
         end_reason:
-          type: string
+          $ref: '#/components/schemas/TelephonyCallEndReason'
           maxLength: 128
-          description: The service-generated reason that the call ended.
+          description: The service-generated reason that this single call ended, rather than the outcome of an overall outbound call job. Additional string codes may be returned.
         provider_status_code:
           type: integer
           format: int32
@@ -86073,9 +86181,9 @@ components:
           $ref: '#/components/schemas/FoundryDurationMilliseconds'
           description: The call duration.
         end_reason:
-          type: string
+          $ref: '#/components/schemas/TelephonyCallEndReason'
           maxLength: 128
-          description: The service-generated reason that the call ended.
+          description: The service-generated reason that this single call ended, rather than the outcome of an overall outbound call job. Additional string codes may be returned.
         provider_status_code:
           type: integer
           format: int32

--- a/specification/ai-foundry/data-plane/Foundry/src/voice-agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/voice-agents/models.tsp
@@ -1002,6 +1002,102 @@ union TelephonyCallLifecycleEventName {
   call_disconnect: "telephony.call.disconnect",
 }
 
+@doc("Known service-generated reasons for a telephony lifecycle event. An event reason does not necessarily describe the final outcome of the call. Additional string codes may be returned.")
+@extension("x-ms-foundry-meta", VoiceAgentRequiredPreview)
+union TelephonyCallLifecycleEventReason {
+  string,
+
+  @doc("The provider webhook payload was invalid.")
+  invalid_webhook_payload: "invalid_webhook_payload",
+
+  @doc("Validation of the provider webhook failed.")
+  webhook_validation_failed: "webhook_validation_failed",
+
+  @doc("No matching telephony binding was found.")
+  binding_not_found: "binding_not_found",
+
+  @doc("The telephony binding was suspended.")
+  binding_suspended: "binding_suspended",
+
+  @doc("The call was rejected by admission policy.")
+  admission_rejected: "admission_rejected",
+
+  @doc("The service could not complete the call admission check.")
+  admission_check_failed: "admission_check_failed",
+
+  @doc("The webhook route did not match the resolved voice agent.")
+  route_agent_mismatch: "route_agent_mismatch",
+
+  @doc("The telephony binding configuration was invalid.")
+  invalid_binding_configuration: "invalid_binding_configuration",
+
+  @doc("The service could not resolve the telephony provider credentials.")
+  credential_resolution_failed: "credential_resolution_failed",
+
+  @doc("The provider resource did not match the configured telephony resource.")
+  provider_resource_mismatch: "provider_resource_mismatch",
+
+  @doc("The service could not resolve the endpoint needed to handle the call.")
+  endpoint_resolution_failed: "endpoint_resolution_failed",
+
+  @doc("The service could not set up the incoming call.")
+  ingress_setup_failed: "ingress_setup_failed",
+
+  @doc("The call conflicted with an existing live call.")
+  live_call_conflict: "live_call_conflict",
+
+  @doc("The service could not persist the live call state.")
+  live_call_persistence_failed: "live_call_persistence_failed",
+
+  @doc("The attempt to answer the provider call failed.")
+  answer_failed: "answer_failed",
+
+  @doc("The provider reported that the call disconnected.")
+  provider_disconnected: "provider_disconnected",
+
+  @doc("The provider reported that the destination was busy.")
+  provider_busy: "provider_busy",
+
+  @doc("The provider reported that the call was not answered.")
+  provider_no_answer: "provider_no_answer",
+
+  @doc("The provider reported that the call was cancelled.")
+  provider_cancelled: "provider_cancelled",
+
+  @doc("The provider reported that the call failed.")
+  provider_failed: "provider_failed",
+
+  @doc("The provider reported a media-stream error.")
+  provider_stream_error: "provider_stream_error",
+
+  @doc("The provider reported that the media stream stopped.")
+  provider_stream_stopped: "provider_stream_stopped",
+
+  @doc("The call could not connect to the voice-agent session.")
+  agent_session_connect_failed: "agent_session_connect_failed",
+
+  @doc("The call's media stream ended.")
+  media_stream_ended: "media_stream_ended",
+
+  @doc("The telephony media bridge was cancelled.")
+  bridge_cancelled: "bridge_cancelled",
+
+  @doc("The telephony media bridge failed.")
+  bridge_failed: "bridge_failed",
+
+  @doc("A managed call hang-up command succeeded.")
+  managed_hangup: "managed_hangup",
+
+  @doc("A managed call-transfer command succeeded.")
+  managed_transfer: "managed_transfer",
+
+  @doc("A managed call hang-up command failed.")
+  manage_hangup_failed: "manage_hangup_failed",
+
+  @doc("A managed call-transfer command failed.")
+  manage_transfer_failed: "manage_transfer_failed",
+}
+
 @doc("A bounded durable observation in the lifecycle of one telephony call.")
 @extension("x-ms-foundry-meta", VoiceAgentRequiredPreview)
 model TelephonyCallLifecycleEvent {
@@ -1029,9 +1125,9 @@ model TelephonyCallLifecycleEvent {
   @doc("The source of the event timestamp.")
   timestamp_source: TelephonyCallTimestampSource;
 
-  @doc("A stable service-generated reason associated with the event.")
+  @doc("A stable service-generated reason associated with this lifecycle event, not necessarily the final outcome of the call. Additional string codes may be returned.")
   @maxLength(128)
-  reason?: string;
+  reason?: TelephonyCallLifecycleEventReason;
 
   @doc("The provider event identifier used for idempotency, when supplied.")
   @maxLength(256)
@@ -1048,6 +1144,102 @@ model TelephonyCallLifecycleEvent {
   @doc("The provider subcode associated with the event.")
   @minValue(0)
   provider_sub_code?: int32;
+}
+
+@doc("Known service-generated reasons that one telephony call ended, rather than reasons for an overall outbound call job. Additional string codes may be returned.")
+@extension("x-ms-foundry-meta", VoiceAgentRequiredPreview)
+union TelephonyCallEndReason {
+  string,
+
+  @doc("The provider webhook payload was invalid.")
+  invalid_webhook_payload: "invalid_webhook_payload",
+
+  @doc("Validation of the provider webhook failed.")
+  webhook_validation_failed: "webhook_validation_failed",
+
+  @doc("No matching telephony binding was found.")
+  binding_not_found: "binding_not_found",
+
+  @doc("The telephony binding was suspended.")
+  binding_suspended: "binding_suspended",
+
+  @doc("The call was rejected by admission policy.")
+  admission_rejected: "admission_rejected",
+
+  @doc("The service could not complete the call admission check.")
+  admission_check_failed: "admission_check_failed",
+
+  @doc("The webhook route did not match the resolved voice agent.")
+  route_agent_mismatch: "route_agent_mismatch",
+
+  @doc("The telephony binding configuration was invalid.")
+  invalid_binding_configuration: "invalid_binding_configuration",
+
+  @doc("The service could not resolve the telephony provider credentials.")
+  credential_resolution_failed: "credential_resolution_failed",
+
+  @doc("The provider resource did not match the configured telephony resource.")
+  provider_resource_mismatch: "provider_resource_mismatch",
+
+  @doc("The service could not resolve the endpoint needed to handle the call.")
+  endpoint_resolution_failed: "endpoint_resolution_failed",
+
+  @doc("The service could not set up the incoming call.")
+  ingress_setup_failed: "ingress_setup_failed",
+
+  @doc("The call conflicted with an existing live call.")
+  live_call_conflict: "live_call_conflict",
+
+  @doc("The service could not persist the live call state.")
+  live_call_persistence_failed: "live_call_persistence_failed",
+
+  @doc("The attempt to answer the provider call failed.")
+  answer_failed: "answer_failed",
+
+  @doc("The provider reported that the call disconnected.")
+  provider_disconnected: "provider_disconnected",
+
+  @doc("The provider reported that the destination was busy.")
+  provider_busy: "provider_busy",
+
+  @doc("The provider reported that the call was not answered.")
+  provider_no_answer: "provider_no_answer",
+
+  @doc("The provider reported that the call was cancelled.")
+  provider_cancelled: "provider_cancelled",
+
+  @doc("The provider reported that the call failed.")
+  provider_failed: "provider_failed",
+
+  @doc("The provider reported a media-stream error.")
+  provider_stream_error: "provider_stream_error",
+
+  @doc("The provider reported that the media stream stopped.")
+  provider_stream_stopped: "provider_stream_stopped",
+
+  @doc("The call could not connect to the voice-agent session.")
+  agent_session_connect_failed: "agent_session_connect_failed",
+
+  @doc("The call's media stream ended.")
+  media_stream_ended: "media_stream_ended",
+
+  @doc("The telephony media bridge was cancelled.")
+  bridge_cancelled: "bridge_cancelled",
+
+  @doc("The telephony media bridge failed.")
+  bridge_failed: "bridge_failed",
+
+  @doc("A managed call hang-up command succeeded.")
+  managed_hangup: "managed_hangup",
+
+  @doc("A managed call-transfer command succeeded.")
+  managed_transfer: "managed_transfer",
+
+  @doc("A managed call hang-up command failed.")
+  manage_hangup_failed: "manage_hangup_failed",
+
+  @doc("A managed call-transfer command failed.")
+  manage_transfer_failed: "manage_transfer_failed",
 }
 
 @doc("A summary of a durable inbound call to a voice agent.")
@@ -1095,9 +1287,9 @@ model TelephonyCallSummary {
   @doc("The call duration.")
   duration_ms?: FoundryDurationMilliseconds;
 
-  @doc("The service-generated reason that the call ended.")
+  @doc("The service-generated reason that this single call ended, rather than the outcome of an overall outbound call job. Additional string codes may be returned.")
   @maxLength(128)
-  end_reason?: string;
+  end_reason?: TelephonyCallEndReason;
 
   @doc("The provider status code associated with the terminal result.")
   @minValue(0)
@@ -1309,6 +1501,75 @@ union TelephonyCallJobStatus {
   cancelled: "cancelled",
 }
 
+@doc("Known terminal reasons for an overall outbound call job, which can span multiple provider attempts. These are distinct from individual call lifecycle reasons. Additional string codes may be returned.")
+@extension("x-ms-foundry-meta", VoiceAgentRequiredPreview)
+union TelephonyCallJobTerminalReason {
+  string,
+
+  @doc("The provider call ended before the service observed it as connected.")
+  no_answer: "no_answer",
+
+  @doc("The provider accepted the call, but no connection was observed before the timeout and cancellation was reconciled. This does not prove that the recipient never answered.")
+  no_answer_timeout: "no_answer_timeout",
+
+  @doc("The attempt to answer the provider call failed.")
+  answer_failed: "answer_failed",
+
+  @doc("The telephony media bridge was cancelled.")
+  bridge_cancelled: "bridge_cancelled",
+
+  @doc("The telephony media bridge failed.")
+  bridge_failed: "bridge_failed",
+
+  @doc("The voice-agent session configuration was invalid for outbound calling.")
+  voice_session_configuration_invalid: "voice_session_configuration_invalid",
+
+  @doc("The outbound call job's project context did not match its expected project.")
+  connection_project_mismatch: "connection_project_mismatch",
+
+  @doc("The resolved outbound connection or caller identity no longer matched the call job configuration.")
+  outbound_connection_changed: "outbound_connection_changed",
+
+  @doc("The configured outbound connection could not be resolved or used.")
+  outbound_connection_unavailable: "outbound_connection_unavailable",
+
+  @doc("The telephony binding was invalid for outbound calling.")
+  telephony_binding_invalid: "telephony_binding_invalid",
+
+  @doc("The telephony binding could not be found.")
+  telephony_binding_not_found: "telephony_binding_not_found",
+
+  @doc("The telephony binding was not active.")
+  telephony_binding_inactive: "telephony_binding_inactive",
+
+  @doc("The telephony binding changed after the call job was configured.")
+  telephony_binding_changed: "telephony_binding_changed",
+
+  @doc("The campaign associated with the call job could not be found.")
+  campaign_not_found: "campaign_not_found",
+
+  @doc("The campaign associated with the call job was cancelled.")
+  campaign_cancelled: "campaign_cancelled",
+
+  @doc("The campaign associated with the call job had already completed.")
+  campaign_completed: "campaign_completed",
+
+  @doc("The campaign associated with the call job had failed.")
+  campaign_failed: "campaign_failed",
+
+  @doc("The service could not record the guard against duplicate call origination.")
+  origination_fence_not_recorded: "origination_fence_not_recorded",
+
+  @doc("The service could not reconcile the outcome of call origination before the timeout.")
+  origination_reconciliation_timeout: "origination_reconciliation_timeout",
+
+  @doc("The service could not confirm the outcome of call cancellation before the timeout.")
+  cancellation_reconciliation_timeout: "cancellation_reconciliation_timeout",
+
+  @doc("Provider callbacks timed out, and the service could not confirm the subsequent cancellation before its reconciliation timeout.")
+  provider_callback_timeout_cancellation_reconciliation_timeout: "provider_callback_timeout_cancellation_reconciliation_timeout",
+}
+
 @doc("A cancellation request recorded for an outbound call job.")
 @extension("x-ms-foundry-meta", VoiceAgentRequiredPreview)
 model TelephonyCallJobCancellation {
@@ -1356,8 +1617,8 @@ model TelephonyCallJob {
   @doc("The Unix timestamp in seconds at which the next retry becomes eligible.")
   next_attempt_at?: FoundryTimestamp;
 
-  @doc("The stable reason for the terminal status, when available.")
-  terminal_reason?: string;
+  @doc("The stable service-generated reason for the overall outbound call job, which can span multiple provider attempts, when available. Interpret this with `status`: a queued job can retain a temporary dispatch-deferral reason. Additional string codes may be returned.")
+  terminal_reason?: TelephonyCallJobTerminalReason;
 
   @doc("The monotonically increasing optimistic-concurrency revision.")
   @minValue(0)


### PR DESCRIPTION
## Summary

Replace three optional plain-string telephony reason properties with separate, named extensible string unions:

- `TelephonyCallLifecycleEventReason`: 30 known lifecycle-event reason codes.
- `TelephonyCallEndReason`: 30 known single-call end reason codes, kept distinct from lifecycle-event reasons for independent evolution.
- `TelephonyCallJobTerminalReason`: 21 known overall outbound-job reason codes, distinct from individual provider attempts.

Each known value is documented in TypeSpec. All unions retain a `string` variant so future or otherwise unknown reason codes remain valid. Preserve existing property names, optionality, the 128-character limits on `reason` and `end_reason`, and `VoiceAgents=V1Preview` metadata. Clarify that a queued job can retain a temporary dispatch-deferral reason; those temporary codes are not advertised as known terminal outcomes. Keep `no_answer` and `no_answer_timeout` distinct from `provider_no_answer`.

Regenerate the JSON and YAML OpenAPI documents for both `v1` and `virtual-public-preview`. This PR contains only reason types, documentation, and the four generated documents; there are no runtime, connection-name, event-source, route, or SDK changes. Existing examples are unchanged.

## Validation

- Full Foundry compile with repository TypeSpec 1.15.0 succeeded.
- Exact baseline-normalized comparison passed for all four generated documents: exactly three new union schemas and only the three reason-property type/documentation changes, including the inherited `TelephonyCallRecord.end_reason` projection.
- Structural checks passed for 30/30/21 known codes, arbitrary unknown strings, optionality, existing length limits, preview metadata, unchanged examples (nine reason values per document), and JSON/YAML semantic parity.
- TypeSpec and generated JSON Prettier checks passed with both repository plugins; `git diff --check` passed.
- Azure SDK MCP TypeSpec validation was unavailable in this session; local compilation and structural checks were run instead. Generated YAML already fails Prettier on the target baseline and was left in emitter format to avoid unrelated formatting churn.

## Authoring references

- [TypeSpec unions](https://typespec.io/docs/language-basics/unions/)
- [TypeSpec models and optional properties](https://typespec.io/docs/language-basics/models/)
- [Azure extensible unions instead of closed enums](https://azure.github.io/typespec-azure/docs/libraries/azure-core/rules/no-enum/)

Target branch: `feature/foundry-release`.